### PR TITLE
fix: Keep default values in disabled structure fields

### DIFF
--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -181,11 +181,22 @@ return [
 		},
 	],
 	'save' => function ($value) {
-		$data = [];
-		$form = $this->form();
+		$data     = [];
+		$form     = $this->form();
+		$defaults = $form->defaults();
 
-		foreach ($value as $row) {
-			$row = $form->reset()->submit(input: $row, passthrough: true)->toStoredValues();
+		foreach ($value as $index => $row) {
+			$row = $form
+				->reset()
+				->fill(
+					input: $defaults,
+					passthrough: true
+				)
+				->submit(
+					input: $row,
+					passthrough: true
+				)
+				->toStoredValues();
 
 			// remove frontend helper id
 			unset($row['_id']);

--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -190,7 +190,6 @@ return [
 				->reset()
 				->fill(
 					input: $defaults,
-					passthrough: true
 				)
 				->submit(
 					input: $row,

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -449,6 +449,34 @@ class StructureFieldTest extends TestCase
 		$this->assertTrue($field->isValid());
 	}
 
+	public function testSubmitWithDisabledFieldAndDefaultValue()
+	{
+		$field = $this->field('structure', [
+			'fields' => [
+				'a' => [
+					'type'     => 'text',
+					'default'  => 'Default Title',
+					'disabled' => true
+				],
+				'b' => [
+					'type' => 'text'
+				]
+			],
+		]);
+
+		$field->submit([
+			[
+				'a' => 'A',
+				'b' => 'B'
+			]
+		]);
+
+		$value = $field->toStoredValue();
+
+		$this->assertSame('Default Title', $value[0]['a']);
+		$this->assertSame('B', $value[0]['b']);
+	}
+
 	public function testValidationsInvalid()
 	{
 		$field = $this->field('structure', [


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- When a structure field has disabled fields with a default value, the default value is now properly submitted and saved again. https://github.com/getkirby/kirby/issues/7233

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
