### PR TITLE
test: Use PHPUnit attributes for `Kirby\Http`

### DIFF
--- a/tests/Http/CookieTest.php
+++ b/tests/Http/CookieTest.php
@@ -19,34 +19,34 @@ class CookieTest extends TestCase
 		Cookie::$key = $this->cookieKey;
 	}
 
-	public function testKey()
+	public function testKey(): void
 	{
 		$this->assertSame('KirbyHttpCookieKey', Cookie::$key);
 		Cookie::$key = 'KirbyToolkitCookieKey';
 		$this->assertSame('KirbyToolkitCookieKey', Cookie::$key);
 	}
 
-	public function testLifetime()
+	public function testLifetime(): void
 	{
 		$this->assertSame(253402214400, Cookie::lifetime(253402214400));
 		$this->assertSame((600 + time()), Cookie::lifetime(10));
 		$this->assertSame(0, Cookie::lifetime(-10));
 	}
 
-	public function testSet()
+	public function testSet(): void
 	{
 		Cookie::set('foo', 'bar');
 		$this->assertSame('171fb1229817374e4110110384cb6be060d97351+bar', $_COOKIE['foo']);
 	}
 
-	public function testForever()
+	public function testForever(): void
 	{
 		Cookie::forever('forever', 'bar');
 		$this->assertSame('171fb1229817374e4110110384cb6be060d97351+bar', $_COOKIE['forever']);
 		$this->assertTrue(Cookie::exists('forever'));
 	}
 
-	public function testRemove()
+	public function testRemove(): void
 	{
 		Cookie::forever('forever', 'bar');
 
@@ -55,7 +55,7 @@ class CookieTest extends TestCase
 		$this->assertFalse(Cookie::remove('none'));
 	}
 
-	public function testExists()
+	public function testExists(): void
 	{
 		Cookie::set('foo', 'bar');
 
@@ -63,7 +63,7 @@ class CookieTest extends TestCase
 		$this->assertFalse(Cookie::exists('new'));
 	}
 
-	public function testGet()
+	public function testGet(): void
 	{
 		Cookie::set('foo', 'bar');
 
@@ -72,7 +72,7 @@ class CookieTest extends TestCase
 		$this->assertSame($_COOKIE, Cookie::get());
 	}
 
-	public function testGetSetTrack()
+	public function testGetSetTrack(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -88,7 +88,7 @@ class CookieTest extends TestCase
 		$this->assertSame(['foo', 'bar'], $app->response()->usesCookies());
 	}
 
-	public function testParse()
+	public function testParse(): void
 	{
 		// valid
 		$_COOKIE['foo'] = '171fb1229817374e4110110384cb6be060d97351+bar';

--- a/tests/Http/EnvironmentTest.php
+++ b/tests/Http/EnvironmentTest.php
@@ -5,10 +5,12 @@ namespace Kirby\Http;
 use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use stdClass;
 
-/**
- * @coversDefaultClass \Kirby\Http\Environment
- */
+#[CoversClass(Environment::class)]
 class EnvironmentTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/EnvironmentTest';
@@ -18,7 +20,7 @@ class EnvironmentTest extends TestCase
 		App::destroy();
 	}
 
