### PR TITLE
fix: Version cache invalidation

### DIFF
--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -108,14 +108,15 @@ class Version
 			(new Changes())->track($this->model);
 		}
 
+		// When we don't flush the version cache here,
+		// there are potential UUID race conditions
+		VersionCache::$cache = [];
+
 		$this->model->storage()->create(
 			versionId: $this->id,
 			language:  $language,
 			fields:    $this->prepareFieldsBeforeWrite($fields, $language)
 		);
-
-		// make sure that an older version does not exist in the cache
-		VersionCache::remove($this, $language);
 	}
 
 	/**


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- `Version::create()` will now flush the entire Version cache to fix: https://github.com/getkirby/kirby/issues/7302 

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion