### PR TITLE
fix: Use `WeakMap` for `VersionCache`

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -103,7 +103,7 @@ class App
 		$this->events = new Events($this);
 
 		// start with a fresh version cache
-		VersionCache::$cache = [];
+		VersionCache::reset();
 
 		// register all roots to be able to load stuff afterwards
 		$this->bakeRoots($props['roots'] ?? []);

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -81,7 +81,7 @@ trait FileActions
 
 			// hard reset for the version cache
 			// to avoid broken/overlapping file references
-			VersionCache::$cache = [];
+			VersionCache::reset();
 
 			// move the content storage versions
 			$oldFile->storage()->moveAll(to: $newFile->storage());

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -131,7 +131,7 @@ trait PageActions
 
 				// hard reset for the version cache
 				// to avoid broken/overlapping page references
-				VersionCache::$cache = [];
+				VersionCache::reset();
 
 				// remove from the siblings
 				ModelState::update(

--- a/src/Content/VersionCache.php
+++ b/src/Content/VersionCache.php
@@ -3,6 +3,7 @@
 namespace Kirby\Content;
 
 use Kirby\Cms\Language;
+use WeakMap;
 
 /**
  * The Version cache class keeps content fields
@@ -23,22 +24,17 @@ class VersionCache
 	 * All cache values for all versions
 	 * and language combinations
 	 */
-	public static array $cache = [];
-
-	/**
-	 * Creates a unique cache key for any version/language combination
-	 */
-	public static function key(Version $version, Language $language): string
-	{
-		return spl_object_hash($version->model()) . ':' . $version->id() . ':' . $language->code();
-	}
+	protected static WeakMap $cache;
 
 	/**
 	 * Tries to receive a fields for a version/language combination
 	 */
 	public static function get(Version $version, Language $language): array|null
 	{
-		return static::$cache[static::key($version, $language)] ?? null;
+		$model = $version->model();
+		$key   = $version->id() . ':' . $language->code();
+
+		return static::$cache[$model][$key] ?? null;
 	}
 
 	/**
@@ -46,14 +42,40 @@ class VersionCache
 	 */
 	public static function remove(Version $version, Language $language): void
 	{
-		unset(static::$cache[static::key($version, $language)]);
+		$model = $version->model();
+
+		if (isset(static::$cache[$model]) === false) {
+			return;
+		}
+
+		// Avoid indirect manipulation of WeakMap
+		$key = $version->id() . ':' . $language->code();
+		$map = static::$cache[$model];
+		unset($map[$key]);
+		static::$cache[$model] = $map;
+	}
+
+	/**
+	 * Resets the cache
+	 */
+	public static function reset(): void
+	{
+		static::$cache = new WeakMap();
 	}
 
 	/**
 	 * Keeps fields for a version/language combination
 	 */
-	public static function set(Version $version, Language $language, array $fields = []): void
-	{
-		static::$cache[static::key($version, $language)] = $fields;
+	public static function set(
+		Version $version,
+		Language $language,
+		array $fields = []
+	): void {
+		$model = $version->model();
+		$key   = $version->id() . ':' . $language->code();
+
+		static::$cache ??= new WeakMap();
+		static::$cache[$model] ??= [];
+		static::$cache[$model][$key] = $fields;
 	}
 }

--- a/tests/Content/VersionCacheTest.php
+++ b/tests/Content/VersionCacheTest.php
@@ -5,8 +5,6 @@ namespace Kirby\Content;
 use Kirby\Cms\File;
 use Kirby\Cms\Language;
 use Kirby\Cms\Page;
-use Kirby\Cms\Site;
-use Kirby\Cms\User;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(VersionCache::class)]
@@ -16,47 +14,6 @@ class VersionCacheTest extends TestCase
 	{
 		parent::setUp();
 		$this->setUpMultiLanguage();
-	}
-
-	public function testKeyForFile()
-	{
-		$parent = new Page(['slug' => 'test']);
-		$model  = new File(['filename' => 'test.jpg', 'parent' => $parent]);
-		$hash   = spl_object_hash($model);
-
-		$this->assertSame($hash . ':latest:en', VersionCache::key($model->version(), Language::ensure()));
-		$this->assertSame($hash . ':latest:de', VersionCache::key($model->version(), Language::ensure('de')));
-		$this->assertSame($hash . ':changes:en', VersionCache::key($model->version('changes'), Language::ensure()));
-	}
-
-	public function testKeyForPage()
-	{
-		$model = new Page(['slug' => 'test']);
-		$hash  = spl_object_hash($model);
-
-		$this->assertSame($hash . ':latest:en', VersionCache::key($model->version(), Language::ensure()));
-		$this->assertSame($hash . ':latest:de', VersionCache::key($model->version(), Language::ensure('de')));
-		$this->assertSame($hash . ':changes:en', VersionCache::key($model->version('changes'), Language::ensure()));
-	}
-
-	public function testKeyForSite()
-	{
-		$model = new Site();
-		$hash  = spl_object_hash($model);
-
-		$this->assertSame($hash . ':latest:en', VersionCache::key($model->version(), Language::ensure()));
-		$this->assertSame($hash . ':latest:de', VersionCache::key($model->version(), Language::ensure('de')));
-		$this->assertSame($hash . ':changes:en', VersionCache::key($model->version('changes'), Language::ensure()));
-	}
-
-	public function testKeyForUser()
-	{
-		$model = new User(['id' => 'test']);
-		$hash  = spl_object_hash($model);
-
-		$this->assertSame($hash . ':latest:en', VersionCache::key($model->version(), Language::ensure()));
-		$this->assertSame($hash . ':latest:de', VersionCache::key($model->version(), Language::ensure('de')));
-		$this->assertSame($hash . ':changes:en', VersionCache::key($model->version('changes'), Language::ensure()));
 	}
 
 	public function testGetSetAndRemove()
