### PR TITLE
fix: Wait for upload and refresh the view afterwards

### DIFF
--- a/panel/src/components/Forms/Field/FilesField.vue
+++ b/panel/src/components/Forms/Field/FilesField.vue
@@ -62,9 +62,6 @@ export default {
 						// the `$panel.content.update()` event sends
 						// the updated form value object to the server
 						await this.$panel.content.update();
-
-						this.$events.emit("file.upload");
-						this.$events.emit("model.update");
 					}
 				}
 			};

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -346,8 +346,8 @@ export default {
 		upload() {
 			this.$panel.upload.pick(this.uploadOptions);
 		},
-		wrap(before, after) {
-			this.insert(before + this.selection() + (after ?? before));
+		async wrap(before, after) {
+			return this.insert(before + this.selection() + (after ?? before));
 		}
 	}
 };

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -103,7 +103,7 @@ export default {
 					cancel: async () => await this.setSelectionRange(selectionRange),
 					done: async (files) => {
 						await this.setSelectionRange(selectionRange);
-						this.insertUpload(files);
+						await this.insertUpload(files);
 					}
 				}
 			};
@@ -200,8 +200,8 @@ export default {
 				await this.insert(files.map((file) => file.dragText).join("\n\n"));
 			}
 		},
-		insertUpload(files) {
-			this.insertFile(files);
+		async insertUpload(files) {
+			await this.insertFile(files);
 			this.$events.emit("model.update");
 		},
 		onCommand(command, ...args) {

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -329,7 +329,7 @@ export default {
 			this.$refs.input.setSelectionRange(start, end);
 			return this.$nextTick();
 		},
-		toggle(before, after) {
+		async toggle(before, after) {
 			after = after ?? before;
 			const selection = this.selection();
 

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -160,7 +160,7 @@ export default {
 					submit: async (file) => {
 						this.$panel.dialog.close();
 						await this.setSelectionRange(selectionRange);
-						this.insertFile(file);
+						await this.insertFile(file);
 					}
 				}
 			});
@@ -195,9 +195,9 @@ export default {
 
 			return input.value;
 		},
-		insertFile(files) {
+		async insertFile(files) {
 			if (files?.length > 0) {
-				this.insert(files.map((file) => file.dragText).join("\n\n"));
+				await this.insert(files.map((file) => file.dragText).join("\n\n"));
 			}
 		},
 		insertUpload(files) {

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -202,7 +202,11 @@ export default {
 		},
 		async insertUpload(files) {
 			await this.insertFile(files);
-			this.$events.emit("model.update");
+			// `$panel.content.update()` cancels the previously
+			// started lazy save request from the emitted `input`
+			// event in `insertFile` > `insert` and reloads the view
+			// after the request went through.
+			await this.$panel.content.update();
 		},
 		onCommand(command, ...args) {
 			if (typeof this[command] !== "function") {

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -295,8 +295,8 @@ export default {
 				title: selection
 			};
 		},
-		prepend(text) {
-			this.insert(text + " " + this.selection());
+		async prepend(text) {
+			return this.insert(text + " " + this.selection());
 		},
 		restoreSelectionCallback() {
 			// store selection

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -141,7 +141,7 @@ export default {
 					submit: async (text) => {
 						this.$panel.dialog.close();
 						await this.setSelectionRange(selectionRange);
-						this.insert(text);
+						await this.insert(text);
 					}
 				}
 			});
@@ -168,7 +168,7 @@ export default {
 		focus() {
 			this.$refs.input.focus();
 		},
-		insert(text) {
+		async insert(text) {
 			const input = this.$refs.input;
 			const current = input.value;
 
@@ -176,22 +176,24 @@ export default {
 				text = text(this.$refs.input, this.selection());
 			}
 
-			setTimeout(() => {
-				input.focus();
+			this.focus();
 
-				// try first via execCommand as this will be considered
-				// as a user action and can be undone by the browser's
-				// native undo function
-				document.execCommand("insertText", false, text);
+			// try first via execCommand as this will be considered
+			// as a user action and can be undone by the browser's
+			// native undo function
+			document.execCommand("insertText", false, text);
 
-				if (input.value === current) {
-					const { start, end } = this.selectionRange();
-					const mode = start === end ? "end" : "select";
-					input.setRangeText(text, start, end, mode);
-				}
+			if (input.value === current) {
+				const { start, end } = this.selectionRange();
+				const mode = start === end ? "end" : "select";
+				input.setRangeText(text, start, end, mode);
+			}
 
-				this.$emit("input", input.value);
-			});
+			await this.$nextTick();
+
+			this.$emit("input", input.value);
+
+			return input.value;
 		},
 		insertFile(files) {
 			if (files?.length > 0) {

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -173,7 +173,7 @@ export default {
 			const current = input.value;
 
 			if (typeof text === "function") {
-				text = text(this.$refs.input, this.selection());
+				text = text(input, this.selection());
 			}
 
 			this.focus();
@@ -337,7 +337,7 @@ export default {
 			return this.$nextTick();
 		},
 		async toggle(before, after) {
-			after = after ?? before;
+			after ??= before;
 			const selection = this.selection();
 
 			if (selection.startsWith(before) && selection.endsWith(after)) {
@@ -354,7 +354,8 @@ export default {
 			this.$panel.upload.pick(this.uploadOptions);
 		},
 		async wrap(before, after) {
-			return this.insert(before + this.selection() + (after ?? before));
+			after ??= before;
+			await this.insert(before + this.selection() + after);
 		}
 	}
 };

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -298,6 +298,9 @@ export default {
 		async prepend(text) {
 			return this.insert(text + " " + this.selection());
 		},
+		/**
+		 * @deprecated 5.0.0 Use `setSelectionRange` instead
+		 */
 		restoreSelectionCallback() {
 			// store selection
 			const selectionRange = this.selectionRange();

--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -52,13 +52,7 @@ export default {
 		uploadOptions() {
 			return {
 				...this.options.upload,
-				url: this.$panel.urls.api + "/" + this.options.upload.api,
-				on: {
-					complete: () => {
-						this.$panel.notification.success({ context: "view" });
-						this.$events.emit("file.upload");
-					}
-				}
+				url: this.$panel.urls.api + "/" + this.options.upload.api
 			};
 		}
 	},

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -279,7 +279,9 @@ export default (panel) => {
 		async save(values = {}, env = {}) {
 			// ensure to abort unfinished previous save request
 			// to avoid race conditions with older content
-			this.saveAbortController?.abort();
+			this.cancelSaving();
+
+			// create a new abort controller
 			this.saveAbortController = new AbortController();
 
 			try {

--- a/panel/src/panel/upload.js
+++ b/panel/src/panel/upload.js
@@ -38,6 +38,10 @@ export default (panel) => {
 		...parent,
 		...listeners(),
 		input: null,
+		announce() {
+			panel.notification.success({ context: "view" });
+			panel.events.emit("model.update");
+		},
 		/**
 		 * Called when dialog's cancel button was clicked
 		 */
@@ -53,7 +57,7 @@ export default (panel) => {
 			// been completely uploaded
 			if (this.completed.length > 0) {
 				await this.emit("complete", this.completed);
-				panel.view.reload();
+				this.announce();
 			}
 
 			this.reset();
@@ -75,11 +79,7 @@ export default (panel) => {
 
 			if (this.completed.length > 0) {
 				await this.emit("done", this.completed);
-
-				if (panel.drawer.isOpen === false) {
-					panel.notification.success({ context: "view" });
-					panel.view.reload();
-				}
+				this.announce();
 			}
 
 			this.reset();

--- a/panel/src/panel/upload.js
+++ b/panel/src/panel/upload.js
@@ -344,6 +344,8 @@ export default (panel) => {
 
 				file.completed = true;
 				file.model = response.data;
+
+				panel.events.emit("file.upload", file);
 			} catch (error) {
 				panel.error(error, false);
 

--- a/panel/src/panel/upload.js
+++ b/panel/src/panel/upload.js
@@ -355,6 +355,8 @@ export default (panel) => {
 
 				// reset the progress bar on error
 				file.progress = 0;
+
+				panel.events.emit("file.upload.error", file);
 			}
 		}
 	});

--- a/panel/src/panel/upload.js
+++ b/panel/src/panel/upload.js
@@ -78,6 +78,7 @@ export default (panel) => {
 			panel.dialog.close();
 
 			if (this.completed.length > 0) {
+				await this.emit("complete", this.completed);
 				await this.emit("done", this.completed);
 				this.announce();
 			}


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New async `TextareaInput.restoreSelection()` method 
- New `panel.upload.announce()` method, which sends the success notification and `model.update` event after uploads have successfully completed. 
- The upload module now sends a `file.upload.error` event for every file that could not be uploaded.
- Various TextareaInput methods have been turned into async methods for more stable async/await control throughout all TextareaInput methods.
  - `insert`
  - `insertFile`
  - `insertUpload`
  - `prepend`
  - `toggle`
  - `wrap`

### Fixes

- `panel.content.save()` now calls `panel.content.cancelSaving()` to make sure that any old scheduled save requests are properly cancelled. This could have lead to potential race conditions before.
- The `FilesField` no longer sends unnecessary `file.upload` and `model.update` emitters after upload. Those lead to duplicate section reload requests so far. After uploads, the `panel.upload.done()` already takes care of reloading the current view and all its sections. 
- The `TextareaInput.insertUpload()` method now uses `await panel.content.update()` to push text value changes directly to the changes API and to reload the view correctly. This fixes https://github.com/getkirby/kirby/issues/7249
- The upload module sends the `file.upload` event directly when a file has been uploaded and passes the file object correctly. Before this change, the file.upload event was only called in the FilesField and FilesSection components when all uploads finished. 
- Both the `upload.done()` and `upload.cancel()` handlers now properly emit the `complete` event if there are any completed uploads. 

### Refactoring

- `TextareaInput.selectionRange` and `TextareaInput.restoreSelection()` are used to replace the old `restoreSelectionCallback` method in dialog events for better async control.
- Removed unnecessary complete handler in `FilesSection`. The upload module already takes care of the notifications and events. 

### Deprecated

- `TextareaInput.restoreSelectionCallback()` Use `TextareaInput.restoreSelection()`.

### Breaking changes

None 

## Sandbox

There's a new "Uploads" tab in the Textarea setup in the sandbox. 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
