### PR TITLE
fix: Show text in radio & select field previews

### DIFF
--- a/panel/src/components/Forms/Previews/index.js
+++ b/panel/src/components/Forms/Previews/index.js
@@ -46,8 +46,8 @@ export default {
 
 		app.component("k-checkboxes-field-preview", TagsFieldPreview);
 		app.component("k-multiselect-field-preview", TagsFieldPreview);
-		app.component("k-radio-field-preview", TagFieldPreview);
-		app.component("k-select-field-preview", TagFieldPreview);
+		app.component("k-radio-field-preview", TagsFieldPreview);
+		app.component("k-select-field-preview", TagsFieldPreview);
 		app.component("k-toggles-field-preview", TagsFieldPreview);
 	}
 };


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

`TagFieldPreview` displays the provided value directly in tag UI.
`TagsFieldPreview` actually matches the value to its option and uses that option text for tag UI.

To test, pull latest changes for the `sandbox` and then use https://sandbox.test/panel/pages/fields+select?tab=preview

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixed regressions
- Select & radio field previews: Show option text instead of value 
#7273


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
