### PR TITLE
refact: Move since tag to own section in Lab docs

### DIFF
--- a/config/areas/lab/drawers.php
+++ b/config/areas/lab/drawers.php
@@ -16,12 +16,14 @@ return [
 				];
 			}
 
+			$doc = Doc::factory($component);
+
 			return [
 				'component' => 'k-lab-docs-drawer',
 				'props' => [
 					'icon' => 'book',
 					'title' => $component,
-					'docs'  => Doc::factory($component)->toArray()
+					'docs'  => $doc->toArray()
 				]
 			];
 		},

--- a/panel/src/components/Lab/Docs.vue
+++ b/panel/src/components/Lab/Docs.vue
@@ -7,7 +7,12 @@
 			title="Unstable"
 			text="This component has been marked as unstable and may change in the future."
 		/>
-		<k-lab-docs-description :description="description" :since="since" />
+
+		<section v-if="since" class="k-lab-docs-view-since">
+			Since <k-tag :text="since" theme="light" />
+		</section>
+
+		<k-lab-docs-description :description="description" />
 		<k-lab-docs-examples :examples="examples" />
 		<k-lab-docs-props :props="props" />
 		<k-lab-docs-slots :slots="slots" />
@@ -59,7 +64,8 @@ export default {
 	props: {
 		component: String,
 		deprecated: String,
-		isUnstable: Boolean
+		isUnstable: Boolean,
+		since: String
 	}
 };
 </script>
@@ -92,5 +98,16 @@ export default {
 	margin-top: var(--spacing-1);
 	font-size: var(--text-xs);
 	color: var(--color-gray-600);
+}
+
+.k-lab-docs-view-since {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing-1);
+	margin-bottom: var(--spacing-8);
+}
+
+.k-lab-docs-view-since .k-tag {
+	--tag-color-back: var(--color-yellow-400);
 }
 </style>

--- a/panel/src/components/Lab/Docs/Description.vue
+++ b/panel/src/components/Lab/Docs/Description.vue
@@ -1,13 +1,7 @@
 <template>
-	<section
-		v-if="description?.length || since?.length"
-		class="k-lab-docs-section"
-	>
-		<header class="k-lab-docs-desc-header">
+	<section v-if="description?.length" class="k-lab-docs-section">
+		<header>
 			<k-headline class="h3">Description</k-headline>
-			<k-text v-if="since?.length">
-				Since <code>{{ since }}</code>
-			</k-text>
 		</header>
 
 		<k-box theme="text">
@@ -19,8 +13,7 @@
 <script>
 export const props = {
 	props: {
-		description: String,
-		since: String
+		description: String
 	}
 };
 
@@ -28,11 +21,3 @@ export default {
 	mixins: [props]
 };
 </script>
-
-<style>
-.k-lab-docs-desc-header {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-}
-</style>


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- [x] https://github.com/getkirby/kirby/pull/7295

### Summary
Moves the since tag information into its own simple section. This avoids displaying an empty description box if the component has no description but a since tag.

<img width="463" alt="Screenshot 2025-07-08 at 22 09 31" src="https://github.com/user-attachments/assets/c30e1ca7-97e2-41a1-b2d6-8b4233fe36fc" />
