### PR TITLE
test: Use PHPUnit attributes for `Kirby\Data`

### DIFF
--- a/tests/Data/DataTest.php
+++ b/tests/Data/DataTest.php
@@ -6,18 +6,16 @@ use Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use stdClass;
 
-/**
- * @coversDefaultClass \Kirby\Data\Data
- */
+#[CoversClass(Data::class)]
 class DataTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Data.Data';
 
-	/**
-	 * @covers ::handler
-	 */
-	public function testDefaultHandlers()
+	public function testDefaultHandlers(): void
 	{
 		$this->assertInstanceOf(Json::class, Data::handler('json'));
 		$this->assertInstanceOf(PHP::class, Data::handler('php'));
@@ -36,28 +34,19 @@ class DataTest extends TestCase
 		$this->assertInstanceOf(Json::class, Data::handler('JsOn'));
 	}
 
-	/**
-	 * @covers ::handler
-	 */
-	public function testCustomHandler()
+	public function testCustomHandler(): void
 	{
 		Data::$handlers['test'] = CustomHandler::class;
 		$this->assertInstanceOf(CustomHandler::class, Data::handler('test'));
 	}
 
-	/**
-	 * @covers ::handler
-	 */
-	public function testCustomAlias()
+	public function testCustomAlias(): void
 	{
 		Data::$aliases['plaintext'] = 'txt';
 		$this->assertInstanceOf(Txt::class, Data::handler('plaintext'));
 	}
 
-	/**
-	 * @covers ::handler
-	 */
-	public function testMissingHandler()
+	public function testMissingHandler(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Missing handler for type: "foo"');
@@ -65,10 +54,7 @@ class DataTest extends TestCase
 		Data::handler('foo');
 	}
 
