### PR TITLE
test: Use PHPUnit attributes for `Kirby\Text`

### DIFF
--- a/tests/Text/DateKirbyTagTest.php
+++ b/tests/Text/DateKirbyTagTest.php
@@ -7,7 +7,7 @@ use Kirby\TestCase;
 
 class DateKirbyTagTest extends TestCase
 {
-	public function testDate()
+	public function testDate(): void
 	{
 		$app = App::instance();
 		$this->assertSame(date('d.m.Y'), $app->kirbytags('(date: d.m.Y)'));

--- a/tests/Text/EmailKirbyTagTest.php
+++ b/tests/Text/EmailKirbyTagTest.php
@@ -8,7 +8,7 @@ use Kirby\Toolkit\Html;
 
 class EmailKirbyTagTest extends TestCase
 {
-	public function testEmail()
+	public function testEmail(): void
 	{
 		$app      = App::instance();
 		$html     = $app->kirbytags('(email: mail@company.com?subject=Test class: email)');

--- a/tests/Text/FileKirbyTagTest.php
+++ b/tests/Text/FileKirbyTagTest.php
@@ -26,7 +26,7 @@ class FileKirbyTagTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testFile()
+	public function testFile(): void
 	{
 		$kirby = $this->app->clone([
 			'site' => [
@@ -54,7 +54,7 @@ class FileKirbyTagTest extends TestCase
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
-	public function testFileWithUUID()
+	public function testFileWithUUID(): void
 	{
 		$kirby = $this->app->clone([
 			'site' => [
@@ -84,7 +84,7 @@ class FileKirbyTagTest extends TestCase
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
-	public function testFileDoesNotExist()
+	public function testFileDoesNotExist(): void
 	{
 		$kirby = $this->app->clone([
 			'site' => [
@@ -105,7 +105,7 @@ class FileKirbyTagTest extends TestCase
 		$this->assertSame('<p>a.jpg b</p>', $page->text()->kt()->value());
 	}
 
-	public function testFileWithDisabledDownloadOption()
+	public function testFileWithDisabledDownloadOption(): void
 	{
 		$kirby = $this->app->clone([
 			'site' => [
@@ -133,7 +133,7 @@ class FileKirbyTagTest extends TestCase
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
-	public function testFileWithinFile()
+	public function testFileWithinFile(): void
 	{
 		$kirby = $this->app->clone([
 			'site' => [

--- a/tests/Text/ImageKirbyTagTest.php
+++ b/tests/Text/ImageKirbyTagTest.php
@@ -26,7 +26,7 @@ class ImageKirbyTagTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testWithoutFigure()
+	public function testWithoutFigure(): void
 	{
 		$kirby = $this->app->clone([
 			'options' => [
@@ -43,7 +43,7 @@ class ImageKirbyTagTest extends TestCase
 		$this->assertSame($expected, $kirby->kirbytext('(image: https://test.com/something.jpg)'));
 	}
 
-	public function testWithCaption()
+	public function testWithCaption(): void
 	{
 		$kirby    = $this->app->clone();
 		$expected = '<figure><img alt="" src="/myimage.jpg"><figcaption>This is an <em>awesome</em> image and this a <a href="">link</a></figcaption></figure>';
@@ -51,7 +51,7 @@ class ImageKirbyTagTest extends TestCase
 		$this->assertSame($expected, $kirby->kirbytext('(image: myimage.jpg caption: This is an *awesome* image and this a <a href="">link</a>)'));
 	}
 
-	public function testWithSrcset()
+	public function testWithSrcset(): void
 	{
 		$kirby = $this->app->clone([
 			'site' => [
@@ -79,7 +79,7 @@ class ImageKirbyTagTest extends TestCase
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
-	public function testWithSrcsetFromThumbsOption()
+	public function testWithSrcsetFromThumbsOption(): void
 	{
 		$kirby = $this->app->clone([
 			'options' => [
@@ -117,7 +117,7 @@ class ImageKirbyTagTest extends TestCase
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
-	public function testWithSrcsetFromDefaults()
+	public function testWithSrcsetFromDefaults(): void
 	{
 		$kirby = $this->app->clone([
 			'options' => [
@@ -152,7 +152,7 @@ class ImageKirbyTagTest extends TestCase
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
-	public function testWithFileLink()
+	public function testWithFileLink(): void
 	{
 		$kirby = $this->app->clone([
 			'site' => [
@@ -184,7 +184,7 @@ class ImageKirbyTagTest extends TestCase
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
-	public function testWithFileUUID()
+	public function testWithFileUUID(): void
 	{
 		$kirby = $this->app->clone([
 			'site' => [
@@ -214,7 +214,7 @@ class ImageKirbyTagTest extends TestCase
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
-	public function testWithParent()
+	public function testWithParent(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -249,7 +249,7 @@ class ImageKirbyTagTest extends TestCase
 		]));
 	}
 
-	public function testWithWidthHeightAuto()
+	public function testWithWidthHeightAuto(): void
 	{
 		$app = $this->app->clone([
 			'options' => [

--- a/tests/Text/KirbyTagTest.php
+++ b/tests/Text/KirbyTagTest.php
@@ -6,10 +6,10 @@ use Kirby\Cms\App;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Text\KirbyTag
- */
+#[CoversClass(KirbyTag::class)]
 class KirbyTagTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Text.KirbyTag';
@@ -42,10 +42,7 @@ class KirbyTagTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		KirbyTag::$aliases = [];
 		$tag = KirbyTag::parse('test: foo a: attrA b: attrB c: attrC');
@@ -57,10 +54,7 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('foo', $tag->value);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructAliasedTagType()
+	public function testConstructAliasedTagType(): void
 	{
 		KirbyTag::$aliases = ['foo' => 'test'];
 		$tag = KirbyTag::parse('foo: bar');
@@ -68,21 +62,14 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('bar', $tag->test);
 	}
 
-
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructMissingTagType()
+	public function testConstructMissingTagType(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Undefined tag type: invalid');
 		KirbyTag::parse('invalid: test');
 	}
 
-	/**
-	 * @covers ::__call
-	 */
-	public function test__call()
+	public function test__call(): void
 	{
 		$attr = [
 			'a' => 'attrA',
@@ -101,10 +88,7 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('dataC', $tag->c());
 	}
 
-	/**
-	 * @covers ::__callStatic
-	 */
-	public function test__callStatic()
+	public function test__callStatic(): void
 	{
 		$attr = [
 			'a' => 'attrA',
@@ -115,11 +99,7 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('test: test value-attrA-attrB', $result);
 	}
 
-	/**
-	 * @covers ::__get
-	 * @covers ::attr
-	 */
-	public function testAttr()
+	public function testAttr(): void
 	{
 		$tag = new KirbyTag('test', 'test value', [
 			'a' => 'attrA',
@@ -135,11 +115,7 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('attrB', $tag->attr('b', 'fallback'));
 	}
 
-	/**
-	 * @covers ::__get
-	 * @covers ::attr
-	 */
-	public function testAttrFallback()
+	public function testAttrFallback(): void
 	{
 		$tag = new KirbyTag('test', 'test value', [
 			'a' => 'attrA'
@@ -149,10 +125,7 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('fallback', $tag->attr('b', 'fallback'));
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$attr = [
 			'a' => 'attrA',
@@ -163,10 +136,7 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('test: test value-attrA-attrB', $result);
 	}
 
-	/**
-	 * @covers ::file
-	 */
-	public function testFile()
+	public function testFile(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -192,10 +162,7 @@ class KirbyTagTest extends TestCase
 		$this->assertSame($file, $tag->file('a/a.jpg'));
 	}
 
-	/**
-	 * @covers ::file
-	 */
-	public function testFileInParent()
+	public function testFileInParent(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -223,10 +190,7 @@ class KirbyTagTest extends TestCase
 		$this->assertSame($file, $tag->file('a.jpg'));
 	}
 
-	/**
-	 * @covers ::file
-	 */
-	public function testFileInFileParent()
+	public function testFileInFileParent(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -254,10 +218,7 @@ class KirbyTagTest extends TestCase
 		$this->assertSame($file, $tag->file('a.jpg'));
 	}
 
-	/**
-	 * @covers ::file
-	 */
-	public function testFileFromUuid()
+	public function testFileFromUuid(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -290,10 +251,7 @@ class KirbyTagTest extends TestCase
 		$this->assertSame($file, $tag->file('file://image-uuid'));
 	}
 
-	/**
-	 * @covers ::kirby
-	 */
-	public function testKirby()
+	public function testKirby(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -305,10 +263,7 @@ class KirbyTagTest extends TestCase
 		$this->assertSame($app, $tag->kirby());
 	}
 
-	/**
-	 * @covers ::option
-	 */
-	public function testOption()
+	public function testOption(): void
 	{
 		$attr = [
 			'a' => 'attrA',
@@ -332,10 +287,7 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('optionC', $tag->option('c', 'optionC'));
 	}
 
-	/**
-	 * @covers ::parent
-	 */
-	public function testParent()
+	public function testParent(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -514,22 +466,20 @@ class KirbyTagTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::parse
-	 * @dataProvider parseProvider
-	 */
-	public function testParse(string $string, array $data, array $options, array $expected)
-	{
+	#[DataProvider('parseProvider')]
+	public function testParse(
+		string $string,
+		array $data,
+		array $options,
+		array $expected
+	): void {
 		$tag = KirbyTag::parse($string, $data, $options);
 		foreach ($expected as $key => $value) {
 			$this->assertSame($value, $tag->$key);
 		}
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRender()
+	public function testRender(): void
 	{
 		$tag = new KirbyTag('test', 'test value', [
 			'a' => 'attrA',
@@ -543,10 +493,7 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('test: -attrA-', $tag->render());
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderNoHtml()
+	public function testRenderNoHtml(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Invalid tag render function in tag: noHtml');
@@ -558,10 +505,7 @@ class KirbyTagTest extends TestCase
 		$tag->render();
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderInvalidHtml()
+	public function testRenderInvalidHtml(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('Invalid tag render function in tag: invalidHtml');
@@ -573,10 +517,7 @@ class KirbyTagTest extends TestCase
 		$tag->render();
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testType()
+	public function testType(): void
 	{
 		$tag = new KirbyTag('test', 'test value');
 		$this->assertSame('test', $tag->type());

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -8,10 +8,10 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Text\KirbyTags
- */
+#[CoversClass(KirbyTags::class)]
 class KirbyTagsTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -33,7 +33,7 @@ class KirbyTagsTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public static function dataProvider()
+	public static function dataProvider(): array
 	{
 		$tests = [];
 
@@ -47,10 +47,7 @@ class KirbyTagsTest extends TestCase
 		return $tests;
 	}
 
-	/**
-	 * @covers ::parse
-	 */
-	public function testParse()
+	public function testParse(): void
 	{
 		KirbyTag::$types = [
 			'test' => [
@@ -64,10 +61,7 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame('test', KirbyTags::parse('(tEsT: foo)'));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
-	public function testParseWithValue()
+	public function testParseWithValue(): void
 	{
 		KirbyTag::$types = [
 			'test' => [
@@ -80,10 +74,7 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame('foo', KirbyTags::parse('(TEST: foo)'));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
-	public function testParseWithAttribute()
+	public function testParseWithAttribute(): void
 	{
 		KirbyTag::$types = [
 			'test' => [
@@ -97,10 +88,7 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame('foo|bar', KirbyTags::parse('(TEST: foo a: bar)'));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
-	public function testParseWithException()
+	public function testParseWithException(): void
 	{
 		KirbyTag::$types = [
 			'test' => [
@@ -123,10 +111,7 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame('(undefined: foo)', KirbyTags::parse('(undefined: foo)'));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
-	public function testParseWithExceptionDebug1()
+	public function testParseWithExceptionDebug1(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Just for fun');
@@ -140,10 +125,7 @@ class KirbyTagsTest extends TestCase
 		KirbyTags::parse('(test: foo)', [], ['debug' => true]);
 	}
 
-	/**
-	 * @covers ::parse
-	 */
-	public function testParseWithExceptionDebug2()
+	public function testParseWithExceptionDebug2(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Just for fun');
@@ -157,10 +139,7 @@ class KirbyTagsTest extends TestCase
 		KirbyTags::parse('(invalidargument: foo)', [], ['debug' => true]);
 	}
 
-	/**
-	 * @covers ::parse
-	 */
-	public function testParseWithExceptionDebug3()
+	public function testParseWithExceptionDebug3(): void
 	{
 		KirbyTag::$types = [
 			'undefined' => [
@@ -173,10 +152,7 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame('(undefined: foo)', KirbyTags::parse('(undefined: foo)', [], ['debug' => true]));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
-	public function testParseWithBrackets()
+	public function testParseWithBrackets(): void
 	{
 		KirbyTag::$types = [
 			'test' => [
@@ -203,12 +179,11 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame('(test: foo (bar)', KirbyTags::parse('(test: foo (bar)'));
 	}
 
-	/**
-	 * @covers ::parse
-	 * @dataProvider dataProvider
-	 */
-	public function testWithMarkdown($kirbytext, $expected)
-	{
+	#[DataProvider('dataProvider')]
+	public function testWithMarkdown(
+		string $kirbytext,
+		string $expected
+	): void {
 		$kirby = $this->app->clone([
 			'options' => [
 				'markdown' => [
@@ -220,12 +195,11 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame($expected, $kirby->kirbytext($kirbytext));
 	}
 
-	/**
-	 * @covers ::parse
-	 * @dataProvider dataProvider
-	 */
-	public function testWithMarkdownExtra($kirbytext, $expected)
-	{
+	#[DataProvider('dataProvider')]
+	public function testWithMarkdownExtra(
+		string $kirbytext,
+		string $expected
+	): void {
 		$kirby = $this->app->clone([
 			'options' => [
 				'markdown' => [
@@ -237,10 +211,7 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame($expected, $kirby->kirbytext($kirbytext));
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testHooks()
+	public function testHooks(): void
 	{
 		$app = $this->app->clone([
 			'hooks' => [
@@ -281,12 +252,11 @@ class KirbyTagsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @coversNothing
-	 * @dataProvider globalOptionsProvider
-	 */
-	public function testGlobalOptions($kirbytext, $expected)
-	{
+	#[DataProvider('globalOptionsProvider')]
+	public function testGlobalOptions(
+		string $kirbytext,
+		string $expected
+	): void {
 		$kirby = $this->app->clone([
 			'options' => [
 				'kirbytext' => [

--- a/tests/Text/LinkKirbyTagTest.php
+++ b/tests/Text/LinkKirbyTagTest.php
@@ -27,7 +27,7 @@ class LinkKirbyTagTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testWithLangAttribute()
+	public function testWithLangAttribute(): void
 	{
 		$app = $this->app->clone([
 			'urls' => [
@@ -52,7 +52,7 @@ class LinkKirbyTagTest extends TestCase
 		$this->assertSame('<a href="https://getkirby.com/de/a">getkirby.com/de/a</a>', $app->kirbytags('(link: a lang: de)'));
 	}
 
-	public function testWithHash()
+	public function testWithHash(): void
 	{
 		$app = $this->app->clone([
 			'urls' => [
@@ -79,7 +79,7 @@ class LinkKirbyTagTest extends TestCase
 		$this->assertSame('<a href="https://getkirby.com/de/a#anchor">getkirby.com/de/a</a>', $app->kirbytags('(link: a#anchor lang: de)'));
 	}
 
-	public function testWithUuid()
+	public function testWithUuid(): void
 	{
 		$app = $this->app->clone([
 			'urls' => [
@@ -114,7 +114,7 @@ class LinkKirbyTagTest extends TestCase
 		$this->assertSame('<a href="https://getkirby.com/error">file</a>', $result);
 	}
 
-	public function testWithUuidDebug()
+	public function testWithUuidDebug(): void
 	{
 		$app = $this->app->clone([
 			'urls' => [
@@ -145,7 +145,7 @@ class LinkKirbyTagTest extends TestCase
 		$app->kirbytags('(link: page://not-exists)');
 	}
 
-	public function testWithUuidDebugText()
+	public function testWithUuidDebugText(): void
 	{
 		$app = $this->app->clone([
 			'urls' => [
@@ -176,7 +176,7 @@ class LinkKirbyTagTest extends TestCase
 		$app->kirbytags('(link: page://not-exists text: click here)');
 	}
 
-	public function testWithUuidAndLang()
+	public function testWithUuidAndLang(): void
 	{
 		$app = $this->app->clone([
 			'urls' => [

--- a/tests/Text/MarkdownTest.php
+++ b/tests/Text/MarkdownTest.php
@@ -3,18 +3,14 @@
 namespace Kirby\Text;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Text\Markdown
- */
+#[CoversClass(Markdown::class)]
 class MarkdownTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	/**
-	 * @covers ::defaults
-	 */
-	public function testDefaults()
+	public function testDefaults(): void
 	{
 		$markdown = new Markdown();
 
@@ -25,10 +21,7 @@ class MarkdownTest extends TestCase
 		], $markdown->defaults());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testWithOptions()
+	public function testWithOptions(): void
 	{
 		$markdown = new Markdown([
 			'extra'  => true,
@@ -38,10 +31,7 @@ class MarkdownTest extends TestCase
 		$this->assertInstanceOf(Markdown::class, $markdown);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testSafeModeDisabled()
+	public function testSafeModeDisabled(): void
 	{
 		$markdown = new Markdown([
 			'safe' => false
@@ -50,10 +40,7 @@ class MarkdownTest extends TestCase
 		$this->assertSame('<div>Custom HTML</div>', $markdown->parse('<div>Custom HTML</div>'));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testSafeModeEnabled()
+	public function testSafeModeEnabled(): void
 	{
 		$markdown = new Markdown([
 			'safe' => true
@@ -62,10 +49,7 @@ class MarkdownTest extends TestCase
 		$this->assertSame('<p>&lt;div&gt;Custom HTML&lt;/div&gt;</p>', $markdown->parse('<div>Custom HTML</div>'));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
-	public function testParse()
+	public function testParse(): void
 	{
 		$markdown = new Markdown();
 		$md       = file_get_contents(static::FIXTURES . '/markdown.md');
@@ -73,10 +57,7 @@ class MarkdownTest extends TestCase
 		$this->assertSame($html, $markdown->parse($md));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
-	public function testParseInline()
+	public function testParseInline(): void
 	{
 		$markdown = new Markdown();
 		$md       = file_get_contents(static::FIXTURES . '/inline.md');
@@ -84,10 +65,7 @@ class MarkdownTest extends TestCase
 		$this->assertSame($html, $markdown->parse($md, true));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
-	public function testParseWithExtra()
+	public function testParseWithExtra(): void
 	{
 		$markdown = new Markdown(['extra' => true]);
 		$md       = file_get_contents(static::FIXTURES . '/markdown.md');
@@ -95,10 +73,7 @@ class MarkdownTest extends TestCase
 		$this->assertSame($html, $markdown->parse($md));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
-	public function testParseWithoutBreaks()
+	public function testParseWithoutBreaks(): void
 	{
 		$markdown = new Markdown(['breaks' => false]);
 		$md       = file_get_contents(static::FIXTURES . '/markdown.md');

--- a/tests/Text/SmartyPantsTest.php
+++ b/tests/Text/SmartyPantsTest.php
@@ -3,16 +3,12 @@
 namespace Kirby\Text;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Text\SmartyPants
- */
+#[CoversClass(SmartyPants::class)]
 class SmartyPantsTest extends TestCase
 {
-	/**
-	 * @covers ::parse
-	 */
-	public function testParse()
+	public function testParse(): void
 	{
 		$parser   = new SmartyPants();
 		$result   = $parser->parse('This is a "test quote"');
@@ -21,10 +17,7 @@ class SmartyPantsTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::parse
-	 */
-	public function testParseEmpty()
+	public function testParseEmpty(): void
 	{
 		$parser = new SmartyPants();
 
@@ -32,10 +25,7 @@ class SmartyPantsTest extends TestCase
 		$this->assertSame('', $parser->parse(''));
 	}
 
-	/**
-	 * @covers ::defaults
-	 */
-	public function testDefaults()
+	public function testDefaults(): void
 	{
 		$expected = [
 			'attr'                       => 1,
@@ -71,10 +61,7 @@ class SmartyPantsTest extends TestCase
 		$this->assertSame($expected, $parser->defaults());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testDoubleQuotesOption()
+	public function testDoubleQuotesOption(): void
 	{
 		$parser = new SmartyPants([
 			'doublequote.open'  => '<',
@@ -85,10 +72,7 @@ class SmartyPantsTest extends TestCase
 		$this->assertSame('<test>', $result);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testSingleQuotesOption()
+	public function testSingleQuotesOption(): void
 	{
 		$parser = new SmartyPants([
 			'singlequote.open'  => '<',
@@ -99,10 +83,7 @@ class SmartyPantsTest extends TestCase
 		$this->assertSame('<test>', $result);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testEmDashOption()
+	public function testEmDashOption(): void
 	{
 		$parser = new SmartyPants([
 			'emdash' => 'emdash',
@@ -112,10 +93,7 @@ class SmartyPantsTest extends TestCase
 		$this->assertSame('emdash', $result);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testEllipsisOption()
+	public function testEllipsisOption(): void
 	{
 		$parser = new SmartyPants([
 			'ellipsis' => 'ellipsis',

--- a/tests/Text/VideoKirbyTagTest.php
+++ b/tests/Text/VideoKirbyTagTest.php
@@ -26,7 +26,7 @@ class VideoKirbyTagTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testLocal()
+	public function testLocal(): void
 	{
 		$kirby = $this->app->clone([
 			'site' => [
@@ -52,7 +52,7 @@ class VideoKirbyTagTest extends TestCase
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
-	public function testInlineAttrs()
+	public function testInlineAttrs(): void
 	{
 		$kirby = $this->app->clone([
 			'site' => [
@@ -93,7 +93,7 @@ class VideoKirbyTagTest extends TestCase
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
-	public function testPredefinedAttrs()
+	public function testPredefinedAttrs(): void
 	{
 		$kirby = $this->app->clone([
 			'options' => [
@@ -139,7 +139,7 @@ class VideoKirbyTagTest extends TestCase
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
-	public function testAutoplayRelatedAttrs()
+	public function testAutoplayRelatedAttrs(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -168,7 +168,7 @@ class VideoKirbyTagTest extends TestCase
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
-	public function testAutoplayAttrsOverride()
+	public function testAutoplayAttrsOverride(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -197,7 +197,7 @@ class VideoKirbyTagTest extends TestCase
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$kirby = $this->app->clone([
 			'options' => [
@@ -229,7 +229,7 @@ class VideoKirbyTagTest extends TestCase
 		$this->assertSame($expected, $page->text()->kt()->value());
 	}
 
-	public function testRemote()
+	public function testRemote(): void
 	{
 		$kirby = $this->app->clone([
 			'site' => [


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

This highlights some problems in our test setup: Tests classes linked to `EmailKirbyTagTest` are only supposed to cover the code from `config/tags.php`. However, there is no (known) way with PHPUnit to limit code coverage to this. Adding `CoversNothing` in this PR leaves a lot in `config/tags.php` marked not covered, even when we have tests. At the same time it reveals some other actually uncovered parts in our code, which get marked covered by e.g. tests in `EmailKirbyTagTest` when we don't add any coverage limitation attributes.

We should also move for KirbyTags to class-based code where we then can test the core KirbyTags in their dedicated classes each. We can still support the array notation for plugins.


### Summary of changes
- Use `CoversClass`, `CoversNothing` and `DataProvider` PHPUnit PHP attributes instead of DocBlock annotations in the `Kirby\Text` package


### Reasoning
Switching over package by package (or smaller units) to see how the code coverage is affected.

### Additional context
Put this for the 5.1.0 milestone to not further add to the list of the 5.0.0 milestone as we want to close this very soon.

The changes were created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withPaths([
		__DIR__ . '/tests/Text',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	])
	->withImportNames();
```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass