### PR TITLE
fix: Move trait template annotations to class doc

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -34,6 +34,9 @@
 
 		<!-- Don't warn about duplicate array keys as Psalm will throw false positive when unpacking arrays -->
 		<DuplicateArrayKey errorLevel="suppress" />
+
+		<!-- Don't warn about missing template params as Psalm does not recognize this correctly when using `@uses` for traits in class docblock -->
+		<MissingTemplateParam errorLevel="suppress" />
 	</issueHandlers>
 
 	<plugins>

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -29,15 +29,14 @@ use Kirby\Toolkit\Str;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Files>
  */
 class File extends ModelWithContent
 {
 	use FileActions;
 	use FileModifications;
 	use HasMethods;
-	/**
-	 * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Files>
-	 */
 	use HasSiblings;
 	use IsFile;
 

--- a/src/Cms/Item.php
+++ b/src/Cms/Item.php
@@ -22,12 +22,10 @@ use Kirby\Toolkit\Str;
  * @license   https://getkirby.com/license
  *
  * @template TCollection of \Kirby\Cms\Items
+ * @use \Kirby\Cms\HasSiblings<TCollection>
  */
 class Item
 {
-	/**
-	 * @use \Kirby\Cms\HasSiblings<TCollection>
-	 */
 	use HasSiblings;
 
 	public const ITEMS_CLASS = Items::class;

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -26,12 +26,11 @@ use Stringable;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Languages>
  */
 class Language implements Stringable
 {
-	/**
-	 * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Languages>
-	 */
 	use HasSiblings;
 
 	/**

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -28,6 +28,8 @@ use Throwable;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Pages>
  */
 class Page extends ModelWithContent
 {
@@ -35,9 +37,6 @@ class Page extends ModelWithContent
 	use HasFiles;
 	use HasMethods;
 	use HasModels;
-	/**
-	 * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Pages>
-	 */
 	use HasSiblings;
 	use PageActions;
 	use PageSiblings;

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -24,15 +24,14 @@ use SensitiveParameter;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Users>
  */
 class User extends ModelWithContent
 {
 	use HasFiles;
 	use HasMethods;
 	use HasModels;
-	/**
-	 * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Users>
-	 */
 	use HasSiblings;
 	use UserActions;
 

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -18,12 +18,11 @@ use Kirby\Toolkit\I18n;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
+ *
+ * @use \Kirby\Cms\HasSiblings<\Kirby\Form\Fields>
  */
 class Field extends Component
 {
-	/**
-	 * @use \Kirby\Cms\HasSiblings<\Kirby\Form\Fields>
-	 */
 	use HasSiblings;
 	use Mixin\Api;
 	use Mixin\Model;

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -16,12 +16,11 @@ use Kirby\Toolkit\Str;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @use \Kirby\Cms\HasSiblings<\Kirby\Form\Fields>
  */
 abstract class FieldClass
 {
-	/**
-	 * @use \Kirby\Cms\HasSiblings<\Kirby\Form\Fields>
-	 */
 	use HasSiblings;
 	use Mixin\Api;
 	use Mixin\Model;


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

### Summary of changes
- Move `@use MyTrait<MyTemplateType>` to class docblocks.


### Reasoning
IDEs recognize it in both positions, but our Reference code cannot access the annotation on the `use Trait` statement. That's why we move it to the class docblock.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~
