### PR TITLE
fix: Disable dialog save shortcut when loading

### DIFF
--- a/panel/src/components/Dialogs/Elements/Buttons.vue
+++ b/panel/src/components/Dialogs/Elements/Buttons.vue
@@ -1,11 +1,7 @@
 <template>
 	<k-button-group class="k-dialog-buttons">
 		<k-button v-if="cancel" v-bind="cancel" />
-		<k-button
-			v-if="submit"
-			v-bind="submit"
-			:icon="$panel.dialog.isLoading ? 'loader' : submit.icon"
-		/>
+		<k-button v-if="submit" v-bind="submit" />
 	</k-button-group>
 </template>
 
@@ -77,7 +73,7 @@ export default {
 			return this.button(this.submitButton, {
 				class: "k-dialog-button-submit",
 				disabled: this.disabled || this.$panel.dialog.isLoading,
-				icon: this.icon,
+				icon: this.$panel.dialog.isLoading ? "loader" : this.icon,
 				text: this.$t("confirm"),
 				theme: this.theme,
 				type: "submit",

--- a/panel/src/panel/modal.js
+++ b/panel/src/panel/modal.js
@@ -149,14 +149,18 @@ export default (panel, key, defaults) => {
 		/**
 		 * Custom submitter for the dialog/drawer
 		 * It will automatically close the modal
-		 * if there's no submit listner or backend route.
+		 * if there's no submit listener or backend route.
 		 *
 		 * @param {Object} value
 		 * @param {Object} options
 		 * @returns {Promise} The new state or false if the request failed
 		 */
 		async submit(value, options = {}) {
-			value = value ?? this.props.value;
+			if (this.isLoading === true) {
+				return;
+			}
+
+			value ??= this.props.value;
 
 			if (this.hasEventListener("submit")) {
 				return this.emit("submit", value, options);


### PR DESCRIPTION
## Description

Blocks the `panel.dialog.submit()` method when dialog is currently loading (already being submitted).

In the related issue, this prevents the upload dialog to be submitted multiple times by spamming `Cmd+S` (when the user thinks this would save the form content). 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Dialogs: `Cmd+S` doesn't re-submit the dialog when its already submitting
#7258


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
