### PR TITLE
Remove duplicated slash from router script

### DIFF
--- a/router.php
+++ b/router.php
@@ -12,4 +12,4 @@ if ($uri !== '/' && file_exists($_SERVER['DOCUMENT_ROOT'] . '/' . ltrim($uri, '/
 
 $_SERVER['SCRIPT_NAME'] = '/index.php';
 
-require $_SERVER['DOCUMENT_ROOT'] . '/' . $_SERVER['SCRIPT_NAME'];
+require $_SERVER['DOCUMENT_ROOT'] . $_SERVER['SCRIPT_NAME'];


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

- Remove duplicated slash from router script

### Reasoning

- `SCRIPT_NAME` already includes the slash

### Additional context

Shouldn't have caused an issue as the router works with the duplicated slash anyway, but it may break in the future. So it makes sense to fix it.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Fix duplicated slash in the `router.php` for the built-in PHP server

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

None

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
