### PR TITLE
fix: Don’t use currentColor for the auto-fill text color

### DIFF
--- a/panel/src/styles/reset.css
+++ b/panel/src/styles/reset.css
@@ -85,7 +85,7 @@
 }
 
 :where(input:-webkit-autofill) {
-	-webkit-text-fill-color: var(--input-color-text) !important;
+	-webkit-text-fill-color: var(--color-text) !important;
 	-webkit-background-clip: text;
 }
 


### PR DESCRIPTION

### Additional context

Safari does not seem to allow currentColor as value for `-webkit-text-fill-color` That's why we need to explicitely use the text color variable here. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Fix illegible text after using autofill in the login view in dark mode https://github.com/getkirby/kirby/issues/7275

### Breaking changes

None

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
