### PR TITLE
fix: Don’t skip title field in forms

### DIFF
--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -6,8 +6,6 @@ use Closure;
 use Kirby\Cms\App;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
-use Kirby\Cms\Page;
-use Kirby\Cms\Site;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Toolkit\A;
@@ -352,15 +350,6 @@ class Fields extends Collection
 		$props       = [];
 		$language    = $this->language();
 		$permissions = $this->model->permissions()->can('update');
-
-		if (
-			$this->model instanceof Page ||
-			$this->model instanceof Site
-		) {
-			// the title should never be updated directly via
-			// fields section to avoid conflicts with the rename dialog
-			unset($fields['title']);
-		}
 
 		foreach ($fields as $name => $field) {
 			$props[$name] = $field->toArray();

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -5,7 +5,6 @@ namespace Kirby\Form;
 use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\Language;
-use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Cms\TestCase;
@@ -13,7 +12,6 @@ use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(Fields::class)]
 class FieldsTest extends TestCase
@@ -810,35 +808,6 @@ class FieldsTest extends TestCase
 			[new User(['email' => 'test@getkirby.com']), false],
 			[new File(['filename' => 'test.jpg', 'parent' => new Site()]), false],
 		];
-	}
-
-	#[DataProvider('modelProvider')]
-	public function testToPropsWithSkippedTitleFieldForPage(ModelWithContent $model, bool $skip): void
-	{
-		$this->setUpSingleLanguage();
-
-		$fields = new Fields(
-			fields: [
-				'title' => [
-					'type' => 'text',
-				],
-				'subtitle' => [
-					'type' => 'text',
-				]
-			],
-			model: $model
-		);
-
-		$props = $fields->toProps();
-
-		if ($skip === false) {
-			$this->assertCount(2, $props);
-			$this->assertArrayHasKey('title', $props);
-			$this->assertArrayHasKey('subtitle', $props);
-		} else {
-			$this->assertCount(1, $props);
-			$this->assertArrayHasKey('subtitle', $props);
-		}
 	}
 
 	public function testToPropsWithoutUpdatePermission(): void


### PR DESCRIPTION
## Context

We moved title field skipping into the `Fields::toProps` method, but this will remove the title from any form. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Don’t skip title field in forms https://github.com/getkirby/kirby/issues/7232

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
