### PR TITLE
build: Separate PHPUnit confs for local and CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,8 @@
 .php-cs-fixer.dist.php export-ignore
 phpbench.json export-ignore
 phpmd.xml.dist export-ignore
-phpunit.xml.dist export-ignore
+phpunit.ci.xml export-ignore
+phpunit.dist.xml export-ignore
 psalm.xml.dist export-ignore
 bench/ export-ignore
 tests/ export-ignore

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Run tests
         if: always() && steps.finishPrepare.outcome == 'success'
-        run: phpunit --fail-on-skipped --coverage-clover ${{ github.workspace }}/clover.xml
+        run: phpunit -c phpunit.ci.xml --coverage-clover ${{ github.workspace }}/clover.xml
 
       - name: Statically analyze using Psalm
         if: always() && steps.finishPrepare.outcome == 'success' && matrix.php != '8.4'

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 # tests
 .phpbench
 .phpunit.cache
+phpunit.xml
 /tests/coverage
 /tests/tmp
 

--- a/phpunit.ci.xml
+++ b/phpunit.ci.xml
@@ -8,7 +8,7 @@
 	colors="true"
 	controlGarbageCollector="true"
 	displayDetailsOnIncompleteTests="true"
-	displayDetailsOnSkippedTests="false"
+	displayDetailsOnSkippedTests="true"
 	displayDetailsOnTestsThatTriggerDeprecations="true"
 	displayDetailsOnTestsThatTriggerErrors="true"
 	displayDetailsOnTestsThatTriggerNotices="true"
@@ -18,6 +18,7 @@
 	failOnIncomplete="true"
 	failOnNotice="true"
 	failOnRisky="true"
+	failOnSkipped="true"
 	failOnWarning="true"
 	stderr="true"
 >

--- a/phpunit.ci.xml
+++ b/phpunit.ci.xml
@@ -17,6 +17,7 @@
 	failOnEmptyTestSuite="true"
 	failOnIncomplete="true"
 	failOnNotice="true"
+	failOnPhpunitDeprecation="true"
 	failOnRisky="true"
 	failOnSkipped="true"
 	failOnWarning="true"

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+	beStrictAboutOutputDuringTests="true"
+	bootstrap="tests/bootstrap.php"
+	cacheDirectory=".phpunit.cache"
+	colors="true"
+	controlGarbageCollector="true"
+	displayDetailsOnIncompleteTests="true"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
+	displayDetailsOnTestsThatTriggerErrors="true"
+	displayDetailsOnTestsThatTriggerNotices="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
+	failOnDeprecation="true"
+	failOnEmptyTestSuite="true"
+	failOnIncomplete="true"
+	failOnNotice="true"
+	failOnRisky="true"
+	failOnWarning="true"
+	stderr="true"
+>
+	<source>
+		<include>
+			<directory>./config</directory>
+			<directory>./src</directory>
+		</include>
+
+		<exclude>
+			<directory suffix=".php">./config/areas/lab</directory>
+			<directory suffix=".php">./config/blocks</directory>
+			<directory suffix=".php">./config/templates</directory>
+			<file>./config/api/routes/changes.php</file>
+			<file>./config/areas/account/buttons.php</file>
+			<file>./config/areas/files/buttons.php</file>
+			<file>./config/areas/languages/buttons.php</file>
+			<file>./config/areas/site/buttons.php</file>
+			<file>./config/areas/users/buttons.php</file>
+			<file>./config/aliases.php</file>
+			<file>./config/setup.php</file>
+			<file>./config/areas/files/requests.php</file>
+			<file>./config/areas/site/requests.php</file>
+		</exclude>
+	</source>
+
+	<testsuites>
+		<testsuite name="Classes">
+			<directory>./tests/</directory>
+		</testsuite>
+	</testsuites>
+
+	<php>
+		<ini name="memory_limit" value="2048M" />
+	</php>
+
+	<coverage ignoreDeprecatedCodeUnits="true" />
+
+	<extensions>
+		<bootstrap class="Kirby\PhpUnitExtension"/>
+	</extensions>
+</phpunit>


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

- Separate PHPUnit configs for local development (`phpunit.dist.xml`, used automatically) and CI (`phpunit.ci.xml`, used with CLI option)
- In addition it is possible to create a local `phpunit.xml` that overrides the `phpunit.dist.xml` if it exists.
- Rename default PHPUnit conf from `phpunit.xml.dist` to `phpunit.dist.xml` for consistency with the CI one (PHPUnit accepts either)
- Make PHPUnit fail on all issues in CI

### Reasoning

- Local development and CI have different requirements, so IMO at this point it makes sense to differentiate the configs (advantage: allows additional customization, disadvantage: we need to make changes to both files, but we don't do that often)

### Additional context

There are options `displayDetailsOnAllIssues` and `failOnAllIssues` in the docs, but when used, PHPUnit marks them as invalid. :(

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass
