### PR TITLE
Content module improvements

### DIFF
--- a/panel/src/components/Forms/FormControls.vue
+++ b/panel/src/components/Forms/FormControls.vue
@@ -57,7 +57,7 @@
 export default {
 	props: {
 		editor: String,
-		hasChanges: Boolean,
+		hasDiff: Boolean,
 		isLocked: Boolean,
 		modified: [String, Date],
 		/**
@@ -81,7 +81,7 @@ export default {
 				];
 			}
 
-			if (this.hasChanges === true) {
+			if (this.hasDiff === true) {
 				return [
 					{
 						theme: "notice",

--- a/panel/src/components/Navigation/ModelTabs.vue
+++ b/panel/src/components/Navigation/ModelTabs.vue
@@ -8,7 +8,7 @@
  */
 export default {
 	props: {
-		changes: Object,
+		diff: Object,
 		tab: String,
 		tabs: {
 			type: Array,
@@ -17,7 +17,7 @@ export default {
 	},
 	computed: {
 		withBadges() {
-			const changes = Object.keys(this.changes);
+			const changes = Object.keys(this.diff);
 
 			return this.tabs.map((tab) => {
 				// collect all fields per tab

--- a/panel/src/components/View/Buttons/LanguagesDropdown.vue
+++ b/panel/src/components/View/Buttons/LanguagesDropdown.vue
@@ -56,16 +56,16 @@ export default {
 		 * If translations other than the currently-viewed one
 		 * have any unsaved changes
 		 */
-		hasChanges: Boolean,
+		hasDiff: Boolean,
 		options: String
 	},
 	computed: {
 		changesBadge() {
-			// `hasChanges` provides the state for all other than the current
+			// `hasDiff` provides the state for all other than the current
 			// translation from the backend; for the current translation we need to
-			// check `content.hasChanges` as this state can change dynamically without
-			// any other backend request that would update `hasChanges`
-			if (this.hasChanges || this.$panel.content.hasChanges) {
+			// check `content.diff` as this state can change dynamically without
+			// any other backend request that would update `hasDiff`
+			if (this.hasDiff || this.$panel.content.hasDiff()) {
 				return {
 					theme: this.$panel.content.isLocked() ? "red" : "orange"
 				};

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -20,7 +20,7 @@
 				<k-view-buttons :buttons="buttons" @action="onAction" />
 				<k-form-controls
 					:editor="editor"
-					:has-changes="hasChanges"
+					:has-diff="hasDiff"
 					:is-locked="isLocked"
 					:modified="modified"
 					@discard="onDiscard"

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -37,7 +37,7 @@
 			@submit="onSubmit"
 		/>
 
-		<k-model-tabs :changes="changes" :tab="tab.name" :tabs="tabs" />
+		<k-model-tabs :diff="diff" :tab="tab.name" :tabs="tabs" />
 
 		<k-sections
 			:blueprint="blueprint"

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -9,7 +9,6 @@ export default {
 		api: String,
 		blueprint: String,
 		buttons: Array,
-		content: Object,
 		id: String,
 		link: String,
 		lock: {
@@ -17,7 +16,6 @@ export default {
 		},
 		model: Object,
 		next: Object,
-		originals: Object,
 		prev: Object,
 		permissions: {
 			type: Object,
@@ -35,7 +33,8 @@ export default {
 			type: Array,
 			default: () => []
 		},
-		uuid: String
+		uuid: String,
+		versions: Object
 	},
 	data() {
 		return {
@@ -43,8 +42,11 @@ export default {
 		};
 	},
 	computed: {
-		changes() {
-			return this.$panel.content.changes({
+		content() {
+			return this.versions.changes;
+		},
+		diff() {
+			return this.$panel.content.diff({
 				api: this.api,
 				language: this.$panel.language.code
 			});
@@ -53,7 +55,7 @@ export default {
 			return this.lock.user.email;
 		},
 		hasChanges() {
-			return length(this.changes) > 0;
+			return length(this.diff) > 0;
 		},
 		isLocked() {
 			return this.lock.isLocked;

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -1,6 +1,4 @@
 <script>
-import { length } from "@/helpers/object";
-
 /**
  * @internal
  */
@@ -46,16 +44,13 @@ export default {
 			return this.versions.changes;
 		},
 		diff() {
-			return this.$panel.content.diff({
-				api: this.api,
-				language: this.$panel.language.code
-			});
+			return this.$panel.content.diff();
 		},
 		editor() {
 			return this.lock.user.email;
 		},
-		hasChanges() {
-			return length(this.diff) > 0;
+		hasDiff() {
+			return this.$panel.content.hasDiff();
 		},
 		isLocked() {
 			return this.lock.isLocked;

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -20,7 +20,7 @@
 				<k-view-buttons :buttons="buttons" />
 				<k-form-controls
 					:editor="editor"
-					:has-changes="hasChanges"
+					:has-diff="hasDiff"
 					:is-locked="isLocked"
 					:modified="modified"
 					:preview="permissions.preview ? api + '/preview/compare' : false"

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -30,7 +30,7 @@
 			</template>
 		</k-header>
 
-		<k-model-tabs :changes="changes" :tab="tab.name" :tabs="tabs" />
+		<k-model-tabs :diff="diff" :tab="tab.name" :tabs="tabs" />
 
 		<k-sections
 			:blueprint="blueprint"

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -26,7 +26,7 @@
 			</template>
 		</k-header>
 
-		<k-model-tabs :changes="changes" :tab="tab.name" :tabs="tabs" />
+		<k-model-tabs :diff="diff" :tab="tab.name" :tabs="tabs" />
 
 		<k-sections
 			:blueprint="blueprint"

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -16,7 +16,7 @@
 				<k-view-buttons :buttons="buttons" />
 				<k-form-controls
 					:editor="editor"
-					:has-changes="hasChanges"
+					:has-diff="hasDiff"
 					:is-locked="isLocked"
 					:modified="modified"
 					:preview="permissions.preview ? api + '/preview/compare' : false"

--- a/panel/src/components/Views/PreviewView.vue
+++ b/panel/src/components/Views/PreviewView.vue
@@ -80,7 +80,7 @@
 						/>
 						<k-form-controls
 							:editor="editor"
-							:has-changes="hasChanges"
+							:has-diff="hasDiff"
 							:is-locked="isLocked"
 							:modified="modified"
 							size="sm"
@@ -89,7 +89,7 @@
 						/>
 					</k-button-group>
 				</header>
-				<iframe v-if="hasChanges" ref="changes" :src="src.changes"></iframe>
+				<iframe v-if="hasDiff" ref="changes" :src="src.changes"></iframe>
 				<k-empty v-else>
 					<template v-if="lock.isLegacy">
 						This content is locked by our old lock system. <br />

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -25,7 +25,7 @@
 				<k-view-buttons :buttons="buttons" />
 				<k-form-controls
 					:editor="editor"
-					:has-changes="hasChanges"
+					:has-diff="hasDiff"
 					:is-locked="isLocked"
 					:modified="modified"
 					@discard="onDiscard"

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -48,7 +48,7 @@
 			:role="role"
 		/>
 
-		<k-model-tabs :changes="changes" :tab="tab.name" :tabs="tabs" />
+		<k-model-tabs :diff="diff" :tab="tab.name" :tabs="tabs" />
 
 		<k-sections
 			:blueprint="blueprint"

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -19,26 +19,28 @@ export default (panel) => {
 			this.saveAbortController?.abort();
 		},
 
+		dialog: null,
+
 		/**
 		 * Returns an object with all changed fields
 		 * @param {Object} env
 		 * @returns {Object}
 		 */
-		changes(env = {}) {
+		diff(env = {}) {
 			// changes can only be computed for the current view
 			if (this.isCurrent(env) === false) {
 				throw new Error("Cannot get changes for another view");
 			}
 
 			const versions = this.versions();
-			const changes = {};
+			const diff = {};
 
 			for (const field in versions.changes) {
 				const changed = JSON.stringify(versions.changes[field]);
 				const original = JSON.stringify(versions.latest[field]);
 
 				if (changed !== original) {
-					changes[field] = versions.changes[field];
+					diff[field] = versions.changes[field];
 				}
 			}
 
@@ -46,14 +48,12 @@ export default (panel) => {
 			// but have been removed from the current content
 			for (const field in versions.latest) {
 				if (versions.changes[field] === undefined) {
-					changes[field] = null;
+					diff[field] = null;
 				}
 			}
 
-			return changes;
+			return diff;
 		},
-
-		dialog: null,
 
 		/**
 		 * Removes all unpublished changes
@@ -344,10 +344,7 @@ export default (panel) => {
 		 * @returns {Object}
 		 */
 		versions() {
-			return {
-				latest: panel.view.props.originals,
-				changes: panel.view.props.content
-			};
+			return panel.view.props.versions;
 		}
 	});
 

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -85,7 +85,7 @@ export default (panel) => {
 				await this.request("discard", {}, env);
 
 				// update the props for the current view
-				panel.view.props.versions.changes = this.versions().latest;
+				panel.view.props.versions.changes = this.versions("latest");
 
 				this.emit("discard", {}, env);
 			} catch (error) {
@@ -195,12 +195,10 @@ export default (panel) => {
 				values = {};
 			}
 
-			panel.view.props.versions.changes = {
-				...this.versions().changes,
+			return (panel.view.props.versions.changes = {
+				...this.versions("changes"),
 				...values
-			};
-
-			return panel.view.props.versions.changes;
+			});
 		},
 
 		/**
@@ -231,7 +229,7 @@ export default (panel) => {
 				this.dialog?.close();
 
 				// update the props for the current view
-				panel.view.props.versions.latest = this.versions().changes;
+				panel.view.props.versions.latest = this.versions("changes");
 
 				this.emit("publish", { values }, env);
 			} catch (error) {

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -1,4 +1,4 @@
-import { isObject } from "@/helpers/object";
+import { isObject, length } from "@/helpers/object";
 import { reactive } from "vue";
 import throttle from "@/helpers/throttle.js";
 
@@ -122,6 +122,13 @@ export default (panel) => {
 				language: panel.language.code,
 				...env
 			};
+		},
+
+		/**
+		 * Whether there are any changes
+		 */
+		hasDiff(env = {}) {
+			return length(this.diff(env)) > 0;
 		},
 
 		/**

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -85,7 +85,7 @@ export default (panel) => {
 				await this.request("discard", {}, env);
 
 				// update the props for the current view
-				this.versions().changes = this.versions().latest;
+				panel.view.props.versions.changes = this.versions().latest;
 
 				this.emit("discard", {}, env);
 			} catch (error) {
@@ -195,14 +195,12 @@ export default (panel) => {
 				values = {};
 			}
 
-			let changes = this.versions().changes;
-
-			changes = {
-				...changes,
+			panel.view.props.versions.changes = {
+				...this.versions().changes,
 				...values
 			};
 
-			return changes;
+			return panel.view.props.versions.changes;
 		},
 
 		/**
@@ -233,7 +231,7 @@ export default (panel) => {
 				this.dialog?.close();
 
 				// update the props for the current view
-				this.versions().latest = this.versions().changes;
+				panel.view.props.versions.latest = this.versions().changes;
 
 				this.emit("publish", { values }, env);
 			} catch (error) {

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -401,7 +401,6 @@ class File extends Model
 		// Additional model information
 		// @deprecated Use the top-level props instead
 		$model = [
-			'content'    => $props['content'],
 			'dimensions' => $file->dimensions()->toArray(),
 			'extension'  => $file->extension(),
 			'filename'   => $file->filename(),

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -373,14 +373,16 @@ abstract class Model
 		$props = [
 			'api'         => $link,
 			'buttons'     => fn () => $this->buttons(),
-			'content'     => (object)$versions['changes'],
 			'id'          => $this->model->id(),
 			'link'        => $link,
 			'lock'        => $this->model->lock()->toArray(),
-			'originals'   => (object)$versions['latest'],
 			'permissions' => $this->model->permissions()->toArray(),
 			'tabs'        => $tabs,
-			'uuid'        => fn () => $this->model->uuid()?->toString()
+			'uuid'        => fn () => $this->model->uuid()?->toString(),
+			'versions'    => [
+				'latest'  => (object)$versions['latest'],
+				'changes' => (object)$versions['changes']
+			]
 		];
 
 		// only send the tab if it exists

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -355,7 +355,6 @@ class Page extends Model
 		// Additional model information
 		// @deprecated Use the top-level props instead
 		$model = [
-			'content'    => $props['content'],
 			'id'         => $props['id'],
 			'link'       => $props['link'],
 			'parent'     => $this->model->parentModel()->panel()->url(true),

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -82,7 +82,6 @@ class Site extends Model
 		// Additional model information
 		// @deprecated Use the top-level props instead
 		$model = [
-			'content'    => $props['content'],
 			'link'       => $props['link'],
 			'previewUrl' => $this->model->previewUrl(),
 			'title'      => $this->model->title()->toString(),

--- a/src/Panel/Ui/Buttons/LanguagesDropdown.php
+++ b/src/Panel/Ui/Buttons/LanguagesDropdown.php
@@ -46,7 +46,7 @@ class LanguagesDropdown extends ViewButton
 	 * (the current language has to be handled in `k-languages-dropdown` as its
 	 * state can change dynamically without another backend request)
 	 */
-	public function hasChanges(): bool
+	public function hasDiff(): bool
 	{
 		foreach (Languages::ensure() as $language) {
 			if ($this->kirby->language()?->code() !== $language->code()) {
@@ -104,7 +104,7 @@ class LanguagesDropdown extends ViewButton
 	{
 		return [
 			...parent::props(),
-			'hasChanges' => $this->hasChanges()
+			'hasDiff' => $this->hasDiff()
 		];
 	}
 

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -243,7 +243,6 @@ class User extends Model
 		$model = [
 			'account'  => $user->isLoggedIn(),
 			'avatar'   => $user->avatar()?->url(),
-			'content'  => $props['content'],
 			'email'    => $user->email(),
 			'id'       => $props['id'],
 			'language' => $this->translation()->name(),

--- a/tests/Panel/Areas/SiteTest.php
+++ b/tests/Panel/Areas/SiteTest.php
@@ -49,8 +49,10 @@ class SiteTest extends AreaTestCase
 		$this->assertArrayNotHasKey('tab', $props);
 		$this->assertSame([], $props['tabs']);
 
+		$this->assertSame('Test', $props['versions']['latest']['title']);
+		$this->assertSame('Test', $props['versions']['changes']['title']);
+
 		// model
-		$this->assertSame('Test', $model['content']['title']);
 		$this->assertSame('test', $model['id']);
 		$this->assertSame('draft', $model['status']);
 		$this->assertSame('Test', $model['title']);
@@ -106,9 +108,10 @@ class SiteTest extends AreaTestCase
 		], $props['lock']);
 		$this->assertArrayNotHasKey('tab', $props);
 		$this->assertSame([], $props['tabs']);
+		$this->assertSame([], $props['versions']['changes']);
+		$this->assertSame([], $props['versions']['latest']);
 
 		// model
-		$this->assertSame([], $model['content']);
 		$this->assertSame('jpg', $model['extension']);
 		$this->assertSame('test.jpg', $model['filename']);
 		$this->assertSame('test/test.jpg', $model['id']);
@@ -174,7 +177,6 @@ class SiteTest extends AreaTestCase
 		$this->assertSame('k-site-view', $view['component']);
 
 		$this->assertSame('site', $props['blueprint']);
-		$this->assertSame([], $props['model']['content']);
 		$this->assertSame('/site', $props['model']['link']);
 		$this->assertSame('/', $props['model']['previewUrl']);
 		$this->assertSame('', $props['model']['title']);
@@ -213,7 +215,8 @@ class SiteTest extends AreaTestCase
 		$this->assertSame([], $props['tabs']);
 
 		// model
-		$this->assertSame([], $model['content']);
+		$this->assertSame([], $props['versions']['changes']);
+		$this->assertSame([], $props['versions']['latest']);
 		$this->assertSame('jpg', $model['extension']);
 		$this->assertSame('test.jpg', $model['filename']);
 		$this->assertSame('test.jpg', $model['id']);

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -832,7 +832,6 @@ class FileTest extends TestCase
 		$props = $panel->props();
 
 		$this->assertArrayHasKey('model', $props);
-		$this->assertArrayHasKey('content', $props['model']);
 		$this->assertArrayHasKey('dimensions', $props['model']);
 		$this->assertArrayHasKey('extension', $props['model']);
 		$this->assertArrayHasKey('filename', $props['model']);
@@ -851,6 +850,7 @@ class FileTest extends TestCase
 		$this->assertArrayHasKey('permissions', $props);
 		$this->assertArrayNotHasKey('tab', $props);
 		$this->assertArrayHasKey('tabs', $props);
+		$this->assertArrayHasKey('versions', $props);
 	}
 
 	/**

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -530,7 +530,6 @@ class PageTest extends TestCase
 		$props = $panel->props();
 
 		$this->assertArrayHasKey('model', $props);
-		$this->assertArrayHasKey('content', $props['model']);
 		$this->assertArrayHasKey('id', $props['model']);
 		$this->assertArrayHasKey('parent', $props['model']);
 		$this->assertArrayHasKey('previewUrl', $props['model']);
@@ -543,6 +542,7 @@ class PageTest extends TestCase
 		$this->assertArrayHasKey('permissions', $props);
 		$this->assertArrayNotHasKey('tab', $props);
 		$this->assertArrayHasKey('tabs', $props);
+		$this->assertArrayHasKey('versions', $props);
 
 		$this->assertNull($props['next']());
 		$this->assertNull($props['prev']());

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -143,7 +143,6 @@ class SiteTest extends TestCase
 		$props = $this->panel()->props();
 
 		$this->assertArrayHasKey('model', $props);
-		$this->assertArrayHasKey('content', $props['model']);
 		$this->assertArrayHasKey('previewUrl', $props['model']);
 		$this->assertArrayHasKey('title', $props['model']);
 
@@ -153,6 +152,7 @@ class SiteTest extends TestCase
 		$this->assertArrayHasKey('permissions', $props);
 		$this->assertArrayHasKey('tab', $props);
 		$this->assertArrayHasKey('tabs', $props);
+		$this->assertArrayHasKey('versions', $props);
 	}
 
 	public function testPreviewPermissionsWithoutHomePage()

--- a/tests/Panel/Ui/Buttons/LanguagesDropdownTest.php
+++ b/tests/Panel/Ui/Buttons/LanguagesDropdownTest.php
@@ -13,9 +13,9 @@ use Kirby\Panel\Areas\AreaTestCase;
 class LanguagesDropdownTest extends AreaTestCase
 {
 	/**
-	 * @covers ::hasChanges
+	 * @covers ::hasDiff
 	 */
-	public function testHasChanges()
+	public function testHasDiff()
 	{
 		$this->install();
 		$this->installLanguages();
@@ -24,17 +24,17 @@ class LanguagesDropdownTest extends AreaTestCase
 		$button = new LanguagesDropdown($page);
 
 		// no changes
-		$this->assertFalse($button->hasChanges());
+		$this->assertFalse($button->hasDiff());
 
 		// changes in current translation (not considered)
 		$page->version('latest')->save([], 'en');
 		$page->version('changes')->save([], 'en');
-		$this->assertFalse($button->hasChanges());
+		$this->assertFalse($button->hasDiff());
 
 		// changes in other translations
 		$page->version('latest')->save([], 'de');
 		$page->version('changes')->save([], 'de');
-		$this->assertTrue($button->hasChanges());
+		$this->assertTrue($button->hasDiff());
 	}
 
 	/**
@@ -105,7 +105,7 @@ class LanguagesDropdownTest extends AreaTestCase
 		$page   = new Page(['slug' => 'test']);
 		$button = new LanguagesDropdown($page);
 		$props  = $button->props();
-		$this->assertFalse($props['hasChanges']);
+		$this->assertFalse($props['hasDiff']);
 	}
 
 	/**

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -391,7 +391,6 @@ class UserTest extends TestCase
 
 		$this->assertArrayHasKey('model', $props);
 		$this->assertArrayHasKey('avatar', $props['model']);
-		$this->assertArrayHasKey('content', $props['model']);
 		$this->assertArrayHasKey('email', $props['model']);
 		$this->assertArrayHasKey('id', $props['model']);
 		$this->assertArrayHasKey('language', $props['model']);
@@ -405,6 +404,7 @@ class UserTest extends TestCase
 		$this->assertArrayHasKey('permissions', $props);
 		$this->assertArrayNotHasKey('tab', $props);
 		$this->assertArrayHasKey('tabs', $props);
+		$this->assertArrayHasKey('versions', $props);
 
 		$this->assertNull($props['next']());
 		$this->assertNull($props['prev']());


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements from previous betas

- `panel.content.changes()` has been renamed to `panel.content.diff()`
- New `panel.content.hasDiff()` method.
- New `panel.content.version(versionId)` method
- New `panel.content.versions()` method
- The `content`and `original` props have been removed from all model views.
- A new `versions` prop has been added instead with `latest` and `changes` as child objects.
- The `changes` property in the `<k-model-tabs>` component has been renamed to `diff`.
- hasChanges has been renamed to hasDiff in all components. 

### Breaking changes

- The `content` prop has been removed from all model views.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
