### PR TITLE
test: Use PHPUnit attributes for `Kirby\Plugin`

### DIFF
--- a/tests/Plugin/AssetTest.php
+++ b/tests/Plugin/AssetTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Plugin;
 
 use Kirby\Cms\TestCase;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Plugin\Asset
- */
+#[CoversClass(Asset::class)]
 class AssetTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/plugin-assets';
@@ -28,10 +27,7 @@ class AssetTest extends TestCase
 		touch(static::TMP . '/test-plugin/assets/test.css', 1337000000);
 	}
 
-	/**
-	 * @covers ::extension
-	 */
-	public function testExtension()
+	public function testExtension(): void
 	{
 		$asset = new Asset(
 			'test.css',
@@ -42,10 +38,7 @@ class AssetTest extends TestCase
 		$this->assertSame('css', $asset->extension());
 	}
 
-	/**
-	 * @covers ::filename
-	 */
-	public function testFilename()
+	public function testFilename(): void
 	{
 		$asset = new Asset(
 			'test.css',
@@ -56,14 +49,7 @@ class AssetTest extends TestCase
 		$this->assertSame('test.css', $asset->filename());
 	}
 
-	/**
-	 * @covers ::mediaHash
-	 * @covers ::mediaRoot
-	 * @covers ::mediaUrl
-	 * @covers ::url
-	 * @covers ::__toString
-	 */
-	public function testMedia()
+	public function testMedia(): void
 	{
 		$asset = new Asset(
 			'test.css',
@@ -78,10 +64,7 @@ class AssetTest extends TestCase
 		$this->assertSame($url, (string)$asset);
 	}
 
-	/**
-	 * @covers ::modified
-	 */
-	public function testModified()
+	public function testModified(): void
 	{
 		$asset = new Asset(
 			'test.css',
@@ -92,13 +75,7 @@ class AssetTest extends TestCase
 		$this->assertSame(1337000000, $asset->modified());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::path
-	 * @covers ::plugin
-	 * @covers ::root
-	 */
-	public function testPathRoot()
+	public function testPathRoot(): void
 	{
 		$asset = new Asset(
 			$path = 'test.css',
@@ -111,10 +88,7 @@ class AssetTest extends TestCase
 		$this->assertSame($root, $asset->root());
 	}
 
-	/**
-	 * @covers ::publish
-	 */
-	public function testPublish()
+	public function testPublish(): void
 	{
 		$asset = new Asset(
 			'test.css',

--- a/tests/Plugin/AssetsTest.php
+++ b/tests/Plugin/AssetsTest.php
@@ -6,10 +6,9 @@ use Kirby\Cms\App;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Plugin\Assets
- */
+#[CoversClass(Assets::class)]
 class AssetsTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/plugin-assets';
@@ -41,10 +40,7 @@ class AssetsTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::clean
-	 */
-	public function testClean()
+	public function testClean(): void
 	{
 		// create orphans
 		F::write(
@@ -65,11 +61,7 @@ class AssetsTest extends TestCase
 		$this->assertFileDoesNotExist($b);
 	}
 
-	/**
-	 * @covers ::css
-	 * @covers ::js
-	 */
-	public function testCss()
+	public function testCss(): void
 	{
 		// assets defined in plugin config
 		$plugin = new Plugin('getkirby/test-plugin', [
@@ -88,10 +80,7 @@ class AssetsTest extends TestCase
 		$this->assertSame('test.js', $assets->js()->first()->path());
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		// assets defined in plugin config
 		$plugin = new Plugin('getkirby/test-plugin', [
@@ -149,10 +138,7 @@ class AssetsTest extends TestCase
 		$this->assertSame(static::FIXTURES . '/assets/test.css', $assets->get('test.css')->root());
 	}
 
-	/**
-	 * @covers ::plugin
-	 */
-	public function testPlugin()
+	public function testPlugin(): void
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
 			'root' => static::FIXTURES
@@ -162,10 +148,7 @@ class AssetsTest extends TestCase
 		$this->assertSame($plugin, $assets->plugin());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolve()
+	public function testResolve(): void
 	{
 		touch(static::TMP . '/site/plugins/b/foo/bar.css', 1337000000);
 
@@ -219,7 +202,7 @@ class AssetsTest extends TestCase
 		$this->assertSame('text/css', $response->type());
 	}
 
-	public function testResolveAutomaticFromAssetsFolder()
+	public function testResolveAutomaticFromAssetsFolder(): void
 	{
 		touch(static::TMP . '/site/plugins/a/assets/test.css', 1337000000);
 
@@ -245,7 +228,7 @@ class AssetsTest extends TestCase
 		$this->assertFalse(is_link($media));
 	}
 
-	public function testAppCallInvalid()
+	public function testAppCallInvalid(): void
 	{
 		$response = App::instance()->call('media/plugins/test/test/test.invalid');
 		$this->assertNull($response);

--- a/tests/Plugin/LicenseStatusTest.php
+++ b/tests/Plugin/LicenseStatusTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Plugin;
 
 use Kirby\Cms\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Plugin\LicenseStatus
- */
+#[CoversClass(LicenseStatus::class)]
 class LicenseStatusTest extends TestCase
 {
 	public function test__toString(): void
@@ -33,9 +32,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame('active', $status->value());
 	}
 
-	/**
-	 * @covers ::dialog
-	 */
 	public function testDialog(): void
 	{
 		$status = new LicenseStatus(
@@ -48,9 +44,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame($dialog, $status->dialog());
 	}
 
-	/**
-	 * @covers ::drawer
-	 */
 	public function testDrawer(): void
 	{
 		$status = new LicenseStatus(
@@ -63,9 +56,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame($drawer, $status->drawer());
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFromInstance(): void
 	{
 		$status = LicenseStatus::from(new LicenseStatus(
@@ -78,9 +68,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame('active', $status->value());
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFromNull(): void
 	{
 		$status = LicenseStatus::from(null);
@@ -89,9 +76,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame('unknown', $status->value());
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFromString(): void
 	{
 		$status = LicenseStatus::from('active');
@@ -114,9 +98,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame('unknown', $status->value());
 	}
 
-	/**
-	 * @covers ::icon
-	 */
 	public function testIcon(): void
 	{
 		$status = new LicenseStatus(
@@ -128,9 +109,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame('check', $status->icon());
 	}
 
-	/**
-	 * @covers ::label
-	 */
 	public function testLabel(): void
 	{
 		$status = new LicenseStatus(
@@ -142,9 +120,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame('Valid license', $status->label());
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLink(): void
 	{
 		$status = new LicenseStatus(
@@ -157,9 +132,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame($url, $status->link());
 	}
 
-	/**
-	 * @covers ::theme
-	 */
 	public function testTheme(): void
 	{
 		$status = new LicenseStatus(
@@ -172,9 +144,6 @@ class LicenseStatusTest extends TestCase
 		$this->assertSame('success', $status->theme());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray(): void
 	{
 		$status = new LicenseStatus(
@@ -194,9 +163,6 @@ class LicenseStatusTest extends TestCase
 		], $status->toArray());
 	}
 
-	/**
-	 * @covers ::value
-	 */
 	public function testValue(): void
 	{
 		$status = new LicenseStatus(

--- a/tests/Plugin/LicenseTest.php
+++ b/tests/Plugin/LicenseTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Plugin;
 
 use Kirby\Cms\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Plugin\License
- */
+#[CoversClass(License::class)]
 class LicenseTest extends TestCase
 {
 	protected function plugin(): Plugin
@@ -16,9 +15,6 @@ class LicenseTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
 	public function test__toString(): void
 	{
 		$license = new License(
@@ -29,9 +25,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('Custom license', (string)$license);
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFromArray(): void
 	{
 		$license = License::from($this->plugin(), [
@@ -44,9 +37,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('missing', $license->status()->value());
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFromClosure(): void
 	{
 		$license = License::from($this->plugin(), function ($plugin) {
@@ -61,9 +51,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('active', $license->status()->value());
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFromString(): void
 	{
 		$license = License::from($this->plugin(), 'Custom license');
@@ -71,9 +58,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('active', $license->status()->value());
 	}
 
-	/**
-	 * @covers ::from
-	 */
 	public function testFromNull(): void
 	{
 		$license = License::from($this->plugin(), null);
@@ -81,9 +65,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('unknown', $license->status()->value());
 	}
 
-	/**
-	 * @covers ::link
-	 */
 	public function testLink(): void
 	{
 		$license = new License(
@@ -95,9 +76,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('https://getkirby.com', $license->link());
 	}
 
-	/**
-	 * @covers ::name
-	 */
 	public function testName(): void
 	{
 		$license = new License(
@@ -108,9 +86,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('Custom license', $license->name());
 	}
 
-	/**
-	 * @covers ::status
-	 */
 	public function testStatus(): void
 	{
 		$license = new License(
@@ -123,9 +98,6 @@ class LicenseTest extends TestCase
 		$this->assertSame('missing', $license->status()->value());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
 	public function testToArray(): void
 	{
 		$license = new License(

--- a/tests/Plugin/PluginTest.php
+++ b/tests/Plugin/PluginTest.php
@@ -8,11 +8,9 @@ use Kirby\Cms\System\UpdateStatus;
 use Kirby\Cms\TestCase;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Plugin\Plugin
- * @covers ::__construct
- */
+#[CoversClass(Plugin::class)]
 class PluginTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -56,10 +54,7 @@ class PluginTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::__call
-	 */
-	public function test__call()
+	public function test__call(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -69,10 +64,7 @@ class PluginTest extends TestCase
 		$this->assertSame('https://getkirby.com', $plugin->homepage());
 	}
 
-	/**
-	 * @covers ::asset
-	 */
-	public function testAsset()
+	public function testAsset(): void
 	{
 		$root   = static::FIXTURES . '/plugin-assets';
 		$plugin = new Plugin(
@@ -89,10 +81,7 @@ class PluginTest extends TestCase
 		$this->assertSame($b, $plugin->asset('d.css')->root());
 	}
 
-	/**
-	 * @covers ::assets
-	 */
-	public function testAssets()
+	public function testAssets(): void
 	{
 		$root = static::FIXTURES . '/plugin-assets';
 
@@ -111,10 +100,7 @@ class PluginTest extends TestCase
 		$this->assertSame($root . '/a.css', $plugin->asset('c.css')->root());
 	}
 
-	/**
-	 * @covers ::authors
-	 */
-	public function testAuthors()
+	public function testAuthors(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -135,10 +121,7 @@ class PluginTest extends TestCase
 		$this->assertSame($authors, $plugin->authors());
 	}
 
-	/**
-	 * @covers ::authorsNames
-	 */
-	public function testAuthorsNames()
+	public function testAuthorsNames(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -148,10 +131,7 @@ class PluginTest extends TestCase
 		$this->assertSame('A, B', $plugin->authorsNames());
 	}
 
-	/**
-	 * @covers ::extends
-	 */
-	public function testExtends()
+	public function testExtends(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -165,19 +145,13 @@ class PluginTest extends TestCase
 		$this->assertSame($extends, $plugin->extends());
 	}
 
-	/**
-	 * @covers ::id
-	 */
-	public function testId()
+	public function testId(): void
 	{
 		$plugin = new Plugin($id = 'abc-1234/DEF-56789');
 		$this->assertSame($id, $plugin->id());
 	}
 
-	/**
-	 * @covers ::info
-	 */
-	public function testInfo()
+	public function testInfo(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -203,10 +177,7 @@ class PluginTest extends TestCase
 		$this->assertSame($authors, $plugin->info()['authors']);
 	}
 
-	/**
-	 * @covers ::info
-	 */
-	public function testInfoFromProps()
+	public function testInfoFromProps(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -229,10 +200,7 @@ class PluginTest extends TestCase
 		$this->assertSame('A, B', $plugin->authorsNames());
 	}
 
-	/**
-	 * @covers ::info
-	 */
-	public function testInfoFromPropAndManifest()
+	public function testInfoFromPropAndManifest(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -248,10 +216,7 @@ class PluginTest extends TestCase
 		$this->assertSame('5.3.0', $plugin->version());
 	}
 
-	/**
-	 * @covers ::info
-	 */
-	public function testInfoWhenEmpty()
+	public function testInfoWhenEmpty(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -274,10 +239,7 @@ class PluginTest extends TestCase
 		$this->assertSame('mit', $plugin->license()->name());
 	}
 
-	/**
-	 * @covers ::link
-	 */
-	public function testLinkFromHomepage()
+	public function testLinkFromHomepage(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -289,10 +251,7 @@ class PluginTest extends TestCase
 		$this->assertSame('https://getkirby.com', $plugin->link());
 	}
 
-	/**
-	 * @covers ::link
-	 */
-	public function testLinkFromInvalidHomepage()
+	public function testLinkFromInvalidHomepage(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -304,10 +263,7 @@ class PluginTest extends TestCase
 		$this->assertNull($plugin->link());
 	}
 
-	/**
-	 * @covers ::link
-	 */
-	public function testLinkFromSupportDocs()
+	public function testLinkFromSupportDocs(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -321,10 +277,7 @@ class PluginTest extends TestCase
 		$this->assertSame('https://getkirby.com', $plugin->link());
 	}
 
-	/**
-	 * @covers ::link
-	 */
-	public function testLinkFromSupportSource()
+	public function testLinkFromSupportSource(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -338,19 +291,13 @@ class PluginTest extends TestCase
 		$this->assertSame('https://getkirby.com', $plugin->link());
 	}
 
-	/**
-	 * @covers ::link
-	 */
-	public function testLinkWhenEmpty()
+	public function testLinkWhenEmpty(): void
 	{
 		$plugin = new Plugin('getkirby/test-plugin');
 		$this->assertNull($plugin->link());
 	}
 
-	/**
-	 * @covers ::mediaRoot
-	 */
-	public function testMediaRoot()
+	public function testMediaRoot(): void
 	{
 		$this->app->clone([
 			'roots' => [
@@ -363,10 +310,7 @@ class PluginTest extends TestCase
 		$this->assertSame($media . '/plugins/getkirby/test-plugin', $plugin->mediaRoot());
 	}
 
-	/**
-	 * @covers ::mediaUrl
-	 */
-	public function testMediaUrl()
+	public function testMediaUrl(): void
 	{
 		$this->app->clone([
 			'urls' => [
@@ -379,10 +323,7 @@ class PluginTest extends TestCase
 		$this->assertSame('/media/plugins/getkirby/test-plugin', $plugin->mediaUrl());
 	}
 
-	/**
-	 * @covers ::manifest
-	 */
-	public function testManifest()
+	public function testManifest(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -392,30 +333,19 @@ class PluginTest extends TestCase
 		$this->assertSame(__DIR__ . '/composer.json', $plugin->manifest());
 	}
 
-	/**
-	 * @covers ::name
-	 * @covers ::validateName
-	 */
-	public function testName()
+	public function testName(): void
 	{
 		$plugin = new Plugin($name = 'abc-1234/DEF-56789');
 		$this->assertSame($name, $plugin->name());
 	}
 
-	/**
-	 * @covers ::name
-	 * @covers ::validateName
-	 */
-	public function testNameWithInvalidInput()
+	public function testNameWithInvalidInput(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		new Plugin('äöü/!!!');
 	}
 
-	/**
-	 * @covers ::option
-	 */
-	public function testOption()
+	public function testOption(): void
 	{
 		App::plugin(
 			name: 'developer/plugin',
@@ -432,28 +362,19 @@ class PluginTest extends TestCase
 		$this->assertSame('bar', $app->option('developer.plugin.foo'));
 	}
 
-	/**
-	 * @covers ::prefix
-	 */
-	public function testPrefix()
+	public function testPrefix(): void
 	{
 		$plugin = new Plugin('getkirby/test-plugin');
 		$this->assertSame('getkirby.test-plugin', $plugin->prefix());
 	}
 
-	/**
-	 * @covers ::root
-	 */
-	public function testRoot()
+	public function testRoot(): void
 	{
 		$plugin = new Plugin('getkirby/test-plugin');
 		$this->assertSame(__DIR__, $plugin->root());
 	}
 
-	/**
-	 * @covers ::root
-	 */
-	public function testRootWithCustomSetup()
+	public function testRootWithCustomSetup(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -463,10 +384,7 @@ class PluginTest extends TestCase
 		$this->assertSame($custom, $plugin->root());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -501,10 +419,7 @@ class PluginTest extends TestCase
 		$this->assertSame($expected, $plugin->toArray());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatus()
+	public function testUpdateStatus(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/public',
@@ -524,10 +439,7 @@ class PluginTest extends TestCase
 		$this->assertSame('88888.8.8', $updateStatus->targetVersion());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatusWithPrefix()
+	public function testUpdateStatusWithPrefix(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/public',
@@ -547,10 +459,7 @@ class PluginTest extends TestCase
 		$this->assertSame('88888.8.8', $updateStatus->targetVersion());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatusWithoutVersion()
+	public function testUpdateStatusWithoutVersion(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/public',
@@ -572,10 +481,7 @@ class PluginTest extends TestCase
 		$this->assertSame([], $updateStatus->exceptionMessages());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatusUnknownPlugin()
+	public function testUpdateStatusUnknownPlugin(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/unknown',
@@ -600,10 +506,7 @@ class PluginTest extends TestCase
 		], $updateStatus->exceptionMessages());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatusDisabled1()
+	public function testUpdateStatusDisabled1(): void
 	{
 		$this->app->clone([
 			'options' => [
@@ -622,10 +525,7 @@ class PluginTest extends TestCase
 		$this->assertNull($updateStatus);
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatusDisabled2()
+	public function testUpdateStatusDisabled2(): void
 	{
 		$this->app->clone([
 			'options' => [
@@ -650,10 +550,7 @@ class PluginTest extends TestCase
 		$this->assertNull($updateStatus);
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatusDisabled3()
+	public function testUpdateStatusDisabled3(): void
 	{
 		$this->app->clone([
 			'options' => [
@@ -671,10 +568,7 @@ class PluginTest extends TestCase
 		$this->assertNull($updateStatus);
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatusDisabled4()
+	public function testUpdateStatusDisabled4(): void
 	{
 		// the plugin update check does not support the
 		// security mode yet because the hub is missing
@@ -696,10 +590,7 @@ class PluginTest extends TestCase
 		$this->assertNull($updateStatus);
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatusNoCustomConfig()
+	public function testUpdateStatusNoCustomConfig(): void
 	{
 		$this->app->clone([
 			'options' => [
@@ -729,10 +620,7 @@ class PluginTest extends TestCase
 		$this->assertSame('88888.8.8', $updateStatus->targetVersion());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatusCustomData()
+	public function testUpdateStatusCustomData(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/public',
@@ -768,10 +656,7 @@ class PluginTest extends TestCase
 		$this->assertSame('https://other-domain.com/releases/87654', $updateStatus->url());
 	}
 
-	/**
-	 * @covers ::version
-	 */
-	public function testVersion()
+	public function testVersion(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -781,10 +666,7 @@ class PluginTest extends TestCase
 		$this->assertSame('1.0.0', $plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
-	public function testVersionFromArgument()
+	public function testVersionFromArgument(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -795,10 +677,7 @@ class PluginTest extends TestCase
 		$this->assertSame('1.2.0', $plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
-	public function testVersionFromInfo()
+	public function testVersionFromInfo(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -811,10 +690,7 @@ class PluginTest extends TestCase
 		$this->assertSame('1.1.0', $plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
-	public function testVersionMissing()
+	public function testVersionMissing(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -824,10 +700,7 @@ class PluginTest extends TestCase
 		$this->assertNull($plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
-	public function testVersionPrefixed()
+	public function testVersionPrefixed(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -837,10 +710,7 @@ class PluginTest extends TestCase
 		$this->assertSame('1.0.0', $plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
-	public function testVersionInvalid()
+	public function testVersionInvalid(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -850,10 +720,7 @@ class PluginTest extends TestCase
 		$this->assertNull($plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
-	public function testVersionComposer()
+	public function testVersionComposer(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin-composer',
@@ -863,10 +730,7 @@ class PluginTest extends TestCase
 		$this->assertSame('5.2.3', $plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
-	public function testVersionComposerNoVersionSet()
+	public function testVersionComposerNoVersionSet(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin',
@@ -876,10 +740,7 @@ class PluginTest extends TestCase
 		$this->assertNull($plugin->version());
 	}
 
-	/**
-	 * @covers ::version
-	 */
-	public function testVersionComposerOverride()
+	public function testVersionComposerOverride(): void
 	{
 		$plugin = new Plugin(
 			name: 'getkirby/test-plugin-composer',


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Use `CoversClass` and `DataProvider` PHPUnit PHP attributes instead of DocBlock annotations in the `Kirby\Plugin` package


### Reasoning
Switching over package by package (or smaller units) to see how the code coverage is affected.

### Additional context
Put this for the 5.1.0 milestone to not further add to the list of the 5.0.0 milestone as we want to close this very soon.

The changes were created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withPaths([
		__DIR__ . '/tests/Plugin',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	])
	->withImportNames();
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass