### PR TITLE
test: Ensure XML parse entities exceeds memory

### DIFF
--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -280,7 +280,7 @@ class Xml
 	{
 		$xml = @simplexml_load_string($xml);
 
-		if (is_object($xml) !== true) {
+		if (is_object($xml) === false) {
 			return null;
 		}
 

--- a/tests/Toolkit/XmlTest.php
+++ b/tests/Toolkit/XmlTest.php
@@ -136,12 +136,12 @@ class XmlTest extends TestCase
 		$array = Xml::parse($xml);
 
 		$this->assertSame([
-			'@name' => 'x',
+			'@name'  => 'x',
 			'@value' => 'this is a file: foo bar (with entities)'
 		], $array);
 	}
 
-	public function testParseRecursiveEntities()
+	public function testParseRecursiveEntities(): void
 	{
 		$xml = file_get_contents(static::FIXTURES . '/billion-laughs.xml');
 		$this->assertNull(Xml::parse($xml));

--- a/tests/Toolkit/fixtures/xml/billion-laughs.xml
+++ b/tests/Toolkit/fixtures/xml/billion-laughs.xml
@@ -3,7 +3,12 @@
   <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;">
   <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
   <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+  <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+  <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+  <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+  <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+  <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
 ]>
 <xml>
-  <p>&lol4;</p>
+  <p>&lol9;</p>
 </xml>


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Increase the billion laughs attack for `Toolkit\XmlTest::testParseRecursiveEntities()`


### Reasoning
Finally found the source of why this unit test kept failing for me locally. The previous malicious billion laughs XML wasn't malicious enough for my local setup and would actually complete instead of running into a memory limit (and thus return actually something instead of the expected `null`). Extending the malicious XML ensures that `simplexml_load_string` fails again.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass
