### PR TITLE
`Version::create()`: don't always create latest

### DIFF
--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -101,20 +101,6 @@ class Version
 		Language|string $language = 'default'
 	): void {
 		$language = Language::ensure($language);
-		$latest   = $this->sibling('latest');
-
-		// if the latest version of the translation does not exist yet,
-		// we have to copy over the content from the default language first.
-		if (
-			$this->isLatest() === false &&
-			$language->isDefault() === false &&
-			$latest->exists($language) === false
-		) {
-			$latest->create(
-				fields: $latest->read(Language::ensure('default')),
-				language: $language
-			);
-		}
 
 		// check if creating is allowed
 		VersionRules::create($this, $fields, $language);
@@ -126,8 +112,8 @@ class Version
 
 		$this->model->storage()->create(
 			versionId: $this->id,
-			language: $language,
-			fields: $this->prepareFieldsBeforeWrite($fields, $language)
+			language:  $language,
+			fields:    $this->prepareFieldsBeforeWrite($fields, $language)
 		);
 
 		// make sure that an older version does not exist in the cache

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -488,8 +488,8 @@ class Version
 		// check if publishing is allowed
 		VersionRules::publish($this, $language);
 
-		$latest  = $this->sibling('latest')->read($language);
-		$changes = $this->read($language);
+		$latest  = $this->sibling('latest')->read($language) ?? [];
+		$changes = $this->read($language) ?? [];
 
 		// overwrite all fields that are not in the `changes` version
 		// with a null value. The ModelWithContent::update method will merge

--- a/src/Content/VersionRules.php
+++ b/src/Content/VersionRules.php
@@ -31,16 +31,6 @@ class VersionRules
 				message: 'The version already exists'
 			);
 		}
-
-		if ($version->isLatest() === true) {
-			return;
-		}
-
-		if ($version->model()->version('latest')->exists($language) === false) {
-			throw new LogicException(
-				message: 'A matching latest version for the changes does not exist'
-			);
-		}
 	}
 
 	/**

--- a/tests/Content/VersionRulesTest.php
+++ b/tests/Content/VersionRulesTest.php
@@ -6,6 +6,7 @@ use Kirby\Cms\Language;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class ExistingVersion extends Version
 {
@@ -23,17 +24,12 @@ class LockedVersion extends Version
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Content\VersionRules
- */
+#[CoversClass(VersionRules::class)]
 class VersionRulesTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.VersionRules';
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateWhenTheVersionAlreadyExists()
+	public function testCreateWhenTheVersionAlreadyExists(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -48,31 +44,7 @@ class VersionRulesTest extends TestCase
 		VersionRules::create($version, [], Language::ensure());
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateWhenLatestVersionDoesNotExist()
-	{
-		$this->setUpSingleLanguage();
-
-		$version = new Version(
-			model: $this->model,
-			id: VersionId::changes(),
-		);
-
-		// remove the model root to simulate a missing latest version
-		Dir::remove($this->model->root());
-
-		$this->expectException(LogicException::class);
-		$this->expectExceptionMessage('A matching latest version for the changes does not exist');
-
-		VersionRules::create($version, [], Language::ensure());
-	}
-
-	/**
-	 * @covers ::delete
-	 */
-	public function testDeleteWhenTheVersionIsLocked()
+	public function testDeleteWhenTheVersionIsLocked(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -87,9 +59,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::delete($version, Language::ensure());
 	}
 
-	/**
-	 * @covers ::ensure
-	 */
 	public function testEnsureMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -105,9 +74,6 @@ class VersionRulesTest extends TestCase
 		$this->assertNull(VersionRules::ensure($version, Language::ensure('de')));
 	}
 
-	/**
-	 * @covers ::ensure
-	 */
 	public function testEnsureSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -122,9 +88,6 @@ class VersionRulesTest extends TestCase
 		$this->assertNull(VersionRules::ensure($version, Language::ensure()));
 	}
 
-	/**
-	 * @covers ::ensure
-	 */
 	public function testEnsureWhenMissingMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -140,9 +103,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::ensure($version, Language::ensure('de'));
 	}
 
-	/**
-	 * @covers ::ensure
-	 */
 	public function testEnsureWhenMissingSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
@@ -158,9 +118,6 @@ class VersionRulesTest extends TestCase
 		VersionRules::ensure($version, Language::ensure());
 	}
 
