### PR TITLE
fix: Regression in `Media` path traversal hardening

### DIFF
--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -132,18 +132,18 @@ class Media
 			// this adds support for custom assets
 			$source = match (true) {
 				is_string($model) === true
-					=> $index . '/' . $model . '/' . $options['filename'],
+					=> F::realpath(
+						$index . '/' . $model . '/' . $options['filename'],
+						$index
+					),
 				$model instanceof File
 					=> $model->root(),
 				default
 				=> $model->file($options['filename'])->root()
 			};
 
-			// prevent path traversal
-			$root = F::realpath($source, $index);
-
 			// generate the thumbnail and save it in the media folder
-			$kirby->thumb($root, $thumb, $options);
+			$kirby->thumb($source, $thumb, $options);
 
 			// remove the job file once the thumbnail has been created
 			F::remove($job);

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -268,7 +268,7 @@ class MediaTest extends TestCase
 		F::write(dirname($file->mediaRoot()) . '/.jobs/' . $file->filename() . '.json', $jobString);
 
 		$this->expectException(\Exception::class);
-		$this->expectExceptionMessage('The file does not exist');
+		$this->expectExceptionMessage('File not found');
 
 		Media::thumb($site, $file->mediaHash(), $file->filename());
 	}


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

- Only use the realpath check in `Media` when it is needed.

### Reasoning

The `F::realpath()` check was only intended for the case where the path is constructed from an asset path (passed as string). The other cases don’t need it and broke when the content folder was outside the `index` root.

### Additional context

As noted by @jensscherbl in https://github.com/getkirby/kirby/commit/1dbc4365f746b92afefbddce0ec49014f57afd0c#r156932648.

I suggest we publish this in a patch release 4.7.2.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Fix regression in 4.7.1 that broke the creation of thumbs when the `content` folder was outside of the `index` root (e.g. in `public` folder setups) #7218

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

None

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
