### PR TITLE
Media firewall 1c: Fix `$file->previewUrl()` when route is disabled

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1311,8 +1311,9 @@ class App
 
 	/**
 	 * Filters a resolved file object using the configuration
+	 * @internal
 	 */
-	protected function resolveFile(File|null $file): File|null
+	public function resolveFile(File|null $file): File|null
 	{
 		// shortcut for files that don't exist
 		if ($file === null) {

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -619,7 +619,9 @@ class File extends ModelWithContent
 	/**
 	 * Clean file URL that uses the parent page URL
 	 * and the filename as a more stable alternative
-	 * for the media URLs if available
+	 * for the media URLs if available. The `content.fileRedirects`
+	 * option is used to disable this behavior or enable it
+	 * on a per-file basis.
 	 */
 	public function previewUrl(): string|null
 	{

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -617,12 +617,18 @@ class File extends ModelWithContent
 	}
 
 	/**
-	 * Simplified File URL that uses the parent
-	 * Page URL and the filename as a more stable
-	 * alternative for the media URLs.
+	 * Clean file URL that uses the parent page URL
+	 * and the filename as a more stable alternative
+	 * for the media URLs if available
 	 */
 	public function previewUrl(): string|null
 	{
+		// check if the clean file URL is accessible,
+		// otherwise we need to fall back to the media URL
+		if ($this->kirby()->resolveFile($this) === null) {
+			return $this->url();
+		}
+
 		$parent = $this->parent();
 		$url    = Url::to($this->id());
 
@@ -651,6 +657,7 @@ class File extends ModelWithContent
 
 				return $url;
 			case 'user':
+				// there are no clean URL routes for user files
 				return $this->url();
 			default:
 				return $url;

--- a/tests/Cms/App/AppResolveTest.php
+++ b/tests/Cms/App/AppResolveTest.php
@@ -160,7 +160,6 @@ class AppResolveTest extends TestCase
 
 	/**
 	 * @covers ::resolve
-	 * @covers ::resolveFile
 	 */
 	public function testResolveSiteFile()
 	{
@@ -188,7 +187,6 @@ class AppResolveTest extends TestCase
 
 	/**
 	 * @covers ::resolve
-	 * @covers ::resolveFile
 	 */
 	public function testResolvePageFile()
 	{
@@ -223,6 +221,42 @@ class AppResolveTest extends TestCase
 	 * @covers ::resolve
 	 * @covers ::resolveFile
 	 */
+	public function testResolveFileEnabled()
+	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null',
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'test',
+						'files' => [
+							['filename' => 'test.jpg']
+						],
+					]
+				]
+			]
+		]);
+
+		// missing file
+		$result1 = $app->resolve('test/test.png');
+		$result2 = $app->resolveFile($app->page('test')->file('test.png'));
+		$this->assertNull($result1);
+		$this->assertNull($result2);
+
+		// existing file
+		$result1 = $app->resolve('test/test.jpg');
+		$result2 = $app->resolveFile($app->page('test')->file('test.jpg'));
+		$this->assertSame($result1, $result2);
+		$this->assertIsFile($result1);
+		$this->assertSame('test/test.jpg', $result1->id());
+	}
+
+	/**
+	 * @covers ::resolve
+	 * @covers ::resolveFile
+	 */
 	public function testResolveFileDisabled()
 	{
 		$app = new App([
@@ -247,12 +281,16 @@ class AppResolveTest extends TestCase
 		]);
 
 		// missing file
-		$result = $app->resolve('test/test.png');
-		$this->assertNull($result);
+		$result1 = $app->resolve('test/test.png');
+		$result2 = $app->resolveFile($app->page('test')->file('test.png'));
+		$this->assertNull($result1);
+		$this->assertNull($result2);
 
 		// existing file
-		$result = $app->resolve('test/test.jpg');
-		$this->assertNull($result);
+		$result1 = $app->resolve('test/test.jpg');
+		$result2 = $app->resolveFile($app->page('test')->file('test.jpg'));
+		$this->assertNull($result1);
+		$this->assertNull($result2);
 	}
 
 	/**
@@ -294,17 +332,23 @@ class AppResolveTest extends TestCase
 		]);
 
 		// missing file
-		$result = $app->resolve('test/test.png');
-		$this->assertNull($result);
+		$result1 = $app->resolve('test/test.png');
+		$result2 = $app->resolveFile($app->page('test')->file('test.png'));
+		$this->assertNull($result1);
+		$this->assertNull($result2);
 
 		// existing file (allowed)
-		$result = $app->resolve('test/test-public.jpg');
-		$this->assertIsFile($result);
-		$this->assertSame('test/test-public.jpg', $result->id());
+		$result1 = $app->resolve('test/test-public.jpg');
+		$result2 = $app->resolveFile($app->page('test')->file('test-public.jpg'));
+		$this->assertSame($result1, $result2);
+		$this->assertIsFile($result1);
+		$this->assertSame('test/test-public.jpg', $result1->id());
 
 		// existing file (not allowed)
-		$result = $app->resolve('test/test-private.jpg');
-		$this->assertNull($result);
+		$result1 = $app->resolve('test/test-private.jpg');
+		$result2 = $app->resolveFile($app->page('test')->file('test-private.jpg'));
+		$this->assertNull($result1);
+		$this->assertNull($result2);
 	}
 
 	/**

--- a/tests/Cms/Files/FileTest.php
+++ b/tests/Cms/Files/FileTest.php
@@ -723,7 +723,7 @@ class FileTest extends TestCase
 		$this->assertSame('//@/file/my-file-uuid', $page->file('test.pdf')->permalink());
 	}
 
-	public function testPreviewUrl()
+	public function testPreviewUrlRedirects()
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -738,6 +738,11 @@ class FileTest extends TestCase
 					'id'    => 'editor',
 					'name'  => 'editor',
 				]
+			],
+			'options' => [
+				'content' => [
+					'fileRedirects' => fn (File $file) => $file->filename() === 'allowed.pdf'
+				]
 			]
 		]);
 
@@ -748,13 +753,19 @@ class FileTest extends TestCase
 			'slug'  => 'test',
 			'files' => [
 				[
-					'filename' => 'test.pdf'
+					'filename' => 'allowed.pdf'
+				],
+				[
+					'filename' => 'not-allowed.pdf'
 				]
 			]
 		]);
 
-		$file = $page->file('test.pdf');
-		$this->assertSame('/test/test.pdf', $file->previewUrl());
+		$file1 = $page->file('allowed.pdf');
+		$this->assertSame('/test/allowed.pdf', $file1->previewUrl());
+
+		$file2 = $page->file('not-allowed.pdf');
+		$this->assertSame('/media/pages/test/' . $file2->mediaHash() . '/not-allowed.pdf', $file2->previewUrl());
 	}
 
 	public function testPreviewUrlUnauthenticated()


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

- The new `$app->resolveFile()` is now public as `@internal`
- `$file->previewUrl()` takes this into account and falls back to the media URL if the route is disabled for the current file or in general

### Reasoning

- Ensures that the returned URL always leads to the file

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

None (release note snippet from PR 1 contains all needed user-facing info)

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
