### PR TITLE
fix: Fix empty writer toolbar when marks are disabled and inline mode is activated

### DIFF
--- a/panel/src/components/Forms/Input/WriterInput.vue
+++ b/panel/src/components/Forms/Input/WriterInput.vue
@@ -140,7 +140,10 @@ export default {
 		toolbarOptions() {
 			return {
 				// if custom set of marks is enabled, use as toolbar default as well
-				marks: Array.isArray(this.marks) ? this.marks : undefined,
+				marks:
+					Array.isArray(this.marks) || this.marks === false
+						? this.marks
+						: undefined,
 				...this.toolbar,
 				editor: this.editor
 			};


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Fix empty writer toolbar when marks are disabled and inline mode is activated https://github.com/getkirby/kirby/issues/7231

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
