### PR TITLE
fix: Panel view button referenced from config

### DIFF
--- a/src/Panel/Ui/Buttons/ViewButton.php
+++ b/src/Panel/Ui/Buttons/ViewButton.php
@@ -117,8 +117,11 @@ class ViewButton extends Button
 		string $name,
 		string|null $view = null
 	): array|Closure {
-		// collect all buttons from areas
-		$buttons = Panel::buttons();
+		// collect all buttons from areas and config
+		$buttons = [
+			...Panel::buttons(),
+			...App::instance()->option('panel.viewButtons.' . $view, [])
+		];
 
 		// try to find by full name (view-prefixed)
 		if ($view && $button = $buttons[$view . '.' . $name] ?? null) {

--- a/tests/Panel/Ui/Buttons/ViewButtonsTest.php
+++ b/tests/Panel/Ui/Buttons/ViewButtonsTest.php
@@ -82,12 +82,12 @@ class ViewButtonsTest extends AreaTestCase
 	 */
 	public function testRender()
 	{
-		$buttons = new ViewButtons('test', buttons: ['a', 'b']);
+		$buttons = new ViewButtons('test', buttons: ['a', 'y']);
 		$result  = $buttons->render();
 
 		$this->assertCount(2, $result);
-		$this->assertSame('k-a-view-button', $result[0]['component']);
-		$this->assertSame('k-b-view-button', $result[1]['component']);
+		$this->assertSame('result-a', $result[0]['component']);
+		$this->assertSame('k-y-view-button', $result[1]['component']);
 	}
 
 	/**


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Allows to reference view buttons by name in the blueprint not only from core buttons or custom Panel area buttons but also buttons defined in the config file as defaults for the view.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixed from earlier pre-release candidates
- Fixed referencing view buttons from config file in blueprint.
#7278



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