-	/**
-	 * @covers ::ensure
-	 */
 	public function testEnsureWithInvalidLanguage(): void
 	{
 		$this->setUpMultiLanguage();
@@ -176,10 +133,7 @@ class VersionRulesTest extends TestCase
 		VersionRules::ensure($version, Language::ensure('fr'));
 	}
 
-	/**
-	 * @covers ::move
-	 */
-	public function testMoveWhenTheSourceVersionIsLocked()
+	public function testMoveWhenTheSourceVersionIsLocked(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -202,10 +156,7 @@ class VersionRulesTest extends TestCase
 		VersionRules::move($source, Language::ensure(), $target, Language::ensure());
 	}
 
-	/**
-	 * @covers ::move
-	 */
-	public function testMoveWhenTheTargetVersionIsLocked()
+	public function testMoveWhenTheTargetVersionIsLocked(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -229,10 +180,7 @@ class VersionRulesTest extends TestCase
 		VersionRules::move($source, Language::ensure(), $target, Language::ensure());
 	}
 
-	/**
-	 * @covers ::publish
-	 */
-	public function testPublishTheLatestVersion()
+	public function testPublishTheLatestVersion(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -247,10 +195,7 @@ class VersionRulesTest extends TestCase
 		VersionRules::publish($version, Language::ensure());
 	}
 
-	/**
-	 * @covers ::publish
-	 */
-	public function testPublishWhenTheVersionIsLocked()
+	public function testPublishWhenTheVersionIsLocked(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -267,10 +212,7 @@ class VersionRulesTest extends TestCase
 		VersionRules::publish($version, Language::ensure());
 	}
 
-	/**
-	 * @covers ::read
-	 */
-	public function testReadWhenMissing()
+	public function testReadWhenMissing(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -289,10 +231,7 @@ class VersionRulesTest extends TestCase
 		VersionRules::read($version, Language::ensure());
 	}
 
-	/**
-	 * @covers ::replace
-	 */
-	public function testReplaceWhenTheVersionIsLocked()
+	public function testReplaceWhenTheVersionIsLocked(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -309,10 +248,7 @@ class VersionRulesTest extends TestCase
 		VersionRules::replace($version, [], Language::ensure());
 	}
 
-	/**
-	 * @covers ::touch
-	 */
-	public function testTouchWhenMissing()
+	public function testTouchWhenMissing(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -331,10 +267,7 @@ class VersionRulesTest extends TestCase
 		VersionRules::touch($version, Language::ensure());
 	}
 
-	/**
-	 * @covers ::update
-	 */
-	public function testUpdateWhenTheVersionIsLocked()
+	public function testUpdateWhenTheVersionIsLocked(): void
 	{
 		$this->setUpSingleLanguage();
 

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -196,41 +196,6 @@ class VersionTest extends TestCase
 		$this->assertContentFileExists('de');
 	}
 
-	public function testCreateMultiLanguageWhenLatestTranslationIsMissing(): void
-	{
-		$this->setUpMultiLanguage();
-
-		$latest = new Version(
-			model: $this->model,
-			id: VersionId::latest()
-		);
-
-		$changes = new Version(
-			model: $this->model,
-			id: VersionId::changes()
-		);
-
-		$this->assertContentFileDoesNotExist('en', $latest->id());
-		$this->assertContentFileDoesNotExist('en', $changes->id());
-		$this->assertContentFileDoesNotExist('de', $latest->id());
-		$this->assertContentFileDoesNotExist('de', $changes->id());
-
-		// create the latest version for the default translation
-		$latest->save([
-			'title' => 'Test'
-		], $this->app->language('en'));
-
-		// create a changes version in the other language
-		$changes->save([
-			'title' => 'Translated Test',
-		], $this->app->language('de'));
-
-		$this->assertContentFileExists('en', $latest->id());
-		$this->assertContentFileDoesNotExist('en', $changes->id());
-		$this->assertContentFileExists('de', $latest->id());
-		$this->assertContentFileExists('de', $changes->id());
-	}
-
 	public function testCreateSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- `Version::create()` does not automatically create a latest version a language anymore when creating a changes version for the language. This allows for the following scenario
  - Page has a latest version of the default language, not translated in any secondary language
  - Start drafting the version for. a secondary language (as changes version)
  - Only have a latest version once the changes version for the secondary language is published


### Reasoning
We do not want to create latest/published versions for a secondary language immediately when a Panel user starts editing/creating it.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes from earlier pre-releases
- https://github.com/getkirby/kirby/issues/7184
- https://github.com/getkirby/kirby/issues/7185


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
