### PR TITLE
test: Use PHPUnit attributes for `Kirby\Sane`

### DIFF
--- a/tests/Sane/DomHandlerTest.php
+++ b/tests/Sane/DomHandlerTest.php
@@ -3,17 +3,16 @@
 namespace Kirby\Sane;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @covers \Kirby\Sane\DomHandler
- */
+#[CoversClass(DomHandler::class)]
 class DomHandlerTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Sane.DomHandler';
 
 	protected static string $type = 'sane';
 
-	public function testSanitize()
+	public function testSanitize(): void
 	{
 		$fixture = '<xml><test attr="value">Hello world</test></xml>';
 		$this->assertSame($fixture, DomHandler::sanitize($fixture));
@@ -31,13 +30,13 @@ class DomHandlerTest extends TestCase
 		$this->assertSame('<xml><a>Very malicious</a></xml>', DomHandler::sanitize($string, isExternal: true));
 	}
 
-	public function testValidate()
+	public function testValidate(): void
 	{
 		$this->assertNull(DomHandler::validate('<!DOCTYPE xml><xml><test attr="value">Hello world</test></xml>'));
 		$this->assertNull(DomHandler::validate('<xml><a xlink:href="/another-folder">Very malicious</a></xml>'));
 	}
 
-	public function testValidateException1()
+	public function testValidateException1(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The URL is not allowed in attribute "href" (line 2): Unknown URL type');
@@ -45,7 +44,7 @@ class DomHandlerTest extends TestCase
 		DomHandler::validate("<xml>\n<a href='javascript:alert(1)'></a>\n</xml>");
 	}
 
-	public function testValidateException2()
+	public function testValidateException2(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The doctype must not reference external files');
@@ -53,7 +52,7 @@ class DomHandlerTest extends TestCase
 		DomHandler::validate("<!DOCTYPE xml SYSTEM \"https://malicious.com/something.dtd\">\n<xml>\n<a href='javascript:alert(1)'></a>\n</xml>");
 	}
 
