### PR TITLE
Media firewall 2: Differentiate between `mediaRoot`/`mediaDir`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -76,7 +76,7 @@ return [
 		}
 
 		// create url and root
-		$mediaRoot = $file->mediaRoot();
+		$mediaRoot = $file->mediaDir();
 		$template  = $mediaRoot . '/{{ name }}{{ attributes }}.{{ extension }}';
 		$thumbRoot = (new Filename($file->root(), $template, $options))->toString();
 		$thumbName = basename($thumbRoot);

--- a/config/components.php
+++ b/config/components.php
@@ -76,7 +76,7 @@ return [
 		}
 
 		// create url and root
-		$mediaRoot = dirname($file->mediaRoot());
+		$mediaRoot = $file->mediaRoot();
 		$template  = $mediaRoot . '/{{ name }}{{ attributes }}.{{ extension }}';
 		$thumbRoot = (new Filename($file->root(), $template, $options))->toString();
 		$thumbName = basename($thumbRoot);
@@ -102,7 +102,7 @@ return [
 			'modifications' => $options,
 			'original'      => $file,
 			'root'          => $thumbRoot,
-			'url'           => dirname($file->mediaUrl()) . '/' . $thumbName,
+			'url'           => $file->mediaUrl($thumbName),
 		]);
 	},
 

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -374,6 +374,7 @@ class File extends ModelWithContent
 	/**
 	 * Returns the absolute path to the media folder for the file and its versions
 	 * @internal
+	 * @since 5.0.0
 	 */
 	public function mediaDir(): string
 	{

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -372,6 +372,15 @@ class File extends ModelWithContent
 	}
 
 	/**
+	 * Returns the absolute path to the media folder for the file and its versions
+	 * @internal
+	 */
+	public function mediaDir(): string
+	{
+		return $this->parent()->mediaDir() . '/' . $this->mediaHash();
+	}
+
+	/**
 	 * Creates a unique media hash
 	 * @internal
 	 */
@@ -386,20 +395,11 @@ class File extends ModelWithContent
 	 *
 	 * @param string|null $filename Optional override for the filename
 	 */
-	public function mediaPath(string|null $filename = null): string
+	public function mediaRoot(string|null $filename = null): string
 	{
 		$filename ??= $this->filename();
 
-		return $this->mediaRoot() . '/' . $filename;
-	}
-
-	/**
-	 * Returns the absolute path to the media folder for the file and its versions
-	 * @internal
-	 */
-	public function mediaRoot(): string
-	{
-		return $this->parent()->mediaRoot() . '/' . $this->mediaHash();
+		return $this->mediaDir() . '/' . $filename;
 	}
 
 	/**

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -383,10 +383,23 @@ class File extends ModelWithContent
 	/**
 	 * Returns the absolute path to the file in the public media folder
 	 * @internal
+	 *
+	 * @param string|null $filename Optional override for the filename
+	 */
+	public function mediaPath(string|null $filename = null): string
+	{
+		$filename ??= $this->filename();
+
+		return $this->mediaRoot() . '/' . $filename;
+	}
+
+	/**
+	 * Returns the absolute path to the media folder for the file and its versions
+	 * @internal
 	 */
 	public function mediaRoot(): string
 	{
-		return $this->parent()->mediaRoot() . '/' . $this->mediaHash() . '/' . $this->filename();
+		return $this->parent()->mediaRoot() . '/' . $this->mediaHash();
 	}
 
 	/**
@@ -402,10 +415,15 @@ class File extends ModelWithContent
 	/**
 	 * Returns the absolute Url to the file in the public media folder
 	 * @internal
+	 *
+	 * @param string|null $filename Optional override for the filename
 	 */
-	public function mediaUrl(): string
+	public function mediaUrl(string|null $filename = null): string
 	{
-		return $this->parent()->mediaUrl() . '/' . $this->mediaHash() . '/' . $this->filename();
+		$url        = $this->parent()->mediaUrl() . '/' . $this->mediaHash();
+		$filename ??= $this->filename();
+
+		return $url . '/' . $filename;
 	}
 
 	/**

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -362,7 +362,7 @@ trait FileActions
 	 */
 	public function publish(): static
 	{
-		Media::publish($this, $this->mediaRoot());
+		Media::publish($this, $this->mediaPath());
 		return $this;
 	}
 

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -362,7 +362,7 @@ trait FileActions
 	 */
 	public function publish(): static
 	{
-		Media::publish($this, $this->mediaPath());
+		Media::publish($this, $this->mediaRoot());
 		return $this;
 	}
 

--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -53,7 +53,7 @@ class Media
 			}
 
 			// send the file to the browser
-			return Response::file($file->publish()->mediaPath());
+			return Response::file($file->publish()->mediaRoot());
 		}
 
 		// try to generate a thumb for the file
