### PR TITLE
Consistent VersionId code style

### DIFF
--- a/src/Api/Controller/Changes.php
+++ b/src/Api/Controller/Changes.php
@@ -5,7 +5,6 @@ namespace Kirby\Api\Controller;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Content\Lock;
-use Kirby\Content\VersionId;
 use Kirby\Filesystem\F;
 use Kirby\Form\Fields;
 use Kirby\Form\Form;
@@ -41,7 +40,7 @@ class Changes
 	 */
 	public static function discard(ModelWithContent $model): array
 	{
-		$model->version(VersionId::changes())->delete('current');
+		$model->version('changes')->delete('current');
 
 		// Removes the old .lock file when it is no longer needed
 		// @todo Remove in 6.0.0
@@ -53,7 +52,7 @@ class Changes
 	}
 
 	/**
-	 * Saves the lastest state of changes first and then publishs them
+	 * Saves the lastest state of changes first and then publishes them
 	 */
 	public static function publish(ModelWithContent $model, array $input): array
 	{
@@ -68,7 +67,7 @@ class Changes
 		static::cleanup($model);
 
 		// get the changes version
-		$changes = $model->version(VersionId::changes());
+		$changes = $model->version('changes');
 
 		// if the changes version does not exist, we need to return early
 		if ($changes->exists('current') === false) {
@@ -103,8 +102,8 @@ class Changes
 		$fields = Fields::for($model, $language);
 
 		// get the changes and latest version for the model
-		$changes = $model->version(VersionId::changes());
-		$latest  = $model->version(VersionId::latest());
+		$changes = $model->version('changes');
+		$latest  = $model->version('latest');
 
 		// get the source version for the existing content
 		$source  = $changes->exists($language) === true ? $changes : $latest;

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -4,7 +4,6 @@ namespace Kirby\Cms;
 
 use Exception;
 use IntlDateFormatter;
-use Kirby\Content\VersionId;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\F;
 use Kirby\Filesystem\IsFile;
@@ -432,7 +431,7 @@ class File extends ModelWithContent
 	 */
 	protected function modifiedContent(string|null $languageCode = null): int
 	{
-		return $this->version(VersionId::latest())->modified($languageCode ?? 'current') ?? 0;
+		return $this->version('latest')->modified($languageCode ?? 'current') ?? 0;
 	}
 
 	/**

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -170,7 +170,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	{
 		// get the targeted language
 		$language  = Language::ensure($languageCode ?? 'current');
-		$versionId = VersionId::$render ?? VersionId::latest();
+		$versionId = VersionId::$render ?? 'latest';
 		$version   = $this->version($versionId);
 
 		if ($version->exists($language) === true) {
@@ -368,7 +368,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 */
 	public function lock(): Lock
 	{
-		return $this->version(VersionId::changes())->lock('*');
+		return $this->version('changes')->lock('*');
 	}
 
 	/**
@@ -702,7 +702,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	{
 		return new Version(
 			model: $this,
-			id: VersionId::from($versionId ?? VersionId::latest())
+			id: VersionId::from($versionId ?? 'latest')
 		);
 	}
 

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -922,7 +922,7 @@ class Page extends ModelWithContent
 		// make sure to convert it to an object no matter what happened
 		$versionId ??= VersionId::$render;
 		$versionId ??= $this->renderVersionFromRequest();
-		$versionId ??= VersionId::latest();
+		$versionId ??= 'latest';
 		$versionId   = VersionId::from($versionId);
 
 		// try to get the page from cache

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -3,7 +3,6 @@
 namespace Kirby\Cms;
 
 use Kirby\Cms\System\UpdateStatus;
-use Kirby\Content\VersionId;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
@@ -76,7 +75,7 @@ class System
 
 		switch ($folder) {
 			case 'content':
-				return $url . '/' . basename($this->app->site()->version(VersionId::latest())->contentFile());
+				return $url . '/' . basename($this->app->site()->version('latest')->contentFile());
 			case 'git':
 				return $url . '/config';
 			case 'kirby':

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -5,7 +5,6 @@ namespace Kirby\Cms;
 use Closure;
 use Exception;
 use Kirby\Content\Field;
-use Kirby\Content\VersionId;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Exception\PermissionException;
@@ -210,7 +209,7 @@ class User extends ModelWithContent
 	 */
 	public function exists(): bool
 	{
-		return $this->version(VersionId::latest())->exists('default');
+		return $this->version('latest')->exists('default');
 	}
 
 	/**
@@ -453,7 +452,7 @@ class User extends ModelWithContent
 		string|null $handler = null,
 		string|null $languageCode = null
 	): int|string|false {
-		$modifiedContent = $this->version(VersionId::latest())->modified($languageCode ?? 'current');
+		$modifiedContent = $this->version('latest')->modified($languageCode ?? 'current');
 		$modifiedIndex   = F::modified($this->root() . '/index.php');
 		$modifiedTotal   = max([$modifiedContent, $modifiedIndex]);
 

--- a/src/Content/Changes.php
+++ b/src/Content/Changes.php
@@ -64,7 +64,7 @@ class Changes
 	public function ensure(Files|Pages|Users $tracked): Files|Pages|Users
 	{
 		foreach ($tracked as $model) {
-			if ($model->version(VersionId::changes())->exists('*') === false) {
+			if ($model->version('changes')->exists('*') === false) {
 				$this->untrack($model);
 				$tracked->remove($model);
 			}
@@ -101,7 +101,7 @@ class Changes
 		];
 
 		foreach ($this->kirby->models() as $model) {
-			if ($model->version(VersionId::changes())->exists('*') === true) {
+			if ($model->version('changes')->exists('*') === true) {
 				$models[$this->cacheKey($model)][] = (string)($model->uuid() ?? $model->id());
 			}
 		}

--- a/src/Content/PlainTextStorage.php
+++ b/src/Content/PlainTextStorage.php
@@ -151,7 +151,7 @@ class PlainTextStorage extends Storage
 
 		// delete empty _drafts directories for pages
 		if (
-			$versionId->is(VersionId::latest()) === true &&
+			$versionId->is(VersionId::LATEST) === true &&
 			$this->model instanceof Page &&
 			$this->model->isDraft() === true
 		) {
@@ -195,7 +195,10 @@ class PlainTextStorage extends Storage
 
 		// A changed version or non-default language version does not exist
 		// if the content file was not found
-		if (VersionId::latest()->is($versionId) === false || $language->isDefault() === false) {
+		if (
+			$versionId->is(VersionId::LATEST) === false ||
+			$language->isDefault() === false
+		) {
 			return false;
 		}
 

--- a/src/Content/PlainTextStorage.php
+++ b/src/Content/PlainTextStorage.php
@@ -39,7 +39,7 @@ class PlainTextStorage extends Storage
 			=> $this->model->root()
 		};
 
-		if ($versionId->is(VersionId::CHANGES)) {
+		if ($versionId->is('changes')) {
 			$directory .= '/_changes';
 		}
 
@@ -151,7 +151,7 @@ class PlainTextStorage extends Storage
 
 		// delete empty _drafts directories for pages
 		if (
-			$versionId->is(VersionId::LATEST) === true &&
+			$versionId->is('latest') === true &&
 			$this->model instanceof Page &&
 			$this->model->isDraft() === true
 		) {
@@ -196,7 +196,7 @@ class PlainTextStorage extends Storage
 		// A changed version or non-default language version does not exist
 		// if the content file was not found
 		if (
-			$versionId->is(VersionId::LATEST) === false ||
+			$versionId->is('latest') === false ||
 			$language->isDefault() === false
 		) {
 			return false;

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -101,7 +101,7 @@ class Version
 		Language|string $language = 'default'
 	): void {
 		$language = Language::ensure($language);
-		$latest   = $this->sibling(VersionId::latest());
+		$latest   = $this->sibling('latest');
 
 		// if the latest version of the translation does not exist yet,
 		// we have to copy over the content from the default language first.
@@ -120,7 +120,7 @@ class Version
 		VersionRules::create($this, $fields, $language);
 
 		// track the changes
-		if ($this->id->is(VersionId::changes()) === true) {
+		if ($this->id->is(VersionId::CHANGES) === true) {
 			(new Changes())->track($this->model);
 		}
 
@@ -156,7 +156,10 @@ class Version
 
 		// untrack the changes if the version does no longer exist
 		// in any of the available languages
-		if ($this->id->is(VersionId::changes()) === true && $this->exists('*') === false) {
+		if (
+			$this->id->is(VersionId::CHANGES) === true &&
+			$this->exists('*') === false
+		) {
 			(new Changes())->untrack($this->model);
 		}
 
@@ -260,7 +263,7 @@ class Version
 	 */
 	public function isLatest(): bool
 	{
-		return $this->id->is('latest');
+		return $this->id->is(VersionId::LATEST);
 	}
 
 	/**
@@ -366,7 +369,7 @@ class Version
 		// add the editing user
 		if (
 			Lock::isEnabled() === true &&
-			$this->id->is(VersionId::changes()) === true
+			$this->id->is(VersionId::CHANGES) === true
 		) {
 			$fields['lock'] = $this->model->kirby()->user()?->id();
 
@@ -499,7 +502,7 @@ class Version
 		// check if publishing is allowed
 		VersionRules::publish($this, $language);
 
-		$latest  = $this->sibling(VersionId::latest())->read($language);
+		$latest  = $this->sibling('latest')->read($language);
 		$changes = $this->read($language);
 
 		// overwrite all fields that are not in the `changes` version

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -120,7 +120,7 @@ class Version
 		VersionRules::create($this, $fields, $language);
 
 		// track the changes
-		if ($this->id->is(VersionId::CHANGES) === true) {
+		if ($this->id->is('changes') === true) {
 			(new Changes())->track($this->model);
 		}
 
@@ -157,7 +157,7 @@ class Version
 		// untrack the changes if the version does no longer exist
 		// in any of the available languages
 		if (
-			$this->id->is(VersionId::CHANGES) === true &&
+			$this->id->is('changes') === true &&
 			$this->exists('*') === false
 		) {
 			(new Changes())->untrack($this->model);
@@ -263,7 +263,7 @@ class Version
 	 */
 	public function isLatest(): bool
 	{
-		return $this->id->is(VersionId::LATEST);
+		return $this->id->is('latest');
 	}
 
 	/**
@@ -369,7 +369,7 @@ class Version
 		// add the editing user
 		if (
 			Lock::isEnabled() === true &&
-			$this->id->is(VersionId::CHANGES) === true
+			$this->id->is('changes') === true
 		) {
 			$fields['lock'] = $this->model->kirby()->user()?->id();
 

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -79,11 +79,11 @@ class VersionId implements Stringable
 	}
 
 	/**
-	 * Compares a string value with the id value
+	 * Compares a VersionId object or string value with this id
 	 */
-	public function is(string $value): bool
+	public function is(VersionId|string $id): bool
 	{
-		return $value === $this->value;
+		return static::from($id)->value === $this->value;
 	}
 
 	/**

--- a/src/Content/VersionRules.php
+++ b/src/Content/VersionRules.php
@@ -36,7 +36,7 @@ class VersionRules
 			return;
 		}
 
-		if ($version->model()->version(VersionId::latest())->exists($language) === false) {
+		if ($version->model()->version('latest')->exists($language) === false) {
 			throw new LogicException(
 				message: 'A matching latest version for the changes does not exist'
 			);

--- a/src/Panel/Ui/Buttons/LanguagesDropdown.php
+++ b/src/Panel/Ui/Buttons/LanguagesDropdown.php
@@ -6,7 +6,6 @@ use Kirby\Cms\App;
 use Kirby\Cms\Language;
 use Kirby\Cms\Languages;
 use Kirby\Cms\ModelWithContent;
-use Kirby\Content\VersionId;
 use Kirby\Toolkit\Str;
 
 /**
@@ -51,7 +50,7 @@ class LanguagesDropdown extends ViewButton
 	{
 		foreach (Languages::ensure() as $language) {
 			if ($this->kirby->language()?->code() !== $language->code()) {
-				if ($this->model->version(VersionId::changes())->exists($language) === true) {
+				if ($this->model->version('changes')->exists($language) === true) {
 					return true;
 				}
 			}

--- a/tests/Cms/Page/PageChangeTemplateTest.php
+++ b/tests/Cms/Page/PageChangeTemplateTest.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Content\VersionId;
 use Kirby\Exception\PermissionException;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -107,9 +106,9 @@ class PageChangeTemplateTest extends ModelTestCase
 		$this->assertSame('article', $modified->intendedTemplate()->name());
 		$this->assertSame(2, $calls);
 
-		$this->assertFileExists($modified->version(VersionId::latest())->contentFile('en'));
-		$this->assertFileExists($modified->version(VersionId::latest())->contentFile('de'));
-		$this->assertFileDoesNotExist($modified->version(VersionId::latest())->contentFile('fr'));
+		$this->assertFileExists($modified->version('latest')->contentFile('en'));
+		$this->assertFileExists($modified->version('latest')->contentFile('de'));
+		$this->assertFileDoesNotExist($modified->version('latest')->contentFile('fr'));
 		$this->assertNull($modified->caption()->value());
 		$this->assertSame('Text', $modified->text()->value());
 		$this->assertNull($modified->content('de')->get('caption')->value());

--- a/tests/Cms/Page/PageDuplicateTest.php
+++ b/tests/Cms/Page/PageDuplicateTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Cms;
 
 use Kirby\Content\Translation;
-use Kirby\Content\VersionId;
 use Kirby\Filesystem\F;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -54,17 +53,15 @@ class PageDuplicateTest extends ModelTestCase
 			language: $this->app->language('en')
 		);
 
-		$versionId = VersionId::latest();
-
-		$this->assertFileExists($page->version($versionId)->contentFile('en'));
+		$this->assertFileExists($page->version('latest')->contentFile('en'));
 
 		$drafts = $this->app->site()->drafts();
 		$childrenAndDrafts = $this->app->site()->childrenAndDrafts();
 
 		$copy = $page->duplicate('test-copy');
 
-		$this->assertFileExists($copy->version($versionId)->contentFile('en'));
-		$this->assertFileDoesNotExist($copy->version($versionId)->contentFile('de'));
+		$this->assertFileExists($copy->version('latest')->contentFile('en'));
+		$this->assertFileDoesNotExist($copy->version('latest')->contentFile('de'));
 
 		$this->assertIsPage($page, $drafts->find('test'));
 		$this->assertIsPage($page, $childrenAndDrafts->find('test'));
@@ -84,10 +81,8 @@ class PageDuplicateTest extends ModelTestCase
 			'slug'  => 'test-de'
 		], 'de');
 
-		$versionId = VersionId::latest();
-
-		$this->assertFileExists($page->version($versionId)->contentFile('en'));
-		$this->assertFileExists($page->version($versionId)->contentFile('de'));
+		$this->assertFileExists($page->version('latest')->contentFile('en'));
+		$this->assertFileExists($page->version('latest')->contentFile('de'));
 
 		$this->assertSame('test', $page->slug());
 		$this->assertSame('test-de', $page->slug('de'));
@@ -180,12 +175,10 @@ class PageDuplicateTest extends ModelTestCase
 			language: $this->app->language('en')
 		);
 
-		$versionId = VersionId::latest();
-
 		$copy = $page->duplicate('test-copy', ['children' => true]);
 
-		$this->assertFileExists($copy->version($versionId)->contentFile('en'));
-		$this->assertFileDoesNotExist($copy->version($versionId)->contentFile('de'));
+		$this->assertFileExists($copy->version('latest')->contentFile('en'));
+		$this->assertFileDoesNotExist($copy->version('latest')->contentFile('de'));
 
 		$this->assertNotSame($page->uuid()->id(), $copy->uuid()->id());
 		$this->assertNotSame($this->app->page('test/foo')->uuid()->id(), $this->app->page('test-copy/foo')->uuid()->id());

--- a/tests/Content/ChangesTest.php
+++ b/tests/Content/ChangesTest.php
@@ -86,11 +86,11 @@ class ChangesTest extends TestCase
 		// in cache and changes exist in reality. We need to save
 		// at least a single field here. Otherwise, the content file
 		// is not going to be created and the changes will not be detected.
-		$this->app->file('test/test.jpg')->version(VersionId::latest())->save([
+		$this->app->file('test/test.jpg')->version('latest')->save([
 			'alt' => 'Test'
 		]);
 
-		$this->app->file('test/test.jpg')->version(VersionId::changes())->save([
+		$this->app->file('test/test.jpg')->version('changes')->save([
 			'alt' => 'Test'
 		]);
 
@@ -124,16 +124,16 @@ class ChangesTest extends TestCase
 		$changes = new Changes();
 
 		$file = $this->app->file('test/test.jpg');
-		$file->version(VersionId::latest())->save(['foo' => 'bar']);
-		$file->version(VersionId::changes())->save(['foo' => 'bar']);
+		$file->version('latest')->save(['foo' => 'bar']);
+		$file->version('changes')->save(['foo' => 'bar']);
 
 		$page = $this->app->page('test');
-		$page->version(VersionId::latest())->save(['foo' => 'bar']);
-		$page->version(VersionId::changes())->save(['foo' => 'bar']);
+		$page->version('latest')->save(['foo' => 'bar']);
+		$page->version('changes')->save(['foo' => 'bar']);
 
 		$user = $this->app->user('test');
-		$user->version(VersionId::latest())->save(['foo' => 'bar']);
-		$user->version(VersionId::changes())->save(['foo' => 'bar']);
+		$user->version('latest')->save(['foo' => 'bar']);
+		$user->version('changes')->save(['foo' => 'bar']);
 
 		$this->app->cache('changes')->flush();
 
@@ -167,8 +167,8 @@ class ChangesTest extends TestCase
 		$this->assertSame([], $this->app->cache('changes')->get('pages'));
 
 		// in cache and changes exist in reality
-		$this->app->page('test')->version(VersionId::latest())->save([]);
-		$this->app->page('test')->version(VersionId::changes())->save([]);
+		$this->app->page('test')->version('latest')->save([]);
+		$this->app->page('test')->version('changes')->save([]);
 
 		$this->assertSame($cache, $this->app->cache('changes')->get('pages'));
 		$this->assertCount(1, $changes->pages());
@@ -360,8 +360,8 @@ class ChangesTest extends TestCase
 		$this->assertSame([], $this->app->cache('changes')->get('users'));
 
 		// in cache and changes exist in reality
-		$this->app->user('test')->version(VersionId::latest())->save([]);
-		$this->app->user('test')->version(VersionId::changes())->save([]);
+		$this->app->user('test')->version('latest')->save([]);
+		$this->app->user('test')->version('changes')->save([]);
 
 		$this->assertSame($cache, $this->app->cache('changes')->get('users'));
 		$this->assertCount(1, $changes->users());

--- a/tests/Content/VersionIdTest.php
+++ b/tests/Content/VersionIdTest.php
@@ -69,8 +69,10 @@ class VersionIdTest extends TestCase
 
 		$this->assertTrue($version->is('latest'));
 		$this->assertTrue($version->is(VersionId::LATEST));
-		$this->assertFalse($version->is('something-else'));
+		$this->assertTrue($version->is(VersionId::latest()));
+		$this->assertFalse($version->is('changes'));
 		$this->assertFalse($version->is(VersionId::CHANGES));
+		$this->assertFalse($version->is(VersionId::changes()));
 	}
 
 	/**

--- a/tests/Panel/ChangesDialogTest.php
+++ b/tests/Panel/ChangesDialogTest.php
@@ -4,7 +4,6 @@ namespace Kirby\Panel;
 
 use Kirby\Cms\Pages;
 use Kirby\Content\Changes;
-use Kirby\Content\VersionId;
 use Kirby\Panel\Areas\AreaTestCase;
 use Kirby\Uuid\Uuids;
 
@@ -68,11 +67,11 @@ class ChangesDialogTest extends AreaTestCase
 	{
 		$this->setUpModels();
 
-		$this->app->file('file://test')->version(VersionId::latest())->save([
+		$this->app->file('file://test')->version('latest')->save([
 			'alt' => 'Test'
 		]);
 
-		$this->app->file('file://test')->version(VersionId::changes())->save([
+		$this->app->file('file://test')->version('changes')->save([
 			'alt' => 'Test'
 		]);
 
@@ -100,8 +99,8 @@ class ChangesDialogTest extends AreaTestCase
 	{
 		$this->setUpModels();
 		$page = $this->app->page('page://test');
-		$page->version(VersionId::latest())->save([]);
-		$page->version(VersionId::changes())->save([]);
+		$page->version('latest')->save([]);
+		$page->version('changes')->save([]);
 
 		$dialog = new ChangesDialog();
 		$pages  = new Pages([$page]);
@@ -139,8 +138,8 @@ class ChangesDialogTest extends AreaTestCase
 	{
 		$this->setUpModels();
 
-		$this->app->page('page://test')->version(VersionId::latest())->save([]);
-		$this->app->page('page://test')->version(VersionId::changes())->save([]);
+		$this->app->page('page://test')->version('latest')->save([]);
+		$this->app->page('page://test')->version('changes')->save([]);
 
 		$dialog = new ChangesDialog();
 		$pages  = $dialog->pages();
@@ -166,8 +165,8 @@ class ChangesDialogTest extends AreaTestCase
 	{
 		$this->setUpModels();
 
-		$this->app->user('user://test')->version(VersionId::latest())->save([]);
-		$this->app->user('user://test')->version(VersionId::changes())->save([]);
+		$this->app->user('user://test')->version('latest')->save([]);
+		$this->app->user('user://test')->version('changes')->save([]);
 
 		$dialog = new ChangesDialog();
 		$users  = $dialog->users();


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Use simple strings (`'latest'`/`'changes'`) for `$model->version($versionId)` and similar
- Use constant for `$versionId->is($versionID)`, e.g. `$versionId->is(VersionId::LATEST)`
- Use static methods `VersionId::latest()` and `VersionId::changes()` whenever a `VersionId` object is directly required or the method doesn't ensure a proper object by using `VersionId::from()`


### Reasoning
Over time, our code started to be a bit inconsistent how we use version ID references when. This tries to clean it up.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass
