### PR TITLE
test: Normalize timezone during unit tests

### DIFF
--- a/phpunit.ci.xml
+++ b/phpunit.ci.xml
@@ -53,6 +53,7 @@
 	</testsuites>
 
 	<php>
+		<ini name="date.timezone" value="UTC" />
 		<ini name="memory_limit" value="2048M" />
 	</php>
 

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -50,6 +50,7 @@
 	</testsuites>
 
 	<php>
+		<ini name="date.timezone" value="UTC" />
 		<ini name="memory_limit" value="2048M" />
 	</php>
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

Always set timezone to UTC during PHPUnit tests

### Reasoning

We have some tests that assume UTC in their expected values. If the timezone is set differently in `php.ini`, those tests would fail.
