### PR TITLE
Media firewall 3: Introduce media subhashes

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -76,7 +76,7 @@ return [
 		}
 
 		// create url and root
-		$mediaRoot = dirname($file->mediaRoot());
+		$mediaRoot = $file->mediaRoot();
 		$template  = $mediaRoot . '/{{ name }}{{ attributes }}.{{ extension }}';
 		$thumbRoot = (new Filename($file->root(), $template, $options))->toString();
 		$thumbName = basename($thumbRoot);
@@ -102,7 +102,7 @@ return [
 			'modifications' => $options,
 			'original'      => $file,
 			'root'          => $thumbRoot,
-			'url'           => dirname($file->mediaUrl()) . '/' . $thumbName,
+			'url'           => $file->mediaUrl($thumbName),
 		]);
 	},
 

--- a/config/components.php
+++ b/config/components.php
@@ -75,16 +75,17 @@ return [
 			return $file;
 		}
 
-		// create url and root
-		$mediaRoot = $file->mediaRoot();
-		$template  = $mediaRoot . '/{{ name }}{{ attributes }}.{{ extension }}';
-		$thumbRoot = (new Filename($file->root(), $template, $options))->toString();
-		$thumbName = basename($thumbRoot);
+		// create url and root;
+		// include the thumb attributes in the media hash to prevent
+		// direct access to individual file versions by URL guessing
+		$template  = '{{ name }}{{ attributes }}.{{ extension }}';
+		$thumbName = (new Filename($file->root(), $template, $options))->toString();
+		$thumbRoot = $file->mediaPath($thumbName);
 
 		// check if the thumb already exists
 		if (file_exists($thumbRoot) === false) {
 			// if not, create job file
-			$job = $mediaRoot . '/.jobs/' . $thumbName . '.json';
+			$job = $file->mediaRoot() . '/.jobs/' . $thumbName . '.json';
 
 			try {
 				Data::write(

--- a/config/routes.php
+++ b/config/routes.php
@@ -79,35 +79,38 @@ return function (App $kirby) {
 			}
 		],
 		[
-			'pattern' => $media . '/pages/(:all)/(:any)/(:any)',
+			'pattern' => $media . '/pages/(:all)/(:any)/(:any)/(:any)',
 			'env'     => 'media',
 			'action'  => function (
 				string $path,
 				string $hash,
+				string $subhash,
 				string $filename
 			) use ($kirby) {
-				return Media::link($kirby->page($path), $hash, $filename);
+				return Media::link($kirby->page($path), $hash, $subhash, $filename);
 			}
 		],
 		[
-			'pattern' => $media . '/site/(:any)/(:any)',
+			'pattern' => $media . '/site/(:any)/(:any)/(:any)',
 			'env'     => 'media',
 			'action'  => function (
 				string $hash,
+				string $subhash,
 				string $filename
 			) use ($kirby) {
-				return Media::link($kirby->site(), $hash, $filename);
+				return Media::link($kirby->site(), $hash, $subhash, $filename);
 			}
 		],
 		[
-			'pattern' => $media . '/users/(:any)/(:any)/(:any)',
+			'pattern' => $media . '/users/(:any)/(:any)/(:any)/(:any)',
 			'env'     => 'media',
 			'action'  => function (
 				string $id,
 				string $hash,
+				string $subhash,
 				string $filename
 			) use ($kirby) {
-				return Media::link($kirby->user($id), $hash, $filename);
+				return Media::link($kirby->user($id), $hash, $subhash, $filename);
 			}
 		],
 		[
@@ -118,7 +121,7 @@ return function (App $kirby) {
 				string $hash,
 				string $filename
 			) {
-				return Media::thumb($path, $hash, $filename);
+				return Media::thumb($path, $hash, null, $filename);
 			}
 		],
 		[

--- a/config/routes.php
+++ b/config/routes.php
@@ -87,7 +87,29 @@ return function (App $kirby) {
 				string $subhash,
 				string $filename
 			) use ($kirby) {
-				return Media::link($kirby->page($path), $hash, $subhash, $filename);
+				// support old URLs without the new subhash
+				// TODO: Remove this logic in v6 and directly pass `$kirby->page($path)` to `Media::link()`
+				$page = $kirby->page($path);
+				if ($page === null) {
+					$page    = $kirby->page($path . '/' . $hash);
+					$hash    = $subhash;
+					$subhash = null;
+				}
+
+				return Media::link($page, $hash, $subhash, $filename);
+			}
+		],
+		[
+			// support old URLs for pages in the topmost level without the new subhash
+			// TODO: Remove this route in v6
+			'pattern' => $media . '/pages/(:any)/(:any)/(:any)',
+			'env'     => 'media',
+			'action'  => function (
+				string $uid,
+				string $hash,
+				string $filename
+			) use ($kirby) {
+				return Media::link($kirby->page($uid), $hash, null, $filename);
 			}
 		],
 		[
@@ -102,6 +124,18 @@ return function (App $kirby) {
 			}
 		],
 		[
+			// support old URLs without the new subhash
+			// TODO: Remove this route in v6
+			'pattern' => $media . '/site/(:any)/(:any)',
+			'env'     => 'media',
+			'action'  => function (
+				string $hash,
+				string $filename
+			) use ($kirby) {
+				return Media::link($kirby->site(), $hash, null, $filename);
+			}
+		],
+		[
 			'pattern' => $media . '/users/(:any)/(:any)/(:any)/(:any)',
 			'env'     => 'media',
 			'action'  => function (
@@ -111,6 +145,20 @@ return function (App $kirby) {
 				string $filename
 			) use ($kirby) {
 				return Media::link($kirby->user($id), $hash, $subhash, $filename);
+			}
+		],
+		[
+			// support old URLs without the new subhash
+			// TODO: Remove this route in v6
+			'pattern' => $media . '/users/(:any)/(:any)/(:any)',
+			'env'     => 'media',
+			'action'  => function (
+				string $id,
+				string $hash,
+				string $subhash,
+				string $filename
+			) use ($kirby) {
+				return Media::link($kirby->user($id), $hash, null, $filename);
 			}
 		],
 		[

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -383,10 +383,23 @@ class File extends ModelWithContent
 	/**
 	 * Returns the absolute path to the file in the public media folder
 	 * @internal
+	 *
+	 * @param string|null $filename Optional override for the filename
+	 */
+	public function mediaPath(string|null $filename = null): string
+	{
+		$filename ??= $this->filename();
+
+		return $this->mediaRoot() . '/' . $filename;
+	}
+
+	/**
+	 * Returns the absolute path to the media folder for the file and its versions
+	 * @internal
 	 */
 	public function mediaRoot(): string
 	{
-		return $this->parent()->mediaRoot() . '/' . $this->mediaHash() . '/' . $this->filename();
+		return $this->parent()->mediaRoot() . '/' . $this->mediaHash();
 	}
 
 	/**
@@ -402,10 +415,15 @@ class File extends ModelWithContent
 	/**
 	 * Returns the absolute Url to the file in the public media folder
 	 * @internal
+	 *
+	 * @param string|null $filename Optional override for the filename
 	 */
-	public function mediaUrl(): string
+	public function mediaUrl(string|null $filename = null): string
 	{
-		return $this->parent()->mediaUrl() . '/' . $this->mediaHash() . '/' . $this->filename();
+		$url        = $this->parent()->mediaUrl() . '/' . $this->mediaHash();
+		$filename ??= $this->filename();
+
+		return $url . '/' . $filename;
 	}
 
 	/**

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -390,7 +390,7 @@ class File extends ModelWithContent
 	{
 		$filename ??= $this->filename();
 
-		return $this->mediaRoot() . '/' . $filename;
+		return $this->mediaRoot() . '/' . $this->mediaToken($filename) . '/' . $filename;
 	}
 
 	/**
@@ -405,10 +405,12 @@ class File extends ModelWithContent
 	/**
 	 * Creates a non-guessable token string for this file
 	 * @internal
+	 *
+	 * @param string $key Optional thumb/original key to differentiate the media path
 	 */
-	public function mediaToken(): string
+	public function mediaToken(string $key = ''): string
 	{
-		$token = $this->kirby()->contentToken($this, $this->id());
+		$token = $this->kirby()->contentToken($this, $this->id() . $key);
 		return substr($token, 0, 10);
 	}
 
@@ -423,7 +425,7 @@ class File extends ModelWithContent
 		$url        = $this->parent()->mediaUrl() . '/' . $this->mediaHash();
 		$filename ??= $this->filename();
 
-		return $url . '/' . $filename;
+		return $url . '/' . $this->mediaToken($filename) . '/' . $filename;
 	}
 
 	/**

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -362,7 +362,7 @@ trait FileActions
 	 */
 	public function publish(): static
 	{
-		Media::publish($this, $this->mediaRoot());
+		Media::publish($this, $this->mediaPath());
 		return $this;
 	}
 

--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -53,7 +53,7 @@ class Media
 			}
 
 			// send the file to the browser
-			return Response::file($file->publish()->mediaRoot());
+			return Response::file($file->publish()->mediaPath());
 		}
 
 		// try to generate a thumb for the file
@@ -102,7 +102,7 @@ class Media
 				=> $kirby->root('media') . '/assets/' . $model . '/' . $hash,
 			// parent files for file model that already included hash
 			$model instanceof File
-				=> dirname($model->mediaRoot()),
+				=> $model->mediaRoot(),
 			// model files
 			default
 			=> $model->mediaRoot() . '/' . $hash

--- a/tests/Cms/File/FileMediaTest.php
+++ b/tests/Cms/File/FileMediaTest.php
@@ -15,6 +15,9 @@ class FileMediaTest extends ModelTestCase
 		parent::setUp();
 
 		$this->app = $this->app->clone([
+			'roots' => [
+				'index' => self::TMP
+			],
 			'options' => [
 				'content.salt' => 'test'
 			]
@@ -23,8 +26,8 @@ class FileMediaTest extends ModelTestCase
 
 	public function testMediaHash(): void
 	{
-		F::write($file = static::TMP . '/content/test.jpg', 'test');
-		touch($file, 5432112345);
+		F::write($root = static::TMP . '/content/test.jpg', 'test');
+		touch($root, 5432112345);
 
 		$file = new File([
 			'filename' => 'test.jpg',
@@ -32,6 +35,33 @@ class FileMediaTest extends ModelTestCase
 		]);
 
 		$this->assertSame('08756f3115-5432112345', $file->mediaHash());
+	}
+
+	public function testMediaPath(): void
+	{
+		F::write($root = static::TMP . '/content/test.jpg', 'test');
+		touch($root, 5432112345);
+
+		$file = new File([
+			'filename' => 'test.jpg',
+			'parent'   => $this->app->site()
+		]);
+
+		$this->assertSame(self::TMP . '/media/site/08756f3115-5432112345/test.jpg', $file->mediaPath());
+		$this->assertSame(self::TMP . '/media/site/08756f3115-5432112345/test-120x.jpg', $file->mediaPath('test-120x.jpg'));
+	}
+
+	public function testMediaRoot(): void
+	{
+		F::write($root = static::TMP . '/content/test.jpg', 'test');
+		touch($root, 5432112345);
+
+		$file = new File([
+			'filename' => 'test.jpg',
+			'parent'   => $this->app->site()
+		]);
+
+		$this->assertSame(self::TMP . '/media/site/08756f3115-5432112345', $file->mediaRoot());
 	}
 
 	public function testMediaToken(): void
@@ -42,5 +72,19 @@ class FileMediaTest extends ModelTestCase
 		]);
 
 		$this->assertSame('08756f3115', $file->mediaToken());
+	}
+
+	public function testMediaUrl(): void
+	{
+		F::write($root = static::TMP . '/content/test.jpg', 'test');
+		touch($root, 5432112345);
+
+		$file = new File([
+			'filename' => 'test.jpg',
+			'parent'   => $this->app->site()
+		]);
+
+		$this->assertSame('/media/site/08756f3115-5432112345/test.jpg', $file->mediaUrl());
+		$this->assertSame('/media/site/08756f3115-5432112345/test-120x.jpg', $file->mediaUrl('test-120x.jpg'));
 	}
 }

