### PR TITLE
fix: Save sort in changes version

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -104,10 +104,23 @@ trait FileActions
 			return $this;
 		}
 
+		$arguments = [
+			'file'     => $this,
+			'position' => $sort
+		];
+
 		return $this->commit(
 			'changeSort',
-			['file' => $this, 'position' => $sort],
-			fn ($file, $sort) => $file->save(['sort' => $sort])
+			$arguments,
+			function ($file, $sort) {
+				// make sure to update the sort in the changes version as well
+				// otherwise the new sort would be lost as soon as the changes are saved
+				if ($file->version('changes')->exists() === true) {
+					$file->version('changes')->update(['sort' => $sort]);
+				}
+
+				return $file->save(['sort' => $sort]);
+			}
 		);
 	}
 

--- a/tests/Cms/File/FileChangeSortTest.php
+++ b/tests/Cms/File/FileChangeSortTest.php
@@ -57,4 +57,30 @@ class FileChangeSortTest extends ModelTestCase
 		$file1->changeSort(3);
 		$this->assertSame(2, $calls);
 	}
+
+	public function testChangeSortWhenChangesExist(): void
+	{
+		$page = Page::create([
+			'slug' => 'test'
+		]);
+
+		$file = File::create([
+			'filename' => 'doc.pdf',
+			'parent'   => $page,
+			'source'   => __DIR__ . '/fixtures/files/doc.pdf'
+		]);
+
+		$file->version('changes')->save([
+			'text' => 'Some additional text'
+		]);
+
+		$modified = $file->changeSort(3);
+
+		$this->assertSame(3, $modified->sort()->toInt());
+
+		$changes = $modified->version('changes')->content();
+
+		$this->assertSame(3, $changes->get('sort')->toInt());
+		$this->assertSame('Some additional text', $changes->get('text')->value());
+	}
 }


### PR DESCRIPTION
## 🚨 Merge first

- https://github.com/getkirby/kirby/pull/7229

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Store the sort value in the `changes` version in `File::changeSort()` if a `changes` version exists. Otherwise, the changed sorting number would get lost as soon as the changes are published.

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