@@ -104,7 +104,7 @@ class Media
 				=> $media . '/assets/' . $model . '/' . $hash,
 			// parent files for file model that already included hash
 			$model instanceof File
-				=> $model->mediaRoot(),
+				=> $model->mediaDir(),
 			// model files
 			default
 			=> $model->mediaRoot() . '/' . $hash

--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -53,7 +53,7 @@ class Media
 			}
 
 			// send the file to the browser
-			return Response::file($file->publish()->mediaRoot());
+			return Response::file($file->publish()->mediaPath());
 		}
 
 		// try to generate a thumb for the file
@@ -104,7 +104,7 @@ class Media
 				=> $media . '/assets/' . $model . '/' . $hash,
 			// parent files for file model that already included hash
 			$model instanceof File
-				=> dirname($model->mediaRoot()),
+				=> $model->mediaRoot(),
 			// model files
 			default
 			=> $model->mediaRoot() . '/' . $hash

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -770,12 +770,21 @@ class Page extends ModelWithContent
 	}
 
 	/**
-	 * Returns the root to the media folder for the page
+	 * Returns the absolute path to the media folder for the page
+	 * @internal
+	 */
+	public function mediaDir(): string
+	{
+		return $this->kirby()->root('media') . '/pages/' . $this->id();
+	}
+
+	/**
+	 * @see `::mediaDir`
 	 * @internal
 	 */
 	public function mediaRoot(): string
 	{
-		return $this->kirby()->root('media') . '/pages/' . $this->id();
+		return $this->mediaDir();
 	}
 
 	/**

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -275,12 +275,21 @@ class Site extends ModelWithContent
 	}
 
 	/**
-	 * Returns the root to the media folder for the site
+	 * Returns the absolute path to the media folder for the page
+	 * @internal
+	 */
+	public function mediaDir(): string
+	{
+		return $this->kirby()->root('media') . '/site';
+	}
+
+	/**
+	 * @see `::mediaDir`
 	 * @internal
 	 */
 	public function mediaRoot(): string
 	{
-		return $this->kirby()->root('media') . '/site';
+		return $this->mediaDir();
 	}
 
 	/**

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -427,12 +427,21 @@ class User extends ModelWithContent
 	}
 
 	/**
-	 * Returns the root to the media folder for the user
+	 * Returns the absolute path to the media folder for the user
+	 * @internal
+	 */
+	public function mediaDir(): string
+	{
+		return $this->kirby()->root('media') . '/users/' . $this->id();
+	}
+
+	/**
+	 * @see `::mediaDir`
 	 * @internal
 	 */
 	public function mediaRoot(): string
 	{
-		return $this->kirby()->root('media') . '/users/' . $this->id();
+		return $this->mediaDir();
 	}
 
 	/**

--- a/tests/Cms/File/FileMediaTest.php
+++ b/tests/Cms/File/FileMediaTest.php
@@ -15,6 +15,9 @@ class FileMediaTest extends ModelTestCase
 		parent::setUp();
 
 		$this->app = $this->app->clone([
+			'roots' => [
+				'index' => self::TMP
+			],
 			'options' => [
 				'content.salt' => 'test'
 			]
@@ -23,8 +26,8 @@ class FileMediaTest extends ModelTestCase
 
 	public function testMediaHash(): void
 	{
-		F::write($file = static::TMP . '/content/test.jpg', 'test');
-		touch($file, 5432112345);
+		F::write($root = static::TMP . '/content/test.jpg', 'test');
+		touch($root, 5432112345);
 
 		$file = new File([
 			'filename' => 'test.jpg',
@@ -32,6 +35,33 @@ class FileMediaTest extends ModelTestCase
 		]);
 
 		$this->assertSame('08756f3115-5432112345', $file->mediaHash());
+	}
+
+	public function testMediaPath(): void
+	{
+		F::write($root = static::TMP . '/content/test.jpg', 'test');
+		touch($root, 5432112345);
+
+		$file = new File([
+			'filename' => 'test.jpg',
+			'parent'   => $this->app->site()
+		]);
+
+		$this->assertSame(self::TMP . '/media/site/08756f3115-5432112345/test.jpg', $file->mediaPath());
+		$this->assertSame(self::TMP . '/media/site/08756f3115-5432112345/test-120x.jpg', $file->mediaPath('test-120x.jpg'));
+	}
+
+	public function testMediaRoot(): void
+	{
+		F::write($root = static::TMP . '/content/test.jpg', 'test');
+		touch($root, 5432112345);
+
+		$file = new File([
+			'filename' => 'test.jpg',
+			'parent'   => $this->app->site()
+		]);
+
+		$this->assertSame(self::TMP . '/media/site/08756f3115-5432112345', $file->mediaRoot());
 	}
 
 	public function testMediaToken(): void
@@ -42,5 +72,19 @@ class FileMediaTest extends ModelTestCase
 		]);
 
 		$this->assertSame('08756f3115', $file->mediaToken());
+	}
+
+	public function testMediaUrl(): void
+	{
+		F::write($root = static::TMP . '/content/test.jpg', 'test');
+		touch($root, 5432112345);
+
+		$file = new File([
+			'filename' => 'test.jpg',
+			'parent'   => $this->app->site()
+		]);
+
+		$this->assertSame('/media/site/08756f3115-5432112345/test.jpg', $file->mediaUrl());
+		$this->assertSame('/media/site/08756f3115-5432112345/test-120x.jpg', $file->mediaUrl('test-120x.jpg'));
 	}
 }

--- a/tests/Cms/File/FileMediaTest.php
+++ b/tests/Cms/File/FileMediaTest.php
@@ -24,6 +24,19 @@ class FileMediaTest extends ModelTestCase
 		]);
 	}
 
+	public function testMediaDir(): void
+	{
+		F::write($root = static::TMP . '/content/test.jpg', 'test');
+		touch($root, 5432112345);
+
+		$file = new File([
+			'filename' => 'test.jpg',
+			'parent'   => $this->app->site()
+		]);
+
+		$this->assertSame(self::TMP . '/media/site/08756f3115-5432112345', $file->mediaDir());
+	}
+
 	public function testMediaHash(): void
 	{
 		F::write($root = static::TMP . '/content/test.jpg', 'test');
@@ -37,20 +50,6 @@ class FileMediaTest extends ModelTestCase
 		$this->assertSame('08756f3115-5432112345', $file->mediaHash());
 	}
 
-	public function testMediaPath(): void
-	{
-		F::write($root = static::TMP . '/content/test.jpg', 'test');
-		touch($root, 5432112345);
-
-		$file = new File([
-			'filename' => 'test.jpg',
-			'parent'   => $this->app->site()
-		]);
-
-		$this->assertSame(self::TMP . '/media/site/08756f3115-5432112345/test.jpg', $file->mediaPath());
-		$this->assertSame(self::TMP . '/media/site/08756f3115-5432112345/test-120x.jpg', $file->mediaPath('test-120x.jpg'));
-	}
-
 	public function testMediaRoot(): void
 	{
 		F::write($root = static::TMP . '/content/test.jpg', 'test');
@@ -61,7 +60,8 @@ class FileMediaTest extends ModelTestCase
 			'parent'   => $this->app->site()
 		]);
 
-		$this->assertSame(self::TMP . '/media/site/08756f3115-5432112345', $file->mediaRoot());
+		$this->assertSame(self::TMP . '/media/site/08756f3115-5432112345/test.jpg', $file->mediaRoot());
+		$this->assertSame(self::TMP . '/media/site/08756f3115-5432112345/test-120x.jpg', $file->mediaRoot('test-120x.jpg'));
 	}
 
 	public function testMediaToken(): void

--- a/tests/Cms/File/FileUrlTest.php
+++ b/tests/Cms/File/FileUrlTest.php
@@ -2,12 +2,28 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Filesystem\F;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(File::class)]
 class FileUrlTest extends ModelTestCase
 {
+	public const FIXTURES = __DIR__ . '/fixtures/files';
 	public const TMP = KIRBY_TMP_DIR . '/Cms.FileUrl';
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->app = $this->app->clone([
+			'roots' => [
+				'index' => self::TMP
+			],
+			'options' => [
+				'content.salt' => 'test'
+			]
+		]);
+	}
 
 	public function testPermalink(): void
 	{
@@ -21,7 +37,7 @@ class FileUrlTest extends ModelTestCase
 		$this->assertSame('//@/file/my-file-uuid', $file->permalink());
 	}
 
-	public function testUrl(): void
+	public function testUrlFixed(): void
 	{
 		$file = new File([
 			'filename' => 'test.pdf',
@@ -30,5 +46,18 @@ class FileUrlTest extends ModelTestCase
 		]);
 
 		$this->assertSame($url, $file->url());
+	}
+
+	public function testUrlMedia(): void
+	{
+		F::copy(self::FIXTURES . '/test.pdf', $root = self::TMP . '/content/test.pdf');
+		touch($root, 1234567890);
+
+		$file = new File([
+			'filename' => 'test.pdf',
+			'parent'   => $this->app->site()
+		]);
+
+		$this->assertSame('/media/site/b22a2d4f82-1234567890/test.pdf', $file->url());
 	}
 }

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -190,15 +190,15 @@ class MediaTest extends TestCase
 
 		// get file object
 		$file  = $this->app->file('test.jpg');
-		Dir::make(dirname($file->mediaRoot()));
+		Dir::make($file->mediaRoot());
 		$this->assertIsFile($file);
 
 		// create job file
 		$jobString = '{"width":64,"height":64,"quality":null,"crop":"center","filename":"test.jpg"}';
-		F::write(dirname($file->mediaRoot()) . '/.jobs/' . $file->filename() . '.json', $jobString);
+		F::write($file->mediaRoot() . '/.jobs/' . $file->filename() . '.json', $jobString);
 
 		// copy to media folder
-		$file->asset()->copy($mediaPath = $file->mediaRoot());
+		$file->asset()->copy($mediaPath = $file->mediaPath());
 
 		$thumb = Media::thumb($file, $file->mediaHash(), $file->filename());
 		$this->assertInstanceOf(Response::class, $thumb);
@@ -240,7 +240,7 @@ class MediaTest extends TestCase
 		$file = $this->app->file('test.jpg');
 
 		// create an empty job file
-		F::write(dirname($file->mediaRoot()) . '/.jobs/' . $file->filename() . '.json', '{}');
+		F::write($file->mediaRoot() . '/.jobs/' . $file->filename() . '.json', '{}');
 
 		$this->expectException(\Kirby\Exception\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Incomplete thumbnail configuration');
@@ -265,7 +265,7 @@ class MediaTest extends TestCase
 
 		// create a valid job file
 		$jobString = '{"width":64,"height":64,"quality":null,"crop":"center","filename":"test.jpg"}';
-		F::write(dirname($file->mediaRoot()) . '/.jobs/' . $file->filename() . '.json', $jobString);
+		F::write($file->mediaRoot() . '/.jobs/' . $file->filename() . '.json', $jobString);
 
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('The file does not exist');

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -190,15 +190,15 @@ class MediaTest extends TestCase
 
 		// get file object
 		$file  = $this->app->file('test.jpg');
-		Dir::make($file->mediaRoot());
+		Dir::make($file->mediaDir());
 		$this->assertIsFile($file);
 
 		// create job file
 		$jobString = '{"width":64,"height":64,"quality":null,"crop":"center","filename":"test.jpg"}';
-		F::write($file->mediaRoot() . '/.jobs/' . $file->filename() . '.json', $jobString);
+		F::write($file->mediaDir() . '/.jobs/' . $file->filename() . '.json', $jobString);
 
 		// copy to media folder
-		$file->asset()->copy($mediaPath = $file->mediaPath());
+		$file->asset()->copy($mediaRoot = $file->mediaRoot());
 
 		$thumb = Media::thumb($file, $file->mediaHash(), $file->filename());
 		$this->assertInstanceOf(Response::class, $thumb);
@@ -206,7 +206,7 @@ class MediaTest extends TestCase
 		$this->assertSame(200, $thumb->code());
 		$this->assertSame('image/jpeg', $thumb->type());
 
-		$thumbInfo = getimagesize($mediaPath);
+		$thumbInfo = getimagesize($mediaRoot);
 		$this->assertSame(64, $thumbInfo[0]);
 		$this->assertSame(64, $thumbInfo[1]);
 	}
@@ -240,7 +240,7 @@ class MediaTest extends TestCase
 		$file = $this->app->file('test.jpg');
 
 		// create an empty job file
-		F::write($file->mediaRoot() . '/.jobs/' . $file->filename() . '.json', '{}');
+		F::write($file->mediaDir() . '/.jobs/' . $file->filename() . '.json', '{}');
 
 		$this->expectException(\Kirby\Exception\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Incomplete thumbnail configuration');
@@ -265,7 +265,7 @@ class MediaTest extends TestCase
 
 		// create a valid job file
 		$jobString = '{"width":64,"height":64,"quality":null,"crop":"center","filename":"test.jpg"}';
-		F::write($file->mediaRoot() . '/.jobs/' . $file->filename() . '.json', $jobString);
+		F::write($file->mediaDir() . '/.jobs/' . $file->filename() . '.json', $jobString);
 
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('The file does not exist');


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

- New custom `$filename` param for `$file->mediaRoot()` and `$file->mediaUrl()`
- New `$file->mediaDir()` method (= directory where media of that file model is stored)
- Rename `mediaRoot()` to `mediaDir()` for other model classes

### Reasoning

- With the new media path structure introduced by #7195, methods throughout the core need access to both the "topmost" media root and the individual file paths.
- Being able to pass a custom filename to `mediaRoot()` and `mediaUrl()` allows to clean up thumb-related code and is also needed for the media firewall PR 3 #7195.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New `$file->mediaDir()` method that returns the directories where media of that file model is stored. Matching method aliases for the `Page`, `Site` and `User` classes are provided.
- The `$file->mediaRoot()` and `$file->mediaUrl()` methods now accept a new optional `$filename` argument so they can be used to construct roots and URLs to thumbs.

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
