### PR TITLE
Media firewall 1b: Don’t resolve files on site if page doesn't exist

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1304,16 +1304,21 @@ class App
 			}
 		}
 
+		// try to resolve clean URLs to site files
+		if (str_contains($path, '/') === false) {
+			return $this->resolveFile($site->file($path));
+		}
+
 		$id       = dirname($path);
 		$filename = basename($path);
 
-		// try to resolve image urls for pages and drafts
+		// try to resolve clean URLs to files for pages and drafts
 		if ($page = $site->findPageOrDraft($id)) {
 			return $this->resolveFile($page->file($filename));
 		}
 
-		// try to resolve site files at least
-		return $this->resolveFile($site->file($filename));
+		// none of our resolvers were successful
+		return null;
 	}
 
 	/**

--- a/tests/Cms/App/AppResolveTest.php
+++ b/tests/Cms/App/AppResolveTest.php
@@ -280,6 +280,9 @@ class AppResolveTest extends TestCase
 							['filename' => 'test.jpg']
 						],
 					]
+				],
+				'files' => [
+					['filename' => 'test-site.jpg']
 				]
 			],
 			'options' => [
@@ -291,6 +294,10 @@ class AppResolveTest extends TestCase
 
 		// missing file
 		$result = $app->resolve('test/test.png');
+		$this->assertNull($result);
+
+		// file that only exists on the site
+		$result = $app->resolve('another-page/test-site.jpg');
 		$this->assertNull($result);
 
 		// existing file


### PR DESCRIPTION
## 🚨 Merge first

- [x] https://github.com/getkirby/kirby/pull/7216

## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

- Site files are only queried if the request path to resolve is at the root (no slash in the path)

### Reasoning

- Requests to an invalid page ID but with a filename that exists on the site were resolved to the site file. This lead to duplicate content redirects and is just a weird behavior.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- URLs like `https://example.com/some-invalid-page/some-site-file.pdf` are no longer resolved to an existing site file

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
