### PR TITLE
fix: Tags in multiselect field do no overflow

### DIFF
--- a/panel/lab/components/tags/1_tag/index.vue
+++ b/panel/lab/components/tags/1_tag/index.vue
@@ -41,5 +41,11 @@
 				text="Foo"
 			/>
 		</k-lab-example>
+		<k-lab-example label="Too long">
+			<k-tag
+				:removable="true"
+				text="Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sed diam eget risus varius blandit sit amet non magna. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor."
+			/>
+		</k-lab-example>
 	</k-lab-examples>
 </template>

--- a/panel/src/components/Forms/Input.vue
+++ b/panel/src/components/Forms/Input.vue
@@ -173,6 +173,7 @@ export default {
 /* Element container */
 .k-input-element {
 	flex-grow: 1;
+	min-width: 0;
 }
 
 /* Icon */

--- a/panel/src/components/Navigation/Tag.vue
+++ b/panel/src/components/Navigation/Tag.vue
@@ -106,6 +106,7 @@ export default {
 .k-tag {
 	position: relative;
 	height: var(--tag-height);
+	max-width: 100%;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;

--- a/panel/src/components/Navigation/Tags.vue
+++ b/panel/src/components/Navigation/Tags.vue
@@ -234,6 +234,7 @@ export default {
 
 .k-tags {
 	display: inline-flex;
+	max-width: 100%;
 	gap: var(--tags-gap);
 	align-items: center;
 	flex-wrap: wrap;


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- CSS changes to make the text ellipsis overflow logic actually work


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Tags in multiselect field do no overflow the input
#7221


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
