### PR TITLE
Remove dead code from role shortcuts

### DIFF
--- a/src/Cms/Role.php
+++ b/src/Cms/Role.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Cms;
 
-use Exception;
 use Kirby\Data\Data;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\I18n;
@@ -49,13 +48,14 @@ class Role implements Stringable
 		return $this->name();
 	}
 
-	public static function admin(array $inject = []): static
+	public static function defaultAdmin(array $inject = []): static
 	{
-		try {
-			return static::load('admin');
-		} catch (Exception) {
-			return static::factory(static::defaults()['admin'], $inject);
-		}
+		return static::factory(static::defaults()['admin'], $inject);
+	}
+
+	public static function defaultNobody(array $inject = []): static
+	{
+		return static::factory(static::defaults()['nobody'], $inject);
 	}
 
 	protected static function defaults(): array
@@ -118,15 +118,6 @@ class Role implements Stringable
 	public function name(): string
 	{
 		return $this->name;
-	}
-
-	public static function nobody(array $inject = []): static
-	{
-		try {
-			return static::load('nobody');
-		} catch (Exception) {
-			return static::factory(static::defaults()['nobody'], $inject);
-		}
 	}
 
 	public function permissions(): Permissions

--- a/src/Cms/Roles.php
+++ b/src/Cms/Roles.php
@@ -91,7 +91,7 @@ class Roles extends Collection
 
 		// always include the admin role
 		if ($collection->find('admin') === null) {
-			$collection->set('admin', Role::admin());
+			$collection->set('admin', Role::defaultAdmin());
 		}
 
 		// return the collection sorted by name
@@ -138,7 +138,7 @@ class Roles extends Collection
 
 		// always include the admin role
 		if ($roles->find('admin') === null) {
-			$roles->set('admin', Role::admin($inject));
+			$roles->set('admin', Role::defaultAdmin($inject));
 		}
 
 		// return the collection sorted by name

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -546,7 +546,7 @@ class User extends ModelWithContent
 
 		return $this->role =
 			$this->kirby()->roles()->find($name) ??
-			Role::nobody();
+			Role::defaultNobody();
 	}
 
 	/**

--- a/tests/Cms/Roles/RoleTest.php
+++ b/tests/Cms/Roles/RoleTest.php
@@ -48,19 +48,19 @@ class RoleTest extends TestCase
 		Role::load('does-not-exist');
 	}
 
-	public function testAdmin()
+	public function testDefaultAdmin()
 	{
 		$app  = $this->app();
-		$role = Role::admin();
+		$role = Role::defaultAdmin();
 
 		$this->assertSame('admin', $role->name());
 		$this->assertSame('Admin', $role->title());
 	}
 
-	public function testNobody()
+	public function testDefaultNobody()
 	{
 		$app  = $this->app();
-		$role = Role::nobody();
+		$role = Role::defaultNobody();
 
 		$this->assertSame('nobody', $role->name());
 		$this->assertSame('Nobody', $role->title());


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

- Remove dead code from role shortcut methods
- Rename methods from `Role::admin()` and `Role::nobody()` to `Role::default*()`

### Reasoning

- Loading a role blueprint by name without the full path will never succeed, so the `try` parts have always been dead code.
- New names `default*` to make the purpose clearer

### Additional context

As discussed in Discord: https://discord.com/channels/525634039965679616/1361643894177271839/1366347011007447100

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Refactoring

- Remove dead code from role shortcut methods for the default `admin` and `nobody` roles

### Breaking changes

- `Role::admin()` has been renamed to `Role::defaultAdmin()`
- `Role::nobody()` has been renamed to `Role::defaultNobody()`

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
