### PR TITLE
Fix UUID access in after hook

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -290,6 +290,9 @@ trait FileActions
 			// to still have access to it in after hooks
 			$file->changeStorage(ImmutableMemoryStorage::class);
 
+			// clear UUID cache
+			$file->uuid()?->clear();
+
 			// remove all public versions and clear the UUID cache
 			$old->unpublish();
 

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Closure;
+use Kirby\Content\ImmutableMemoryStorage;
 use Kirby\Content\MemoryStorage;
 use Kirby\Content\VersionCache;
 use Kirby\Exception\InvalidArgumentException;
@@ -283,14 +284,20 @@ trait FileActions
 	public function delete(): bool
 	{
 		return $this->commit('delete', ['file' => $this], function ($file) {
+			$old = $file->clone();
+
+			// keep the content in iummtable memory storage
+			// to still have access to it in after hooks
+			$file->changeStorage(ImmutableMemoryStorage::class);
+
 			// remove all public versions and clear the UUID cache
-			$file->unpublish();
+			$old->unpublish();
 
 			// delete all versions
-			$file->versions()->delete();
+			$old->versions()->delete();
 
 			// delete the file from disk
-			F::remove($file->root());
+			F::remove($old->root());
 
 			return true;
 		});

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Closure;
+use Kirby\Content\ImmutableMemoryStorage;
 use Kirby\Content\MemoryStorage;
 use Kirby\Content\VersionCache;
 use Kirby\Content\VersionId;
@@ -550,29 +551,35 @@ trait PageActions
 	public function delete(bool $force = false): bool
 	{
 		return $this->commit('delete', ['page' => $this, 'force' => $force], function ($page, $force) {
+			$old = $page->clone();
+
+			// keep the content in iummtable memory storage
+			// to still have access to it in after hooks
+			$page->changeStorage(ImmutableMemoryStorage::class);
+
 			// clear UUID cache
-			$page->uuid()?->clear();
+			$old->uuid()?->clear();
 
 			// delete all files individually
-			foreach ($page->files() as $file) {
+			foreach ($old->files() as $file) {
 				$file->delete();
 			}
 
 			// delete all children individually
-			foreach ($page->childrenAndDrafts() as $child) {
+			foreach ($old->childrenAndDrafts() as $child) {
 				$child->delete(true);
 			}
 
 			// delete all versions,
 			// the plain text storage handler will then clean
 			// up the directory if it's empty
-			$page->versions()->delete();
+			$old->versions()->delete();
 
 			if (
-				$page->isListed() === true &&
-				$page->blueprint()->num() === 'default'
+				$old->isListed() === true &&
+				$old->blueprint()->num() === 'default'
 			) {
-				$page->resortSiblingsAfterUnlisting();
+				$old->resortSiblingsAfterUnlisting();
 			}
 
 			return true;

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -558,7 +558,7 @@ trait PageActions
 			$page->changeStorage(ImmutableMemoryStorage::class);
 
 			// clear UUID cache
-			$old->uuid()?->clear();
+			$page->uuid()?->clear();
 
 			// delete all files individually
 			foreach ($old->files() as $file) {

--- a/tests/Cms/File/FileDeleteTest.php
+++ b/tests/Cms/File/FileDeleteTest.php
@@ -10,6 +10,18 @@ class FileDeleteTest extends ModelTestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.FileDelete';
 
+	protected function createDummyFile(): File
+	{
+		// create the dummy source
+		F::write($source = static::TMP . '/source.md', '# Test');
+
+		return File::create([
+			'filename' => 'test.md',
+			'parent'   => new Page(['slug' => 'test']),
+			'source'   => $source
+		]);
+	}
+
 	public function testDelete(): void
 	{
 		$file = new File([
@@ -17,25 +29,26 @@ class FileDeleteTest extends ModelTestCase
 			'parent'   => $this->app->site(),
 		]);
 
+		$contentFile = $file->version('latest')->contentFile('default');
+
 		// create an empty dummy file
 		F::write($file->root(), '');
 		// ...and an empty content file for it
-		F::write($file->version('latest')->contentFile('default'), '');
+		F::write($contentFile, '');
 
 		$this->assertFileExists($file->root());
-		$this->assertFileExists($file->version('latest')->contentFile('default'));
+		$this->assertFileExists($contentFile);
 
 		$result = $file->delete();
 
 		$this->assertTrue($result);
 
 		$this->assertFileDoesNotExist($file->root());
-		$this->assertFileDoesNotExist($file->version('latest')->contentFile('default'));
+		$this->assertFileDoesNotExist($contentFile);
 	}
 
 	public function testDeleteHooks(): void
 	{
-		$parent  = new Page(['slug' => 'test']);
 		$calls   = 0;
 		$phpunit = $this;
 
@@ -57,17 +70,30 @@ class FileDeleteTest extends ModelTestCase
 
 		$this->app->impersonate('kirby');
 
-		// create the dummy source
-		F::write($source = static::TMP . '/source.md', '# Test');
-
-		$file = File::create([
-			'filename' => 'test.md',
-			'source'   => $source,
-			'parent'   => $parent
-		]);
-
+		$file = $this->createDummyFile();
 		$file->delete();
 
 		$this->assertSame(2, $calls);
+	}
+
+	public function testDeleteHookWithUUIDAccess(): void
+	{
+		$phpunit = $this;
+		$uuid    = null;
+
+		$this->app = $this->app->clone([
+			'hooks' => [
+				'file.delete:after' => function ($status, File $file) use ($phpunit, &$uuid) {
+					$phpunit->assertSame($uuid, $file->uuid()->id());
+				}
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		$file = $this->createDummyFile();
+		$uuid = $file->uuid()->id();
+
+		$file->delete();
 	}
 }

--- a/tests/Cms/File/FileDeleteTest.php
+++ b/tests/Cms/File/FileDeleteTest.php
@@ -91,9 +91,14 @@ class FileDeleteTest extends ModelTestCase
 
 		$this->app->impersonate('kirby');
 
-		$file = $this->createDummyFile();
-		$uuid = $file->uuid()->id();
+		$file        = $this->createDummyFile();
+		$uuid        = $file->uuid()->id();
+		$contentFile = $file->root() . '.txt';
+
+		$this->assertFileExists($contentFile);
 
 		$file->delete();
+
+		$this->assertFileDoesNotExist($contentFile);
 	}
 }

--- a/tests/Cms/Page/PageDeleteTest.php
+++ b/tests/Cms/Page/PageDeleteTest.php
@@ -160,9 +160,14 @@ class PageDeleteTest extends ModelTestCase
 
 		$this->app->impersonate('kirby');
 
-		$page = Page::create(['slug' => 'test']);
-		$uuid = $page->uuid()->id();
+		$page        = Page::create(['slug' => 'test']);
+		$uuid        = $page->uuid()->id();
+		$contentFile = $page->root() . '/default.txt';
+
+		$this->assertFileExists($contentFile);
 
 		$page->delete();
+
+		$this->assertFileDoesNotExist($contentFile);
 	}
 }

--- a/tests/Cms/Page/PageDeleteTest.php
+++ b/tests/Cms/Page/PageDeleteTest.php
@@ -145,4 +145,24 @@ class PageDeleteTest extends ModelTestCase
 		$this->assertFalse($page->exists());
 	}
 
+	public function testDeleteHookWithUUIDAccess(): void
+	{
+		$phpunit = $this;
+		$uuid    = null;
+
+		$this->app = $this->app->clone([
+			'hooks' => [
+				'page.delete:after' => function ($status, Page $page) use ($phpunit, &$uuid) {
+					$phpunit->assertSame($uuid, $page->uuid()->id());
+				}
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		$page = Page::create(['slug' => 'test']);
+		$uuid = $page->uuid()->id();
+
+		$page->delete();
+	}
 }

--- a/tests/Cms/User/UserDeleteTest.php
+++ b/tests/Cms/User/UserDeleteTest.php
@@ -88,9 +88,14 @@ class UserDeleteTest extends ModelTestCase
 		// we need to authenticate again after the app has been cloned
 		$this->app->impersonate('kirby');
 
-		$user = User::create(['email' => 'editor@domain.com']);
-		$uuid = $user->uuid()->id();
+		$user        = User::create(['email' => 'editor@domain.com']);
+		$uuid        = $user->uuid()->id();
+		$contentFile = $user->root() . '/user.txt';
+
+		$this->assertFileExists($contentFile);
 
 		$user->delete();
+
+		$this->assertFileDoesNotExist($contentFile);
 	}
 }

--- a/tests/Cms/User/UserDeleteTest.php
+++ b/tests/Cms/User/UserDeleteTest.php
@@ -71,4 +71,26 @@ class UserDeleteTest extends ModelTestCase
 
 		$this->assertSame(2, $calls);
 	}
+
+	public function testDeleteHookWithUUIDAccess(): void
+	{
+		$phpunit = $this;
+		$uuid    = null;
+
+		$this->app = $this->app->clone([
+			'hooks' => [
+				'user.delete:after' => function ($status, User $user) use ($phpunit, &$uuid) {
+					$phpunit->assertSame($uuid, $user->uuid()->id());
+				}
+			]
+		]);
+
+		// we need to authenticate again after the app has been cloned
+		$this->app->impersonate('kirby');
+
+		$user = User::create(['email' => 'editor@domain.com']);
+		$uuid = $user->uuid()->id();
+
+		$user->delete();
+	}
 }


### PR DESCRIPTION
## Description

The Model delete actions did not properly clone the models yet and put them in immutable storage for proper access in the after hooks. This PR fixes this issue and adds unit tests for `Page::delete`, `User::delete` and `File::delete` with after hooks that access the old UUID. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes from previous betas

- #7180

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
