### PR TITLE
fix: Bring back the old `Content::update()`

### DIFF
--- a/src/Content/Content.php
+++ b/src/Content/Content.php
@@ -5,7 +5,6 @@ namespace Kirby\Content;
 use Kirby\Cms\Blueprint;
 use Kirby\Cms\File;
 use Kirby\Cms\ModelWithContent;
-use Kirby\Exception\Exception;
 use Kirby\Form\Form;
 
 /**
@@ -237,17 +236,18 @@ class Content
 	}
 
 	/**
-	 * Removed in 5.0.0. We only keep it to simplify debugging,
-	 * when this method is still in use in the wild.
-	 *
-	 * Use $model->version()->update() instead.
-	 *
-	 * @todo Remove in 7.0.0
+	 * Updates the content in memory.
 	 */
 	public function update(
 		array|null $content = null,
 		bool $overwrite = false
 	): static {
-		throw new Exception('`$content->update()` is no longer functional. Please use `$model->version()->update()` instead');
+		$content = array_change_key_case((array)$content, CASE_LOWER);
+		$this->data = $overwrite === true ? $content : array_merge($this->data, $content);
+
+		// clear cache of Field objects
+		$this->fields = [];
+
+		return $this;
 	}
 }

--- a/tests/Content/ContentTest.php
+++ b/tests/Content/ContentTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Content;
 
 use Kirby\Cms\Page;
-use Kirby\Exception\Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(Content::class)]
@@ -197,9 +196,33 @@ class ContentTest extends TestCase
 			'b' => 'B'
 		]);
 
-		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('`$content->update()` is no longer functional. Please use `$model->version()->update()` instead');
+		$content->update([
+			'a' => 'aaa'
+		]);
 
-		$content->update();
+		$this->assertSame('aaa', $content->get('a')->value());
+
+		$content->update([
+			'miXED' => 'mixed!'
+		]);
+
+		$this->assertSame('mixed!', $content->get('mixed')->value());
+
+		// Field objects should be cleared on update
+		$content->update([
+			'a' => 'aaaaaa'
+		]);
+
+		$this->assertSame('aaaaaa', $content->get('a')->value());
+
+		$content->update($expected = [
+			'TEST' => 'TEST'
+		], true);
+
+		$this->assertSame(['test' => 'TEST'], $content->data());
+
+		$content->update(null, true);
+
+		$this->assertSame([], $content->data());
 	}
 }


### PR DESCRIPTION
## Description

We have a couple issues related to no longer being able to manipulate the content object in memory. One step to solve this, could be to bring back the `Content::update()` method. There's no harm to allow modifying the object in memory. But it still needs to be used differently after this change, so it would only a part of the solution. 

### Before

```php
$page->title();
// Foo

$page->content()->update([
  'title' => 'Bar'
]);

$page->title(); 
// Bar
```

### After 

```php
$page->title();
// Foo

$content = $page->content()->update([
  'title' => 'Bar'
]);

$page->title(); 
// Foo

$content->title();
// Bar
```

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Unbreak `Content::update()`

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