-	/**
-	 * @covers ::handler
-	 */
-	public function testInvalidHandler()
+	public function testInvalidHandler(): void
 	{
 		Data::$handlers['invalid'] = CustomInvalidHandler::class;
 
@@ -78,12 +64,8 @@ class DataTest extends TestCase
 		Data::handler('invalid');
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::decode
-	 * @dataProvider handlerProvider
-	 */
-	public function testEncodeDecode($handler)
+	#[DataProvider('handlerProvider')]
+	public function testEncodeDecode($handler): void
 	{
 		$data = [
 			'name'  => 'Homer Simpson',
@@ -96,11 +78,8 @@ class DataTest extends TestCase
 		$this->assertSame($data, $decoded);
 	}
 
-	/**
-	 * @covers ::decode
-	 * @dataProvider handlerProvider
-	 */
-	public function testDecodeInvalid1($handler)
+	#[DataProvider('handlerProvider')]
+	public function testDecodeInvalid1($handler): void
 	{
 		// decode invalid integer value
 		$this->expectException(InvalidArgumentException::class);
@@ -108,23 +87,17 @@ class DataTest extends TestCase
 		Data::decode(1, $handler);
 	}
 
-	/**
-	 * @covers ::decode
-	 * @dataProvider handlerProvider
-	 */
-	public function testDecodeInvalid2($handler)
+	#[DataProvider('handlerProvider')]
+	public function testDecodeInvalid2($handler): void
 	{
 		// decode invalid object value
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid ' . strtoupper($handler) . ' data; please pass a string');
-		Data::decode(new \stdClass(), $handler);
+		Data::decode(new stdClass(), $handler);
 	}
 
-	/**
-	 * @covers ::decode
-	 * @dataProvider handlerProvider
-	 */
-	public function testDecodeInvalid3($handler)
+	#[DataProvider('handlerProvider')]
+	public function testDecodeInvalid3($handler): void
 	{
 		// decode invalid boolean value
 		$this->expectException(InvalidArgumentException::class);
@@ -132,11 +105,8 @@ class DataTest extends TestCase
 		Data::decode(true, $handler);
 	}
 
-	/**
-	 * @covers ::decode
-	 * @dataProvider handlerProvider
-	 */
-	public function testDecodeInvalidNoExceptions($handler)
+	#[DataProvider('handlerProvider')]
+	public function testDecodeInvalidNoExceptions($handler): void
 	{
 		$data = Data::decode(1, $handler, fail: false);
 		$this->assertSame([], $data);
@@ -154,11 +124,7 @@ class DataTest extends TestCase
 		return array_map(fn ($handler) => [$handler], $handlers);
 	}
 
-	/**
-	 * @covers ::read
-	 * @covers ::write
-	 */
-	public function testReadWrite()
+	public function testReadWrite(): void
 	{
 		$data = [
 			'name'  => 'Homer Simpson',
@@ -184,11 +150,7 @@ class DataTest extends TestCase
 		$this->assertSame($data, $result);
 	}
 
-	/**
-	 * @covers ::read
-	 * @covers ::handler
-	 */
-	public function testReadInvalid()
+	public function testReadInvalid(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Missing handler for type: "foo"');
@@ -196,20 +158,13 @@ class DataTest extends TestCase
 		Data::read(static::TMP . '/data.foo');
 	}
 
-	/**
-	 * @covers ::read
-	 */
-	public function testReadInvalidNoException()
+	public function testReadInvalidNoException(): void
 	{
 		$data = Data::read(static::TMP . '/data.foo', fail: false);
 		$this->assertSame([], $data);
 	}
 
-	/**
-	 * @covers ::write
-	 * @covers ::handler
-	 */
-	public function testWriteInvalid()
+	public function testWriteInvalid(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Missing handler for type: "foo"');

--- a/tests/Data/HandlerTest.php
+++ b/tests/Data/HandlerTest.php
@@ -5,19 +5,14 @@ namespace Kirby\Data;
 use Exception;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Data\Handler
- */
+#[CoversClass(Handler::class)]
 class HandlerTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Data.Handler';
 
-	/**
-	 * @covers ::read
-	 * @covers ::write
-	 */
-	public function testReadWrite()
+	public function testReadWrite(): void
 	{
 		$data = [
 			'name'  => 'Homer Simpson',
@@ -34,10 +29,7 @@ class HandlerTest extends TestCase
 		$this->assertSame($data, $result);
 	}
 
-	/**
-	 * @covers ::read
-	 */
-	public function testReadFileMissing()
+	public function testReadFileMissing(): void
 	{
 		$file = static::TMP . '/does-not-exist.json';
 

--- a/tests/Data/JsonTest.php
+++ b/tests/Data/JsonTest.php
@@ -5,17 +5,13 @@ namespace Kirby\Data;
 use Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use stdClass;
 
-/**
- * @coversDefaultClass \Kirby\Data\Json
- */
+#[CoversClass(Json::class)]
 class JsonTest extends TestCase
 {
-	/**
-	 * @covers ::encode
-	 * @covers ::decode
-	 */
-	public function testEncodeDecode()
+	public function testEncodeDecode(): void
 	{
 		$array = [
 			'name'     => 'Homer',
@@ -35,21 +31,15 @@ class JsonTest extends TestCase
 		$this->assertSame(['this is' => 'an array'], Json::decode(['this is' => 'an array']));
 	}
 
-	/**
-	 * @covers ::decode
-	 */
-	public function testDecodeInvalid1()
+	public function testDecodeInvalid1(): void
 	{
 		// pass invalid object
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid JSON data; please pass a string');
-		Json::decode(new \stdClass());
+		Json::decode(new stdClass());
 	}
 
-	/**
-	 * @covers ::decode
-	 */
-	public function testDecodeInvalid2()
+	public function testDecodeInvalid2(): void
 	{
 		// pass invalid int
 		$this->expectException(InvalidArgumentException::class);
@@ -57,10 +47,7 @@ class JsonTest extends TestCase
 		Json::decode(1);
 	}
 
-	/**
-	 * @covers ::decode
-	 */
-	public function testDecodeCorrupted1()
+	public function testDecodeCorrupted1(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('JSON string is invalid');
@@ -68,10 +55,7 @@ class JsonTest extends TestCase
 		Json::decode('some gibberish');
 	}
 
-	/**
-	 * @covers ::decode
-	 */
-	public function testDecodeCorrupted2()
+	public function testDecodeCorrupted2(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('JSON string is invalid');
@@ -79,10 +63,7 @@ class JsonTest extends TestCase
 		Json::decode('true');
 	}
 
-	/**
-	 * @covers ::encode
-	 */
-	public function testEncodePretty()
+	public function testEncodePretty(): void
 	{
 		$array = [
 			'name'     => 'Homer',
@@ -100,10 +81,7 @@ class JsonTest extends TestCase
 }', $data);
 	}
 
-	/**
-	 * @covers ::encode
-	 */
-	public function testEncodeUnicode()
+	public function testEncodeUnicode(): void
 	{
 		$string  = 'здравей';
 		$this->assertSame('"' . $string . '"', Json::encode($string));

--- a/tests/Data/PHPTest.php
+++ b/tests/Data/PHPTest.php
@@ -6,20 +6,15 @@ use Exception;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Data\PHP
- */
+#[CoversClass(PHP::class)]
 class PHPTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/php';
 	public const TMP      = KIRBY_TMP_DIR . '/Data.PHP';
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeArray
-	 */
-	public function testEncode()
+	public function testEncode(): void
 	{
 		$input    = static::FIXTURES . '/input.php';
 		$expected = static::FIXTURES . '/expected.php';
@@ -32,10 +27,7 @@ class PHPTest extends TestCase
 		$this->assertSame('123', PHP::encode(123));
 	}
 
-	/**
-	 * @covers ::decode
-	 */
-	public function testDecode()
+	public function testDecode(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 		$this->expectExceptionMessage('The PHP::decode() method is not implemented');
@@ -44,10 +36,7 @@ class PHPTest extends TestCase
 		$result = PHP::decode($input);
 	}
 
-	/**
-	 * @covers ::read
-	 */
-	public function testRead()
+	public function testRead(): void
 	{
 		$input  = static::FIXTURES . '/input.php';
 		$result = PHP::read($input);
@@ -55,10 +44,7 @@ class PHPTest extends TestCase
 		$this->assertSame($result, include $input);
 	}
 
-	/**
-	 * @covers ::read
-	 */
-	public function testReadFileMissing()
+	public function testReadFileMissing(): void
 	{
 		$file = static::TMP . '/does-not-exist.php';
 
@@ -68,10 +54,7 @@ class PHPTest extends TestCase
 		PHP::read($file);
 	}
 
-	/**
-	 * @covers ::write
-	 */
-	public function testWrite()
+	public function testWrite(): void
 	{
 		$input = include static::FIXTURES . '/input.php';
 		$file  = static::TMP . '/tmp.php';

--- a/tests/Data/TxtTest.php
+++ b/tests/Data/TxtTest.php
@@ -4,21 +4,15 @@ namespace Kirby\Data;
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use stdClass;
 
-/**
- * @coversDefaultClass \Kirby\Data\Txt
- */
+#[CoversClass(Txt::class)]
 class TxtTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 * @covers ::decode
-	 */
-	public function testEncodeDecode()
+	public function testEncodeDecode(): void
 	{
 		$array = [
 			'title' => 'Title',
@@ -41,13 +35,7 @@ class TxtTest extends TestCase
 		$this->assertSame(['this is' => 'an array'], Txt::decode(['this is' => 'an array']));
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 * @covers ::decode
-	 */
-	public function testEncodeDecodeMixedCase()
+	public function testEncodeDecodeMixedCase(): void
 	{
 		$array = [
 			'title' => 'Title',
@@ -69,12 +57,7 @@ class TxtTest extends TestCase
 		], $result);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 */
-	public function testEncodeMissingValues()
+	public function testEncodeMissingValues(): void
 	{
 		$array = [
 			'title' => 'Title',
@@ -90,12 +73,7 @@ class TxtTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 */
-	public function testEncodeMultiline()
+	public function testEncodeMultiline(): void
 	{
 		$array = [
 			'title' => 'Title',
@@ -109,12 +87,7 @@ class TxtTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 */
-	public function testEncodeDecodeDivider()
+	public function testEncodeDecodeDivider(): void
 	{
 		$array = [
 			'title' => 'Title',
@@ -131,12 +104,7 @@ class TxtTest extends TestCase
 		$this->assertSame($array, Txt::decode($data));
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 */
-	public function testEncodeArray()
+	public function testEncodeArray(): void
 	{
 		$array = [
 			'title' => 'Title',
@@ -148,12 +116,7 @@ class TxtTest extends TestCase
 		$this->assertSame(file_get_contents(static::FIXTURES . '/test.txt'), $data);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 */
-	public function testEncodeFloat()
+	public function testEncodeFloat(): void
 	{
 		$data = Txt::encode([
 			'number' => (float)3.2
@@ -162,12 +125,7 @@ class TxtTest extends TestCase
 		$this->assertSame('Number: 3.2', $data);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::encodeValue
-	 * @covers ::encodeResult
-	 */
-	public function testEncodeFloatWithLocaleSetting()
+	public function testEncodeFloatWithLocaleSetting(): void
 	{
 		$currentLocale = setlocale(LC_ALL, 0);
 		setlocale(LC_ALL, 'de_DE');
@@ -181,10 +139,7 @@ class TxtTest extends TestCase
 		setlocale(LC_ALL, $currentLocale);
 	}
 
-	/**
-	 * @covers ::decode
-	 */
-	public function testDecodeFile()
+	public function testDecodeFile(): void
 	{
 		$array = [
 			'title_with_spaces' => 'Title',
@@ -195,10 +150,7 @@ class TxtTest extends TestCase
 		$this->assertSame($array, $data);
 	}
 
-	/**
-	 * @covers ::decode
-	 */
-	public function testDecodeBom1()
+	public function testDecodeBom1(): void
 	{
 		$string = "\xEF\xBB\xBFTitle: title field with BOM \xEF\xBB\xBF\n----\nText: text field";
 		$array  = [
@@ -209,10 +161,7 @@ class TxtTest extends TestCase
 		$this->assertSame($array, Txt::decode($string));
 	}
 
-	/**
-	 * @covers ::decode
-	 */
-	public function testDecodeBom2()
+	public function testDecodeBom2(): void
 	{
 		$string = "\xEF\xBB\xBFTitle: title field with BOM\n--\xEF\xBB\xBF--\nand more text\n----\nText: text field";
 		$array  = [
@@ -223,21 +172,15 @@ class TxtTest extends TestCase
 		$this->assertSame($array, Txt::decode($string));
 	}
 
-	/**
-	 * @covers ::decode
-	 */
-	public function testDecodeInvalid1()
+	public function testDecodeInvalid1(): void
 	{
 		// pass invalid object
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid TXT data; please pass a string');
-		Txt::decode(new \stdClass());
+		Txt::decode(new stdClass());
 	}
 
-	/**
-	 * @covers ::decode
-	 */
-	public function testDecodeInvalid2()
+	public function testDecodeInvalid2(): void
 	{
 		// pass invalid int
 		$this->expectException(InvalidArgumentException::class);

--- a/tests/Data/XmlTest.php
+++ b/tests/Data/XmlTest.php
@@ -5,17 +5,13 @@ namespace Kirby\Data;
 use Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use stdClass;
 
-/**
- * @coversDefaultClass \Kirby\Data\Xml
- */
+#[CoversClass(Xml::class)]
 class XmlTest extends TestCase
 {
-	/**
-	 * @covers ::encode
-	 * @covers ::decode
-	 */
-	public function testEncodeDecode()
+	public function testEncodeDecode(): void
 	{
 		$array = [
 			'name'     => 'Homer',
@@ -46,21 +42,15 @@ class XmlTest extends TestCase
 		$this->assertSame(['this is' => 'an array'], Xml::decode(['this is' => 'an array']));
 	}
 
-	/**
-	 * @covers ::decode
-	 */
-	public function testDecodeInvalid1()
+	public function testDecodeInvalid1(): void
 	{
 		// pass invalid object
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid XML data; please pass a string');
-		Xml::decode(new \stdClass());
+		Xml::decode(new stdClass());
 	}
 
-	/**
-	 * @covers ::decode
-	 */
-	public function testDecodeInvalid2()
+	public function testDecodeInvalid2(): void
 	{
 		// pass invalid int
 		$this->expectException(InvalidArgumentException::class);
@@ -68,19 +58,13 @@ class XmlTest extends TestCase
 		Xml::decode(1);
 	}
 
-	/**
-	 * @covers ::encode
-	 */
-	public function testEncodeScalar()
+	public function testEncodeScalar(): void
 	{
 		$expected = '<?xml version="1.0" encoding="UTF-8"?>' . "\n" . '<data>test</data>';
 		$this->assertSame($expected, Xml::encode('test'));
 	}
 
-	/**
-	 * @covers ::decode
-	 */
-	public function testDecodeCorrupted()
+	public function testDecodeCorrupted(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('XML string is invalid');

--- a/tests/Data/YamlSymfonyTest.php
+++ b/tests/Data/YamlSymfonyTest.php
@@ -5,10 +5,11 @@ namespace Kirby\Data;
 use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use stdClass;
 
-/**
- * @coversDefaultClass \Kirby\Data\Yaml
- */
+#[CoversClass(Yaml::class)]
+#[CoversClass(YamlSymfony::class)]
 class YamlSymfonyTest extends TestCase
 {
 	public function setUp(): void
@@ -21,13 +22,7 @@ class YamlSymfonyTest extends TestCase
 		new App([]);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers ::decode
-	 * @covers \Kirby\Data\YamlSymfony::encode
-	 * @covers \Kirby\Data\YamlSymfony::decode
-	 */
-	public function testEncodeDecode()
+	public function testEncodeDecode(): void
 	{
 		$array = [
 			'name'     => 'Homer',
@@ -50,23 +45,15 @@ class YamlSymfonyTest extends TestCase
 		$this->assertSame(['this is' => 'an array'], Yaml::decode(['this is' => 'an array']));
 	}
 
-	/**
-	 * @covers ::decode
-	 * @covers \Kirby\Data\YamlSymfony::decode
-	 */
-	public function testDecodeInvalid1()
+	public function testDecodeInvalid1(): void
 	{
 		// pass invalid object
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid YAML data; please pass a string');
-		Yaml::decode(new \stdClass());
+		Yaml::decode(new stdClass());
 	}
 
-	/**
-	 * @covers ::decode
-	 * @covers \Kirby\Data\YamlSymfony::decode
-	 */
-	public function testDecodeInvalid2()
+	public function testDecodeInvalid2(): void
 	{
 		// pass invalid int
 		$this->expectException(InvalidArgumentException::class);
@@ -74,11 +61,7 @@ class YamlSymfonyTest extends TestCase
 		Yaml::decode(1);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers \Kirby\Data\YamlSymfony::encode
-	 */
-	public function testEncodeFloat()
+	public function testEncodeFloat(): void
 	{
 		$data = Yaml::encode([
 			'number' => 3.2
@@ -87,11 +70,7 @@ class YamlSymfonyTest extends TestCase
 		$this->assertSame('number: 3.2' . PHP_EOL, $data);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers \Kirby\Data\YamlSymfony::encode
-	 */
-	public function testEncodeFloatWithNonUSLocale()
+	public function testEncodeFloatWithNonUSLocale(): void
 	{
 		$locale = setlocale(LC_ALL, 0);
 
@@ -106,11 +85,7 @@ class YamlSymfonyTest extends TestCase
 		setlocale(LC_ALL, $locale);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers \Kirby\Data\YamlSymfony::encode
-	 */
-	public function testEncodeNodeTypes()
+	public function testEncodeNodeTypes(): void
 	{
 		$data = Yaml::encode(['test' => '']);
 		$this->assertSame('test: \'\'' . PHP_EOL, $data);

--- a/tests/Data/YamlTest.php
+++ b/tests/Data/YamlTest.php
@@ -4,19 +4,14 @@ namespace Kirby\Data;
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use stdClass;
 
-/**
- * @coversDefaultClass \Kirby\Data\Yaml
- */
+#[CoversClass(Yaml::class)]
+#[CoversClass(YamlSpyc::class)]
 class YamlTest extends TestCase
 {
-	/**
-	 * @covers ::encode
-	 * @covers ::decode
-	 * @covers \Kirby\Data\YamlSpyc::encode
-	 * @covers \Kirby\Data\YamlSpyc::decode
-	 */
-	public function testEncodeDecode()
+	public function testEncodeDecode(): void
 	{
 		$array = [
 			'name'     => 'Homer',
@@ -39,23 +34,15 @@ class YamlTest extends TestCase
 		$this->assertSame(['this is' => 'an array'], Yaml::decode(['this is' => 'an array']));
 	}
 
-	/**
-	 * @covers ::decode
-	 * @covers \Kirby\Data\YamlSpyc::decode
-	 */
-	public function testDecodeInvalid1()
+	public function testDecodeInvalid1(): void
 	{
 		// pass invalid object
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid YAML data; please pass a string');
-		Yaml::decode(new \stdClass());
+		Yaml::decode(new stdClass());
 	}
 
-	/**
-	 * @covers ::decode
-	 * @covers \Kirby\Data\YamlSpyc::decode
-	 */
-	public function testDecodeInvalid2()
+	public function testDecodeInvalid2(): void
 	{
 		// pass invalid int
 		$this->expectException(InvalidArgumentException::class);
@@ -63,11 +50,7 @@ class YamlTest extends TestCase
 		Yaml::decode(1);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers \Kirby\Data\YamlSpyc::encode
-	 */
-	public function testEncodeFloat()
+	public function testEncodeFloat(): void
 	{
 		$data = Yaml::encode([
 			'number' => 3.2
@@ -76,11 +59,7 @@ class YamlTest extends TestCase
 		$this->assertSame('number: 3.2' . PHP_EOL, $data);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers \Kirby\Data\YamlSpyc::encode
-	 */
-	public function testEncodeFloatWithNonUSLocale()
+	public function testEncodeFloatWithNonUSLocale(): void
 	{
 		$locale = setlocale(LC_ALL, 0);
 
@@ -95,11 +74,7 @@ class YamlTest extends TestCase
 		setlocale(LC_ALL, $locale);
 	}
 
-	/**
-	 * @covers ::encode
-	 * @covers \Kirby\Data\YamlSpyc::encode
-	 */
-	public function testEncodeNodeTypes()
+	public function testEncodeNodeTypes(): void
 	{
 		$data = Yaml::encode(['test' => '']);
 		$this->assertSame('test: ""' . PHP_EOL, $data);


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Use `CoversClass` and `DataProvider` PHPUnit attributes instead of DocBlock annotations in the `Kirby\Data` package


### Reasoning
Switching over package by package (or smaller units) to see how the code coverage is affected.

### Additional context
Put this for the 5.1.0 milestone to not further add to the list of the 5.0.0 milestone as we want to close this very soon.

The changes were created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withPaths([
		__DIR__ . '/tests/Data',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	])
	->withImportNames();
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass