### PR TITLE
fix: Slug input with custom `allow`

### DIFF
--- a/panel/src/components/Forms/Input/SlugInput.vue
+++ b/panel/src/components/Forms/Input/SlugInput.vue
@@ -2,10 +2,10 @@
 	<k-string-input
 		v-bind="$props"
 		:spellcheck="false"
-		:value="slug"
+		:value="value"
 		autocomplete="off"
 		class="k-slug-input"
-		@input="$emit('input', $event)"
+		@input="onInput"
 	/>
 </template>
 
@@ -50,7 +50,6 @@ export default {
 	mixins: [props],
 	data() {
 		return {
-			slug: this.sluggify(this.value),
 			slugs: this.$panel.language.rules ?? this.$panel.system.slugs,
 			syncValue: null
 		};
@@ -71,19 +70,14 @@ export default {
 				}
 
 				this.syncValue = newValue[this.sync];
-				this.onInput(this.sluggify(this.syncValue));
+				this.onInput(this.syncValue);
 			},
 			deep: true,
 			immediate: true
-		},
-		value(newValue) {
-			newValue = this.sluggify(newValue);
-
-			if (newValue !== this.slug) {
-				this.slug = newValue;
-				this.$emit("input", this.slug);
-			}
 		}
+	},
+	mounted() {
+		this.onInput(this.value);
 	},
 	methods: {
 		sluggify(value) {
@@ -94,8 +88,7 @@ export default {
 			);
 		},
 		onInput(value) {
-			this.slug = this.sluggify(value);
-			this.$emit("input", this.slug);
+			this.$emit("input", this.sluggify(value));
 		}
 	}
 };

--- a/panel/src/helpers/string.js
+++ b/panel/src/helpers/string.js
@@ -184,11 +184,11 @@ export function slug(string, rules = [], allowed = "", separator = "-") {
 	// replace according to language and ascii rules
 	for (const ruleset of rules) {
 		for (const rule in ruleset) {
-			const isTrimmed = rule.slice(0, 1) !== "/";
-			const trimmed = rule.slice(1, rule.length - 1);
-			const regex = isTrimmed ? rule : trimmed;
+			const isRegex = rule.startsWith("/") && rule.endsWith("/");
+			const pattern = isRegex ? rule.slice(1, -1) : rule;
+
 			string = string.replace(
-				new RegExp(RegExp.escape(regex), "g"),
+				new RegExp(RegExp.escape(pattern), "g"),
 				ruleset[rule]
 			);
 		}
@@ -200,18 +200,18 @@ export function slug(string, rules = [], allowed = "", separator = "-") {
 	// replace non-allowed characters (e.g. spaces) with separator
 	string = string.replace(new RegExp("[^" + allowed + "]", "ig"), separator);
 
-	// remove double separators
+	// replace slashes with dashes
+	string = string.replace("/", separator);
+
+	// remove groups of multiple separators
 	string = string.replace(
 		new RegExp("[" + RegExp.escape(separator) + "]{2,}", "g"),
 		separator
 	);
 
-	// replace slashes with dashes
-	string = string.replace("/", separator);
-
 	// trim leading and trailing non-word-chars
-	string = string.replace(new RegExp("^[^a-z0-9]+", "g"), "");
-	string = string.replace(new RegExp("[^a-z0-9]+$", "g"), "");
+	string = string.replace(/^\W+/g, "");
+	string = string.replace(/\W+$/g, "");
 
 	return string;
 }

--- a/panel/src/helpers/string.js
+++ b/panel/src/helpers/string.js
@@ -201,7 +201,7 @@ export function slug(string, rules = [], allowed = "", separator = "-") {
 	string = string.replace(new RegExp("[^" + allowed + "]", "ig"), separator);
 
 	// replace slashes with dashes
-	string = string.replace("/", separator);
+	string = string.replaceAll("/", separator);
 
 	// remove groups of multiple separators
 	string = string.replace(

--- a/panel/src/helpers/string.slug.test.js
+++ b/panel/src/helpers/string.slug.test.js
@@ -71,8 +71,8 @@ describe.concurrent("$helper.string.slug()", () => {
 	});
 
 	it("should produces safe filenames", () => {
-		const result = slug("-what a view@2x.png_", [], "a-z0-9@._-");
-		expect(result).toBe("what-a-view@2x.png");
+		const result = slug("-what a_view@2x.png", [], "a-z0-9@._-");
+		expect(result).toBe("what-a_view@2x.png");
 	});
 
 	it("should return empty string when no param sent", () => {

--- a/panel/src/helpers/string.slug.test.js
+++ b/panel/src/helpers/string.slug.test.js
@@ -71,7 +71,7 @@ describe.concurrent("$helper.string.slug()", () => {
 	});
 
 	it("should produces safe filenames", () => {
-		const result = slug("-what a_view@2x.png", [], "a-z0-9@._-");
+		const result = slug("-what a_view@2x.png-", [], "a-z0-9@._-");
 		expect(result).toBe("what-a_view@2x.png");
 	});
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- `$helper.string.slug()` would trim all trailing/leading characters that aren't `a-z0-9`. When a custom `allow` argument was passed, this prohibited any other characters that actually should be allowed.
- Slug input would emit unsluggified and sluggified value on input simultaneously. Refactored it to not use `this.slug` as local state but all use `onInput` when any input occurs.



## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Fixed slug field with custom `allow` character set 
#7309 
- `$helper.string.slug()` respects `allow` argument

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