-	public function testAllowFromInsecureHost()
+	public function testAllowFromInsecureHost(): void
 	{
 		$env = new Environment([
 			'allowed' => '*'
@@ -30,7 +32,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('example.com', $env->host());
 	}
 
-	public function testAllowFromInsecureForwardedHost()
+	public function testAllowFromInsecureForwardedHost(): void
 	{
 		$env = new Environment([
 			'allowed' => '*'
@@ -42,7 +44,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('example.com', $env->host());
 	}
 
-	public function testAllowFromRelativeUrl()
+	public function testAllowFromRelativeUrl(): void
 	{
 		$env = new Environment([
 			'allowed' => '/'
@@ -52,7 +54,7 @@ class EnvironmentTest extends TestCase
 		$this->assertNull($env->host());
 	}
 
-	public function testAllowFromRelativeUrlWithSubfolder()
+	public function testAllowFromRelativeUrlWithSubfolder(): void
 	{
 		$env = new Environment([
 			'allowed' => '/subfolder'
@@ -62,7 +64,7 @@ class EnvironmentTest extends TestCase
 		$this->assertNull($env->host());
 	}
 
-	public function testAllowFromServerName()
+	public function testAllowFromServerName(): void
 	{
 		$env = new Environment([], [
 			'SERVER_NAME' => 'example.com'
@@ -72,7 +74,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('example.com', $env->host());
 	}
 
-	public function testAllowFromUrl()
+	public function testAllowFromUrl(): void
 	{
 		$env = new Environment([
 			'allowed' => 'http://example.com'
@@ -84,7 +86,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('example.com', $env->host());
 	}
 
-	public function testAllowFromUrls()
+	public function testAllowFromUrls(): void
 	{
 		$env = new Environment([
 			'allowed' => [
@@ -100,7 +102,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('example.com', $env->host());
 	}
 
-	public function testAllowFromUrlsWithSubfolders()
+	public function testAllowFromUrlsWithSubfolders(): void
 	{
 		$env = new Environment([
 			'cli'     => false,
@@ -118,7 +120,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('localhost', $env->host());
 	}
 
-	public function testAllowFromUrlsWithSlash()
+	public function testAllowFromUrlsWithSlash(): void
 	{
 		$env = new Environment([
 			'allowed' => [
@@ -133,20 +135,14 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('getkirby.com', $env->host());
 	}
 
-	/**
-	 * @covers ::baseUri
-	 */
-	public function testBaseUri()
+	public function testBaseUri(): void
 	{
 		// nothing given
 		$env = new Environment();
 		$this->assertInstanceOf(Uri::class, $env->baseUri());
 	}
 
-	/**
-	 * @covers ::baseUrl
-	 */
-	public function testBaseUrl()
+	public function testBaseUrl(): void
 	{
 		// nothing given
 		$env = new Environment();
@@ -201,10 +197,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('https://getkirby.com:8888', $env->baseUrl());
 	}
 
-	/**
-	 * @covers ::cli
-	 */
-	public function testCli()
+	public function testCli(): void
 	{
 		// enabled
 		$env = new Environment();
@@ -223,10 +216,7 @@ class EnvironmentTest extends TestCase
 		$this->assertFalse($env->cli());
 	}
 
-	/**
-	 * @covers ::detect
-	 */
-	public function testDetect()
+	public function testDetect(): void
 	{
 		// empty server info
 		$env = new Environment();
@@ -357,21 +347,15 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::detectForwarded
-	 * @covers ::detectForwardedHost
-	 * @covers ::detectForwardedHttps
-	 * @covers ::detectForwardedPort
-	 * @dataProvider detectForwardedProvider
-	 */
-	public function testDetectForwarded($info, $expected)
+	#[DataProvider('detectForwardedProvider')]
+	public function testDetectForwarded($info, $expected): void
 	{
 		$env = new Environment(['allowed' => '*'], $info);
 
 		$this->assertSame($expected, $env->baseUrl());
 	}
 
-	public function testDisallowFromInsecureHost()
+	public function testDisallowFromInsecureHost(): void
 	{
 		$env = new Environment([], [
 			'HTTP_HOST' => 'example.com'
@@ -380,7 +364,7 @@ class EnvironmentTest extends TestCase
 		$this->assertNull($env->host());
 	}
 
-	public function testDisallowFromInvalidSubfolders()
+	public function testDisallowFromInvalidSubfolders(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The environment is not allowed');
@@ -396,10 +380,7 @@ class EnvironmentTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::get
-	 */
-	public function testGet()
+	public function testGet(): void
 	{
 		$env = new Environment(null, $info = [
 			'HTTP_HOST'        => 'something/GETKIRBY.COM',
@@ -419,11 +400,8 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('lower case stuff', $env->get('argv'));
 	}
 
-	/**
-	 * @covers ::getGlobally
-	 * @backupGlobals enabled
-	 */
-	public function testGetGlobally()
+	#[BackupGlobals(true)]
+	public function testGetGlobally(): void
 	{
 		$_SERVER = [
 			'HTTP_HOST'        => 'something/GETKIRBY.COM',
@@ -463,10 +441,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('lower case stuff (app)', Environment::getGlobally('argv'));
 	}
 
-	/**
-	 * @covers ::host
-	 */
-	public function testHost()
+	public function testHost(): void
 	{
 		// via server name
 		$env = new Environment(null, [
@@ -483,20 +458,14 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('127.0.0.1', $env->host());
 	}
 
-	/**
-	 * @covers ::host
-	 */
-	public function testHostAllowedSingle()
+	public function testHostAllowedSingle(): void
 	{
 		$env = new Environment(['allowed' => 'https://getkirby.com']);
 
 		$this->assertSame('getkirby.com', $env->host());
 	}
 
-	/**
-	 * @covers ::host
-	 */
-	public function testHostAllowedMultiple()
+	public function testHostAllowedMultiple(): void
 	{
 		$options = [
 			'allowed' => [
@@ -534,10 +503,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('test.getkirby.com', $env->host());
 	}
 
-	/**
-	 * @covers ::host
-	 */
-	public function testHostForbidden()
+	public function testHostForbidden(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The environment is not allowed');
@@ -555,10 +521,7 @@ class EnvironmentTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::host
-	 */
-	public function testHostIgnoreInsecure()
+	public function testHostIgnoreInsecure(): void
 	{
 		// not possible via insecure header
 		$env = new Environment(null, [
@@ -581,10 +544,7 @@ class EnvironmentTest extends TestCase
 		$this->assertNull($env->host());
 	}
 
-	/**
-	 * @covers ::host
-	 */
-	public function testHostInsecure()
+	public function testHostInsecure(): void
 	{
 		// insecure host header
 		$env = new Environment(['allowed' => '*'], [
@@ -629,12 +589,8 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::https
-	 * @covers ::detectHttps
-	 * @dataProvider httpsProvider
-	 */
-	public function testHttps($value, $expected)
+	#[DataProvider('httpsProvider')]
+	public function testHttps($value, $expected): void
 	{
 		// via server config
 		$env = new Environment(null, [
@@ -644,10 +600,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame($expected, $env->https());
 	}
 
-	/**
-	 * @covers ::https
-	 */
-	public function testHttpsAllowedSingle()
+	public function testHttpsAllowedSingle(): void
 	{
 		$env = new Environment(['allowed' => 'http://getkirby.com']);
 		$this->assertFalse($env->https());
@@ -656,10 +609,7 @@ class EnvironmentTest extends TestCase
 		$this->assertTrue($env->https());
 	}
 
-	/**
-	 * @covers ::https
-	 */
-	public function testHttpsAllowedMultiple()
+	public function testHttpsAllowedMultiple(): void
 	{
 		$options = [
 			'allowed' => [
@@ -737,10 +687,7 @@ class EnvironmentTest extends TestCase
 		$this->assertTrue($env->https());
 	}
 
-	/**
-	 * @covers ::https
-	 */
-	public function testHttpsForbidden()
+	public function testHttpsForbidden(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The environment is not allowed');
@@ -771,12 +718,8 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::https
-	 * @covers ::detectHttpsProtocol
-	 * @dataProvider httpsFromProtocolProvider
-	 */
-	public function testHttpsFromProtocol($value, $expected)
+	#[DataProvider('httpsFromProtocolProvider')]
+	public function testHttpsFromProtocol($value, $expected): void
 	{
 		$env = new Environment(['allowed' => '*'], [
 			'HTTP_FORWARDED' => 'host=getkirby.com;proto="' . $value . '"',
@@ -792,10 +735,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame($expected, $env->https());
 	}
 
-	/**
-	 * @covers ::https
-	 */
-	public function testHttpsIgnoreInsecure()
+	public function testHttpsIgnoreInsecure(): void
 	{
 		$env = new Environment(null, [
 			'HTTP_FORWARDED' => 'proto=https'
@@ -810,10 +750,7 @@ class EnvironmentTest extends TestCase
 		$this->assertFalse($env->https());
 	}
 
-	/**
-	 * @covers ::https
-	 */
-	public function testHttpsInsecure()
+	public function testHttpsInsecure(): void
 	{
 		// insecure forwarded https header
 		$env = new Environment(['allowed' => '*'], [
@@ -831,7 +768,7 @@ class EnvironmentTest extends TestCase
 		$this->assertTrue($env->https());
 	}
 
-	public function testIgnoreFromInsecureForwardedHost()
+	public function testIgnoreFromInsecureForwardedHost(): void
 	{
 		$env = new Environment([], [
 			'HTTP_FORWARDED' => 'host=example.com'
@@ -846,10 +783,7 @@ class EnvironmentTest extends TestCase
 		$this->assertNull($env->host());
 	}
 
-	/**
-	 * @covers ::info
-	 */
-	public function testInfo()
+	public function testInfo(): void
 	{
 		// no info
 		$env = new Environment();
@@ -872,23 +806,19 @@ class EnvironmentTest extends TestCase
 		$this->assertSame($info, $env->info());
 	}
 
-	public function testInvalidAllowList()
+	public function testInvalidAllowList(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid allow list setup for base URLs');
 
 		new Environment([
-			'allowed' => [new \stdClass()]
+			'allowed' => [new stdClass()]
 		], [
 			'HTTP_HOST' => 'example.com'
 		]);
 	}
 
-	/**
-	 * @covers ::address
-	 * @covers ::ip
-	 */
-	public function testIp()
+	public function testIp(): void
 	{
 		// no ip
 		$env = new Environment();
@@ -905,10 +835,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('127.0.0.1', $env->ip());
 	}
 
-	/**
-	 * @covers ::isBehindProxy
-	 */
-	public function testIsBehindProxy()
+	public function testIsBehindProxy(): void
 	{
 		// no value given
 		$env = new Environment();
@@ -1016,11 +943,8 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::isLocal
-	 * @dataProvider isLocalWithIpProvider
-	 */
-	public function testIsLocalWithIp($address, $forwardedFor, $clientIp, bool $expected)
+	#[DataProvider('isLocalWithIpProvider')]
+	public function testIsLocalWithIp($address, $forwardedFor, $clientIp, bool $expected): void
 	{
 		$env = new Environment(null, [
 			'REMOTE_ADDR' => $address,
@@ -1051,11 +975,8 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::isLocal
-	 * @dataProvider isLocalWithServerNameProvider
-	 */
-	public function testIsLocalWithServerName($name, $expected)
+	#[DataProvider('isLocalWithServerNameProvider')]
+	public function testIsLocalWithServerName($name, $expected): void
 	{
 		$env = new Environment(null, [
 			'SERVER_NAME' => $name
@@ -1064,7 +985,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame($expected, $env->isLocal());
 	}
 
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$env = new Environment(null, [
 			'SERVER_NAME' => 'example.com'
@@ -1073,7 +994,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('test option', $env->options(static::FIXTURES)['test']);
 	}
 
-	public function testOptionsFromServerAddress()
+	public function testOptionsFromServerAddress(): void
 	{
 		$env = new Environment(null, [
 			'SERVER_ADDR' => '127.0.0.1'
@@ -1082,7 +1003,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('test address option', $env->options(static::FIXTURES)['test']);
 	}
 
-	public function testOptionsFromInvalidHost()
+	public function testOptionsFromInvalidHost(): void
 	{
 		$env = new Environment([
 			'cli' => false,
@@ -1096,7 +1017,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame([], $env->options(static::FIXTURES));
 	}
 
-	public function testOptionsFromCLI()
+	public function testOptionsFromCLI(): void
 	{
 		$env = new Environment([
 			'cli' => true
@@ -1105,10 +1026,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('test cli option', $env->options(static::FIXTURES)['test']);
 	}
 
-	/**
-	 * @covers ::path
-	 */
-	public function testPath()
+	public function testPath(): void
 	{
 		// the path in cli requests is always empty
 		$env = new Environment();
@@ -1131,11 +1049,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame('subfolder', $env->path());
 	}
 
-	/**
-	 * @covers ::port
-	 * @covers ::detectPort
-	 */
-	public function testPort()
+	public function testPort(): void
 	{
 		// no port given
 		$env = new Environment();
@@ -1200,10 +1114,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame(443, $env->port());
 	}
 
-	/**
-	 * @covers ::port
-	 */
-	public function testPortAllowedSingle()
+	public function testPortAllowedSingle(): void
 	{
 		$env = new Environment(['allowed' => 'http://getkirby.com']);
 		$this->assertNull($env->port());
@@ -1212,10 +1123,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame(9999, $env->port());
 	}
 
-	/**
-	 * @covers ::port
-	 */
-	public function testPortAllowedMultiple()
+	public function testPortAllowedMultiple(): void
 	{
 		$options = [
 			'allowed' => [
@@ -1276,10 +1184,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame(9999, $env->port());
 	}
 
-	/**
-	 * @covers ::port
-	 */
-	public function testPortForbidden()
+	public function testPortForbidden(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The environment is not allowed');
@@ -1297,10 +1202,7 @@ class EnvironmentTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::port
-	 */
-	public function testPortIgnoreInsecure()
+	public function testPortIgnoreInsecure(): void
 	{
 		$env = new Environment(null, [
 			'HTTP_FORWARDED' => 'host=getkirby.com:8888'
@@ -1315,10 +1217,7 @@ class EnvironmentTest extends TestCase
 		$this->assertNull($env->port());
 	}
 
-	/**
-	 * @covers ::port
-	 */
-	public function testPortInsecure()
+	public function testPortInsecure(): void
 	{
 		$env = new Environment(['allowed' => '*'], [
 			'HTTP_FORWARDED' => 'host=getkirby.com:9999'
@@ -1334,7 +1233,7 @@ class EnvironmentTest extends TestCase
 		$this->assertSame(9999, $env->port());
 	}
 
-	public function testRequestUrl()
+	public function testRequestUrl(): void
 	{
 		// basic
 		$env = new Environment(['cli' => false], []);
@@ -1421,11 +1320,8 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::requestUri
-	 * @dataProvider requestUriProvider
-	 */
-	public function testRequestUri($value, $expected)
+	#[DataProvider('requestUriProvider')]
+	public function testRequestUri($value, $expected): void
 	{
 		$env = new Environment(null, [
 			'REQUEST_URI' => $value,
@@ -1509,23 +1405,13 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::sanitize
-	 * @covers ::sanitizeHost
-	 * @covers ::sanitizePort
-	 * @dataProvider sanitizeProvider
-	 */
-	public function testSanitize($key, $value, $expected)
+	#[DataProvider('sanitizeProvider')]
+	public function testSanitize($key, $value, $expected): void
 	{
 		$this->assertSame($expected, Environment::sanitize($key, $value));
 	}
 
-	/**
-	 * @covers ::sanitize
-	 * @covers ::sanitizeHost
-	 * @covers ::sanitizePort
-	 */
-	public function testSanitizeAll()
+	public function testSanitizeAll(): void
 	{
 		$input    = [];
 		$expected = [];
@@ -1572,12 +1458,8 @@ class EnvironmentTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::scriptPath
-	 * @covers ::sanitizeScriptPath
-	 * @dataProvider scriptPathProvider
-	 */
-	public function testScriptPath($value, $expected)
+	#[DataProvider('scriptPathProvider')]
+	public function testScriptPath($value, $expected): void
 	{
 		$env = new Environment(['cli' => false], [
 			'SCRIPT_NAME' => $value
@@ -1586,20 +1468,14 @@ class EnvironmentTest extends TestCase
 		$this->assertSame($expected, $env->scriptPath());
 	}
 
-	/**
-	 * @covers ::scriptPath
-	 */
-	public function testScriptPathOnCli()
+	public function testScriptPathOnCli(): void
 	{
 		$env = new Environment(['cli' => true]);
 
 		$this->assertSame('', $env->scriptPath());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$env = new Environment([
 			'root' => static::FIXTURES,

--- a/tests/Http/Exceptions/NextRouteExceptionTest.php
+++ b/tests/Http/Exceptions/NextRouteExceptionTest.php
@@ -4,13 +4,12 @@ namespace Kirby\Http\Exceptions;
 
 use Exception;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class NextRouteExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
-	public function testException()
+	public function testException(): void
 	{
 		$exception = new NextRouteException(message: 'test');
 		$this->assertInstanceOf(Exception::class, $exception);

--- a/tests/Http/HeaderTest.php
+++ b/tests/Http/HeaderTest.php
@@ -23,12 +23,12 @@ class HeaderTest extends TestCase
 		503 => 'HTTP/1.1 503 Service Unavailable'
 	];
 
-	public function testCreateSingle()
+	public function testCreateSingle(): void
 	{
 		$this->assertSame('Key: Value', Header::create('Key', 'Value'));
 	}
 
-	public function testCreateMultiple()
+	public function testCreateMultiple(): void
 	{
 		$input = [
 			'a' => 'value a',
@@ -43,7 +43,7 @@ class HeaderTest extends TestCase
 		$this->assertSame(implode("\r\n", $expected), Header::create($input));
 	}
 
-	public function testNamedStatuses()
+	public function testNamedStatuses(): void
 	{
 		$h = $this->statusHeaders;
 		$this->assertSame($h[200], Header::success(false), 'success status should be 200');
@@ -58,7 +58,7 @@ class HeaderTest extends TestCase
 		$this->assertSame($h[503], Header::unavailable(false), 'unavailable status should be 503');
 	}
 
-	public function testStatusCodeOnly()
+	public function testStatusCodeOnly(): void
 	{
 		$h = $this->statusHeaders;
 
@@ -107,7 +107,7 @@ class HeaderTest extends TestCase
 		);
 	}
 
-	public function testRedirect()
+	public function testRedirect(): void
 	{
 		$h = $this->statusHeaders;
 		$this->assertSame(
@@ -122,7 +122,7 @@ class HeaderTest extends TestCase
 		);
 	}
 
-	public function testContentType()
+	public function testContentType(): void
 	{
 		$this->assertSame(
 			'Content-type: video/webm',

--- a/tests/Http/IdnTest.php
+++ b/tests/Http/IdnTest.php
@@ -6,14 +6,14 @@ use Kirby\TestCase;
 
 class IdnTest extends TestCase
 {
-	public function testDecodeEmail()
+	public function testDecodeEmail(): void
 	{
 		$this->assertSame('test@example.com', Idn::decodeEmail('test@example.com'));
 		$this->assertSame('test@exämple.com', Idn::decodeEmail('test@exämple.com'));
 		$this->assertSame('test@exämple.com', Idn::decodeEmail('test@xn--exmple-cua.com'));
 	}
 
-	public function testEncodeEmail()
+	public function testEncodeEmail(): void
 	{
 		$this->assertSame('test@example.com', Idn::encodeEmail('test@example.com'));
 		$this->assertSame('test@xn--exmple-cua.com', Idn::encodeEmail('test@xn--exmple-cua.com'));

--- a/tests/Http/ParamsTest.php
+++ b/tests/Http/ParamsTest.php
@@ -6,7 +6,7 @@ use Kirby\TestCase;
 
 class ParamsTest extends TestCase
 {
-	public function testConstructWithArray()
+	public function testConstructWithArray(): void
 	{
 		$params = new Params([
 			'a' => 'value-a',
@@ -17,7 +17,7 @@ class ParamsTest extends TestCase
 		$this->assertSame('value-b', $params->b);
 	}
 
-	public function testConstructWithString()
+	public function testConstructWithString(): void
 	{
 		$params = new Params('a:value-a/b:value-b');
 
@@ -25,7 +25,7 @@ class ParamsTest extends TestCase
 		$this->assertSame('value-b', $params->b);
 	}
 
-	public function testConstructWithEmptyValue()
+	public function testConstructWithEmptyValue(): void
 	{
 		$params = new Params('a:/b:');
 
@@ -33,7 +33,7 @@ class ParamsTest extends TestCase
 		$this->assertNull($params->b);
 	}
 
-	public function testConstructWithSpecialChars()
+	public function testConstructWithSpecialChars(): void
 	{
 		$params = new Params(
 			'a%2Fa%3A%20%3Ba%3F%22%3E:value-A%2FA%3A%20%3BA%3F%22%3E/' .
@@ -44,7 +44,7 @@ class ParamsTest extends TestCase
 		$this->assertSame('value-B/B: ;B?">', $params->{'b/b: ;b?">'});
 	}
 
-	public function testExtractFromNull()
+	public function testExtractFromNull(): void
 	{
 		$params   = Params::extract();
 		$expected = [
@@ -56,7 +56,7 @@ class ParamsTest extends TestCase
 		$this->assertSame($expected, $params);
 	}
 
-	public function testExtractFromEmptyString()
+	public function testExtractFromEmptyString(): void
 	{
 		$params   = Params::extract('');
 		$expected = [
@@ -68,7 +68,7 @@ class ParamsTest extends TestCase
 		$this->assertSame($expected, $params);
 	}
 
-	public function testExtractFromZeroString()
+	public function testExtractFromZeroString(): void
 	{
 		$params   = Params::extract('price:0');
 		$expected = ['price' => '0'];
@@ -76,7 +76,7 @@ class ParamsTest extends TestCase
 		$this->assertSame($expected, $params['params']);
 	}
 
-	public function testExtractFromSeparator()
+	public function testExtractFromSeparator(): void
 	{
 		$params   = Params::extract(Params::separator());
 		$expected = [
@@ -88,7 +88,7 @@ class ParamsTest extends TestCase
 		$this->assertSame($expected, $params);
 	}
 
-	public function testToString()
+	public function testToString(): void
 	{
 		$params = new Params([
 			'a' => 'value-a',
@@ -98,7 +98,7 @@ class ParamsTest extends TestCase
 		$this->assertSame('a:value-a/b:value-b', $params->toString());
 	}
 
-	public function testToStringWithLeadingSlash()
+	public function testToStringWithLeadingSlash(): void
 	{
 		$params = new Params([
 			'a' => 'value-a',
@@ -108,7 +108,7 @@ class ParamsTest extends TestCase
 		$this->assertSame('/a:value-a/b:value-b', $params->toString(true));
 	}
 
-	public function testToStringWithTrailingSlash()
+	public function testToStringWithTrailingSlash(): void
 	{
 		$params = new Params([
 			'a' => 'value-a',
@@ -118,7 +118,7 @@ class ParamsTest extends TestCase
 		$this->assertSame('a:value-a/b:value-b/', $params->toString(false, true));
 	}
 
-	public function testToStringWithWindowsSeparator()
+	public function testToStringWithWindowsSeparator(): void
 	{
 		Params::$separator = ';';
 
@@ -132,7 +132,7 @@ class ParamsTest extends TestCase
 		Params::$separator = null;
 	}
 
-	public function testToStringWithSpecialChars()
+	public function testToStringWithSpecialChars(): void
 	{
 		$params = new Params([
 			'a/a: ;a?">' => 'value-A/A: ;A?">',
@@ -146,7 +146,7 @@ class ParamsTest extends TestCase
 		);
 	}
 
-	public function testUnsetParam()
+	public function testUnsetParam(): void
 	{
 		$params = new Params(['foo' => 'bar']);
 		$params->foo = null;

--- a/tests/Http/PathTest.php
+++ b/tests/Http/PathTest.php
@@ -3,16 +3,12 @@
 namespace Kirby\Http;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Http\Path
- */
+#[CoversClass(Path::class)]
 class PathTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructWithArray()
+	public function testConstructWithArray(): void
 	{
 		$path = new Path(['docs', 'reference']);
 
@@ -21,10 +17,7 @@ class PathTest extends TestCase
 		$this->assertSame('reference', $path->last());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructWithString()
+	public function testConstructWithString(): void
 	{
 		$path = new Path('/docs/reference');
 
@@ -33,11 +26,7 @@ class PathTest extends TestCase
 		$this->assertSame('reference', $path->last());
 	}
 
-	/**
-	 * @covers ::__toString
-	 * @covers ::toString
-	 */
-	public function testToString()
+	public function testToString(): void
 	{
 		$path = new Path('/docs/reference');
 		$this->assertSame('docs/reference', $path->toString());
@@ -45,21 +34,13 @@ class PathTest extends TestCase
 		$this->assertSame('docs/reference', (string)$path);
 	}
 
-	/**
-	 * @covers ::__toString
-	 * @covers ::toString
-	 */
-	public function testToStringWithLeadingSlash()
+	public function testToStringWithLeadingSlash(): void
 	{
 		$path = new Path('/docs/reference');
 		$this->assertSame('/docs/reference', $path->toString(true));
 	}
 
-	/**
-	 * @covers ::__toString
-	 * @covers ::toString
-	 */
-	public function testToStringWithLeadingAndTrailingSlash()
+	public function testToStringWithLeadingAndTrailingSlash(): void
 	{
 		$path = new Path('/docs/reference');
 		$this->assertSame('/docs/reference/', $path->toString(true, true));

--- a/tests/Http/RemoteTest.php
+++ b/tests/Http/RemoteTest.php
@@ -40,7 +40,7 @@ class RemoteTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testOptionsHeaders()
+	public function testOptionsHeaders(): void
 	{
 		$request = Remote::get('https://getkirby.com', [
 			'headers' => [
@@ -54,7 +54,7 @@ class RemoteTest extends TestCase
 		], $request->curlopt[CURLOPT_HTTPHEADER]);
 	}
 
-	public function testOptionsBasicAuth()
+	public function testOptionsBasicAuth(): void
 	{
 		$request = Remote::get('https://getkirby.com', [
 			'basicAuth' => 'user:pw'
@@ -62,7 +62,7 @@ class RemoteTest extends TestCase
 		$this->assertSame('user:pw', $request->curlopt[CURLOPT_USERPWD]);
 	}
 
-	public function testOptionsCa()
+	public function testOptionsCa(): void
 	{
 		// default: internal CA
 		$request = Remote::get('https://getkirby.com');
@@ -162,7 +162,7 @@ class RemoteTest extends TestCase
 		]);
 	}
 
-	public function testOptionsFromApp()
+	public function testOptionsFromApp(): void
 	{
 		new App([
 			'options' => [
@@ -180,25 +180,25 @@ class RemoteTest extends TestCase
 		$this->assertFalse($options['body']);
 	}
 
-	public function testContent()
+	public function testContent(): void
 	{
 		$request = Remote::put('https://getkirby.com');
 		$this->assertNull($request->content());
 	}
 
-	public function testCode()
+	public function testCode(): void
 	{
 		$request = Remote::put('https://getkirby.com');
 		$this->assertNull($request->code());
 	}
 
-	public function testDelete()
+	public function testDelete(): void
 	{
 		$request = Remote::delete('https://getkirby.com');
 		$this->assertSame('DELETE', $request->method());
 	}
 
-	public function testGet()
+	public function testGet(): void
 	{
 		// default
 		$request = Remote::get('https://getkirby.com');
@@ -215,43 +215,43 @@ class RemoteTest extends TestCase
 		$this->assertSame('https://getkirby.com/a?b=c&d=foo', $request->url());
 	}
 
-	public function testHead()
+	public function testHead(): void
 	{
 		$request = Remote::head('https://getkirby.com');
 		$this->assertSame('HEAD', $request->method());
 	}
 
-	public function testHeaders()
+	public function testHeaders(): void
 	{
 		$request = new Remote('https://getkirby.com');
 		$this->assertSame([], $request->headers());
 	}
 
-	public function testInfo()
+	public function testInfo(): void
 	{
 		$request = new Remote('https://getkirby.com');
 		$this->assertSame([], $request->info());
 	}
 
-	public function testPatch()
+	public function testPatch(): void
 	{
 		$request = Remote::patch('https://getkirby.com');
 		$this->assertSame('PATCH', $request->method());
 	}
 
-	public function testPost()
+	public function testPost(): void
 	{
 		$request = Remote::post('https://getkirby.com');
 		$this->assertSame('POST', $request->method());
 	}
 
-	public function testPut()
+	public function testPut(): void
 	{
 		$request = Remote::put('https://getkirby.com');
 		$this->assertSame('PUT', $request->method());
 	}
 
-	public function testRequest()
+	public function testRequest(): void
 	{
 		$request = new Remote($url = 'https://getkirby.com');
 

--- a/tests/Http/Request/Auth/BasicAuthTest.php
+++ b/tests/Http/Request/Auth/BasicAuthTest.php
@@ -2,15 +2,15 @@
 
 namespace Kirby\Http\Request\Auth;
 
+use Kirby\Http\Request\Auth;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @covers \Kirby\Http\Request\Auth
- * @covers \Kirby\Http\Request\Auth\BasicAuth
- */
+#[CoversClass(Auth::class)]
+#[CoversClass(BasicAuth::class)]
 class BasicAuthTest extends TestCase
 {
-	public function testInstance()
+	public function testInstance(): void
 	{
 		$auth = new BasicAuth($data = base64_encode($credentials = 'testuser:testpass'));
 

--- a/tests/Http/Request/Auth/BearerAuthTest.php
+++ b/tests/Http/Request/Auth/BearerAuthTest.php
@@ -2,15 +2,15 @@
 
 namespace Kirby\Http\Request\Auth;
 
+use Kirby\Http\Request\Auth;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @covers \Kirby\Http\Request\Auth
- * @covers \Kirby\Http\Request\Auth\BearerAuth
- */
+#[CoversClass(Auth::class)]
+#[CoversClass(BearerAuth::class)]
 class BearerAuthTest extends TestCase
 {
-	public function testInstance()
+	public function testInstance(): void
 	{
 		$auth = new BearerAuth('abcd');
 

--- a/tests/Http/Request/Auth/SessionAuthTest.php
+++ b/tests/Http/Request/Auth/SessionAuthTest.php
@@ -4,12 +4,12 @@ namespace Kirby\Http\Request\Auth;
 
 use Kirby\Cms\App;
 use Kirby\Filesystem\Dir;
+use Kirby\Http\Request\Auth;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @covers \Kirby\Http\Request\Auth
- * @covers \Kirby\Http\Request\Auth\SessionAuth
- */
+#[CoversClass(Auth::class)]
+#[CoversClass(SessionAuth::class)]
 class SessionAuthTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Http.Request.Auth.SessionAuth';
@@ -31,7 +31,7 @@ class SessionAuthTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testInstance()
+	public function testInstance(): void
 	{
 		$session = $this->app->session();
 		$session->ensureToken();

--- a/tests/Http/Request/BodyTest.php
+++ b/tests/Http/Request/BodyTest.php
@@ -6,7 +6,7 @@ use Kirby\TestCase;
 
 class BodyTest extends TestCase
 {
-	public function testContents()
+	public function testContents(): void
 	{
 		// default contents
 		$body = new Body();
@@ -28,7 +28,7 @@ class BodyTest extends TestCase
 		$this->assertSame('foo', $body->contents());
 	}
 
-	public function testData()
+	public function testData(): void
 	{
 		// default
 		$data = [];
@@ -56,7 +56,7 @@ class BodyTest extends TestCase
 		$this->assertSame([], $body->data());
 	}
 
-	public function testToArrayAndDebuginfo()
+	public function testToArrayAndDebuginfo(): void
 	{
 		$data = ['a' => 'a'];
 		$body = new Body($data);
@@ -64,14 +64,14 @@ class BodyTest extends TestCase
 		$this->assertSame($data, $body->__debugInfo());
 	}
 
-	public function testToJson()
+	public function testToJson(): void
 	{
 		$data = ['a' => 'a'];
 		$body = new Body($data);
 		$this->assertSame(json_encode($data), $body->toJson());
 	}
 
-	public function testToString()
+	public function testToString(): void
 	{
 		// default
 		$body = new Body();

--- a/tests/Http/Request/FilesTest.php
+++ b/tests/Http/Request/FilesTest.php
@@ -6,7 +6,7 @@ use Kirby\TestCase;
 
 class FilesTest extends TestCase
 {
-	public function testMultipleUploads()
+	public function testMultipleUploads(): void
 	{
 		$upload = [
 			'upload' => [
@@ -30,7 +30,7 @@ class FilesTest extends TestCase
 		$this->assertSame(0, $files->get('upload')[1]['error']);
 	}
 
-	public function testData()
+	public function testData(): void
 	{
 		// default
 		$files = new Files();
@@ -50,7 +50,7 @@ class FilesTest extends TestCase
 		$this->assertSame($upload, $files->data());
 	}
 
-	public function testGet()
+	public function testGet(): void
 	{
 		// test with default data
 		$files = new Files();
@@ -69,7 +69,7 @@ class FilesTest extends TestCase
 		$this->assertSame(123, $files->get('upload')['size']);
 	}
 
-	public function testToArrayAndDebuginfo()
+	public function testToArrayAndDebuginfo(): void
 	{
 		$data  = [
 			'upload' => [
@@ -85,7 +85,7 @@ class FilesTest extends TestCase
 		$this->assertSame($data, $files->__debugInfo());
 	}
 
-	public function testToJson()
+	public function testToJson(): void
 	{
 		$data  = [
 			'upload' => [

--- a/tests/Http/Request/QueryTest.php
+++ b/tests/Http/Request/QueryTest.php
@@ -6,7 +6,7 @@ use Kirby\TestCase;
 
 class QueryTest extends TestCase
 {
-	public function testData()
+	public function testData(): void
 	{
 		// default
 		$query = new Query();
@@ -24,7 +24,7 @@ class QueryTest extends TestCase
 		$this->assertSame($data, $query->data());
 	}
 
-	public function testIsEmpty()
+	public function testIsEmpty(): void
 	{
 		// without data
 		$query = new Query();
@@ -37,7 +37,7 @@ class QueryTest extends TestCase
 		$this->assertTrue($query->isNotEmpty());
 	}
 
-	public function testGet()
+	public function testGet(): void
 	{
 		// default
 		$query = new Query();
@@ -52,7 +52,7 @@ class QueryTest extends TestCase
 		$this->assertSame(['a' => 'a', 'b' => 'b', 'c' => null], $query->get(['a', 'b', 'c']));
 	}
 
-	public function testToString()
+	public function testToString(): void
 	{
 		// default
 		$query = new Query();
@@ -67,7 +67,7 @@ class QueryTest extends TestCase
 		$this->assertEquals('foo=bar', $query); // cannot use strict assertion (string conversion)
 	}
 
-	public function testToArrayAndDebuginfo()
+	public function testToArrayAndDebuginfo(): void
 	{
 		$data  = ['a' => 'a'];
 		$query = new Query($data);
@@ -75,7 +75,7 @@ class QueryTest extends TestCase
 		$this->assertSame($data, $query->__debugInfo());
 	}
 
-	public function testToJson()
+	public function testToJson(): void
 	{
 		$data  = ['a' => 'a'];
 		$query = new Query($data);

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -9,6 +9,7 @@ use Kirby\Http\Request\Body;
 use Kirby\Http\Request\Files;
 use Kirby\Http\Request\Query;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RequestTest extends TestCase
 {
@@ -17,7 +18,7 @@ class RequestTest extends TestCase
 		App::destroy();
 	}
 
-	public function testCustomProps()
+	public function testCustomProps(): void
 	{
 		$file = [
 			'name'     => 'test.txt',
@@ -44,9 +45,9 @@ class RequestTest extends TestCase
 		// with instances
 		$request = new Request([
 			'method' => 'POST',
-			'body'   => new Request\Body(['a' => 'a']),
-			'query'  => new Request\Query(['b' => 'b']),
-			'files'  => new Request\Files(['upload' => $file]),
+			'body'   => new Body(['a' => 'a']),
+			'query'  => new Query(['b' => 'b']),
+			'files'  => new Files(['upload' => $file]),
 			'url'    => new Uri('https://getkirby.com')
 		]);
 
@@ -57,7 +58,7 @@ class RequestTest extends TestCase
 		$this->assertSame('https://getkirby.com', $request->url()->toString());
 	}
 
-	public function testData()
+	public function testData(): void
 	{
 		$request = new Request([
 			'body'   => ['a' => 'a'],
@@ -70,7 +71,7 @@ class RequestTest extends TestCase
 		$this->assertNull($request->get('c'));
 	}
 
-	public function testDataNumeric()
+	public function testDataNumeric(): void
 	{
 		$request = new Request([
 			'body'   => [1 => 'a'],
@@ -89,7 +90,7 @@ class RequestTest extends TestCase
 		$this->assertSame('c', $request->get('2'));
 	}
 
-	public function test__debuginfo()
+	public function test__debuginfo(): void
 	{
 		$request = new Request();
 		$info    = $request->__debugInfo();
@@ -101,13 +102,13 @@ class RequestTest extends TestCase
 		$this->assertArrayHasKey('url', $info);
 	}
 
-	public function testAuthMissing()
+	public function testAuthMissing(): void
 	{
 		$request = new Request();
 		$this->assertFalse($request->auth());
 	}
 
-	public function testBasicAuth()
+	public function testBasicAuth(): void
 	{
 		new App([
 			'server' => [
@@ -122,7 +123,7 @@ class RequestTest extends TestCase
 		$this->assertSame('testpass', $request->auth()->password());
 	}
 
-	public function testBearerAuth()
+	public function testBearerAuth(): void
 	{
 		new App([
 			'server' => [
@@ -136,7 +137,7 @@ class RequestTest extends TestCase
 		$this->assertSame('abcd', $request->auth()->token());
 	}
 
-	public function testCli()
+	public function testCli(): void
 	{
 		$request = new Request();
 		$this->assertTrue($request->cli());
@@ -149,7 +150,7 @@ class RequestTest extends TestCase
 	}
 
 
-	public function testUnknownAuth()
+	public function testUnknownAuth(): void
 	{
 		new App([
 			'server' => [
@@ -162,7 +163,7 @@ class RequestTest extends TestCase
 		$this->assertFalse($request->auth());
 	}
 
-	public function testAuthTrack()
+	public function testAuthTrack(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -178,10 +179,8 @@ class RequestTest extends TestCase
 		$this->assertTrue($app->response()->usesAuth());
 	}
 
-	/**
-	 * @dataProvider hasAuthProvider
-	 */
-	public function testHasAuth($option, $header, $expected)
+	#[DataProvider('hasAuthProvider')]
+	public function testHasAuth($option, $header, $expected): void
 	{
 		new App([
 			'server' => [
@@ -211,7 +210,7 @@ class RequestTest extends TestCase
 		];
 	}
 
-	public function testMethod()
+	public function testMethod(): void
 	{
 		$request = new Request();
 
@@ -220,49 +219,49 @@ class RequestTest extends TestCase
 		$this->assertInstanceOf(Files::class, $request->files());
 	}
 
-	public function testQuery()
+	public function testQuery(): void
 	{
 		$request = new Request();
 		$this->assertInstanceOf(Query::class, $request->query());
 	}
 
-	public function testBody()
+	public function testBody(): void
 	{
 		$request = new Request();
 		$this->assertInstanceOf(Body::class, $request->body());
 	}
 
-	public function testFiles()
+	public function testFiles(): void
 	{
 		$request = new Request();
 		$this->assertInstanceOf(Files::class, $request->files());
 	}
 
-	public function testFile()
+	public function testFile(): void
 	{
 		$request = new Request();
 		$this->assertNull($request->file('test'));
 	}
 
-	public function testIs()
+	public function testIs(): void
 	{
 		$request = new Request();
 		$this->assertTrue($request->is('GET'));
 	}
 
-	public function testIsWithLowerCaseInput()
+	public function testIsWithLowerCaseInput(): void
 	{
 		$request = new Request();
 		$this->assertTrue($request->is('get'));
 	}
 
-	public function testUrl()
+	public function testUrl(): void
 	{
 		$request = new Request();
 		$this->assertInstanceOf(Uri::class, $request->url());
 	}
 
-	public function testUrlUpdates()
+	public function testUrlUpdates(): void
 	{
 		$request = new Request();
 
@@ -282,13 +281,13 @@ class RequestTest extends TestCase
 		$this->assertSame('http://getkirby.com/yay?foo=bar', $clone->toString());
 	}
 
-	public function testPath()
+	public function testPath(): void
 	{
 		$request = new Request();
 		$this->assertInstanceOf(Path::class, $request->path());
 	}
 
-	public function testDomain()
+	public function testDomain(): void
 	{
 		$request = new Request([
 			'url' => 'https://getkirby.com/a/b'

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -5,10 +5,11 @@ namespace Kirby\Http;
 use Exception;
 use Kirby\Exception\LogicException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
-/**
- * @coversDefaultClass \Kirby\Http\Response
- */
+#[CoversClass(Response::class)]
 class ResponseTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -18,7 +19,7 @@ class ResponseTest extends TestCase
 		HeadersSent::$value = false;
 	}
 
-	public function testBody()
+	public function testBody(): void
 	{
 		$response = new Response();
 		$this->assertSame('', $response->body());
@@ -33,7 +34,7 @@ class ResponseTest extends TestCase
 		$this->assertSame('test', $response->body());
 	}
 
-	public function testDownload()
+	public function testDownload(): void
 	{
 		$response = Response::download(__FILE__);
 
@@ -85,7 +86,7 @@ class ResponseTest extends TestCase
 		], $response->headers());
 	}
 
-	public function testDownloadWithMissingFile()
+	public function testDownloadWithMissingFile(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('The file could not be found');
@@ -93,10 +94,7 @@ class ResponseTest extends TestCase
 		Response::download('does/not/exist.txt');
 	}
 
-	/**
-	 * @covers ::guardAgainstOutput
-	 */
-	public function testGuardAgainstOutput()
+	public function testGuardAgainstOutput(): void
 	{
 		$result = Response::guardAgainstOutput(
 			fn ($arg1, $arg2) => $arg1 . '-' . $arg2,
@@ -107,10 +105,7 @@ class ResponseTest extends TestCase
 		$this->assertSame('12-34', $result);
 	}
 
-	/**
-	 * @covers ::guardAgainstOutput
-	 */
-	public function testGuardAgainstOutputWithSubsequentOutput()
+	public function testGuardAgainstOutputWithSubsequentOutput(): void
 	{
 		HeadersSent::$value = true;
 
@@ -123,10 +118,7 @@ class ResponseTest extends TestCase
 		$this->assertSame('12-34', $result);
 	}
 
-	/**
-	 * @covers ::guardAgainstOutput
-	 */
-	public function testGuardAgainstOutputWithFirstOutput()
+	public function testGuardAgainstOutputWithFirstOutput(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('Disallowed output from file file.php:123, possible accidental whitespace?');
@@ -136,7 +128,7 @@ class ResponseTest extends TestCase
 		});
 	}
 
-	public function testHeaders()
+	public function testHeaders(): void
 	{
 		$response = new Response();
 		$this->assertSame([], $response->headers());
@@ -150,7 +142,7 @@ class ResponseTest extends TestCase
 		$this->assertSame(['test' => 'test'], $response->headers());
 	}
 
-	public function testHeader()
+	public function testHeader(): void
 	{
 		$response = new Response();
 		$this->assertNull($response->header('test'));
@@ -164,7 +156,7 @@ class ResponseTest extends TestCase
 		$this->assertSame('test', $response->header('test'));
 	}
 
-	public function testJson()
+	public function testJson(): void
 	{
 		$response = Response::json();
 
@@ -173,7 +165,7 @@ class ResponseTest extends TestCase
 		$this->assertSame('', $response->body());
 	}
 
-	public function testJsonWithArray()
+	public function testJsonWithArray(): void
 	{
 		$data     = ['foo' => 'bar'];
 		$expected = json_encode($data);
@@ -182,7 +174,7 @@ class ResponseTest extends TestCase
 		$this->assertSame($expected, $response->body());
 	}
 
-	public function testJsonWithPrettyArray()
+	public function testJsonWithPrettyArray(): void
 	{
 		$data     = ['foo' => 'bar'];
 		$expected = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
@@ -191,7 +183,7 @@ class ResponseTest extends TestCase
 		$this->assertSame($expected, $response->body());
 	}
 
-	public function testFile()
+	public function testFile(): void
 	{
 		$file = static::FIXTURES . '/download.json';
 
@@ -216,7 +208,7 @@ class ResponseTest extends TestCase
 		], $response->headers());
 	}
 
-	public function testFileInvalid()
+	public function testFileInvalid(): void
 	{
 		$file = static::FIXTURES . '/download.xyz';
 
@@ -245,7 +237,7 @@ class ResponseTest extends TestCase
 		], $response->headers());
 	}
 
-	public function testType()
+	public function testType(): void
 	{
 		$response = new Response();
 		$this->assertSame('text/html', $response->type());
@@ -260,7 +252,7 @@ class ResponseTest extends TestCase
 		$this->assertSame('image/jpeg', $response->type());
 	}
 
-	public function testCharset()
+	public function testCharset(): void
 	{
 		$response = new Response();
 		$this->assertSame('UTF-8', $response->charset());
@@ -275,7 +267,7 @@ class ResponseTest extends TestCase
 		$this->assertSame('test', $response->charset());
 	}
 
-	public function testCode()
+	public function testCode(): void
 	{
 		$response = new Response();
 		$this->assertSame(200, $response->code());
@@ -290,7 +282,7 @@ class ResponseTest extends TestCase
 		$this->assertSame(404, $response->code());
 	}
 
-	public function testRedirect()
+	public function testRedirect(): void
 	{
 		$response = Response::redirect();
 		$this->assertSame('', $response->body());
@@ -298,7 +290,7 @@ class ResponseTest extends TestCase
 		$this->assertEquals(['Location' => '/'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
-	public function testRedirectWithLocation()
+	public function testRedirectWithLocation(): void
 	{
 		$response = Response::redirect('https://getkirby.com');
 		$this->assertSame('', $response->body());
@@ -306,7 +298,7 @@ class ResponseTest extends TestCase
 		$this->assertEquals(['Location' => 'https://getkirby.com'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
-	public function testRedirectWithInternationalLocation()
+	public function testRedirectWithInternationalLocation(): void
 	{
 		$response = Response::redirect('https://täst.de');
 		$this->assertSame('', $response->body());
@@ -314,7 +306,7 @@ class ResponseTest extends TestCase
 		$this->assertEquals(['Location' => 'https://xn--tst-qla.de'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
-	public function testRedirectWithResponseCode()
+	public function testRedirectWithResponseCode(): void
 	{
 		$response = Response::redirect('/', 301);
 		$this->assertSame('', $response->body());
@@ -322,11 +314,9 @@ class ResponseTest extends TestCase
 		$this->assertEquals(['Location' => '/'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function testSend()
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState(false)]
+	public function testSend(): void
 	{
 		$response = new Response([
 			'body'    => 'test',
@@ -348,11 +338,9 @@ class ResponseTest extends TestCase
 		$this->assertSame($code, 200);
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function testToString()
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState(false)]
+	public function testToString(): void
 	{
 		$response = new Response([
 			'body'    => 'test',
@@ -374,7 +362,7 @@ class ResponseTest extends TestCase
 		$this->assertSame($code, 200);
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		// default setup
 		$response = new Response();

--- a/tests/Http/RouteTest.php
+++ b/tests/Http/RouteTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Http;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RouteTest extends TestCase
 {
@@ -13,7 +14,7 @@ class RouteTest extends TestCase
 		return $route;
 	}
 
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$route = new Route('/', 'POST', $func = fn () => 'test');
 
@@ -23,7 +24,7 @@ class RouteTest extends TestCase
 		$this->assertSame('test', $route->action()->call($route));
 	}
 
-	public function testName()
+	public function testName(): void
 	{
 		$route = new Route('a', 'GET', function () {
 		}, [
@@ -33,7 +34,7 @@ class RouteTest extends TestCase
 		$this->assertSame('test', $route->name());
 	}
 
-	public function testAttributes()
+	public function testAttributes(): void
 	{
 		$route = new Route('a', 'GET', function () {
 		}, $attributes = [
@@ -44,7 +45,7 @@ class RouteTest extends TestCase
 		$this->assertSame($attributes, $route->attributes());
 	}
 
-	public function testAttributesGetter()
+	public function testAttributesGetter(): void
 	{
 		$route = new Route('a', 'GET', function () {
 		}, [
@@ -55,19 +56,19 @@ class RouteTest extends TestCase
 		$this->assertNull($route->b());
 	}
 
-	public function testPattern()
+	public function testPattern(): void
 	{
 		$route = $this->_route();
 		$this->assertSame('a', $route->pattern());
 	}
 
-	public function testMethod()
+	public function testMethod(): void
 	{
 		$route = $this->_route();
 		$this->assertSame('GET', $route->method());
 	}
 
-	public function testRegex()
+	public function testRegex(): void
 	{
 		$route = $this->_route();
 		$this->assertSame('a/(-?[0-9]+)/b', $route->regex('a/(:num)/b'));
@@ -114,10 +115,8 @@ class RouteTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider patternProvider
-	 */
-	public function testParse($pattern, $input, $match)
+	#[DataProvider('patternProvider')]
+	public function testParse($pattern, $input, $match): void
 	{
 		$route = $this->_route();
 

--- a/tests/Http/RouterTest.php
+++ b/tests/Http/RouterTest.php
@@ -9,7 +9,7 @@ use TypeError;
 
 class RouterTest extends TestCase
 {
-	public function testRegisterSingleRoute()
+	public function testRegisterSingleRoute(): void
 	{
 		$router = new Router([
 			[
@@ -27,7 +27,7 @@ class RouterTest extends TestCase
 		$this->assertSame('GET', $result->method());
 	}
 
-	public function testRegisterMultipleRoutes()
+	public function testRegisterMultipleRoutes(): void
 	{
 		$router = new Router([
 			[
@@ -56,7 +56,7 @@ class RouterTest extends TestCase
 		$this->assertSame('POST', $resultB->method());
 	}
 
-	public function testRegisterInvalidRoute()
+	public function testRegisterInvalidRoute(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid route parameters');
@@ -66,14 +66,14 @@ class RouterTest extends TestCase
 		]);
 	}
 
-	public function testRegisterInvalidData()
+	public function testRegisterInvalidData(): void
 	{
 		$this->expectException(TypeError::class);
 
 		new Router('route');
 	}
 
-	public function testFindWithNonexistingMethod()
+	public function testFindWithNonexistingMethod(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid routing method: KIRBY');
@@ -83,7 +83,7 @@ class RouterTest extends TestCase
 		$router->find('a', 'KIRBY');
 	}
 
-	public function testFindNonexistingRoute()
+	public function testFindNonexistingRoute(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('No route found for path: "a" and request method: "GET"');
@@ -93,7 +93,7 @@ class RouterTest extends TestCase
 		$router->find('a', 'GET');
 	}
 
-	public function testBeforeEach()
+	public function testBeforeEach(): void
 	{
 		$hooks = [
 			'beforeEach' => function ($route, $path, $method) {
@@ -117,7 +117,7 @@ class RouterTest extends TestCase
 		$router->call('/', 'GET');
 	}
 
-	public function testAfterEach()
+	public function testAfterEach(): void
 	{
 		$hooks = [
 			'afterEach' => function ($route, $path, $method, $result, $final) {
@@ -144,7 +144,7 @@ class RouterTest extends TestCase
 		$this->assertSame('test:after', $router->call('/', 'GET'));
 	}
 
-	public function testNext()
+	public function testNext(): void
 	{
 		$router = new Router([
 			[
@@ -197,7 +197,7 @@ class RouterTest extends TestCase
 		$result = $router->call('d');
 	}
 
-	public function testNextAfterEach()
+	public function testNextAfterEach(): void
 	{
 		$numTotal = 0;
 		$numFinal = 0;
@@ -234,7 +234,7 @@ class RouterTest extends TestCase
 		$this->assertSame(1, $numFinal);
 	}
 
-	public function testCallWithCallback()
+	public function testCallWithCallback(): void
 	{
 		$router = new Router([
 			[

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Http;
 use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 class UriTest extends TestCase
@@ -18,7 +19,7 @@ class UriTest extends TestCase
 		Uri::$current = null;
 	}
 
-	public function testClone()
+	public function testClone(): void
 	{
 		$uri = new Uri([
 			'host' => 'getkirby.com',
@@ -34,7 +35,7 @@ class UriTest extends TestCase
 		$this->assertSame('http://getkirby.com/yay?foo=bar', $clone->toString());
 	}
 
-	public function testCurrent()
+	public function testCurrent(): void
 	{
 		new App([
 			'cli' => false,
@@ -50,20 +51,20 @@ class UriTest extends TestCase
 		$this->assertSame('https://getkirby.com/docs/reference', $uri->toString());
 	}
 
-	public function testCurrentInCli()
+	public function testCurrentInCli(): void
 	{
 		$uri = Uri::current();
 		$this->assertSame('/', $uri->toString());
 	}
 
-	public function testCurrentWithCustomObject()
+	public function testCurrentWithCustomObject(): void
 	{
 		Uri::$current = $uri = new Uri('/');
 
 		$this->assertSame($uri, Uri::current());
 	}
 
-	public function testCurrentWithRequestUri()
+	public function testCurrentWithRequestUri(): void
 	{
 		new App([
 			'cli' => false,
@@ -76,7 +77,7 @@ class UriTest extends TestCase
 		$this->assertSame('/a/b', $uri->toString());
 	}
 
-	public function testCurrentWithHostAndPathInRequestUri()
+	public function testCurrentWithHostAndPathInRequestUri(): void
 	{
 		new App([
 			'cli' => false,
@@ -89,7 +90,7 @@ class UriTest extends TestCase
 		$this->assertSame('/a/b', $uri->toString());
 	}
 
-	public function testCurrentWithHostAndSchemeInRequestUri()
+	public function testCurrentWithHostAndSchemeInRequestUri(): void
 	{
 		new App([
 			'cli' => false,
@@ -102,7 +103,7 @@ class UriTest extends TestCase
 		$this->assertSame('/', $uri->toString());
 	}
 
-	public function testCurrentWithHostInRequestUri()
+	public function testCurrentWithHostInRequestUri(): void
 	{
 		new App([
 			'cli' => false,
@@ -115,7 +116,7 @@ class UriTest extends TestCase
 		$this->assertSame('/a/b/ktest.loc', $uri->toString());
 	}
 
-	public function testValidScheme()
+	public function testValidScheme(): void
 	{
 		$url = new Uri();
 
@@ -126,7 +127,7 @@ class UriTest extends TestCase
 		$this->assertSame('https', $url->scheme());
 	}
 
-	public function testIndex()
+	public function testIndex(): void
 	{
 		new App([
 			'cli' => false,
@@ -139,13 +140,13 @@ class UriTest extends TestCase
 		$this->assertSame('https://getkirby.com', $uri->toString());
 	}
 
-	public function testIndexInCli()
+	public function testIndexInCli(): void
 	{
 		$uri = Uri::index();
 		$this->assertSame('/', $uri->toString());
 	}
 
-	public function testInvalidScheme()
+	public function testInvalidScheme(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid URL scheme: abc');
@@ -154,7 +155,7 @@ class UriTest extends TestCase
 		$url->setScheme('abc');
 	}
 
-	public function testValidHost()
+	public function testValidHost(): void
 	{
 		$url = new Uri();
 
@@ -162,25 +163,25 @@ class UriTest extends TestCase
 		$this->assertSame('getkirby.com', $url->host());
 	}
 
-	public function testMissingHost()
+	public function testMissingHost(): void
 	{
 		$url = new Uri(['host' => false]);
 		$this->assertSame('', $url->host());
 	}
 
-	public function testIsAbsolute()
+	public function testIsAbsolute(): void
 	{
 		$url = new Uri(['host' => 'localhost']);
 		$this->assertTrue($url->isAbsolute());
 	}
 
-	public function testIsNotAbsolute()
+	public function testIsNotAbsolute(): void
 	{
 		$url = new Uri();
 		$this->assertFalse($url->isAbsolute());
 	}
 
-	public function testValidPort()
+	public function testValidPort(): void
 	{
 		$url = new Uri(['port' => 1234]);
 		$this->assertSame(1234, $url->port());
@@ -189,20 +190,20 @@ class UriTest extends TestCase
 		$this->assertNull($url->port());
 	}
 
-	public function testZeroPort()
+	public function testZeroPort(): void
 	{
 		$url = new Uri(['port' => 0]);
 		$this->assertNull($url->port());
 	}
 
-	public function testInvalidPortFormat1()
+	public function testInvalidPortFormat1(): void
 	{
 		$this->expectException(TypeError::class);
 
 		new Uri(['port' => 'a']);
 	}
 
-	public function testInvalidPortFormat2()
+	public function testInvalidPortFormat2(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid port format: 12010210210');
@@ -210,7 +211,7 @@ class UriTest extends TestCase
 		$url = new Uri(['port' => 12010210210]);
 	}
 
-	public function testValidUsername()
+	public function testValidUsername(): void
 	{
 		$url = new Uri(['username' => 'testuser']);
 		$this->assertSame('testuser', $url->username());
@@ -219,7 +220,7 @@ class UriTest extends TestCase
 		$this->assertNull($url->username());
 	}
 
-	public function testValidPassword()
+	public function testValidPassword(): void
 	{
 		$url = new Uri(['password' => 'weakpassword']);
 		$this->assertSame('weakpassword', $url->password());
@@ -228,7 +229,7 @@ class UriTest extends TestCase
 		$this->assertNull($url->password());
 	}
 
-	public function testValidPath()
+	public function testValidPath(): void
 	{
 		$url = new Uri(['path' => '/a/b/c']);
 		$this->assertSame('a/b/c', $url->path()->toString());
@@ -243,7 +244,7 @@ class UriTest extends TestCase
 		$this->assertTrue($url->path()->isEmpty());
 	}
 
-	public function testValidQuery()
+	public function testValidQuery(): void
 	{
 		$url = new Uri(['query' => 'foo=bar']);
 		$this->assertSame('foo=bar', $url->query()->toString());
@@ -258,7 +259,7 @@ class UriTest extends TestCase
 		$this->assertTrue($url->query()->isEmpty());
 	}
 
-	public function testValidFragment()
+	public function testValidFragment(): void
 	{
 		$url = new Uri(['fragment' => 'top']);
 		$this->assertSame('top', $url->fragment());
@@ -270,13 +271,13 @@ class UriTest extends TestCase
 		$this->assertNull($url->fragment());
 	}
 
-	public function testAuth()
+	public function testAuth(): void
 	{
 		$url = new Uri(['username' => 'testuser', 'password' => 'weakpassword']);
 		$this->assertSame('testuser:weakpassword', $url->auth());
 	}
 
-	public function testBase()
+	public function testBase(): void
 	{
 		$url = new Uri(['scheme' => 'https', 'host' => 'getkirby.com']);
 		$this->assertSame('https://getkirby.com', $url->base());
@@ -290,13 +291,13 @@ class UriTest extends TestCase
 		$this->assertSame('https://testuser:weakpassword@getkirby.com:3000', $url->base());
 	}
 
-	public function testBaseWithoutHost()
+	public function testBaseWithoutHost(): void
 	{
 		$url = new Uri();
 		$this->assertNull($url->base());
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$url = new Uri(static::$example2);
 		$result = $url->toArray();
@@ -437,17 +438,15 @@ class UriTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider buildProvider
-	 */
-	public function testToString(string $url, array $props, string $expected)
+	#[DataProvider('buildProvider')]
+	public function testToString(string $url, array $props, string $expected): void
 	{
 		$url = new Uri($url, $props);
 		$this->assertSame($expected, $url->toString());
 		$this->assertSame($expected, (string)$url);
 	}
 
-	public function testConstructParamsDisabled()
+	public function testConstructParamsDisabled(): void
 	{
 		// with slash
 		$url = new Uri('https://getkirby.com/search/page:2/?q=something', ['params' => false]);
@@ -474,7 +473,7 @@ class UriTest extends TestCase
 		$this->assertSame('', $url->path()->toString());
 	}
 
-	public function testHttps()
+	public function testHttps(): void
 	{
 		$url = new Uri(['scheme' => 'http']);
 		$this->assertFalse($url->https());
@@ -483,7 +482,7 @@ class UriTest extends TestCase
 		$this->assertTrue($url->https());
 	}
 
-	public function testHasFragment()
+	public function testHasFragment(): void
 	{
 		$uri = new Uri('https://getkirby.com/#footer');
 		$this->assertTrue($uri->hasFragment());
@@ -492,7 +491,7 @@ class UriTest extends TestCase
 		$this->assertFalse($uri->hasFragment());
 	}
 
-	public function testHasPath()
+	public function testHasPath(): void
 	{
 		$uri = new Uri('https://getkirby.com/docs');
 		$this->assertTrue($uri->hasPath());
@@ -501,7 +500,7 @@ class UriTest extends TestCase
 		$this->assertFalse($uri->hasPath());
 	}
 
-	public function testHasQuery()
+	public function testHasQuery(): void
 	{
 		$uri = new Uri('https://getkirby.com?search=foo');
 		$this->assertTrue($uri->hasQuery());

--- a/tests/Http/UrlTest.php
+++ b/tests/Http/UrlTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Http;
 
 use Kirby\Cms\App;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UrlTest extends TestCase
 {
@@ -19,7 +20,7 @@ class UrlTest extends TestCase
 		Url::$home    = '/';
 	}
 
-	public function testCurrent()
+	public function testCurrent(): void
 	{
 		$this->assertSame('/', Url::current());
 
@@ -27,18 +28,18 @@ class UrlTest extends TestCase
 		$this->assertSame($this->_yts, Url::current());
 	}
 
-	public function testCurrentDir()
+	public function testCurrentDir(): void
 	{
 		Url::$current = $this->_yts;
 		$this->assertSame('https://www.youtube.com', Url::currentDir());
 	}
 
-	public function testHome()
+	public function testHome(): void
 	{
 		$this->assertSame('/', Url::home());
 	}
 
-	public function testTo()
+	public function testTo(): void
 	{
 		$this->assertSame('/', Url::to());
 		$this->assertSame($this->_yt, Url::to($this->_yt));
@@ -47,12 +48,12 @@ class UrlTest extends TestCase
 		$this->assertSame('../something', Url::to('../something'));
 	}
 
-	public function testLast()
+	public function testLast(): void
 	{
 		$this->assertSame('', Url::last());
 	}
 
-	public function testBuild()
+	public function testBuild(): void
 	{
 		$this->assertSame('/', Url::build());
 
@@ -74,7 +75,7 @@ class UrlTest extends TestCase
 		$this->assertSame($result, Url::build($parts, 'http://getkirby.com'));
 	}
 
-	public function testIsAbsolute()
+	public function testIsAbsolute(): void
 	{
 		$this->assertTrue(Url::isAbsolute('http://getkirby.com/docs'));
 		$this->assertTrue(Url::isAbsolute('https://getkirby.com/docs'));
@@ -86,7 +87,7 @@ class UrlTest extends TestCase
 		$this->assertFalse(Url::isAbsolute('javascript:alert("XSS")'));
 	}
 
-	public function testMakeAbsolute()
+	public function testMakeAbsolute(): void
 	{
 		$this->assertSame('http://getkirby.com', Url::makeAbsolute('http://getkirby.com'));
 		$this->assertSame('/docs/cheatsheet', Url::makeAbsolute('docs/cheatsheet'));
@@ -94,7 +95,7 @@ class UrlTest extends TestCase
 		$this->assertSame('http://getkirby.com', Url::makeAbsolute('', 'http://getkirby.com'));
 	}
 
-	public function testFix()
+	public function testFix(): void
 	{
 		$this->assertSame('http://', Url::fix());
 		$this->assertSame('http://', Url::fix(''));
@@ -102,13 +103,13 @@ class UrlTest extends TestCase
 		$this->assertSame('ftp://getkirby.com', Url::fix('ftp://getkirby.com'));
 	}
 
-	public function testBase()
+	public function testBase(): void
 	{
 		$this->assertNull(Url::base());
 		$this->assertSame('http://getkirby.com', Url::base('http://getkirby.com/docs/cheatsheet'));
 	}
 
-	public function testPath()
+	public function testPath(): void
 	{
 		// stripped
 		$this->assertSame('', Url::path('https://getkirby.com'));
@@ -139,25 +140,25 @@ class UrlTest extends TestCase
 		$this->assertSame('/a/b/', Url::path('https://getkirby.com/a/b/', true, true));
 	}
 
-	public function testStripPath()
+	public function testStripPath(): void
 	{
 		$this->assertSame('https://getkirby.com', Url::stripPath('https://getkirby.com/a/b'));
 		$this->assertSame('https://getkirby.com/', Url::stripPath('https://getkirby.com/a/b/'));
 	}
 
-	public function testStripQuery()
+	public function testStripQuery(): void
 	{
 		$this->assertSame('https://getkirby.com', Url::stripQuery('https://getkirby.com?a=b'));
 		$this->assertSame('https://getkirby.com/', Url::stripQuery('https://getkirby.com/?a=b'));
 	}
 
-	public function testStripFragment()
+	public function testStripFragment(): void
 	{
 		$this->assertSame('https://getkirby.com', Url::stripFragment('https://getkirby.com#a/b'));
 		$this->assertSame('https://getkirby.com/', Url::stripFragment('https://getkirby.com/#a/b'));
 	}
 
-	public function testQuery()
+	public function testQuery(): void
 	{
 		$this->assertSame('', Url::query('https://getkirby.com'));
 		$this->assertSame('a=b', Url::query('?a=b'));
@@ -165,7 +166,7 @@ class UrlTest extends TestCase
 		$this->assertSame('a=b', Url::query('https://getkirby.com/?a=b'));
 	}
 
-	public function testShort()
+	public function testShort(): void
 	{
 		$this->assertSame('getkirby.com/docs', Url::short($this->_docs));
 		$this->assertSame('getkirby.com/docs', Url::short($this->_docs, 100));
@@ -174,7 +175,7 @@ class UrlTest extends TestCase
 		$this->assertSame('getkirby.com###', Url::short($this->_docs, 12, false, '###'));
 	}
 
-	public function testIdn()
+	public function testIdn(): void
 	{
 		$object = Url::idn('https://xn--tst-qla.de');
 		$this->assertInstanceOf(Uri::class, $object);
@@ -206,10 +207,8 @@ class UrlTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider scriptNameProvider
-	 */
-	public function testIndex($host, $scriptName, $expected)
+	#[DataProvider('scriptNameProvider')]
+	public function testIndex($host, $scriptName, $expected): void
 	{
 		new App([
 			'cli' => false,

--- a/tests/Http/VisitorTest.php
+++ b/tests/Http/VisitorTest.php
@@ -8,7 +8,7 @@ use Kirby\Toolkit\Obj;
 
 class VisitorTest extends TestCase
 {
-	public function testVisitorDefaults()
+	public function testVisitorDefaults(): void
 	{
 		$visitor = new Visitor();
 
@@ -20,7 +20,7 @@ class VisitorTest extends TestCase
 		$this->assertInstanceOf(Collection::class, $visitor->acceptedMimeTypes());
 	}
 
-	public function testVisitorWithArguments()
+	public function testVisitorWithArguments(): void
 	{
 		$visitor = new Visitor([
 			'ip'               => '192.168.1.1',
@@ -37,7 +37,7 @@ class VisitorTest extends TestCase
 		$this->assertSame('text/html', $visitor->acceptedMimeType()->type());
 	}
 
-	public function testIp()
+	public function testIp(): void
 	{
 		$visitor = new Visitor();
 		$this->assertSame('', $visitor->ip());
@@ -45,14 +45,14 @@ class VisitorTest extends TestCase
 		$this->assertSame('192.168.1.1', $visitor->ip());
 	}
 
-	public function testUserAgent()
+	public function testUserAgent(): void
 	{
 		$visitor = new Visitor();
 		$this->assertInstanceOf(Visitor::class, $visitor->userAgent('Kirby'));
 		$this->assertSame('Kirby', $visitor->userAgent());
 	}
 
-	public function testAcceptsMimeType()
+	public function testAcceptsMimeType(): void
 	{
 		$visitor = new Visitor();
 		$this->assertFalse($visitor->acceptsMimeType('text/html'));
@@ -62,7 +62,7 @@ class VisitorTest extends TestCase
 		$this->assertFalse($visitor->acceptsMimeType('application/json'));
 	}
 
-	public function testPreferredMimeType()
+	public function testPreferredMimeType(): void
 	{
 		$visitor = new Visitor(['acceptedMimeType' => 'text/html;q=0.8,application/json,text/plain;q=0.9,text/*;q=0.7']);
 
@@ -84,7 +84,7 @@ class VisitorTest extends TestCase
 		$this->assertSame('application/json', $visitor->preferredMimeType('application/yaml', 'application/json'));
 	}
 
-	public function testPrefersJson()
+	public function testPrefersJson(): void
 	{
 		$visitor = new Visitor(['acceptedMimeType' => 'text/html;q=0.8,application/json']);
 		$this->assertTrue($visitor->prefersJson());
@@ -102,7 +102,7 @@ class VisitorTest extends TestCase
 		$this->assertFalse($visitor->prefersJson());
 	}
 
-	public function testAcceptsLanguage()
+	public function testAcceptsLanguage(): void
 	{
 		$visitor = new Visitor(['acceptedLanguage' => 'en-US']);
 		$this->assertTrue($visitor->acceptsLanguage('en_US'));


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Use `CoversClass` and `DataProvider` PHPUnit attributes instead of DocBlock annotations in the `Kirby\Http` package


### Reasoning
Switching over package by package (or smaller units) to see how the code coverage is affected.

### Additional context
Put this for the 5.1.0 milestone to not further add to the list of the 5.0.0 milestone as we want to close this very soon.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Http',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

Only a few rare attributes (`#[RunInSeparateProcess]`, `#[PreserveGlobalState(false)]`) were changed manually based on PHPUnit deprecation warnings.

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass