### PR TITLE
fix: Save title and slug in changes if they exist

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -10,7 +10,6 @@ use Kirby\Content\VersionId;
 use Kirby\Exception\DuplicateException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
-use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
@@ -88,13 +87,14 @@ trait PageActions
 		string|null $languageCode = null
 	): static {
 		// always sanitize the slug
-		$slug = Url::slug($slug);
+		$slug     = Url::slug($slug);
+		$language = Language::ensure($languageCode ?? 'current');
 
 		// in multi-language installations the slug for the non-default
 		// languages is stored in the text file. The changeSlugForLanguage
 		// method takes care of that.
-		if ($this->kirby()->language($languageCode)?->isDefault() === false) {
-			return $this->changeSlugForLanguage($slug, $languageCode);
+		if ($language->isDefault() === false) {
+			return $this->changeSlugForLanguage($slug, $language->code());
 		}
 
 		// if the slug stays exactly the same,
@@ -103,8 +103,14 @@ trait PageActions
 			return $this;
 		}
 
-		$arguments = ['page' => $this, 'slug' => $slug, 'languageCode' => null];
-		return $this->commit('changeSlug', $arguments, function ($oldPage, $slug) {
+		$arguments = [
+			'page'         => $this,
+			'slug'         => $slug,
+			'languageCode' => null,
+			'language'     => $language
+		];
+
+		return $this->commit('changeSlug', $arguments, function ($oldPage, $slug, $languageCode, $language) {
 			$newPage = $oldPage->clone([
 				'slug'     => $slug,
 				'dirname'  => null,
@@ -150,13 +156,7 @@ trait PageActions
 		string $slug,
 		string|null $languageCode = null
 	): static {
-		$language = $this->kirby()->language($languageCode);
-
-		if (!$language) {
-			throw new NotFoundException(
-				message: 'The language: "' . $languageCode . '" does not exist'
-			);
-		}
+		$language = Language::ensure($languageCode ?? 'current');
 
 		if ($language->isDefault() === true) {
 			throw new InvalidArgumentException(
@@ -164,11 +164,23 @@ trait PageActions
 			);
 		}
 
-		$arguments = ['page' => $this, 'slug' => $slug, 'languageCode' => $language->code()];
-		return $this->commit('changeSlug', $arguments, function ($page, $slug, $languageCode) {
+		$arguments = [
+			'page'         => $this,
+			'slug'         => $slug,
+			'languageCode' => $language->code(),
+			'language'     => $language
+		];
+
+		return $this->commit('changeSlug', $arguments, function ($page, $slug, $languageCode, $language) {
 			// remove the slug if it's the same as the folder name
 			if ($slug === $page->uid()) {
 				$slug = null;
+			}
+
+			// make sure to update the slug in the changes version as well
+			// otherwise the new slug would be lost as soon as the changes are saved
+			if ($page->version('changes')->exists($language) === true) {
+				$page->version('changes')->update(['slug' => $slug], $language);
 			}
 
 			return $page->save(['slug' => $slug], $languageCode);
@@ -303,21 +315,24 @@ trait PageActions
 		string $title,
 		string|null $languageCode = null
 	): static {
-		// if the `$languageCode` argument is not set and is not the default language
-		// the `$languageCode` argument is sent as the current language
-		if (
-			$languageCode === null &&
-			$language = $this->kirby()->language()
-		) {
-			if ($language->isDefault() === false) {
-				$languageCode = $language->code();
+		$language = Language::ensure($languageCode ?? 'current');
+
+		$arguments = [
+			'page'         => $this,
+			'title'        => $title,
+			'languageCode' => $languageCode,
+			'language'     => $language
+		];
+
+		return $this->commit('changeTitle', $arguments, function ($page, $title, $languageCode, $language) {
+
+			// make sure to update the title in the changes version as well
+			// otherwise the new title would be lost as soon as the changes are saved
+			if ($page->version('changes')->exists($language) === true) {
+				$page->version('changes')->update(['title' => $title], $language);
 			}
-		}
 
-		$arguments = ['page' => $this, 'title' => $title, 'languageCode' => $languageCode];
-
-		return $this->commit('changeTitle', $arguments, function ($page, $title, $languageCode) {
-			return $page->save(['title' => $title], $languageCode);
+			return $page->save(['title' => $title], $language->code());
 		});
 	}
 

--- a/tests/Cms/Page/PageChangeTitleTest.php
+++ b/tests/Cms/Page/PageChangeTitleTest.php
@@ -28,6 +28,32 @@ class PageChangeTitleTest extends ModelTestCase
 		$this->assertSame($modified, $childrenAndDrafts->find('test'));
 	}
 
+	public function testChangeTitleWhenChangesExist()
+	{
+		$page = Page::create([
+			'slug' => 'test',
+		]);
+
+		// save the original title
+		$page->version('latest')->save([
+			'title' => 'Old Title'
+		]);
+
+		// add some changes
+		$page->version('changes')->save([
+			'text' => 'Some additional text'
+		]);
+
+		$modified = $page->changeTitle('New Title');
+
+		$this->assertSame('New Title', $modified->title()->value());
+
+		$changes = $modified->version('changes')->content();
+
+		$this->assertSame('New Title', $changes->get('title')->value(), 'The title should be updated in the changes version');
+		$this->assertSame('Some additional text', $changes->get('text')->value(), 'Other changes should remain the same');
+	}
+
 	public function testChangeTitleHooks(): void
 	{
 		$calls = 0;

--- a/tests/Cms/Page/PageSlugTest.php
+++ b/tests/Cms/Page/PageSlugTest.php
@@ -60,6 +60,8 @@ class PageSlugTest extends ModelTestCase
 	{
 		$this->setUpMultiLanguage();
 
+		$this->app->impersonate('kirby');
+
 		$page = Page::create([
 			'slug' => 'test'
 		]);
@@ -73,7 +75,7 @@ class PageSlugTest extends ModelTestCase
 		$this->assertSame('test-translated', $modified->slug('de'));
 		$this->assertSame('test', $modified->slug());
 
-		$changes = $modified->version('changes')->content();
+		$changes = $modified->version('changes')->content('de');
 
 		$this->assertSame('test-translated', $changes->get('slug')->value());
 		$this->assertSame('Some additional text', $changes->get('text')->value());

--- a/tests/Cms/Page/PageSlugTest.php
+++ b/tests/Cms/Page/PageSlugTest.php
@@ -56,6 +56,29 @@ class PageSlugTest extends ModelTestCase
 		$this->assertSame('test', $page->slug('en'));
 	}
 
+	public function testSlugInMultiLanguageModeWhenChangesExist(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$page = Page::create([
+			'slug' => 'test'
+		]);
+
+		$page->version('changes')->save([
+			'text' => 'Some additional text'
+		], 'de');
+
+		$modified = $page->changeSlug('test-translated', 'de');
+
+		$this->assertSame('test-translated', $modified->slug('de'));
+		$this->assertSame('test', $modified->slug());
+
+		$changes = $modified->version('changes')->content();
+
+		$this->assertSame('test-translated', $changes->get('slug')->value());
+		$this->assertSame('Some additional text', $changes->get('text')->value());
+	}
+
 	public function testSlugWithInvalidValue(): void
 	{
 		$this->expectException(TypeError::class);


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- `page.changeTitle` and `page.changeSlug` hooks receive a new optional `$language` parameter, which passes a full Language object. 

### Fixes

- When changing the title or slug (in a secondary language), the `::changeTitle()` and `::changeSlug()` methods will check for an existing `changes` version and store them there as well. Otherwise, the changed title or slug would get reverted as soon as the `changes` version is published.

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
