### PR TITLE
fix: Add missing submit handler

### DIFF
--- a/panel/src/components/Forms/Input.vue
+++ b/panel/src/components/Forms/Input.vue
@@ -20,6 +20,7 @@
 					v-bind="inputProps"
 					:value="value"
 					@input="$emit('input', $event)"
+					@submit="$emit('submit', $event)"
 				/>
 			</slot>
 		</span>
@@ -53,7 +54,7 @@ export const props = {
 			default: null
 		}
 	},
-	emits: ["input"]
+	emits: ["input", "submit"]
 };
 
 export default {


### PR DESCRIPTION
## Description

For some reason, we removed the submit handler in the Input component, which leads to a broken enter key in the date field. It's probably going to cause similar issues in other fields, but we haven't noticed yet. The fix is easy though :) 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixed regression

- <kbd>Enter</kbd> works again as shortcut in the date field https://github.com/getkirby/kirby/issues/7257

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
