### PR TITLE
fix: Adjust back button background for dark mode

### DIFF
--- a/panel/src/components/Navigation/FileBrowser.vue
+++ b/panel/src/components/Navigation/FileBrowser.vue
@@ -113,7 +113,10 @@ export default {
 
 <style>
 :root {
-	--file-browser-items-color-back: light-dark(var(--color-gray-100), var(--panel-color-back));
+	--file-browser-items-color-back: light-dark(
+		var(--color-gray-100),
+		var(--panel-color-back)
+	);
 }
 
 .k-file-browser {
@@ -164,7 +167,7 @@ export default {
 		justify-content: flex-start;
 		padding-inline: 0.25rem;
 		margin-bottom: 0.5rem;
-		background: var(--color-gray-200);
+		background: light-dark(var(--color-gray-200), var(--color-gray-800));
 		border-radius: var(--rounded);
 	}
 	.k-file-browser-tree {


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Adjust the background color of the mobile back button in the file browser in dark mode. https://github.com/getkirby/kirby/issues/7280

### Breaking changes

None

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
