### PR TITLE
Collapsed button group: remove coloured borders on buttons

### DIFF
--- a/panel/src/components/Navigation/ButtonGroup.vue
+++ b/panel/src/components/Navigation/ButtonGroup.vue
@@ -84,9 +84,10 @@ export default {
 	border-end-end-radius: 0;
 }
 
-.k-button-group[data-layout="collapsed"] > .k-button:not([data-theme]) {
+.k-button-group[data-layout="collapsed"] > .k-button {
 	--theme-color-border: var(--panel-color-back);
 }
+
 .k-button-group[data-layout="collapsed"]
 	> .k-button[data-variant="filled"]:not(:first-child) {
 	border-start-start-radius: 0;


### PR DESCRIPTION
### Summary of changes

Removes border colour on collapsed buttons, regardless of theme (`*`, `*-icon`).

### Reasoning

I think it looks better.

![CleanShot 2025-06-10 at 16 04 38@2x](https://github.com/user-attachments/assets/6a8d2ef4-b32a-4aac-b26b-418fbfe7fb7e)
![CleanShot 2025-06-10 at 16 03 40@2x](https://github.com/user-attachments/assets/bb0d410a-6ae1-497d-b315-8057bc77f6bb)


### Additional context

I'm super cool if you decide against this.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

Weirdly coloured lines that look out of place.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
