### PR TITLE
fix: URI builder: Trailing slash on relative URL

### DIFF
--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -472,7 +472,7 @@ class Uri implements Stringable
 
 		$path = $this->path->toString($slash) . $this->params->toString(true);
 
-		if ($this->slash && $slash === true) {
+		if ($this->slash && ($path !== '' || $slash === true)) {
 			$path .= '/';
 		}
 

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -233,6 +233,9 @@ class UriTest extends TestCase
 		$url = new Uri(['path' => '/a/b/c']);
 		$this->assertSame('a/b/c', $url->path()->toString());
 
+		$url = new Uri(['path' => '/a/b/c/']);
+		$this->assertSame('a/b/c', $url->path()->toString());
+
 		$url = new Uri(['path' => ['a', 'b', 'c']]);
 		$this->assertSame('a/b/c', $url->path()->toString());
 
@@ -316,6 +319,20 @@ class UriTest extends TestCase
 			[static::$example1, [], static::$example1],
 			[static::$example2, [], static::$example2],
 
+			// relative path
+			[
+				'/search',
+				[],
+				'/search'
+			],
+
+			// relative path with trailing slash
+			[
+				'/search/',
+				[],
+				'/search/'
+			],
+
 			// relative path + adding params
 			[
 				'/search',
@@ -324,6 +341,16 @@ class UriTest extends TestCase
 					'query'  => ['q' => 'something']
 				],
 				'/search/page:2?q=something'
+			],
+
+			// relative path with trailing slash + adding params
+			[
+				'/search/',
+				[
+					'params' => ['page' => 2],
+					'query'  => ['q' => 'something']
+				],
+				'/search/page:2/?q=something'
 			],
 
 			// relative path with colon + adding query


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes

If the URI path is non-empty, the trailing slash flag needs to be respected independent of the base URI.

### Reasoning

Ensures that URIs that come in are correctly serialized when they come out

### Additional context

I’ve discovered this bug while working on the fix for #7240 due to a failing unit test. Passing `/subfolder/` to `Uri` made it swallow the trailing slash. We’ve had this bug since Kirby 3.0.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- The `Uri` class now properly serializes URIs of the form `/subfolder/`

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
