### PR TITLE
fix: Allow submitting disabled fields

### DIFF
--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -666,7 +666,10 @@ abstract class ModelWithContent implements Identifiable, Stringable
 			language: $languageCode,
 		);
 
-		$form->submit($input ?? []);
+		$form->submit(
+			input: $input ?? [],
+			force: $validate === false
+		);
 
 		if ($validate === true) {
 			$form->validate();

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -277,7 +277,10 @@ class Fields extends Collection
 	/**
 	 * Sets the value for each field with a matching key in the input array
 	 * but only if the field is not disabled
+	 *
 	 * @since 5.0.0
+	 * @param bool $passthrough If true, values for undefined fields will be submitted
+	 * @param bool $force If true, values for fields that cannot be submitted (e.g. disabled or untranslatable fields) will be submitted
 	 */
 	public function submit(
 		array $input,

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -281,7 +281,8 @@ class Fields extends Collection
 	 */
 	public function submit(
 		array $input,
-		bool $passthrough = true
+		bool $passthrough = true,
+		bool $force = false
 	): static {
 		$language = $this->language();
 
@@ -294,8 +295,13 @@ class Fields extends Collection
 				continue;
 			}
 
-			// don't change the value of non-submittable fields
-			if ($field->isSubmittable($language) === false) {
+			// don't submit fields without a value
+			if ($force === true && $field->hasValue() === false) {
+				continue;
+			}
+
+			// don't submit fields that are not submittable
+			if ($force === false && $field->isSubmittable($language) === false) {
 				continue;
 			}
 

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -318,11 +318,13 @@ class Form
 	 */
 	public function submit(
 		array $input,
-		bool $passthrough = true
+		bool $passthrough = true,
+		bool $force = false
 	): static {
 		$this->fields->submit(
-			input:       $input,
-			passthrough: $passthrough
+			input: $input,
+			passthrough: $passthrough,
+			force: $force
 		);
 		return $this;
 	}

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -315,6 +315,8 @@ class Form
 	 * but only if the field is not disabled
 	 *
 	 * @since 5.0.0
+	 * @param bool $passthrough If true, values for undefined fields will be submitted
+	 * @param bool $force If true, values for fields that cannot be submitted (e.g. disabled or untranslatable fields) will be submitted
 	 */
 	public function submit(
 		array $input,

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -637,6 +637,35 @@ class FieldsTest extends TestCase
 		], $fields->toStoredValues());
 	}
 
+	public function testSubmitWithForceAndANoValueField(): void
+	{
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type'  => 'text',
+					'value' => 'A',
+				],
+				'b' => [
+					'type'  => 'info',
+					'value' => 'B',
+				],
+			],
+			model: $this->model
+		);
+
+		$fields->submit(
+			input: [
+				'a' => 'A updated',
+				'b' => 'B updated',
+			],
+			force: true
+		);
+
+		$this->assertSame([
+			'a' => 'A updated',
+		], $fields->toStoredValues(), 'The info field can never be submitted. It has no value.');
+	}
+
 	public function testSubmitWithClosureValues(): void
 	{
 		$fields = new Fields(

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -666,6 +666,37 @@ class FieldsTest extends TestCase
 		], $fields->toStoredValues(), 'The info field can never be submitted. It has no value.');
 	}
 
+	public function testSubmitWithForceAndAComplexDisabledField(): void
+	{
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type'  => 'text',
+					'value' => 'A',
+				],
+				'b' => [
+					'type'     => 'date',
+					'disabled' => true,
+					'value'    => '2025-01-01',
+				],
+			],
+			model: $this->model
+		);
+
+		$fields->submit(
+			input: [
+				'a' => 'A updated',
+				'b' => '03.04.2025',
+			],
+			force: true
+		);
+
+		$this->assertSame([
+			'a' => 'A updated',
+			'b' => '2025-04-03',
+		], $fields->toStoredValues(), 'The date field should still be able to format the value correctly even if it was disabled.');
+	}
+
 	public function testSubmitWithClosureValues(): void
 	{
 		$fields = new Fields(


### PR DESCRIPTION
## Description

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New `$force` argument for `Kirby\Form\Fields::submit()` and `Kirby\Form\Form::submit()` to submit any value, even if the field is disabled, inactive or not translatable.

### Fixed regressions from previous pre-releases

- `Kirby\Cms\ModelWithContent::update()` will accept disabled fields again, unless `$validate` is switched on. https://github.com/getkirby/kirby/issues/7268

### Breaking changes

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

### Submitting any value 

Sometimes, you need to make sure that all values are submitted, even if the field is disabled or not translatable. The `$force` parameter for the submit method can help here. 

```php
use Kirby\Form\Form;

$form = new Form(
  fields: [
    'text' => [
      'type' => 'text',
      'disabled' => true
    ]
  ]
);

$form->submit(
  input: [
    'text' => 'This will be submitted'
  ],
  force: true
);
```

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
