### PR TITLE
feat: `content.fileRedirects` option

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1292,11 +1292,35 @@ class App
 
 		// try to resolve image urls for pages and drafts
 		if ($page = $site->findPageOrDraft($id)) {
-			return $page->file($filename);
+			return $this->resolveFile($page->file($filename));
 		}
 
 		// try to resolve site files at least
-		return $site->file($filename);
+		return $this->resolveFile($site->file($filename));
+	}
+
+	/**
+	 * Filters a resolved file object using the configuration
+	 */
+	protected function resolveFile(File|null $file): File|null
+	{
+		// shortcut for files that don't exist
+		if ($file === null) {
+			return null;
+		}
+
+		$option = $this->option('content.fileRedirects', true);
+
+		if ($option === true) {
+			return $file;
+		}
+
+		if ($option instanceof Closure) {
+			return $option($file) === true ? $file : null;
+		}
+
+		// option was set to `false` or an invalid value
+		return null;
 	}
 
 	/**

--- a/tests/Cms/App/AppResolveTest.php
+++ b/tests/Cms/App/AppResolveTest.php
@@ -160,6 +160,7 @@ class AppResolveTest extends TestCase
 
 	/**
 	 * @covers ::resolve
+	 * @covers ::resolveFile
 	 */
 	public function testResolveSiteFile()
 	{
@@ -187,6 +188,7 @@ class AppResolveTest extends TestCase
 
 	/**
 	 * @covers ::resolve
+	 * @covers ::resolveFile
 	 */
 	public function testResolvePageFile()
 	{
@@ -215,6 +217,94 @@ class AppResolveTest extends TestCase
 
 		$this->assertIsFile($result);
 		$this->assertSame('test/test.jpg', $result->id());
+	}
+
+	/**
+	 * @covers ::resolve
+	 * @covers ::resolveFile
+	 */
+	public function testResolveFileDisabled()
+	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null',
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'test',
+						'files' => [
+							['filename' => 'test.jpg']
+						],
+					]
+				]
+			],
+			'options' => [
+				'content' => [
+					'fileRedirects' => false
+				]
+			]
+		]);
+
+		// missing file
+		$result = $app->resolve('test/test.png');
+		$this->assertNull($result);
+
+		// existing file
+		$result = $app->resolve('test/test.jpg');
+		$this->assertNull($result);
+	}
+
+	/**
+	 * @covers ::resolve
+	 * @covers ::resolveFile
+	 */
+	public function testResolveFileClosure()
+	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null',
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'test',
+						'files' => [
+							[
+								'content'  => [
+									'public' => 'true'
+								],
+								'filename' => 'test-public.jpg'
+							],
+							[
+								'content'  => [
+									'public' => 'false'
+								],
+								'filename' => 'test-private.jpg'
+							]
+						],
+					]
+				]
+			],
+			'options' => [
+				'content' => [
+					'fileRedirects' => fn (File $file): bool => $file->public()->toBool()
+				]
+			]
+		]);
+
+		// missing file
+		$result = $app->resolve('test/test.png');
+		$this->assertNull($result);
+
+		// existing file (allowed)
+		$result = $app->resolve('test/test-public.jpg');
+		$this->assertIsFile($result);
+		$this->assertSame('test/test-public.jpg', $result->id());
+
+		// existing file (not allowed)
+		$result = $app->resolve('test/test-private.jpg');
+		$this->assertNull($result);
 	}
 
 	/**

--- a/tests/Cms/Routes/RouterTest.php
+++ b/tests/Cms/Routes/RouterTest.php
@@ -161,6 +161,32 @@ class RouterTest extends TestCase
 		$this->assertSame('background.jpg', $file->id());
 	}
 
+	public function testPageFileRouteDisabled()
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'  => 'projects',
+						'files' => [
+							[
+								'filename' => 'cover.jpg'
+							]
+						]
+					]
+				]
+			],
+			'options' => [
+				'content' => [
+					'fileRedirects' => false
+				]
+			]
+		]);
+
+		$file = $app->call('projects/cover.jpg');
+		$this->assertNull($file);
+	}
+
 	public function testNestedPageRoute()
 	{
 		$app = $this->app->clone([


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

- New `content.fileRedirects` option that controls whether "clean" file routes should be accessible
- Can be set to `true` (default), `false` or a closure to control dynamically per file

### Reasoning

- Allows to limit access to sensitive file originals

### Additional context

Follow-up will be two PRs for v5 (change default to `true` and fix lookup of site files)

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Features

- URLs of the form `https://example.com/some/page/file.pdf` or `https://example.com/some-site-file.pdf` can be disabled or dynamically controlled with a new `content.fileRedirects` option to protect against unauthorized file downloads.

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

### Config reference for `content` option: https://getkirby.com/docs/reference/system/options/content

    <since v="4.8.0">
    ## Access to file originals by URL

    Uploaded files can be accessed with URLs of the form `https://example.com/some/page/file.pdf` or `https://example.com/some-site-file.pdf`. This can be useful to share clean links to files that keep working even if the media URL changes, e.g. when moving the site to a different server.

    Depending on the nature of your files, you can control this behavior either globally or dynamically per file by setting the `content.fileRedirects` option.

    Possible values: `true`| `false` | `Closure` (default: `true`)

    ```php
    return [
      'content' => [
        'fileRedirects' => false
      ]
    ];
    ```

    You can also dynamically control this behavior, e.g. based on a file field or other custom logic:

    ```php
    return [
      'content' => [
        'fileRedirects' => fn (File $file): bool => $file->public()->toBool()
      ]
    ];
    ```
    </since>

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
