### PR TITLE
fix: Grouping Cms\Collection by Closure

### DIFF
--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -163,9 +163,9 @@ class Collection extends BaseCollection
 		$field,
 		bool $caseInsensitive = true
 	): self {
-		if (is_string($field) === true) {
-			$groups = new self([], $this->parent());
+		$groups = new self(parent: $this->parent());
 
+		if (is_string($field) === true) {
 			foreach ($this->data as $key => $item) {
 				$value = $this->getAttribute($item, $field);
 
@@ -196,11 +196,9 @@ class Collection extends BaseCollection
 		}
 
 		// use the parent method but unwrap the Toolkit collection
-		// and rewrap it as a Cms collection
-		return new self(
-			parent::group($field, $caseInsensitive)->data,
-			$this->parent()
-		);
+		// and rewrap it as a Cms\Collection instance
+		$groups->data = parent::group($field, $caseInsensitive)->data;
+		return $groups;
 	}
 
 	/**

--- a/tests/Cms/Collections/CollectionTest.php
+++ b/tests/Cms/Collections/CollectionTest.php
@@ -45,7 +45,7 @@ class CollectionTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Collection';
 
-	public function testCollectionMethods()
+	public function testCollectionMethods(): void
 	{
 		$kirby = $this->kirby([
 			'collectionMethods' => [
@@ -68,7 +68,7 @@ class CollectionTest extends TestCase
 		Pages::$methods = [];
 	}
 
-	public function testWithValidObjects()
+	public function testWithValidObjects(): void
 	{
 		$collection = new Collection([
 			$a = new MockObject(['id' => 'a', 'name' => 'a']),
@@ -80,7 +80,7 @@ class CollectionTest extends TestCase
 		$this->assertSame($c, $collection->last());
 	}
 
-	public function testWithArray()
+	public function testWithArray(): void
 	{
 		$collection = new Collection([
 			$a = ['id' => 'a', 'name' => 'a'],
@@ -92,7 +92,7 @@ class CollectionTest extends TestCase
 		$this->assertSame($c, $collection->last());
 	}
 
-	public function testGetAttribute()
+	public function testGetAttribute(): void
 	{
 		$object     = new MockObject(['id' => 'a']);
 		$collection = new Collection();
@@ -101,7 +101,7 @@ class CollectionTest extends TestCase
 		$this->assertSame('a', $value);
 	}
 
-	public function testGetAttributeWithField()
+	public function testGetAttributeWithField(): void
 	{
 		$object = new MockObject([
 			'id' => $field = new Field(null, 'id', 'a')
@@ -113,7 +113,7 @@ class CollectionTest extends TestCase
 		$this->assertSame($field, $value);
 	}
 
-	public function testAppend()
+	public function testAppend(): void
 	{
 		$a = new MockObject(['id' => 'a', 'name' => 'A']);
 		$b = new MockObject(['id' => 'b', 'name' => 'B']);
@@ -145,7 +145,7 @@ class CollectionTest extends TestCase
 		$this->assertSame([$a, $b, $c, $d, 'a simple string'], $collection->values());
 	}
 
-	public function testFindByUuid()
+	public function testFindByUuid(): void
 	{
 		$collection = new Collection([
 			$page = new Page([
@@ -166,7 +166,7 @@ class CollectionTest extends TestCase
 		$this->assertNull($result);
 	}
 
-	public function testGroup()
+	public function testGroup(): void
 	{
 		$collection = new Collection([
 			new MockObject(['id' => 'a', 'group' => 'a']),
@@ -186,7 +186,7 @@ class CollectionTest extends TestCase
 		$this->assertCount(1, $groupB);
 	}
 
-	public function testGroupWithInvalidKey()
+	public function testGroupWithInvalidKey(): void
 	{
 		$collection = new Collection([
 			new MockObject(['id' => 'a', 'group' => 'a']),
@@ -200,7 +200,7 @@ class CollectionTest extends TestCase
 		$collection->group(1);
 	}
 
-	public function testGroupCaseSensitive()
+	public function testGroupCaseSensitive(): void
 	{
 		$collection = new Collection([
 			new Page(['slug' => 'a', 'content' => ['group' => 'a']]),
@@ -221,7 +221,27 @@ class CollectionTest extends TestCase
 		$this->assertCount(1, $groupB);
 	}
 
-	public function testIndexOfWithObject()
+	public function testGroupWithClosure(): void
+	{
+		$collection = new Collection([
+			new MockObject(['id' => 'a', 'group' => 'a']),
+			new MockObject(['id' => 'b', 'group' => 'a']),
+			new MockObject(['id' => 'c', 'group' => 'b']),
+		]);
+
+		$groups = $collection->group(fn ($object) => $object->group());
+
+		$this->assertInstanceOf(Collection::class, $groups);
+		$this->assertCount(2, $groups);
+
+		$groupA = $groups->first();
+		$groupB = $groups->last();
+
+		$this->assertCount(2, $groupA);
+		$this->assertCount(1, $groupB);
+	}
+
+	public function testIndexOfWithObject(): void
 	{
 		$collection = new Collection([
 			$a = new MockObject(['id' => 'a']),
@@ -237,7 +257,7 @@ class CollectionTest extends TestCase
 		$this->assertFalse($collection->indexOf($d));
 	}
 
-	public function testIndexOfWithString()
+	public function testIndexOfWithString(): void
 	{
 		$collection = new Collection([
 			new MockObject(['id' => 'a']),
@@ -251,7 +271,7 @@ class CollectionTest extends TestCase
 		$this->assertFalse($collection->indexOf('d'));
 	}
 
-	public function testNotWithObjects()
+	public function testNotWithObjects(): void
 	{
 		$collection = new Collection([
 			$a = new MockObject(['id' => 'a']),
@@ -272,7 +292,7 @@ class CollectionTest extends TestCase
 		$this->assertSame($c, $result->last());
 	}
 
-	public function testNotWithCollection()
+	public function testNotWithCollection(): void
 	{
 		$collection = new Collection([
 			new MockObject(['id' => 'a']),
@@ -287,7 +307,7 @@ class CollectionTest extends TestCase
 		$this->assertSame('b', $result->first()->id());
 	}
 
-	public function testNotWithSimpleArray()
+	public function testNotWithSimpleArray(): void
 	{
 		$collection = new Collection([
 			new MockObject(['id' => 'a']),
@@ -302,7 +322,7 @@ class CollectionTest extends TestCase
 		$this->assertSame('b', $result->first()->id());
 	}
 
-	public function testNotWithCollectionsArray()
+	public function testNotWithCollectionsArray(): void
 	{
 		$collection = new Collection([
 			new MockObject(['id' => 'a']),
@@ -325,7 +345,7 @@ class CollectionTest extends TestCase
 		$this->assertSame('c', $result->first()->id());
 	}
 
-	public function testNotWithObjectsArray()
+	public function testNotWithObjectsArray(): void
 	{
 		$collection = new Collection([
 			new MockObject(['id' => 'a']),
@@ -344,7 +364,7 @@ class CollectionTest extends TestCase
 		$this->assertSame('a', $result->first()->id());
 	}
 
-	public function testNotWithString()
+	public function testNotWithString(): void
 	{
 		$collection = new Collection([
 			$a = new MockObject(['id' => 'a']),
@@ -365,7 +385,7 @@ class CollectionTest extends TestCase
 		$this->assertSame($c, $result->last());
 	}
 
-	public function testPaginate()
+	public function testPaginate(): void
 	{
 		$collection = new Collection([
 			$a = new MockObject(['id' => 'a']),
@@ -395,7 +415,7 @@ class CollectionTest extends TestCase
 		$this->assertSame($c, $result->last());
 	}
 
-	public function testPrepend()
+	public function testPrepend(): void
 	{
 		$a = new MockObject(['id' => 'a', 'name' => 'A']);
 		$b = new MockObject(['id' => 'b', 'name' => 'B']);
@@ -427,7 +447,7 @@ class CollectionTest extends TestCase
 		$this->assertSame(['a simple string', $d, $c, $b, $a], $collection->values());
 	}
 
-	public function testQuerySearch()
+	public function testQuerySearch(): void
 	{
 		$collection = new Collection([
 			new Page(['slug' => 'project-a']),
@@ -454,7 +474,7 @@ class CollectionTest extends TestCase
 		$this->assertSame('project-b', $result->first()->id());
 	}
 
-	public function testQueryPagination()
+	public function testQueryPagination(): void
 	{
 		$collection = new Collection([
 			new Page(['slug' => 'project-a']),
@@ -471,7 +491,7 @@ class CollectionTest extends TestCase
 		$this->assertSame(3, $result->pagination()->pages());
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$collection = new Collection([
 			new MockObject(['id' => 'a']),
@@ -494,7 +514,7 @@ class CollectionTest extends TestCase
 		]);
 	}
 
-	public function testToArrayWithCallback()
+	public function testToArrayWithCallback(): void
 	{
 		$collection = new Collection([
 			new MockObject(['id' => 'a']),


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- https://github.com/getkirby/kirby/commit/af357de5ca4c2d43a0e7d3d8a7b209cb44966850 actually broke grouping `Cms\Collection` with a callback function. Passing the parent data to the class constructor seems to have caused problems (as I think it ignores the keys of `$data`).
- Instead we now inject the data directly via `$groups->data`.
- Added a unit test for `Cms\Collection::group(Closure)` which does fail on `v5/develop` before this PR and passes with this PR.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixed regressions from earlier pre-releases
- Grouping collections by closure works again #7208


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
