### PR TITLE
fix: `File::create()` does no longer throw a missing extension error

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -215,7 +215,7 @@ trait FileActions
 			'translations' => null,
 		]);
 
-		$upload = $file->asset($props['source']);
+		$upload = $file->assetFactory($props['source']);
 
 		// merge the content with the defaults
 		$props['content'] = [

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -215,7 +215,8 @@ trait FileActions
 			'translations' => null,
 		]);
 
-		$upload = $file->assetFactory($props['source']);
+		$upload   = $file->assetFactory($props['source']);
+		$existing = null;
 
 		// merge the content with the defaults
 		$props['content'] = [
@@ -247,7 +248,14 @@ trait FileActions
 		$storage = $file->storage()::class;
 
 		// make sure that the temporary page is stored in memory
-		$file->changeStorage(MemoryStorage::class);
+		$file->changeStorage(
+			toStorage: MemoryStorage::class,
+			// when there’s already an existing file,
+			// we need to make sure that the content is
+			// copied to memory and the existing content
+			// storage entry is not deleted by this step
+			copy: $existing !== null
+		);
 
 		// inject the content
 		$file->setContent($props['content']);

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -860,7 +860,7 @@ class F
 			false => pathinfo($file, PATHINFO_EXTENSION)
 		};
 
-		if (empty($extension) === true) {
+		if (empty($extension) === true || $extension === 'tmp') {
 			// detect the mime type first to get the most reliable extension
 			$mime      = static::mime($file);
 			$extension = static::mimeToExtension($mime);

--- a/src/Filesystem/IsFile.php
+++ b/src/Filesystem/IsFile.php
@@ -76,23 +76,27 @@ trait IsFile
 	}
 
 	/**
-	 * Returns the file asset object
+	 * Returns the file asset object. A new object will be created if it doesn't
+	 * exist yet. The instance will be cached to avoid multiple instantiations,
+	 * when calling asset methods.
 	 */
 	public function asset(array|string|null $props = null): File
 	{
-		if ($this->asset !== null) {
-			return $this->asset;
-		}
+		return $this->asset ??= $this->assetFactory($props ?? []);
+	}
 
-		$props ??= [];
-
+	/**
+	 * Creates a new asset object based on the file type
+	 */
+	protected function assetFactory(array|string $props = []): File|Image
+	{
 		if (is_string($props) === true) {
 			$props = ['root' => $props];
 		}
 
 		$props['model'] ??= $this;
 
-		return $this->asset = match ($this->type()) {
+		return match ($this->type()) {
 			'image' => new Image($props),
 			default => new File($props)
 		};

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -864,6 +864,7 @@ class FTest extends TestCase
 		$this->assertSame('code', F::type('py'));
 		$this->assertSame('code', F::type('java'));
 		$this->assertNull(F::type('foo'));
+		$this->assertNull(F::type('tmp'));
 	}
 
 	/**
@@ -872,6 +873,17 @@ class FTest extends TestCase
 	public function testTypeWithoutExtension()
 	{
 		F::write($file = static::TMP . '/test', '<?php echo "foo"; ?>');
+
+		$this->assertSame('text/x-php', F::mime($file));
+		$this->assertSame('code', F::type($file));
+	}
+
+	/**
+	 * @covers ::type
+	 */
+	public function testTypeWithTmpExtension()
+	{
+		F::write($file = static::TMP . '/test.tmp', '<?php echo "foo"; ?>');
 
 		$this->assertSame('text/x-php', F::mime($file));
 		$this->assertSame('code', F::type($file));


### PR DESCRIPTION
## Sandbox

I've added a new `Other > Frontend Upload` example to the sandbox, based on Manu's test setup. It's useful not just for this issue. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New protected `IsFile::assetFactory()` method to create a new asset instance based on the file type, but without adding it to the property cache. 

### Bug fixes

- `F::type()` does no longer interpret `.tmp` as valid file extension, but uses mime detection to get the correct type. 

### Fixed regressions

- `File::create()` does no longer throw a missing extension error https://github.com/getkirby/kirby/issues/7289 
- `File::create()` does no longer remove the content file of an existing file if a duplicate error is thrown. 

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