-	public function testValidateException3()
+	public function testValidateException3(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The URL points outside of the site index URL');

--- a/tests/Sane/HandlerTest.php
+++ b/tests/Sane/HandlerTest.php
@@ -4,21 +4,16 @@ namespace Kirby\Sane;
 
 use Exception;
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Sane\Handler
- */
+#[CoversClass(Handler::class)]
 class HandlerTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Sane.Handler';
 
 	protected static string $type = 'sane';
 
-	/**
-	 * @covers ::sanitizeFile
-	 * @covers ::readFile
-	 */
-	public function testSanitizeFile()
+	public function testSanitizeFile(): void
 	{
 		$expected = $this->fixture('doctype-valid.svg');
 		$tmp      = $this->fixture('doctype-valid.svg', true);
@@ -42,11 +37,7 @@ class HandlerTest extends TestCase
 		$this->assertFileEquals($expected, $tmp);
 	}
 
-	/**
-	 * @covers ::sanitizeFile
-	 * @covers ::readFile
-	 */
-	public function testSanitizeFileMissing()
+	public function testSanitizeFileMissing(): void
 	{
 		$file = $this->fixture('does-not-exist.svg');
 
@@ -56,22 +47,14 @@ class HandlerTest extends TestCase
 		CustomHandler::sanitizeFile($file);
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::readFile
-	 */
-	public function testValidateFile()
+	public function testValidateFile(): void
 	{
 		$this->assertNull(
 			CustomHandler::validateFile($this->fixture('doctype-valid.svg'))
 		);
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::readFile
-	 */
-	public function testValidateFileError()
+	public function testValidateFileError(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The URL is not allowed in attribute "style"');
@@ -79,11 +62,7 @@ class HandlerTest extends TestCase
 		CustomHandler::validateFile($this->fixture('external-source-1.svg'));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::readFile
-	 */
-	public function testValidateFileErrorExternalFile()
+	public function testValidateFileErrorExternalFile(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The URL points outside of the site index URL');
@@ -91,11 +70,7 @@ class HandlerTest extends TestCase
 		CustomHandler::validateFile($this->fixture('xlink-subfolder.svg'));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::readFile
-	 */
-	public function testValidateFileMissing()
+	public function testValidateFileMissing(): void
 	{
 		$file = $this->fixture('does-not-exist.svg');
 

--- a/tests/Sane/HtmlTest.php
+++ b/tests/Sane/HtmlTest.php
@@ -3,21 +3,21 @@
 namespace Kirby\Sane;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * @covers \Kirby\Sane\Html
  * @todo Add more tests from DOMPurify and the other test classes
  */
+#[CoversClass(Html::class)]
 class HtmlTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Sane.Html';
 
 	protected static string $type = 'html';
 
-	/**
-	 * @dataProvider allowedProvider
-	 */
-	public function testAllowed(string $file)
+	#[DataProvider('allowedProvider')]
+	public function testAllowed(string $file): void
 	{
 		$fixture = $this->fixture($file);
 
@@ -27,18 +27,21 @@ class HtmlTest extends TestCase
 		$this->assertStringEqualsFile($fixture, $sanitized);
 	}
 
-	public static function allowedProvider()
+	public static function allowedProvider(): array
 	{
 		return static::fixtureList('allowed', 'html');
 	}
 
-	public function testDisallowedExternalFile()
+	public function testDisallowedExternalFile(): void
 	{
 		$fixture   = $this->fixture('disallowed/link-subfolder.html');
 		$sanitized = $this->fixture('sanitized/link-subfolder.html');
 
-		$this->assertStringEqualsFile($fixture, Html::sanitize(file_get_contents($fixture)));
-		$this->assertStringEqualsFile($sanitized, Html::sanitize(file_get_contents($fixture), isExternal: true));
+		$html = Html::sanitize(file_get_contents($fixture));
+		$this->assertStringEqualsFile($fixture, $html);
+
+		$html = Html::sanitize(file_get_contents($fixture), isExternal: true);
+		$this->assertStringEqualsFile($sanitized, $html);
 
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The URL points outside of the site index URL');

--- a/tests/Sane/SaneTest.php
+++ b/tests/Sane/SaneTest.php
@@ -6,38 +6,28 @@ use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Sane\Sane
- */
+#[CoversClass(Sane::class)]
 class SaneTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Sane.Sane';
 
 	protected static string $type = 'sane';
 
-	/**
-	 * @covers ::handler
-	 */
-	public function testCustomAlias()
+	public function testCustomAlias(): void
 	{
 		Sane::$aliases['scalable'] = 'svg';
 		$this->assertInstanceOf(Svg::class, Sane::handler('scalable'));
 	}
 
-	/**
-	 * @covers ::handler
-	 */
-	public function testCustomHandler()
+	public function testCustomHandler(): void
 	{
 		Sane::$handlers['test'] = CustomHandler::class;
 		$this->assertInstanceOf(CustomHandler::class, Sane::handler('test'));
 	}
 
-	/**
-	 * @covers ::handler
-	 */
-	public function testDefaultHandlers()
+	public function testDefaultHandlers(): void
 	{
 		$this->assertInstanceOf(Html::class, Sane::handler('html'));
 		$this->assertInstanceOf(Svg::class, Sane::handler('svg'));
@@ -54,10 +44,7 @@ class SaneTest extends TestCase
 		$this->assertInstanceOf(Svg::class, Sane::handler('svG', true));
 	}
 
-	/**
-	 * @covers ::handler
-	 */
-	public function testDefaultAliases()
+	public function testDefaultAliases(): void
 	{
 		$this->assertInstanceOf(Html::class, Sane::handler('text/html'));
 		$this->assertInstanceOf(Svg::class, Sane::handler('image/svg+xml'));
@@ -65,10 +52,7 @@ class SaneTest extends TestCase
 		$this->assertInstanceOf(Xml::class, Sane::handler('text/xml'));
 	}
 
-	/**
-	 * @covers ::handler
-	 */
-	public function testMissingHandler()
+	public function testMissingHandler(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Missing handler for type: "foo"');
@@ -76,18 +60,12 @@ class SaneTest extends TestCase
 		Sane::handler('foo');
 	}
 
-	/**
-	 * @covers ::handler
-	 */
-	public function testMissingHandlerLazy()
+	public function testMissingHandlerLazy(): void
 	{
 		$this->assertNull(Sane::handler('foo', true));
 	}
 
-	/**
-	 * @covers ::sanitize
-	 */
-	public function testSanitize()
+	public function testSanitize(): void
 	{
 		$this->assertSame('<svg><path d="123"/></svg>', Sane::sanitize('<svg><path d="123" onclick="alert(1)"></path></svg>', 'svg'));
 
@@ -96,11 +74,7 @@ class SaneTest extends TestCase
 		$this->assertSame('<svg><a>Very malicious</a></svg>', Sane::sanitize($string, 'svg', isExternal: true));
 	}
 
-	/**
-	 * @covers ::sanitizeFile
-	 * @covers ::handlersForFile
-	 */
-	public function testSanitizeFile()
+	public function testSanitizeFile(): void
 	{
 		$expected = $this->fixture('doctype-valid.svg');
 		$tmp      = $this->fixture('doctype-valid.svg', true);
@@ -124,10 +98,7 @@ class SaneTest extends TestCase
 		$this->assertFileEquals($expected, $tmp);
 	}
 
-	/**
-	 * @covers ::sanitizeFile
-	 */
-	public function testSanitizeFileExplicitHandler()
+	public function testSanitizeFileExplicitHandler(): void
 	{
 		$expected = $this->fixture('doctype-valid.svg');
 		$tmp      = $this->fixture('doctype-valid.svg', true);
@@ -144,22 +115,14 @@ class SaneTest extends TestCase
 		$this->assertFileEquals($expected, $tmp);
 	}
 
-	/**
-	 * @covers ::sanitizeFile
-	 * @covers ::handlersForFile
-	 */
-	public function testSanitizeFileLazyHandler()
+	public function testSanitizeFileLazyHandler(): void
 	{
 		$this->assertNull(
 			Sane::sanitizeFile($this->fixture('unknown.xyz'), true)
 		);
 	}
 
-	/**
-	 * @covers ::sanitizeFile
-	 * @covers ::handlersForFile
-	 */
-	public function testSanitizeFileMultipleHandlers()
+	public function testSanitizeFileMultipleHandlers(): void
 	{
 		$fixture = $this->fixture('script-2.xml', true);
 
@@ -169,10 +132,7 @@ class SaneTest extends TestCase
 		Sane::sanitizeFile($fixture);
 	}
 
-	/**
-	 * @covers ::sanitizeFile
-	 */
-	public function testSanitizeFileMultipleHandlersExplicit()
+	public function testSanitizeFileMultipleHandlersExplicit(): void
 	{
 		$expected = $this->fixture('script-2.sanitized.xml');
 		$tmp      = $this->fixture('script-2.xml', true);
@@ -181,18 +141,12 @@ class SaneTest extends TestCase
 		$this->assertFileEquals($expected, $tmp);
 	}
 
-	/**
-	 * @covers ::validate
-	 */
-	public function testValidate()
+	public function testValidate(): void
 	{
 		$this->assertNull(Sane::validate('<svg></svg>', 'svg'));
 	}
 
-	/**
-	 * @covers ::validate
-	 */
-	public function testValidateError()
+	public function testValidateError(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The file is not a SVG (got <html>)');
@@ -200,10 +154,7 @@ class SaneTest extends TestCase
 		Sane::validate('<html></html>', 'svg');
 	}
 
-	/**
-	 * @covers ::validate
-	 */
-	public function testValidateMissingHandler()
+	public function testValidateMissingHandler(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Missing handler for type: "foo"');
@@ -211,11 +162,7 @@ class SaneTest extends TestCase
 		Sane::validate('foo', 'foo');
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
-	public function testValidateFile()
+	public function testValidateFile(): void
 	{
 		$file = $this->fixture('doctype-valid.svg');
 
@@ -223,10 +170,7 @@ class SaneTest extends TestCase
 		$this->assertNull(Sane::validateFile($file, 'svg'));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 */
-	public function testValidateFileError()
+	public function testValidateFileError(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The URL is not allowed in attribute "style"');
@@ -234,10 +178,7 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('external-source-1.svg'), 'svg');
 	}
 
-	/**
-	 * @covers ::validateFile
-	 */
-	public function testValidateFileErrorExternalFile()
+	public function testValidateFileErrorExternalFile(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The URL points outside of the site index URL');
@@ -245,11 +186,7 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('xlink-subfolder.svg'));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
-	public function testValidateFileMime1()
+	public function testValidateFileMime1(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The "script" element (line 2) is not allowed');
@@ -257,11 +194,7 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('script-1.xml'));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
-	public function testValidateFileMime2()
+	public function testValidateFileMime2(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The namespace "http://www.w3.org/2000/svg" is not allowed (around line 1)');
@@ -269,20 +202,12 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('script-2.xml'));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
-	public function testValidateFileMime3()
+	public function testValidateFileMime3(): void
 	{
 		$this->assertNull(Sane::validateFile($this->fixture('compressed.svgz'), true));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
-	public function testValidateFileMime4()
+	public function testValidateFileMime4(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The doctype must not define a subset');
@@ -290,11 +215,7 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('doctype-entity-attack.svgz'), true);
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
-	public function testValidateFileMissing()
+	public function testValidateFileMissing(): void
 	{
 		$file = $this->fixture('does-not-exist.svg');
 
@@ -304,10 +225,7 @@ class SaneTest extends TestCase
 		Sane::validateFile($file);
 	}
 
-	/**
-	 * @covers ::validateFile
-	 */
-	public function testValidateFileMissingHandler1()
+	public function testValidateFileMissingHandler1(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Missing handler for type: "foo"');
@@ -315,11 +233,7 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('doctype-valid.svg'), 'foo');
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
-	public function testValidateFileMissingHandler2()
+	public function testValidateFileMissingHandler2(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Missing handler for type: "xyz"');
@@ -327,11 +241,7 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('unknown.xyz'));
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
-	public function testValidateFileMissingHandler3()
+	public function testValidateFileMissingHandler3(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Missing handler for type: "xyz"');
@@ -339,11 +249,7 @@ class SaneTest extends TestCase
 		Sane::validateFile($this->fixture('unknown.xyz'), false);
 	}
 
-	/**
-	 * @covers ::validateFile
-	 * @covers ::handlersForFile
-	 */
-	public function testValidateFileMissingHandler4()
+	public function testValidateFileMissingHandler4(): void
 	{
 		$this->assertNull(Sane::validateFile($this->fixture('unknown.xyz'), true));
 	}

--- a/tests/Sane/SvgTest.php
+++ b/tests/Sane/SvgTest.php
@@ -3,20 +3,18 @@
 namespace Kirby\Sane;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @covers \Kirby\Sane\Svg
- */
+#[CoversClass(Svg::class)]
 class SvgTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Sane.Svg';
 
 	protected static string $type = 'svg';
 
-	/**
-	 * @dataProvider allowedProvider
-	 */
-	public function testAllowed(string $file)
+	#[DataProvider('allowedProvider')]
+	public function testAllowed(string $file): void
 	{
 		$fixture = $this->fixture($file);
 		$cleaned = $this->fixture(str_replace('allowed', 'cleaned', $file));
@@ -27,12 +25,12 @@ class SvgTest extends TestCase
 		$this->assertStringEqualsFile(is_file($cleaned) ? $cleaned : $fixture, $sanitized);
 	}
 
-	public static function allowedProvider()
+	public static function allowedProvider(): array
 	{
 		return static::fixtureList('allowed', 'svg');
 	}
 
-	public function testAllowedAriaAttr()
+	public function testAllowedAriaAttr(): void
 	{
 		$fixture = '<svg><path aria-label="Test" /></svg>';
 		$cleaned = '<svg><path aria-label="Test"/></svg>';
@@ -41,7 +39,7 @@ class SvgTest extends TestCase
 		$this->assertSame($cleaned, Svg::sanitize($fixture));
 	}
 
-	public function testAllowedAriaData()
+	public function testAllowedAriaData(): void
 	{
 		$fixture = '<svg><path data-color="test" /></svg>';
 		$cleaned = '<svg><path data-color="test"/></svg>';
@@ -50,10 +48,8 @@ class SvgTest extends TestCase
 		$this->assertSame($cleaned, Svg::sanitize($fixture));
 	}
 
-	/**
-	 * @dataProvider invalidProvider
-	 */
-	public function testInvalid(string $file)
+	#[DataProvider('invalidProvider')]
+	public function testInvalid(string $file): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The markup could not be parsed');
@@ -61,12 +57,12 @@ class SvgTest extends TestCase
 		Svg::validateFile($this->fixture($file));
 	}
 
-	public static function invalidProvider()
+	public static function invalidProvider(): array
 	{
 		return static::fixtureList('invalid', 'svg');
 	}
 
-	public function testDisallowedJavascriptUrl()
+	public function testDisallowedJavascriptUrl(): void
 	{
 		$fixture   = "<svg>\n<a href='javascript:alert(1)'><path /></a>\n</svg>";
 		$sanitized = "<svg>\n<a><path/></a>\n</svg>";
@@ -78,7 +74,7 @@ class SvgTest extends TestCase
 		Svg::validate($fixture);
 	}
 
-	public function testDisallowedJavascriptUrlWithUnicodeLS()
+	public function testDisallowedJavascriptUrlWithUnicodeLS(): void
 	{
 		/**
 		 * Test fixture inspired by DOMPurify
@@ -96,7 +92,7 @@ class SvgTest extends TestCase
 		Svg::validate($fixture);
 	}
 
-	public function testDisallowedXlinkAttack()
+	public function testDisallowedXlinkAttack(): void
 	{
 		$fixture   = $this->fixture('disallowed/xlink-attack.svg');
 		$sanitized = $this->fixture('sanitized/xlink-attack.svg');
@@ -108,7 +104,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedExternalFile()
+	public function testDisallowedExternalFile(): void
 	{
 		$fixture   = $this->fixture('disallowed/xlink-subfolder.svg');
 		$sanitized = $this->fixture('sanitized/xlink-subfolder.svg');
@@ -121,7 +117,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedExternalXmlns1()
+	public function testDisallowedExternalXmlns1(): void
 	{
 		$fixture   = $this->fixture('disallowed/external-xmlns-1.svg');
 		$sanitized = $this->fixture('sanitized/external-xmlns-1.svg');
@@ -133,7 +129,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedExternalXmlns2()
+	public function testDisallowedExternalXmlns2(): void
 	{
 		$fixture   = $this->fixture('disallowed/external-xmlns-2.svg');
 		$sanitized = $this->fixture('sanitized/external-xmlns-2.svg');
@@ -145,7 +141,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedDataUriSvg1()
+	public function testDisallowedDataUriSvg1(): void
 	{
 		$fixture   = $this->fixture('disallowed/data-uri-svg-1.svg');
 		$sanitized = $this->fixture('sanitized/data-uri-svg-1.svg');
@@ -157,7 +153,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedDataUriSvg2()
+	public function testDisallowedDataUriSvg2(): void
 	{
 		$fixture   = $this->fixture('disallowed/data-uri-svg-2.svg');
 		$sanitized = $this->fixture('sanitized/data-uri-svg-2.svg');
@@ -169,7 +165,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedExternalSource1()
+	public function testDisallowedExternalSource1(): void
 	{
 		$fixture   = $this->fixture('disallowed/external-source-1.svg');
 		$sanitized = $this->fixture('sanitized/external-source-1.svg');
@@ -181,7 +177,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedExternalSource2()
+	public function testDisallowedExternalSource2(): void
 	{
 		$fixture   = $this->fixture('disallowed/external-source-2.svg');
 		$sanitized = $this->fixture('sanitized/external-source-2.svg');
@@ -193,7 +189,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedOnclickAttr()
+	public function testDisallowedOnclickAttr(): void
 	{
 		$fixture   = "<svg>\n<path onclick='alert(1)' />\n</svg>";
 		$sanitized = "<svg>\n<path/>\n</svg>";
@@ -205,7 +201,7 @@ class SvgTest extends TestCase
 		Svg::validate($fixture);
 	}
 
-	public function testDisallowedOnloadAttr()
+	public function testDisallowedOnloadAttr(): void
 	{
 		$fixture   = '<svg onload="alert(1)"></svg>';
 		$sanitized = '<svg/>';
@@ -217,7 +213,7 @@ class SvgTest extends TestCase
 		Svg::validate($fixture);
 	}
 
-	public function testDisallowedUseAttack1()
+	public function testDisallowedUseAttack1(): void
 	{
 		$fixture   = $this->fixture('disallowed/use-attack-1.svg');
 		$sanitized = $this->fixture('sanitized/use-attack-1.svg');
@@ -229,7 +225,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedUseAttack2()
+	public function testDisallowedUseAttack2(): void
 	{
 		$fixture   = $this->fixture('disallowed/use-attack-2.svg');
 		$sanitized = $this->fixture('sanitized/use-attack-2.svg');
@@ -241,7 +237,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedUseAttack3()
+	public function testDisallowedUseAttack3(): void
 	{
 		$fixture   = $this->fixture('disallowed/use-attack-3.svg');
 		$sanitized = $this->fixture('sanitized/use-attack-3.svg');
@@ -253,7 +249,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedDoctypeExternal1()
+	public function testDisallowedDoctypeExternal1(): void
 	{
 		$fixture   = $this->fixture('disallowed/doctype-external-1.svg');
 		$sanitized = $this->fixture('sanitized/doctype-external-1.svg');
@@ -265,7 +261,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedDoctypeExternal2()
+	public function testDisallowedDoctypeExternal2(): void
 	{
 		$fixture   = $this->fixture('disallowed/doctype-external-2.svg');
 		$sanitized = $this->fixture('sanitized/doctype-external-2.svg');
@@ -277,7 +273,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedDoctypeEntityAttack()
+	public function testDisallowedDoctypeEntityAttack(): void
 	{
 		$fixture   = $this->fixture('disallowed/doctype-entity-attack.svg');
 		$sanitized = $this->fixture('sanitized/doctype-entity-attack.svg');
@@ -289,7 +285,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedDoctypeWrong()
+	public function testDisallowedDoctypeWrong(): void
 	{
 		$fixture   = $this->fixture('disallowed/doctype-wrong.svg');
 		$sanitized = $this->fixture('sanitized/doctype-wrong.svg');
@@ -301,7 +297,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedCaseSensitive()
+	public function testDisallowedCaseSensitive(): void
 	{
 		$fixture   = "<svg>\n<Text x='0' y='20'>Hello</Text>\n</svg>";
 		$sanitized = "<svg>\n\n</svg>";
@@ -313,7 +309,7 @@ class SvgTest extends TestCase
 		Svg::validate($fixture);
 	}
 
-	public function testDisallowedForeignobject()
+	public function testDisallowedForeignobject(): void
 	{
 		$fixture   = '<svg><foreignobject><iframe onload="alert(1)" /></foreignobject></svg>';
 		$sanitized = '<svg/>';
@@ -325,7 +321,7 @@ class SvgTest extends TestCase
 		Svg::validate($fixture);
 	}
 
-	public function testDisallowedSet()
+	public function testDisallowedSet(): void
 	{
 		$fixture   = $this->fixture('disallowed/set.svg');
 		$sanitized = $this->fixture('sanitized/set.svg');
@@ -337,7 +333,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedScript()
+	public function testDisallowedScript(): void
 	{
 		$fixture   = '<svg><script>alert(1)</script></svg>';
 		$sanitized = '<svg/>';
@@ -349,7 +345,7 @@ class SvgTest extends TestCase
 		Svg::validate($fixture);
 	}
 
-	public function testDisallowedBlockquote()
+	public function testDisallowedBlockquote(): void
 	{
 		$fixture   = '<svg><blockquote>SVGs are SVGs are SVGs</blockquote></svg>';
 		$sanitized = '<svg/>';
@@ -361,7 +357,7 @@ class SvgTest extends TestCase
 		Svg::validate($fixture);
 	}
 
-	public function testDisallowedStyleUrlExternal()
+	public function testDisallowedStyleUrlExternal(): void
 	{
 		$fixture   = $this->fixture('disallowed/style-url-external.svg');
 		$sanitized = $this->fixture('sanitized/style-url-external.svg');
@@ -373,7 +369,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testDisallowedStylesheet()
+	public function testDisallowedStylesheet(): void
 	{
 		$fixture   = $this->fixture('disallowed/stylesheet.svg');
 		$sanitized = $this->fixture('sanitized/stylesheet.svg');
@@ -385,7 +381,7 @@ class SvgTest extends TestCase
 		Svg::validateFile($fixture);
 	}
 
-	public function testParseNonSvg()
+	public function testParseNonSvg(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The file is not a SVG (got <html>)');

--- a/tests/Sane/SvgzTest.php
+++ b/tests/Sane/SvgzTest.php
@@ -3,20 +3,18 @@
 namespace Kirby\Sane;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @covers \Kirby\Sane\Svgz
- */
+#[CoversClass(Svgz::class)]
 class SvgzTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Sane.Svgz';
 
 	protected static string $type = 'svgz';
 
-	/**
-	 * @dataProvider allowedProvider
-	 */
-	public function testAllowed(string $file)
+	#[DataProvider('allowedProvider')]
+	public function testAllowed(string $file): void
 	{
 		$fixture = $this->fixture($file);
 
@@ -30,15 +28,13 @@ class SvgzTest extends TestCase
 		$this->assertSame(gzdecode($input), gzdecode($sanitized));
 	}
 
-	public static function allowedProvider()
+	public static function allowedProvider(): array
 	{
 		return static::fixtureList('allowed', 'svgz');
 	}
 
-	/**
-	 * @dataProvider invalidProvider
-	 */
-	public function testInvalid(string $file)
+	#[DataProvider('invalidProvider')]
+	public function testInvalid(string $file): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Could not uncompress gzip data');
@@ -46,12 +42,12 @@ class SvgzTest extends TestCase
 		Svgz::validateFile($this->fixture($file));
 	}
 
-	public static function invalidProvider()
+	public static function invalidProvider(): array
 	{
 		return static::fixtureList('invalid', 'svgz');
 	}
 
-	public function testDisallowedDoctypeEntityAttack()
+	public function testDisallowedDoctypeEntityAttack(): void
 	{
 		$fixture   = $this->fixture('disallowed/doctype-entity-attack.svgz');
 		$sanitized = $this->fixture('sanitized/doctype-entity-attack.svg');
@@ -63,7 +59,7 @@ class SvgzTest extends TestCase
 		Svgz::validateFile($fixture);
 	}
 
-	public function testDisallowedExternalFile()
+	public function testDisallowedExternalFile(): void
 	{
 		$fixture   = $this->fixture('disallowed/xlink-subfolder.svg');
 		$fixtureZ  = $this->fixture('disallowed/xlink-subfolder.svgz');

--- a/tests/Sane/XmlTest.php
+++ b/tests/Sane/XmlTest.php
@@ -3,10 +3,10 @@
 namespace Kirby\Sane;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @covers \Kirby\Sane\Xml
- */
+#[CoversClass(Xml::class)]
 class XmlTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Sane.Xml';
@@ -18,10 +18,8 @@ class XmlTest extends TestCase
 		Xml::$allowedDomains = true;
 	}
 
-	/**
-	 * @dataProvider allowedProvider
-	 */
-	public function testAllowed(string $file)
+	#[DataProvider('allowedProvider')]
+	public function testAllowed(string $file): void
 	{
 		$fixture = $this->fixture($file);
 
@@ -31,12 +29,12 @@ class XmlTest extends TestCase
 		$this->assertStringEqualsFile($fixture, $sanitized);
 	}
 
-	public static function allowedProvider()
+	public static function allowedProvider(): array
 	{
 		return static::fixtureList('allowed', 'xml');
 	}
 
-	public function testAllowedCustomDomainAllowlist()
+	public function testAllowedCustomDomainAllowlist(): void
 	{
 		Xml::$allowedDomains = ['getkirby.com'];
 
@@ -48,10 +46,8 @@ class XmlTest extends TestCase
 		$this->assertStringEqualsFile($fixture, $sanitized);
 	}
 
-	/**
-	 * @dataProvider invalidProvider
-	 */
-	public function testInvalid(string $file)
+	#[DataProvider('invalidProvider')]
+	public function testInvalid(string $file): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The markup could not be parsed');
@@ -59,12 +55,12 @@ class XmlTest extends TestCase
 		Xml::validateFile($this->fixture($file));
 	}
 
-	public static function invalidProvider()
+	public static function invalidProvider(): array
 	{
 		return static::fixtureList('invalid', 'xml');
 	}
 
-	public function testDisallowedJavascriptUrl()
+	public function testDisallowedJavascriptUrl(): void
 	{
 		$fixture   = "<xml>\n<a href='javascript:alert(1)'></a>\n</xml>";
 		$sanitized = "<xml>\n<a/>\n</xml>";
@@ -76,7 +72,7 @@ class XmlTest extends TestCase
 		Xml::validate($fixture);
 	}
 
-	public function testDisallowedJavascriptUrlWithUnicodeLS()
+	public function testDisallowedJavascriptUrlWithUnicodeLS(): void
 	{
 		/**
 		 * Test fixture inspired by DOMPurify
@@ -94,7 +90,7 @@ class XmlTest extends TestCase
 		Xml::validate($fixture);
 	}
 
-	public function testDisallowedXlinkAttack()
+	public function testDisallowedXlinkAttack(): void
 	{
 		$fixture   = $this->fixture('disallowed/xlink-attack.xml');
 		$sanitized = $this->fixture('sanitized/xlink-attack.xml');
@@ -106,7 +102,7 @@ class XmlTest extends TestCase
 		Xml::validateFile($fixture);
 	}
 
-	public function testDisallowedDataUriSvg1()
+	public function testDisallowedDataUriSvg1(): void
 	{
 		$fixture   = $this->fixture('disallowed/data-uri-svg-1.xml');
 		$sanitized = $this->fixture('sanitized/data-uri-svg-1.xml');
@@ -118,7 +114,7 @@ class XmlTest extends TestCase
 		Xml::validateFile($fixture);
 	}
 
-	public function testDisallowedDataUriSvg2()
+	public function testDisallowedDataUriSvg2(): void
 	{
 		$fixture   = $this->fixture('disallowed/data-uri-svg-2.xml');
 		$sanitized = $this->fixture('sanitized/data-uri-svg-2.xml');
@@ -130,7 +126,7 @@ class XmlTest extends TestCase
 		Xml::validateFile($fixture);
 	}
 
-	public function testDisallowedExternalFile()
+	public function testDisallowedExternalFile(): void
 	{
 		$fixture   = $this->fixture('disallowed/xlink-subfolder.xml');
 		$sanitized = $this->fixture('sanitized/xlink-subfolder.xml');
@@ -143,7 +139,7 @@ class XmlTest extends TestCase
 		Xml::validateFile($fixture);
 	}
 
-	public function testDisallowedExternalSource1()
+	public function testDisallowedExternalSource1(): void
 	{
 		$fixture    = $this->fixture('disallowed/external-source-1.xml');
 		$sanitized1 = $this->fixture('sanitized/external-source-1.xml');
@@ -164,7 +160,7 @@ class XmlTest extends TestCase
 		Xml::validateFile($fixture);
 	}
 
-	public function testDisallowedExternalSource2()
+	public function testDisallowedExternalSource2(): void
 	{
 		$fixture    = $this->fixture('disallowed/external-source-2.xml');
 		$sanitized1 = $this->fixture('sanitized/external-source-2.xml');
@@ -185,7 +181,7 @@ class XmlTest extends TestCase
 		Xml::validateFile($fixture);
 	}
 
-	public function testDisallowedNamespaceSvg()
+	public function testDisallowedNamespaceSvg(): void
 	{
 		$fixture   = $this->fixture('disallowed/namespace-svg.xml');
 		$sanitized = $this->fixture('sanitized/namespace-svg.xml');
@@ -197,7 +193,7 @@ class XmlTest extends TestCase
 		Xml::validateFile($fixture);
 	}
 
-	public function testDisallowedNamespaceXhtml1()
+	public function testDisallowedNamespaceXhtml1(): void
 	{
 		$fixture   = $this->fixture('disallowed/namespace-xhtml-1.xml');
 		$sanitized = $this->fixture('sanitized/namespace-xhtml-1.xml');
@@ -209,7 +205,7 @@ class XmlTest extends TestCase
 		Xml::validateFile($fixture);
 	}
 
-	public function testDisallowedNamespaceXhtml2()
+	public function testDisallowedNamespaceXhtml2(): void
 	{
 		$fixture   = $this->fixture('disallowed/namespace-xhtml-2.xml');
 		$sanitized = $this->fixture('sanitized/namespace-xhtml-2.xml');
@@ -221,7 +217,7 @@ class XmlTest extends TestCase
 		Xml::validateFile($fixture);
 	}
 
-	public function testDisallowedDoctypeExternal1()
+	public function testDisallowedDoctypeExternal1(): void
 	{
 		$fixture   = $this->fixture('disallowed/doctype-external-1.xml');
 		$sanitized = $this->fixture('sanitized/doctype-external-1.xml');
@@ -233,7 +229,7 @@ class XmlTest extends TestCase
 		Xml::validateFile($fixture);
 	}
 
-	public function testDisallowedDoctypeExternal2()
+	public function testDisallowedDoctypeExternal2(): void
 	{
 		$fixture   = $this->fixture('disallowed/doctype-external-2.xml');
 		$sanitized = $this->fixture('sanitized/doctype-external-2.xml');
@@ -245,7 +241,7 @@ class XmlTest extends TestCase
 		Xml::validateFile($fixture);
 	}
 
-	public function testDisallowedDoctypeEntityAttack()
+	public function testDisallowedDoctypeEntityAttack(): void
 	{
 		$fixture   = $this->fixture('disallowed/doctype-entity-attack.xml');
 		$sanitized = $this->fixture('sanitized/doctype-entity-attack.xml');
@@ -257,7 +253,7 @@ class XmlTest extends TestCase
 		Xml::validateFile($fixture);
 	}
 
-	public function testDisallowedDoctypeSvg()
+	public function testDisallowedDoctypeSvg(): void
 	{
 		$fixture   = $this->fixture('disallowed/doctype-svg.xml');
 		$sanitized = $this->fixture('sanitized/doctype-svg.xml');
@@ -269,7 +265,7 @@ class XmlTest extends TestCase
 		Xml::validateFile($fixture);
 	}
 
-	public function testDisallowedDoctypeXhtml()
+	public function testDisallowedDoctypeXhtml(): void
 	{
 		$fixture   = $this->fixture('disallowed/doctype-xhtml.xml');
 		$sanitized = $this->fixture('sanitized/doctype-xhtml.xml');
@@ -281,7 +277,7 @@ class XmlTest extends TestCase
 		Xml::validateFile($fixture);
 	}
 
-	public function testDisallowedStylesheet()
+	public function testDisallowedStylesheet(): void
 	{
 		$fixture   = $this->fixture('disallowed/stylesheet.xml');
 		$sanitized = $this->fixture('sanitized/stylesheet.xml');


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Use `CoversClass` and `DataProvider` PHPUnit PHP attributes instead of DocBlock annotations in the `Kirby\Sane` package


### Reasoning
Switching over package by package (or smaller units) to see how the code coverage is affected.

### Additional context
Put this for the 5.1.0 milestone to not further add to the list of the 5.0.0 milestone as we want to close this very soon.

The changes were created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withPaths([
		__DIR__ . '/tests/Sane',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	])
	->withImportNames();
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass