### PR TITLE
feat: Improve disabled UI for structure field

### DIFF
--- a/panel/src/components/Drawers/Drawer.vue
+++ b/panel/src/components/Drawers/Drawer.vue
@@ -1,7 +1,6 @@
 <template>
 	<portal v-if="visible" to="drawer">
 		<form
-			:aria-disabled="disabled"
 			:class="$vnode.data.staticClass"
 			class="k-drawer"
 			method="dialog"

--- a/panel/src/components/Drawers/Elements/Fields.vue
+++ b/panel/src/components/Drawers/Elements/Fields.vue
@@ -1,6 +1,7 @@
 <template>
 	<k-fieldset
 		v-if="hasFields"
+		:disabled="disabled"
 		:fields="fields"
 		:value="value"
 		class="k-drawer-fields"
@@ -13,6 +14,7 @@
 <script>
 export const props = {
 	props: {
+		disabled: Boolean,
 		empty: {
 			type: String,
 			default: () => window.panel.t("drawer.fields.empty")

--- a/panel/src/components/Drawers/FiberDrawer.vue
+++ b/panel/src/components/Drawers/FiberDrawer.vue
@@ -6,8 +6,7 @@
 			:key="drawer.id"
 			v-bind="isCurrent(drawer.id) ? $panel.drawer.props : drawer.props"
 			:breadcrumb="$panel.drawer.breadcrumb"
-			:disabled="isCurrent(drawer.id) === false"
-			:visible="true"
+			:visible="isCurrent(drawer.id) === true"
 			v-on="isCurrent(drawer.id) ? $panel.drawer.listeners() : drawer.on"
 		/>
 	</div>
@@ -22,10 +21,3 @@ export default {
 	}
 };
 </script>
-
-<style>
-.k-drawer[aria-disabled="true"] {
-	display: none;
-	pointer-events: none;
-}
-</style>

--- a/panel/src/components/Drawers/FormDrawer.vue
+++ b/panel/src/components/Drawers/FormDrawer.vue
@@ -13,6 +13,7 @@
 		</template>
 
 		<k-drawer-fields
+			:disabled="disabled"
 			:fields="fields"
 			:value="value"
 			@input="$emit('input', $event)"

--- a/panel/src/components/Drawers/StructureDrawer.vue
+++ b/panel/src/components/Drawers/StructureDrawer.vue
@@ -9,7 +9,7 @@
 		@submit="$emit('submit', $event)"
 		@tab="$emit('tab', $event)"
 	>
-		<template #options>
+		<template v-if="!disabled" #options>
 			<k-button
 				:disabled="!prev"
 				class="k-drawer-option"

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -352,7 +352,7 @@ export default {
 		navigate(item, step) {
 			const index = this.findIndex(item);
 
-			if (this.disabled === true || index === -1) {
+			if (index === -1) {
 				return;
 			}
 
@@ -369,7 +369,7 @@ export default {
 		open(item, field, replace = false) {
 			const index = this.findIndex(item);
 
-			if (this.disabled === true || index === -1) {
+			if (index === -1) {
 				return false;
 			}
 
@@ -377,6 +377,7 @@ export default {
 				component: "k-structure-drawer",
 				id: this.id,
 				props: {
+					disabled: this.disabled,
 					icon: this.icon ?? "list-bullet",
 					next: this.items[index + 1],
 					prev: this.items[index - 1],
@@ -556,12 +557,20 @@ export default {
 </script>
 
 <style>
-.k-structure-field:not([data-disabled="true"]) td.k-table-column {
+.k-structure-field td.k-table-column {
 	cursor: pointer;
 }
 .k-structure-field .k-table + footer {
 	display: flex;
 	justify-content: center;
 	margin-top: var(--spacing-3);
+}
+
+/* Allow interaction with disabled structure field to open the drawer */
+.k-structure-field[data-disabled="true"] {
+	cursor: initial;
+}
+.k-structure-field[data-disabled="true"] * {
+	pointer-events: initial;
 }
 </style>

--- a/panel/src/mixins/drawer.js
+++ b/panel/src/mixins/drawer.js
@@ -11,13 +11,6 @@ export default {
 	mixins: [Header],
 	props: {
 		/**
-		 * If `true`, the drawer form is disabled
-		 */
-		disabled: {
-			default: false,
-			type: Boolean
-		},
-		/**
 		 * The default icon for the drawer header
 		 */
 		icon: String,


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- Table remains interactive when field is disabled: can open drawer (where form is disabled) to see all fields, can still paginate
- Fiber drawer: don't use `disabled` prop to hide drawers in the drawer stack. Instead using `visible` prop.


https://github.com/user-attachments/assets/6883f262-cccf-4c16-8caf-53bcf7507294



### Reasoning
https://feedback.getkirby.com/687

### Additional context
Since we used the `:disabled` prop in this way only in `k-fiber-drawer`, I think the change can be merged without being a breaking change.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### ✨ Enhancements
- Structure field: improved UI when field is disabled that allows to open drawer to see all fields as well as navigate through all entries when paginated

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
