### PR TITLE
fix: Normalize field names in field classes

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -57,21 +57,24 @@ class Field extends Component
 		array $attrs = [],
 		Fields|null $siblings = null
 	) {
+		// use the type as fallback for the name
+		$attrs['name'] ??= $type;
+		$attrs['type']   = $type;
+
+		// set the name to lowercase
+		$attrs['name'] = strtolower($attrs['name']);
+
 		if (isset(static::$types[$type]) === false) {
 			throw new InvalidArgumentException(
 				key: 'field.type.missing',
 				data: [
-					'name' => $attrs['name'] ?? '-',
-					'type' => $type
+					'name' => $attrs['name'],
+					'type' => $attrs['type']
 				]
 			);
 		}
 
 		$this->setModel($attrs['model'] ?? null);
-
-		// use the type as fallback for the name
-		$attrs['name'] ??= $type;
-		$attrs['type']   = $type;
 
 		parent::__construct($type, $attrs);
 

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -57,22 +57,22 @@ class Field extends Component
 		array $attrs = [],
 		Fields|null $siblings = null
 	) {
+		if (isset(static::$types[$type]) === false) {
+			throw new InvalidArgumentException(
+				key: 'field.type.missing',
+				data: [
+					'name' => $attrs['name'] ?? '-',
+					'type' => $type
+				]
+			);
+		}
+
 		// use the type as fallback for the name
 		$attrs['name'] ??= $type;
 		$attrs['type']   = $type;
 
 		// set the name to lowercase
 		$attrs['name'] = strtolower($attrs['name']);
-
-		if (isset(static::$types[$type]) === false) {
-			throw new InvalidArgumentException(
-				key: 'field.type.missing',
-				data: [
-					'name' => $attrs['name'],
-					'type' => $attrs['type']
-				]
-			);
-		}
 
 		$this->setModel($attrs['model'] ?? null);
 

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -255,7 +255,7 @@ abstract class FieldClass
 
 	protected function setName(string|null $name = null): void
 	{
-		$this->name = $name;
+		$this->name = strtolower($name ?? $this->type());
 	}
 
 	protected function setPlaceholder(array|string|null $placeholder = null): void

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -537,6 +537,15 @@ class FieldClassTest extends TestCase
 	}
 
 	/**
+	 * @covers ::name
+	 */
+	public function testNameCase()
+	{
+		$field = new TestField(['name' => 'myTest']);
+		$this->assertSame('mytest', $field->name());
+	}
+
+	/**
 	 * @covers ::params
 	 */
 	public function testParams()

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -833,6 +833,20 @@ class FieldTest extends TestCase
 		$this->assertSame('mytest', $field->name());
 	}
 
+	public function testNameCase()
+	{
+		Field::$types = [
+			'test' => []
+		];
+
+		$field = new Field('test', [
+			'model' => new Page(['slug' => 'test']),
+			'name'  => 'myTest'
+		]);
+
+		$this->assertSame('mytest', $field->name());
+	}
+
 	/**
 	 * @covers ::needsValue
 	 * @covers ::errors


### PR DESCRIPTION
## Sandbox 

There's a new test setup for this in the sandbox. Pull the latest changes, switch to the lab environment and go to: https://sandbox.test/panel/pages/fields+structure You will find a new "Field name cases" example at the bottom. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- `Kirby\Form\Field` and `Kirby\Form\FieldClass` normalize type and name attributes and set the name to lowercase. We did that previously in the Form class and it slipped through with the refactoring. Without turning all names into lowercase, fields might not be matched properly and this is also causing an issue with columns in structure fields. https://github.com/getkirby/kirby/issues/7236

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab example
- [x] Add changes & docs to release notes draft in Notion
