### PR TITLE
test: Use PHPUnit attributes for `Kirby\Template`

### DIFF
--- a/tests/Template/SlotTest.php
+++ b/tests/Template/SlotTest.php
@@ -3,19 +3,13 @@
 namespace Kirby\Template;
 
 use Kirby\Exception\LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionProperty;
 
-/**
- * @coversDefaultClass \Kirby\Template\Slot
- */
+#[CoversClass(Slot::class)]
 class SlotTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::isOpen
-	 * @covers ::name
-	 */
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$slot = new Slot('test');
 
@@ -26,11 +20,7 @@ class SlotTest extends TestCase
 		$this->assertSame('', $slot->__toString());
 	}
 
-	/**
-	 * @covers ::begin
-	 * @covers ::end
-	 */
-	public function testHelpers()
+	public function testHelpers(): void
 	{
 		$this->assertNull(Snippet::$current);
 		$snippet = Snippet::begin('test.php');
@@ -54,11 +44,7 @@ class SlotTest extends TestCase
 		$this->assertCount(1, $slotsProp->getValue($snippet));
 	}
 
-	/**
-	 * @covers ::open
-	 * @covers ::close
-	 */
-	public function testOpenClose()
+	public function testOpenClose(): void
 	{
 		// all output must be captured
 		$this->expectOutputString('');
@@ -77,10 +63,7 @@ class SlotTest extends TestCase
 		$this->assertSame($content, $slot->content);
 	}
 
-	/**
-	 * @covers ::close
-	 */
-	public function testCloseWhenNotOpen()
+	public function testCloseWhenNotOpen(): void
 	{
 		$slot = new Slot('test');
 
@@ -90,11 +73,7 @@ class SlotTest extends TestCase
 		$slot->close();
 	}
 
