### PR TITLE
feat: Add `_preview` param for preview iframe URLs

### DIFF
--- a/panel/src/components/Views/Preview/PreviewBrowser.vue
+++ b/panel/src/components/Views/Preview/PreviewBrowser.vue
@@ -24,7 +24,8 @@
 				<k-button :link="src" icon="open" size="xs" target="_blank" />
 			</k-button-group>
 		</header>
-		<iframe ref="browser" :src="src"></iframe>
+
+		<iframe ref="browser" :src="srcWithPreviewParam" />
 	</div>
 </template>
 
@@ -39,6 +40,13 @@ export default {
 		versionId: String
 	},
 	emits: ["discard", "submit"],
+	computed: {
+		srcWithPreviewParam() {
+			const uri = new URL(this.src);
+			uri.searchParams.append("_preview", true);
+			return uri.toString();
+		}
+	},
 	mounted() {
 		this.$events.on("content.discard", this.reload);
 		this.$events.on("content.publish", this.reload);


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Preview view: Append `_preview` URL param for the iFrame urls that can be used in the frontend to adjust UI for when being shown inside Panel preview view.


### Reasoning
- Solves #7225

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
