### PR TITLE
Media firewall 1a: Disable `content.fileRedirects` by default

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1326,7 +1326,7 @@ class App
 			return null;
 		}
 
-		$option = $this->option('content.fileRedirects', true);
+		$option = $this->option('content.fileRedirects', false);
 
 		if ($option === true) {
 			return $file;

--- a/tests/Cms/App/AppResolveTest.php
+++ b/tests/Cms/App/AppResolveTest.php
@@ -202,6 +202,37 @@ class AppResolveTest extends TestCase
 	 * @covers ::resolve
 	 * @covers ::resolveFile
 	 */
+	public function testResolveFileDefault()
+	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null',
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'test',
+						'files' => [
+							['filename' => 'test.jpg']
+						],
+					]
+				]
+			]
+		]);
+
+		// missing file
+		$result = $app->resolve('test/test.png');
+		$this->assertNull($result);
+
+		// existing file
+		$result = $app->resolve('test/test.jpg');
+		$this->assertNull($result);
+	}
+
+	/**
+	 * @covers ::resolve
+	 * @covers ::resolveFile
+	 */
 	public function testResolveSiteFile()
 	{
 		$app = new App([
@@ -212,6 +243,11 @@ class AppResolveTest extends TestCase
 				'files' => [
 					['filename' => 'test.jpg']
 				],
+			],
+			'options' => [
+				'content' => [
+					'fileRedirects' => true
+				]
 			]
 		]);
 
@@ -245,6 +281,11 @@ class AppResolveTest extends TestCase
 						],
 					]
 				]
+			],
+			'options' => [
+				'content' => [
+					'fileRedirects' => true
+				]
 			]
 		]);
 
@@ -257,42 +298,6 @@ class AppResolveTest extends TestCase
 
 		$this->assertIsFile($result);
 		$this->assertSame('test/test.jpg', $result->id());
-	}
-
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveFile
-	 */
-	public function testResolveFileDisabled()
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null',
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug' => 'test',
-						'files' => [
-							['filename' => 'test.jpg']
-						],
-					]
-				]
-			],
-			'options' => [
-				'content' => [
-					'fileRedirects' => false
-				]
-			]
-		]);
-
-		// missing file
-		$result = $app->resolve('test/test.png');
-		$this->assertNull($result);
-
-		// existing file
-		$result = $app->resolve('test/test.jpg');
-		$this->assertNull($result);
 	}
 
 	/**

--- a/tests/Cms/Routes/RouterTest.php
+++ b/tests/Cms/Routes/RouterTest.php
@@ -123,7 +123,7 @@ class RouterTest extends TestCase
 		$this->assertSame('xml', $result->body());
 	}
 
-	public function testPageFileRoute()
+	public function testPageFileRouteDefault()
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -141,28 +141,10 @@ class RouterTest extends TestCase
 		]);
 
 		$file = $app->call('projects/cover.jpg');
-		$this->assertIsFile($file);
-		$this->assertSame('projects/cover.jpg', $file->id());
+		$this->assertNull($file);
 	}
 
-	public function testSiteFileRoute()
-	{
-		$app = $this->app->clone([
-			'site' => [
-				'files' => [
-					[
-						'filename' => 'background.jpg'
-					]
-				]
-			]
-		]);
-
-		$file = $app->call('background.jpg');
-		$this->assertIsFile($file);
-		$this->assertSame('background.jpg', $file->id());
-	}
-
-	public function testPageFileRouteDisabled()
+	public function testPageFileRouteEnabled()
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -179,13 +161,52 @@ class RouterTest extends TestCase
 			],
 			'options' => [
 				'content' => [
-					'fileRedirects' => false
+					'fileRedirects' => true
 				]
 			]
 		]);
 
 		$file = $app->call('projects/cover.jpg');
+		$this->assertIsFile($file);
+		$this->assertSame('projects/cover.jpg', $file->id());
+	}
+
+	public function testSiteFileRouteDefault()
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'files' => [
+					[
+						'filename' => 'background.jpg'
+					]
+				]
+			]
+		]);
+
+		$file = $app->call('background.jpg');
 		$this->assertNull($file);
+	}
+
+	public function testSiteFileRouteEnabled()
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'files' => [
+					[
+						'filename' => 'background.jpg'
+					]
+				]
+			],
+			'options' => [
+				'content' => [
+					'fileRedirects' => true
+				]
+			]
+		]);
+
+		$file = $app->call('background.jpg');
+		$this->assertIsFile($file);
+		$this->assertSame('background.jpg', $file->id());
 	}
 
 	public function testNestedPageRoute()


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

- Disable `content.fileRedirects` option by default

### Reasoning

- Protect file originals by default (security by design)
- The routes have never been documented and the URLs could never be generated with core methods, so it is unlikely that many have relied on them.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Breaking changes

- The `content.fileRedirects` option is now set to `false` by default. This protects uploaded file originals from unauthorized downloads. If you rely on the `https://example.com/some/page/file.pdf` or `https://example.com/some-site-file.pdf` routes, you can set the option to `true` or to a closure to control access dynamically per file.

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

### Config reference for `content.fileRedirects` option: [getkirby.com/docs/reference/system/options/content](https://getkirby.com/docs/reference/system/options/content)

- Change the default to `false`
- Change the first config example to set `true`
- New alert box right after the first config example:
  ```html
  <alert>
  Setting the option to `true` allows all visitors to download the uploaded file originals in full quality and resolution and with all metadata that the file carries. This can be a copyright, privacy or information security concern. Only set the option to `true` if none of your files require access protection.
  </alert>
  ```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
