### PR TITLE
fix: Add missing array check and fix invalid label value in the entries field

### DIFF
--- a/panel/src/components/Forms/Field/EntriesField.vue
+++ b/panel/src/components/Forms/Field/EntriesField.vue
@@ -229,10 +229,7 @@ export default {
 	watch: {
 		value: {
 			handler(entries) {
-				if (Array.isArray(entries) === false) {
-					this.entries = [];
-					return;
-				}
+				entries ??= [];
 
 				// no need to add ids again if the values are the same
 				if (entries === this.values) {

--- a/panel/src/components/Forms/Field/EntriesField.vue
+++ b/panel/src/components/Forms/Field/EntriesField.vue
@@ -229,6 +229,11 @@ export default {
 	watch: {
 		value: {
 			handler(entries) {
+				if (Array.isArray(entries) === false) {
+					this.entries = [];
+					return;
+				}
+
 				// no need to add ids again if the values are the same
 				if (entries === this.values) {
 					return;

--- a/panel/src/mixins/props/label.js
+++ b/panel/src/mixins/props/label.js
@@ -3,6 +3,6 @@ export default {
 		/**
 		 * A descriptive label for the field
 		 */
-		label: String
+		label: [String, Boolean]
 	}
 };


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Passing `false` as label value to `<k-field>` will no longer throw a console error. We use this in the new `<k-entries-field>` to disable labels for nested fields.  
- The new `<k-entries-field>` checks for a valid array as given value and will no longer throw a console error if `null` is passed. https://github.com/getkirby/kirby/issues/7265

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
