### PR TITLE
fix: Add missing `Asset::mediaDir()` method

### DIFF
--- a/src/Filesystem/Asset.php
+++ b/src/Filesystem/Asset.php
@@ -82,6 +82,16 @@ class Asset
 	}
 
 	/**
+	 * Returns the absolute path to the media folder for the file and its versions
+	 * @internal
+	 * @since 5.0.0
+	 */
+	public function mediaDir(): string
+	{
+		return dirname($this->mediaRoot());
+	}
+
+	/**
 	 * Create a unique media hash
 	 */
 	public function mediaHash(): string

--- a/src/Filesystem/Asset.php
+++ b/src/Filesystem/Asset.php
@@ -119,9 +119,9 @@ class Asset
 	/**
 	 * Returns the absolute Url to the file in the public media folder
 	 */
-	public function mediaUrl(): string
+	public function mediaUrl(string|null $filename = null): string
 	{
-		return $this->kirby()->url('media') . '/' . $this->mediaPath();
+		return $this->kirby()->url('media') . '/' . $this->mediaPath($filename);
 	}
 
 	/**

--- a/src/Filesystem/Asset.php
+++ b/src/Filesystem/Asset.php
@@ -111,9 +111,9 @@ class Asset
 	/**
 	 * Returns the absolute path to the file in the public media folder
 	 */
-	public function mediaRoot(): string
+	public function mediaRoot(string|null $filename = null): string
 	{
-		return $this->kirby()->root('media') . '/' . $this->mediaPath();
+		return $this->kirby()->root('media') . '/' . $this->mediaPath($filename);
 	}
 
 	/**

--- a/src/Filesystem/Asset.php
+++ b/src/Filesystem/Asset.php
@@ -102,9 +102,10 @@ class Asset
 	/**
 	 * Returns the relative path starting at the media folder
 	 */
-	public function mediaPath(): string
+	public function mediaPath(string|null $filename = null): string
 	{
-		return 'assets/' . $this->path() . '/' . $this->mediaHash() . '/' . $this->filename();
+		$filename ??= $this->filename();
+		return 'assets/' . $this->path() . '/' . $this->mediaHash() . '/' . $filename;
 	}
 
 	/**

--- a/tests/Filesystem/AssetTest.php
+++ b/tests/Filesystem/AssetTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Filesystem;
 use Kirby\Cms\App;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Filesystem\Asset
- */
+#[CoversClass(Asset::class)]
 class AssetTest extends TestCase
 {
 	public function setUp(): void
@@ -31,13 +30,6 @@ class AssetTest extends TestCase
 		return new Asset($file);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::root
-	 * @covers ::id
-	 * @covers ::url
-	 * @covers ::path
-	 */
 	public function testConstruct()
 	{
 		$asset = $this->_asset($file = 'images/logo.svg');
@@ -61,9 +53,6 @@ class AssetTest extends TestCase
 		$this->assertSame('images', $asset->path());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
 	public function testCall()
 	{
 		$asset = $this->_asset($file = 'images/logo.svg');
@@ -83,12 +72,6 @@ class AssetTest extends TestCase
 		$asset->foo();
 	}
 
-	/**
-	 * @covers ::mediaHash
-	 * @covers ::mediaPath
-	 * @covers ::mediaRoot
-	 * @covers ::mediaUrl
-	 */
 	public function testMedia()
 	{
 		$asset = $this->_asset();

--- a/tests/Filesystem/AssetTest.php
+++ b/tests/Filesystem/AssetTest.php
@@ -95,11 +95,19 @@ class AssetTest extends TestCase
 
 		$mediaHash = crc32('logo.svg') . '-';
 		$mediaPath = 'assets/images/' . $mediaHash . '/logo.svg';
+		$mediaRoot = $this->app->root('media') . '/' . $mediaPath;
+		$mediaDir  = dirname($mediaRoot);
+		$mediaUrl  = $this->app->url('media') . '/' . $mediaPath;
 
+		$this->assertSame($mediaDir, $asset->mediaDir());
 		$this->assertSame($mediaHash, $asset->mediaHash());
 		$this->assertSame($mediaPath, $asset->mediaPath());
-		$this->assertSame($this->app->root('media') . '/' . $mediaPath, $asset->mediaRoot());
-		$this->assertSame($this->app->url('media') . '/' . $mediaPath, $asset->mediaUrl());
+		$this->assertSame($mediaRoot, $asset->mediaRoot());
+		$this->assertSame($mediaUrl, $asset->mediaUrl());
+
+		$this->assertSame(dirname($mediaPath) . '/test.jpg', $asset->mediaPath('test.jpg'));
+		$this->assertSame($mediaDir . '/test.jpg', $asset->mediaRoot('test.jpg'));
+		$this->assertSame(dirname($mediaUrl) . '/test.jpg', $asset->mediaUrl('test.jpg'));
 	}
 
 	public function testToString()


### PR DESCRIPTION
## Sandbox

There's a new test setup for this in the sandbox. Pull the latest version, switch to the lab environment and go to https://sandbox.test/panel/pages/other+assets

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New `$filename` arguments for `Asset::mediaPath()`, `Asset::mediaUrl()` and `Asset::mediaRoot()` to keep the Asset class consistent with the File class

### Fixes

- Add missing `Asset::mediaDir()` method https://github.com/getkirby/kirby/issues/7238

### Refactoring

- Convert `AssetTest` class to PHPUnit attributes

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