-	/**
-	 * @covers ::render
-	 * @covers ::__toString
-	 */
-	public function testRender()
+	public function testRender(): void
 	{
 		// all output must be captured
 		$this->expectOutputString('');

--- a/tests/Template/SlotsTest.php
+++ b/tests/Template/SlotsTest.php
@@ -2,18 +2,12 @@
 
 namespace Kirby\Template;
 
-/**
- * @coversDefaultClass \Kirby\Template\Slots
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Slots::class)]
 class SlotsTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::__get
-	 * @covers ::__call
-	 * @covers ::count
-	 */
-	public function testSlots()
+	public function testSlots(): void
 	{
 		$header = new Slot('header');
 		$footer = new Slot('footer');

--- a/tests/Template/SnippetTest.php
+++ b/tests/Template/SnippetTest.php
@@ -5,19 +5,16 @@ namespace Kirby\Template;
 use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 
-/**
- * @coversDefaultClass \Kirby\Template\Snippet
- */
+#[CoversClass(Snippet::class)]
 class SnippetTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	/**
-	 * @covers ::close
-	 */
-	public function testCloseWhenNotOpen()
+	public function testCloseWhenNotOpen(): void
 	{
 		$snippet = new Snippet('test.php');
 
@@ -27,10 +24,7 @@ class SnippetTest extends TestCase
 		$snippet->close();
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		// all output must be captured
 		$this->expectOutputString('');
@@ -67,10 +61,7 @@ class SnippetTest extends TestCase
 		$snippet->close(); // close output buffers to reset global state
 	}
 
-	/**
-	 * @covers ::file
-	 */
-	public function testFile()
+	public function testFile(): void
 	{
 		App::plugin('test/d', [
 			'snippets' => [
@@ -90,11 +81,7 @@ class SnippetTest extends TestCase
 		$this->assertSame('bar.php', Snippet::file('foo'));
 	}
 
-	/**
-	 * @covers ::begin
-	 * @covers ::end
-	 */
-	public function testHelpers()
+	public function testHelpers(): void
 	{
 		ob_start();
 
@@ -107,12 +94,7 @@ class SnippetTest extends TestCase
 		$this->assertSame('Nice', ob_get_clean());
 	}
 
-	/**
-	 * @covers ::open
-	 * @covers ::close
-	 * @covers ::parent
-	 */
-	public function testNestedComponents()
+	public function testNestedComponents(): void
 	{
 		$a = new Snippet(file: 'a.php');
 
@@ -134,11 +116,7 @@ class SnippetTest extends TestCase
 		$this->assertSame($a, $b->parent());
 	}
 
-	/**
-	 * @covers ::open
-	 * @covers ::close
-	 */
-	public function testOpenCloseWithSlotsAndSwallowedDefaultContent()
+	public function testOpenCloseWithSlotsAndSwallowedDefaultContent(): void
 	{
 		// all output must be captured
 		$this->expectOutputString('');
@@ -159,11 +137,7 @@ class SnippetTest extends TestCase
 		$this->assertSame('Default content', $slots->default()->render());
 	}
 
-	/**
-	 * @covers ::open
-	 * @covers ::close
-	 */
-	public function testOpenCloseWithDefaultSlotContent()
+	public function testOpenCloseWithDefaultSlotContent(): void
 	{
 		// all output must be captured
 		$this->expectOutputString('');
@@ -187,12 +161,11 @@ class SnippetTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::render
-	 * @dataProvider renderWithSlotsProvider
-	 */
-	public function testRenderWithSlots(string|null $file, string $expected)
-	{
+	#[DataProvider('renderWithSlotsProvider')]
+	public function testRenderWithSlots(
+		string|null $file,
+		string $expected
+	): void {
 		// all output must be captured
 		$this->expectOutputString('');
 
@@ -220,10 +193,7 @@ class SnippetTest extends TestCase
 		$this->assertSame($expected, $snippet->render());
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderWithoutClosing()
+	public function testRenderWithoutClosing(): void
 	{
 		// all output must be captured
 		$this->expectOutputString('');
@@ -235,10 +205,7 @@ class SnippetTest extends TestCase
 		$this->assertSame("<h1>Layout</h1>\ncontent<footer>with other stuff</footer>\n", $snippet->render());
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderWithoutClosingAndMultipleSlots()
+	public function testRenderWithoutClosingAndMultipleSlots(): void
 	{
 		// all output must be captured
 		$this->expectOutputString('');
@@ -256,10 +223,7 @@ class SnippetTest extends TestCase
 		$this->assertSame("<h1>Layout</h1>\n<header>Header content</header>\n<main>Body content</main>\n", $snippet->render());
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderWithLazySlots()
+	public function testRenderWithLazySlots(): void
 	{
 		$snippet = new Snippet(static::FIXTURES . '/slots.php');
 
@@ -276,11 +240,7 @@ class SnippetTest extends TestCase
 		$this->assertSame($expected, $html);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::render
-	 */
-	public function testRenderWithData()
+	public function testRenderWithData(): void
 	{
 		$snippet = new Snippet(
 			file: static::FIXTURES . '/data.php',
@@ -290,10 +250,7 @@ class SnippetTest extends TestCase
 		$this->assertSame('hello', $snippet->render());
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderWithLazyData()
+	public function testRenderWithLazyData(): void
 	{
 		$snippet = new Snippet(
 			file: static::FIXTURES . '/data.php',
@@ -302,10 +259,7 @@ class SnippetTest extends TestCase
 		$this->assertSame('hello', $snippet->render(data: ['message' => 'hello']));
 	}
 
-	/**
-	 * @covers ::root
-	 */
-	public function testRoot()
+	public function testRoot(): void
 	{
 		new App([
 			'roots' => [
@@ -316,10 +270,7 @@ class SnippetTest extends TestCase
 		$this->assertSame($root, Snippet::root());
 	}
 
-	/**
-	 * @covers ::scope
-	 */
-	public function testScope()
+	public function testScope(): void
 	{
 		$closure = function ($scope) use (&$data) {
 			$this->assertArrayHasKey('slots', $scope);
@@ -344,10 +295,7 @@ class SnippetTest extends TestCase
 		$this->assertSame('Scope snippet success', $snippet->render());
 	}
 
-	/**
-	 * @covers ::scope
-	 */
-	public function testScopeWithDefaultSlot()
+	public function testScopeWithDefaultSlot(): void
 	{
 		$closure = function ($scope) use (&$data, &$slot) {
 			$this->assertArrayHasKey('closure', $scope);
@@ -376,10 +324,7 @@ class SnippetTest extends TestCase
 		$this->assertSame('Scope snippet success', $snippet->render());
 	}
 
-	/**
-	 * @covers ::scope
-	 */
-	public function testScopeWithoutSlots()
+	public function testScopeWithoutSlots(): void
 	{
 		new App([
 			'roots' => [
@@ -430,10 +375,7 @@ class SnippetTest extends TestCase
 		$this->assertSame('Scope snippet success', $result);
 	}
 
-	/**
-	 * @covers ::scope
-	 */
-	public function testScopeWithInvalidData()
+	public function testScopeWithInvalidData(): void
 	{
 		new App([
 			'roots' => [
@@ -452,12 +394,7 @@ class SnippetTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::slots
-	 * @covers ::slot
-	 * @covers ::endslot
-	 */
-	public function testSlots()
+	public function testSlots(): void
 	{
 		// all output must be captured
 		$this->expectOutputString('');

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -3,23 +3,14 @@
 namespace Kirby\Template;
 
 use Kirby\Cms\App;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Template\Template
- */
+#[CoversClass(Template::class)]
 class TemplateTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::name
-	 * @covers ::type
-	 * @covers ::defaultType
-	 * @covers ::extension
-	 * @covers ::__toString
-	 */
-	public function testTemplate()
+	public function testTemplate(): void
 	{
 		$template = new Template('Test', 'foo', 'bar');
 		$this->assertSame('test', $template->name());
@@ -30,10 +21,7 @@ class TemplateTest extends TestCase
 		$this->assertSame('php', $template->extension());
 	}
 
-	/**
-	 * @covers ::exists
-	 */
-	public function testExists()
+	public function testExists(): void
 	{
 		new App([
 			'roots' => [
@@ -54,10 +42,7 @@ class TemplateTest extends TestCase
 		$this->assertFalse($template->exists());
 	}
 
-	/**
-	 * @covers ::file
-	 */
-	public function testFile()
+	public function testFile(): void
 	{
 		App::plugin('test/c', [
 			'templates' => [
@@ -84,10 +69,7 @@ class TemplateTest extends TestCase
 		$this->assertSame('plugin.php', $template->file());
 	}
 
-	/**
-	 * @covers ::hasDefaultType
-	 */
-	public function testHasDefaultType()
+	public function testHasDefaultType(): void
 	{
 		$template = new Template('test');
 		$this->assertTrue($template->hasDefaultType());
@@ -99,11 +81,7 @@ class TemplateTest extends TestCase
 		$this->assertFalse($template->hasDefaultType());
 	}
 
-	/**
-	 * @covers ::store
-	 * @covers ::root
-	 */
-	public function testRoot()
+	public function testRoot(): void
 	{
 		new App([
 			'roots' => [
@@ -116,10 +94,7 @@ class TemplateTest extends TestCase
 		$this->assertSame($root, $template->root());
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRender()
+	public function testRender(): void
 	{
 		new App([
 			'roots' => [
@@ -131,10 +106,7 @@ class TemplateTest extends TestCase
 		$this->assertSame('Test', $template->render(['slot' => 'Test']));
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderOpenLayoutSnippet()
+	public function testRenderOpenLayoutSnippet(): void
 	{
 		new App([
 			'roots' => [
@@ -147,10 +119,7 @@ class TemplateTest extends TestCase
 		$this->assertSame("<h1>Layout</h1>\nMy content\n<footer>with other stuff</footer>\n", $template->render());
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderOpenParentSnippet1()
+	public function testRenderOpenParentSnippet1(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -167,10 +136,7 @@ class TemplateTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderOpenParentSnippet2()
+	public function testRenderOpenParentSnippet2(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -190,10 +156,7 @@ class TemplateTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderOpenParentSnippet3()
+	public function testRenderOpenParentSnippet3(): void
 	{
 		$app = new App([
 			'roots' => [


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Use `CoversClass` and `DataProvider` PHPUnit PHP attributes instead of DocBlock annotations in the `Kirby\Template` package


### Reasoning
Switching over package by package (or smaller units) to see how the code coverage is affected.

### Additional context
Put this for the 5.1.0 milestone to not further add to the list of the 5.0.0 milestone as we want to close this very soon.

The changes were created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withPaths([
		__DIR__ . '/tests/Template',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	])
	->withImportNames();
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass