### PR TITLE
fix: Properly resolve plugin's `extends`

### DIFF
--- a/panel/src/panel/plugins.js
+++ b/panel/src/panel/plugins.js
@@ -1,3 +1,4 @@
+import Vue from "vue";
 import { isObject } from "@/helpers/object.js";
 import isComponent from "@/helpers/isComponent.js";
 
@@ -153,7 +154,8 @@ export const resolveComponentMixins = (component) => {
 				// make sure to only include the mixin if the parent component
 				// hasn't already included it (to avoid duplicate mixins)
 				if (component.extends) {
-					const inherited = new component.extends().$options.mixins ?? [];
+					const extended = Vue.extend(component.extends);
+					const inherited = new extended().$options.mixins ?? [];
 
 					if (inherited.includes(mixins[mixin]) === true) {
 						return;


### PR DESCRIPTION
## Description

This change should make both usages of `extends` in plugins work:
- referencing an existing component by name, e.g.
```js
panel.plugin("foo/foo", {
  sections: {
    foo: {
      extends:"k-info-section"
    }
  }
})

```

- referencing an imported Vue SFC, e.g. 
```js
import Section from "./Section.vue"

panel.plugin("foo/foo", {
  sections: {
    foo: {
      extends: Section
    }
  }
})

```

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Fixed plugins using `extends` with Vue SFC
#7253


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
