### PR TITLE
Keep translated slug for non-default languages

### DIFF
--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -56,8 +56,8 @@ class Version
 			];
 		}
 
-		// prepare raw content file fields as fields for Content object
-		$fields = $this->prepareFieldsForContent($fields, $language);
+		// remove fields that should not be used for the Content object
+		unset($fields['lock']);
 
 		return new Content(
 			parent: $this->model,
@@ -238,13 +238,11 @@ class Version
 		$a = $this->read($language) ?? [];
 		$b = $version->read($language) ?? [];
 
-		// apply same preparation as for content
-		$a = $this->prepareFieldsForContent($a, $language);
-		$b = $this->prepareFieldsForContent($b, $language);
-
-		// remove additional fields that should not be
+		// remove fields that should not be
 		// considered in the comparison
 		unset(
+			$a['lock'],
+			$b['lock'],
 			$a['uuid'],
 			$b['uuid']
 		);
@@ -407,23 +405,6 @@ class Version
 
 		// ignore all fields with null values
 		return array_filter($fields, fn ($field) => $field !== null);
-	}
-
-	/**
-	 * Make sure that the Content object receives the right set of fields
-	 * filtering fields used for lower logic (e.g. lock)
-	 */
-	protected function prepareFieldsForContent(
-		array $fields,
-		Language $language
-	): array {
-		unset($fields['lock']);
-
-		if ($this->model instanceof Page) {
-			unset($fields['slug']);
-		}
-
-		return $fields;
 	}
 
 	/**

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -116,6 +116,7 @@ class VersionTest extends TestCase
 		]);
 
 		$this->assertSame([
+			'slug' => 'foo',
 			'text' => 'Lorem ipsum'
 		], $version->content()->toArray());
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Removed `Version::prepareForContent()` - keeps `slug` as part of the content, removing `lock` still but now directly in `Version::content()`


### Reasoning
We ended up removing the slug from content for non-default languages but also not adding it back when saving. So saving would eliminate the custom slug for a secondary language.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixed regressions from previous pre-releases
- https://github.com/getkirby/kirby/issues/7183



### Breaking changes from previous pre-releases
- Removed `Kirby\Content\Version::prepareForContent()`

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
