### PR TITLE
fix: Hides nodes in toolbar when nodes disabled

### DIFF
--- a/panel/src/components/Forms/Input/WriterInput.vue
+++ b/panel/src/components/Forms/Input/WriterInput.vue
@@ -141,9 +141,14 @@ export default {
 			return {
 				// if custom set of marks is enabled, use as toolbar default as well
 				marks:
-					Array.isArray(this.marks) || this.marks === false
+					(Array.isArray(this.marks) || this.marks === false)
 						? this.marks
 						: undefined,
+				nodes:
+					(Array.isArray(this.nodes) || this.nodes === false)
+						? this.nodes
+						: undefined,
+				headings: this.headings,
 				...this.toolbar,
 				editor: this.editor
 			};

--- a/panel/src/components/Forms/Input/WriterInput.vue
+++ b/panel/src/components/Forms/Input/WriterInput.vue
@@ -93,7 +93,7 @@ export const props = {
 		},
 		nodes: {
 			type: [Array, Boolean],
-			default: () => ["heading", "bulletList", "orderedList"]
+			default: () => ["paragraph", "heading", "bulletList", "orderedList"]
 		},
 		paste: {
 			type: Function,

--- a/panel/src/components/Forms/Writer/Toolbar.vue
+++ b/panel/src/components/Forms/Writer/Toolbar.vue
@@ -26,6 +26,13 @@ export default {
 			type: Object
 		},
 		/**
+		 * Which headings to show in the toolbar
+		 */
+		headings: {
+			default: () => [1, 2, 3, 4, 5, 6],
+			type: [Array, Boolean]
+		},
+		/**
 		 * Whether the toolbar is displayed inline or as
 		 * a floating toolbar near the selection
 		 */
@@ -155,10 +162,10 @@ export default {
 				return available;
 			}
 
-			// get requested nodes from available entries
-			// if they are available
+			const expandedNodes = this.expandNodeTypes(this.nodes);
+
 			return Object.fromEntries(
-				this.nodes
+				expandedNodes
 					.filter((node) => available[node])
 					.map((node) => [node, available[node]])
 			);
@@ -296,6 +303,25 @@ export default {
 				label: entry.label,
 				click: () => this.command(entry.command ?? type)
 			};
+		},
+		/**
+		 * Helper method to expand node types
+		 * @returns {Array}
+		 */
+		expandNodeTypes(nodes) {
+			const expanded = [];
+
+			nodes.forEach((node) => {
+				if (node === 'heading') {
+					this.headings.forEach((level) => {
+						expanded.push(`h${level}`);
+					});
+				} else {
+					expanded.push(node);
+				}
+			});
+
+			return expanded;
 		},
 		/**
 		 * Creates an inline button object


### PR DESCRIPTION
## Description

I fixed the issue via solving passing nodes and headings props to toolbar component. I think these params were missing.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- [v5] Writer field without nodes and marks still shows toolbar #7305



### Breaking changes
None


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