@@ -76,8 +33,188 @@ class VersionCacheTest extends TestCase
 
 		$this->assertSame($fields, VersionCache::get($version, $language));
 
+		VersionCache::set($version, $language, $fields = [
+			'foo' => 'baz'
+		]);
+
+		$this->assertSame($fields, VersionCache::get($version, $language));
+
 		VersionCache::remove($version, $language);
 
 		$this->assertNull(VersionCache::get($version, $language));
 	}
+
+	public function testGetSetAndRemoveWithDifferentModels()
+	{
+		$page = new Page(['slug' => 'test1']);
+		$file = new File(['filename' => 'test2.jpg', 'parent' => $page]);
+
+		$versionPage = $page->version();
+		$versionFile = $file->version();
+
+		$language = Language::ensure();
+
+		$this->assertNull(VersionCache::get($versionPage, $language));
+		$this->assertNull(VersionCache::get($versionFile, $language));
+
+		VersionCache::set($versionPage, $language, $fieldsPage = [
+			'foo' => 'bar'
+		]);
+
+		VersionCache::set($versionFile, $language, $fieldsFile = [
+			'foo' => 'baz'
+		]);
+
+		$this->assertSame($fieldsPage, VersionCache::get($versionPage, $language));
+		$this->assertSame($fieldsFile, VersionCache::get($versionFile, $language));
+
+		VersionCache::remove($versionPage, $language);
+
+		$this->assertNull(VersionCache::get($versionPage, $language));
+		$this->assertSame($fieldsFile, VersionCache::get($versionFile, $language));
+
+		VersionCache::remove($versionFile, $language);
+
+		$this->assertNull(VersionCache::get($versionPage, $language));
+		$this->assertNull(VersionCache::get($versionFile, $language));
+	}
+
+	public function testGetSetAndRemoveWithDifferentStorage()
+	{
+		$model    = new Page(['slug' => 'test']);
+		$version  = $model->version();
+		$language = Language::ensure();
+		$fields   = [
+			'foo' => 'bar'
+		];
+
+		$this->assertNull(VersionCache::get($version, $language));
+
+		VersionCache::set($version, $language, $fields);
+
+		$this->assertSame($fields, VersionCache::get($version, $language));
+
+		$model->changeStorage(MemoryStorage::class);
+
+		$this->assertSame($fields, VersionCache::get($version, $language));
+
+		VersionCache::remove($version, $language);
+
+		$this->assertNull(VersionCache::get($version, $language));
+	}
+
+	public function testGetSetAndRemoveWithClonedModel()
+	{
+		$model    = new Page(['slug' => 'test']);
+		$version  = $model->version();
+		$language = Language::ensure();
+		$fields   = [
+			'foo' => 'bar'
+		];
+
+		$this->assertNull(VersionCache::get($version, $language));
+
+		VersionCache::set($version, $language, $fields);
+
+		$this->assertSame($fields, VersionCache::get($version, $language));
+
+		$clonedModel = $model->clone();
+		$clonedVersion = $clonedModel->version();
+
+		$this->assertNull(VersionCache::get($clonedVersion, $language));
+		$this->assertSame($fields, VersionCache::get($version, $language));
+
+		VersionCache::remove($version, $language);
+
+		$this->assertNull(VersionCache::get($version, $language));
+
+		VersionCache::remove($clonedVersion, $language);
+
+		$this->assertNull(VersionCache::get($clonedVersion, $language));
+	}
+
+	public function testGetSetAndRemoveWithDifferentLanguages()
+	{
+		$model    = new Page(['slug' => 'test']);
+		$version  = $model->version();
+		$en       = Language::ensure('en');
+		$de       = Language::ensure('de');
+		$fieldsEn = [
+			'foo' => 'bar'
+		];
+		$fieldsDe = [
+			'foo' => 'baz'
+		];
+
+		$this->assertNull(VersionCache::get($version, $en));
+		$this->assertNull(VersionCache::get($version, $de));
+
+		VersionCache::set($version, $en, $fieldsEn);
+		VersionCache::set($version, $de, $fieldsDe);
+
+		$this->assertSame($fieldsEn, VersionCache::get($version, $en));
+		$this->assertSame($fieldsDe, VersionCache::get($version, $de));
+
+		VersionCache::remove($version, $en);
+
+		$this->assertNull(VersionCache::get($version, $en));
+		$this->assertSame($fieldsDe, VersionCache::get($version, $de));
+
+		VersionCache::remove($version, $de);
+
+		$this->assertNull(VersionCache::get($version, $en));
+		$this->assertNull(VersionCache::get($version, $de));
+	}
+
+	public function testGetSetAndRemoveWithDifferentVersions()
+	{
+		$model        = new Page(['slug' => 'test']);
+		$latest       = $model->version('latest');
+		$changes      = $model->version('changes');
+		$language     = Language::ensure();
+		$fieldsLatest = [
+			'foo' => 'bar'
+		];
+		$fieldsChanges = [
+			'foo' => 'baz'
+		];
+
+		$this->assertNull(VersionCache::get($latest, $language));
+		$this->assertNull(VersionCache::get($changes, $language));
+
+		VersionCache::set($latest, $language, $fieldsLatest);
+		VersionCache::set($changes, $language, $fieldsChanges);
+
+		$this->assertSame($fieldsLatest, VersionCache::get($latest, $language));
+		$this->assertSame($fieldsChanges, VersionCache::get($changes, $language));
+
+		VersionCache::remove($latest, $language);
+
+		$this->assertNull(VersionCache::get($latest, $language));
+		$this->assertSame($fieldsChanges, VersionCache::get($changes, $language));
+
+		VersionCache::remove($changes, $language);
+
+		$this->assertNull(VersionCache::get($latest, $language));
+		$this->assertNull(VersionCache::get($changes, $language));
+	}
+
+	public function testReset()
+	{
+		$model    = new Page(['slug' => 'test']);
+		$version  = $model->version();
+		$language = Language::ensure();
+		$fields   = [
+			'foo' => 'bar'
+		];
+
+		VersionCache::set($version, $language, $fields);
+
+		$this->assertSame($fields, VersionCache::get($version, $language));
+
+		VersionCache::reset();
+
+		$this->assertNull(VersionCache::get($version, $language));
+	}
+
 }


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Use `WeakMap` for `VersionCache` to avoid cache collisions due to a behavior in `spl_object_hash` that will sometimes reuse cache ids for new instances. https://github.com/getkirby/kirby/issues/7302

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