--- a/tests/Cms/File/FileUrlTest.php
+++ b/tests/Cms/File/FileUrlTest.php
@@ -2,12 +2,28 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Filesystem\F;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(File::class)]
 class FileUrlTest extends ModelTestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/files';
 	public const TMP = KIRBY_TMP_DIR . '/Cms.FileUrl';
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->app = $this->app->clone([
+			'roots' => [
+				'index' => self::TMP
+			],
+			'options' => [
+				'content.salt' => 'test'
+			]
+		]);
+	}
 
 	public function testPermalink(): void
 	{
@@ -21,7 +37,7 @@ class FileUrlTest extends ModelTestCase
 		$this->assertSame('//@/file/my-file-uuid', $file->permalink());
 	}
 
-	public function testUrl(): void
+	public function testUrlFixed(): void
 	{
 		$file = new File([
 			'filename' => 'test.pdf',
@@ -30,5 +46,18 @@ class FileUrlTest extends ModelTestCase
 		]);
 
 		$this->assertSame($url, $file->url());
+	}
+
+	public function testUrlMedia(): void
+	{
+		F::copy(self::FIXTURES . '/test.pdf', $root = self::TMP . '/content/test.pdf');
+		touch($root, 1234567890);
+
+		$file = new File([
+			'filename' => 'test.pdf',
+			'parent'   => $this->app->site()
+		]);
+
+		$this->assertSame('/media/site/b22a2d4f82-1234567890/test.pdf', $file->url());
 	}
 }

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -190,15 +190,15 @@ class MediaTest extends TestCase
 
 		// get file object
 		$file  = $this->app->file('test.jpg');
