### PR TITLE
fix: Store site title updates in the `changes` version if the version exists. 

### DIFF
--- a/src/Cms/SiteActions.php
+++ b/src/Cms/SiteActions.php
@@ -50,12 +50,13 @@ trait SiteActions
 			'site'         => $this,
 			'title'        => trim($title),
 			'languageCode' => $languageCode,
+			'language'     => $language
 		];
 
 		return $this->commit(
 			'changeTitle',
 			$arguments,
-			fn ($site, $title, $languageCode) => $site->save(['title' => $title], $language->code())
+			fn ($site, $title, $languageCode, $language) => $site->save(['title' => $title], $language->code())
 		);
 	}
 

--- a/src/Cms/SiteActions.php
+++ b/src/Cms/SiteActions.php
@@ -44,23 +44,18 @@ trait SiteActions
 		string $title,
 		string|null $languageCode = null
 	): static {
-		// if the `$languageCode` argument is not set and is not the default language
-		// the `$languageCode` argument is sent as the current language
-		if (
-			$languageCode === null &&
-			$language = $this->kirby()->language()
-		) {
-			if ($language->isDefault() === false) {
-				$languageCode = $language->code();
-			}
-		}
+		$language = Language::ensure($languageCode ?? 'current');
 
-		$arguments = ['site' => $this, 'title' => trim($title), 'languageCode' => $languageCode];
+		$arguments = [
+			'site'         => $this,
+			'title'        => trim($title),
+			'languageCode' => $languageCode,
+		];
 
 		return $this->commit(
 			'changeTitle',
 			$arguments,
-			fn ($site, $title, $languageCode) => $site->save(['title' => $title], $languageCode)
+			fn ($site, $title, $languageCode) => $site->save(['title' => $title], $language->code())
 		);
 	}
 

--- a/src/Cms/SiteActions.php
+++ b/src/Cms/SiteActions.php
@@ -53,11 +53,16 @@ trait SiteActions
 			'language'     => $language
 		];
 
-		return $this->commit(
-			'changeTitle',
-			$arguments,
-			fn ($site, $title, $languageCode, $language) => $site->save(['title' => $title], $language->code())
-		);
+		return $this->commit('changeTitle', $arguments, function ($site, $title, $languageCode, $language) {
+
+			// make sure to update the title in the changes version as well
+			// otherwise the new title would be lost as soon as the changes are saved
+			if ($site->version('changes')->exists($language) === true) {
+				$site->version('changes')->update(['title' => $title], $language);
+			}
+
+			return $site->save(['title' => $title], $language->code());
+		});
 	}
 
 	/**

--- a/tests/Cms/Site/SiteChangeTitleTest.php
+++ b/tests/Cms/Site/SiteChangeTitleTest.php
@@ -16,6 +16,30 @@ class SiteChangeTitleTest extends ModelTestCase
 		$this->assertSame('Test', $site->title()->value());
 	}
 
+	public function testChangeTitleWhenChangesExist()
+	{
+		$site = new Site();
+
+		// save the original title
+		$site->version('latest')->save([
+			'title' => 'Old Title'
+		]);
+
+		// add some changes
+		$site->version('changes')->save([
+			'text' => 'Some additional text'
+		]);
+
+		$modified = $site->changeTitle('New Title');
+
+		$this->assertSame('New Title', $modified->title()->value());
+
+		$changes = $modified->version('changes')->content();
+
+		$this->assertSame('New Title', $changes->get('title')->value(), 'The title should be updated in the changes version');
+		$this->assertSame('Some additional text', $changes->get('text')->value(), 'Other changes should remain the same');
+	}
+
 	public function testChangeTitleHooks(): void
 	{
 		$calls = 0;


### PR DESCRIPTION
## Sandbox

There's now a test setup for site content changes in the sandbox. Pull the latest changes, switch to the Lab environment and visit https://sandbox.test/panel/site?tab=content

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New optional `$language` arg is passed to the `site.changeTitle` hooks

### Fixes

- fix: Store site title updates in the `changes` version if the version exists. #7227 

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
