### PR TITLE
fix: Make `HasMethods::hasMethod()` public again

### DIFF
--- a/src/Cms/HasMethods.php
+++ b/src/Cms/HasMethods.php
@@ -42,8 +42,9 @@ trait HasMethods
 
 	/**
 	 * Checks if the object has a registered method
+	 * @internal
 	 */
-	protected function hasMethod(string $method): bool
+	public function hasMethod(string $method): bool
 	{
 		return $this->getMethod($method) !== null;
 	}


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- #7266



### Breaking changes
Undoes the breaking change earlier introduced in v5 pre releases.



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