-		Dir::make(dirname($file->mediaRoot()));
+		Dir::make($file->mediaRoot());
 		$this->assertIsFile($file);
 
 		// create job file
 		$jobString = '{"width":64,"height":64,"quality":null,"crop":"center","filename":"test.jpg"}';
-		F::write(dirname($file->mediaRoot()) . '/.jobs/' . $file->filename() . '.json', $jobString);
+		F::write($file->mediaRoot() . '/.jobs/' . $file->filename() . '.json', $jobString);
 
 		// copy to media folder
-		$file->asset()->copy($mediaPath = $file->mediaRoot());
+		$file->asset()->copy($mediaPath = $file->mediaPath());
 
 		$thumb = Media::thumb($file, $file->mediaHash(), $file->filename());
 		$this->assertInstanceOf(Response::class, $thumb);
@@ -240,7 +240,7 @@ class MediaTest extends TestCase
 		$file = $this->app->file('test.jpg');
 
 		// create an empty job file
-		F::write(dirname($file->mediaRoot()) . '/.jobs/' . $file->filename() . '.json', '{}');
+		F::write($file->mediaRoot() . '/.jobs/' . $file->filename() . '.json', '{}');
 
 		$this->expectException(\Kirby\Exception\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Incomplete thumbnail configuration');
@@ -265,7 +265,7 @@ class MediaTest extends TestCase
 
 		// create a valid job file
 		$jobString = '{"width":64,"height":64,"quality":null,"crop":"center","filename":"test.jpg"}';
-		F::write(dirname($file->mediaRoot()) . '/.jobs/' . $file->filename() . '.json', $jobString);
+		F::write($file->mediaRoot() . '/.jobs/' . $file->filename() . '.json', $jobString);
 
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('File not found');


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

- Inside the media hash directory (`/media/site/abcdefghij-1234567890`), there is now another directory layer (e.g. `/media/site/abcdefghij-1234567890/bcdefghija`) to separate all individual files (the original and each thumb)
- Transitional code is added so that all old media URLs stay valid until v6 (these are automatically redirected to the new URLs)
- Existing media files and thumbs are automatically migrated to their new locations to avoid having to regenerate them

### Reasoning

- Prevent access to file versions (especially originals but also different thumb variants) by guessing the media URL (so far if you e.g. had `/media/site/abcdefghij-1234567890/file-120x.jpg` you could change the filename to `file.jpg` to access the original, which may not be intended by devs).
- Using another directory layer makes sure that the filenames stay clean and don't need to include generated hashes.

### Additional context

With the transitional and migration code, there shouldn't be a breaking impact to sites. But since there is already a lot going on in v5, I suggest we include this PR in 5.1 or 5.x. This ensures that users upgrading to v5 with a lot of media files and thumbs don't immediately run into performance problems when all those files are migrated.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- It is no longer possible to guess other URLs to file versions (uploaded file originals and their thumbnails) from a thumbnail URL.

### Deprecated

- The URL structure of media files (file URLs and thumb URLs) has changed. The old URL structure is still supported for now, but will be dropped in Kirby 6.

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [ ] More robust migration code (currently not safe against race conditions when multiple requests migrate the same files at the same time)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
