### PR TITLE
test: Use PHPUnit attributes for `Kirby\Cache`

### DIFF
--- a/tests/Cache/ApcuCacheTest.php
+++ b/tests/Cache/ApcuCacheTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Cache;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cache\ApcuCache
- */
+#[CoversClass(ApcuCache::class)]
 class ApcuCacheTest extends TestCase
 {
 	public function setUp(): void
@@ -19,23 +18,14 @@ class ApcuCacheTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::enabled
-	 */
-	public function testEnabled()
+	public function testEnabled(): void
 	{
 		$cache = new ApcuCache();
 
 		$this->assertTrue($cache->enabled());
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::exists
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
-	public function testOperations()
+	public function testOperations(): void
 	{
 		$cache = new ApcuCache([]);
 
@@ -54,13 +44,7 @@ class ApcuCacheTest extends TestCase
 		$this->assertFalse($cache->remove('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::exists
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
-	public function testOperationsWithPrefix()
+	public function testOperationsWithPrefix(): void
 	{
 		$cache1 = new ApcuCache([
 			'prefix' => 'test1'
@@ -89,10 +73,7 @@ class ApcuCacheTest extends TestCase
 		$this->assertSame('Another basic value', $cache2->retrieve('foo')->value());
 	}
 
-	/**
-	 * @covers ::flush
-	 */
-	public function testFlush()
+	public function testFlush(): void
 	{
 		$cache = new ApcuCache([]);
 
@@ -109,10 +90,7 @@ class ApcuCacheTest extends TestCase
 		$this->assertFalse($cache->exists('c'));
 	}
 
-	/**
-	 * @covers ::flush
-	 */
-	public function testFlushWithPrefix()
+	public function testFlushWithPrefix(): void
 	{
 		$cache1 = new ApcuCache([
 			'prefix' => 'test1'

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -3,27 +3,19 @@
 namespace Kirby\Cache;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionMethod;
 
-/**
- * @coversDefaultClass \Kirby\Cache\Cache
- */
+#[CoversClass(Cache::class)]
 class CacheTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::options
-	 */
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$cache = new TestCache(['some' => 'options']);
 		$this->assertSame(['some' => 'options'], $cache->options());
 	}
 
-	/**
-	 * @covers ::key
-	 */
-	public function testKey()
+	public function testKey(): void
 	{
 		$method = new ReflectionMethod(Cache::class, 'key');
 		$method->setAccessible(true);
@@ -37,10 +29,7 @@ class CacheTest extends TestCase
 		$this->assertSame('test/foo', $method->invoke($cache, 'foo'));
 	}
 
-	/**
-	 * @covers ::get
-	 */
-	public function testGet()
+	public function testGet(): void
 	{
 		$cache = new TestCache();
 
@@ -67,10 +56,7 @@ class CacheTest extends TestCase
 		$this->assertFalse(isset($cache->store['expired']));
 	}
 
-	/**
-	 * @covers ::getOrSet
-	 */
-	public function testGetOrSet()
+	public function testGetOrSet(): void
 	{
 		$cache = new TestCache();
 		$count = 0;
@@ -87,20 +73,14 @@ class CacheTest extends TestCase
 		$this->assertSame(1, $count);
 	}
 
-	/**
-	 * @covers ::enabled
-	 */
-	public function testEnabled()
+	public function testEnabled(): void
 	{
 		$cache = new TestCache();
 
 		$this->assertTrue($cache->enabled());
 	}
 
-	/**
-	 * @covers ::expiration
-	 */
-	public function testExpiration()
+	public function testExpiration(): void
 	{
 		$method = new ReflectionMethod(Cache::class, 'expiration');
 		$method->setAccessible(true);
@@ -111,10 +91,7 @@ class CacheTest extends TestCase
 		$this->assertSame(time() + 600, $method->invoke($cache, 10));
 	}
 
-	/**
-	 * @covers ::expires
-	 */
-	public function testExpires()
+	public function testExpires(): void
 	{
 		$cache = new TestCache();
 
@@ -127,10 +104,7 @@ class CacheTest extends TestCase
 		$this->assertFalse($cache->expires('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::expired
-	 */
-	public function testExpired()
+	public function testExpired(): void
 	{
 		$cache = new TestCache();
 
@@ -146,11 +120,7 @@ class CacheTest extends TestCase
 		$this->assertTrue($cache->expired('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::created
-	 * @covers ::modified
-	 */
-	public function testCreated()
+	public function testCreated(): void
 	{
 		$cache = new TestCache();
 
@@ -162,10 +132,7 @@ class CacheTest extends TestCase
 		$this->assertFalse($cache->modified('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
-	public function testExists()
+	public function testExists(): void
 	{
 		$cache = new TestCache();
 

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -4,11 +4,10 @@ namespace Kirby\Cache;
 
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionMethod;
 
-/**
- * @coversDefaultClass \Kirby\Cache\FileCache
- */
+#[CoversClass(FileCache::class)]
 class FileCacheTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cache.FileCache';
@@ -18,11 +17,7 @@ class FileCacheTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::root
-	 */
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$cache = new FileCache([
 			'root' => $root = static::TMP
@@ -32,11 +27,7 @@ class FileCacheTest extends TestCase
 		$this->assertDirectoryExists($root);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::root
-	 */
-	public function testConstructWithPrefix()
+	public function testConstructWithPrefix(): void
 	{
 		$cache = new FileCache([
 			'root'   => $root = static::TMP,
@@ -47,10 +38,7 @@ class FileCacheTest extends TestCase
 		$this->assertDirectoryExists($root . '/test');
 	}
 
-	/**
-	 * @covers ::enabled
-	 */
-	public function testEnabled()
+	public function testEnabled(): void
 	{
 		$cache = new FileCache([
 			'root' => static::TMP
@@ -59,10 +47,7 @@ class FileCacheTest extends TestCase
 		$this->assertTrue($cache->enabled());
 	}
 
-	/**
-	 * @covers ::enabled
-	 */
-	public function testEnabledNotWritable()
+	public function testEnabledNotWritable(): void
 	{
 		$cache = new FileCache([
 			'root' => $root = static::TMP
@@ -73,10 +58,7 @@ class FileCacheTest extends TestCase
 		$this->assertFalse($cache->enabled());
 	}
 
-	/**
-	 * @covers ::file
-	 */
-	public function testFile()
+	public function testFile(): void
 	{
 		$method = new ReflectionMethod(FileCache::class, 'file');
 		$method->setAccessible(true);
@@ -208,13 +190,7 @@ class FileCacheTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::created
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
-	public function testOperations()
+	public function testOperations(): void
 	{
 		$cache = new FileCache([
 			'root' => $root = static::TMP
@@ -243,13 +219,7 @@ class FileCacheTest extends TestCase
 		$this->assertFalse($cache->remove('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::created
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
-	public function testOperationsWithExtension()
+	public function testOperationsWithExtension(): void
 	{
 		$cache = new FileCache([
 			'root'      => $root = static::TMP,
@@ -277,13 +247,7 @@ class FileCacheTest extends TestCase
 		$this->assertNull($cache->retrieve('foo'));
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::created
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
-	public function testOperationsWithPrefix()
+	public function testOperationsWithPrefix(): void
 	{
 		$cache1 = new FileCache([
 			'root' => $root = static::TMP,
@@ -323,10 +287,7 @@ class FileCacheTest extends TestCase
 		$this->assertSame('Another basic value', $cache2->retrieve('foo')->value());
 	}
 
-	/**
-	 * @covers ::flush
-	 */
-	public function testFlush()
+	public function testFlush(): void
 	{
 		$cache = new FileCache([
 			'root' => $root = static::TMP
@@ -348,10 +309,7 @@ class FileCacheTest extends TestCase
 		$this->assertDirectoryDoesNotExist($root . '/d');
 	}
 
-	/**
-	 * @covers ::flush
-	 */
-	public function testFlushWithPrefix()
+	public function testFlushWithPrefix(): void
 	{
 		$cache1 = new FileCache([
 			'root' => $root = static::TMP,
@@ -384,10 +342,7 @@ class FileCacheTest extends TestCase
 		$this->assertFileExists($root . '/test2/c/a');
 	}
 
-	/**
-	 * @covers ::removeEmptyDirectories
-	 */
-	public function testRemoveEmptyDirectories()
+	public function testRemoveEmptyDirectories(): void
 	{
 		$cache = new FileCache([
 			'root'      => $root = static::TMP,
@@ -408,10 +363,7 @@ class FileCacheTest extends TestCase
 		$this->assertDirectoryExists($root);
 	}
 
-	/**
-	 * @covers ::removeEmptyDirectories
-	 */
-	public function testRemoveEmptyDirectoriesWithNotEmptyDirs()
+	public function testRemoveEmptyDirectoriesWithNotEmptyDirs(): void
 	{
 		$cache = new FileCache([
 			'root'      => $root = static::TMP,

--- a/tests/Cache/MemCachedTest.php
+++ b/tests/Cache/MemCachedTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Cache;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cache\MemCached
- */
+#[CoversClass(MemCached::class)]
 class MemCachedTest extends TestCase
 {
 	public function setUp(): void
@@ -30,22 +29,14 @@ class MemCachedTest extends TestCase
 		$connection->flush();
 	}
 
-	/**
-	 * @covers ::enabled
-	 */
-	public function testEnabled()
+	public function testEnabled(): void
 	{
 		$cache = new MemCached();
 
 		$this->assertTrue($cache->enabled());
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
-	public function testOperations()
+	public function testOperations(): void
 	{
 		$cache = new MemCached([]);
 
@@ -64,12 +55,7 @@ class MemCachedTest extends TestCase
 		$this->assertFalse($cache->remove('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
-	public function testOperationsWithPrefix()
+	public function testOperationsWithPrefix(): void
 	{
 		$cache1 = new MemCached([
 			'prefix' => 'test1'
@@ -98,10 +84,7 @@ class MemCachedTest extends TestCase
 		$this->assertSame('Another basic value', $cache2->retrieve('foo')->value());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructServer()
+	public function testConstructServer(): void
 	{
 		$cache = new MemCached([
 			'host' => 'localhost',
@@ -120,10 +103,7 @@ class MemCachedTest extends TestCase
 		$this->assertFalse($cache->remove('foo'));
 	}
 
-	/**
-	 * @covers ::flush
-	 */
-	public function testFlush()
+	public function testFlush(): void
 	{
 		$cache = new MemCached([]);
 

--- a/tests/Cache/MemoryCacheTest.php
+++ b/tests/Cache/MemoryCacheTest.php
@@ -3,28 +3,19 @@
 namespace Kirby\Cache;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cache\MemoryCache
- */
+#[CoversClass(MemoryCache::class)]
 class MemoryCacheTest extends TestCase
 {
-	/**
-	 * @covers ::enabled
-	 */
-	public function testEnabled()
+	public function testEnabled(): void
 	{
 		$cache = new MemoryCache();
 
 		$this->assertTrue($cache->enabled());
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
-	public function testOperations()
+	public function testOperations(): void
 	{
 		$cache = new MemoryCache();
 
@@ -43,12 +34,7 @@ class MemoryCacheTest extends TestCase
 		$this->assertFalse($cache->remove('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
-	public function testOperationsWithMultipleInstances()
+	public function testOperationsWithMultipleInstances(): void
 	{
 		$cache1 = new MemoryCache();
 		$cache2 = new MemoryCache();
@@ -73,10 +59,7 @@ class MemoryCacheTest extends TestCase
 		$this->assertSame('Another basic value', $cache2->retrieve('foo')->value());
 	}
 
-	/**
-	 * @covers ::flush
-	 */
-	public function testFlush()
+	public function testFlush(): void
 	{
 		$cache = new MemoryCache();
 
@@ -93,10 +76,7 @@ class MemoryCacheTest extends TestCase
 		$this->assertFalse($cache->exists('c'));
 	}
 
-	/**
-	 * @covers ::flush
-	 */
-	public function testFlushWithMultipleInstances()
+	public function testFlushWithMultipleInstances(): void
 	{
 		$cache1 = new MemoryCache();
 		$cache2 = new MemoryCache();
@@ -117,10 +97,7 @@ class MemoryCacheTest extends TestCase
 		$this->assertTrue($cache2->exists('b'));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
-	public function testModified()
+	public function testModified(): void
 	{
 		$cache = new MemoryCache();
 

--- a/tests/Cache/NullCacheTest.php
+++ b/tests/Cache/NullCacheTest.php
@@ -3,28 +3,19 @@
 namespace Kirby\Cache;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cache\NullCache
- */
+#[CoversClass(NullCache::class)]
 class NullCacheTest extends TestCase
 {
-	/**
-	 * @covers ::enabled
-	 */
-	public function testEnabled()
+	public function testEnabled(): void
 	{
 		$cache = new NullCache();
 
 		$this->assertFalse($cache->enabled());
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
-	public function testOperations()
+	public function testOperations(): void
 	{
 		$cache = new NullCache();
 
@@ -34,10 +25,7 @@ class NullCacheTest extends TestCase
 		$this->assertTrue($cache->remove('foo'));
 	}
 
-	/**
-	 * @covers ::flush
-	 */
-	public function testFlush()
+	public function testFlush(): void
 	{
 		$cache = new NullCache();
 

--- a/tests/Cache/RedisCacheTest.php
+++ b/tests/Cache/RedisCacheTest.php
@@ -3,10 +3,11 @@
 namespace Kirby\Cache;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Redis;
+use Throwable;
 
-/**
- * @coversDefaultClass \Kirby\Cache\RedisCache
- */
+#[CoversClass(RedisCache::class)]
 class RedisCacheTest extends TestCase
 {
 	public function setUp(): void
@@ -17,9 +18,9 @@ class RedisCacheTest extends TestCase
 		}
 
 		try {
-			$connection = new \Redis();
+			$connection = new Redis();
 			$connection->ping();
-		} catch (\Throwable) {
+		} catch (Throwable) {
 			$this->markTestSkipped('The Redis server is not running.');
 		}
 	}
@@ -30,11 +31,7 @@ class RedisCacheTest extends TestCase
 		$connection->flush();
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::enabled
-	 */
-	public function testConstructServer()
+	public function testConstructServer(): void
 	{
 		// invalid port
 		$cache = new RedisCache([
@@ -49,10 +46,7 @@ class RedisCacheTest extends TestCase
 		$this->assertFalse($cache->enabled());
 	}
 
-	/**
-	 * @covers ::databaseNum
-	 */
-	public function testDatabase()
+	public function testDatabase(): void
 	{
 		$cache = new RedisCache([
 			'database' => 1
@@ -65,20 +59,13 @@ class RedisCacheTest extends TestCase
 		$this->assertSame('A basic value', $cache->retrieve('a')->value());
 	}
 
-	/**
-	 * @covers ::enabled
-	 */
-	public function testEnabled()
+	public function testEnabled(): void
 	{
 		$cache = new RedisCache();
 		$this->assertTrue($cache->enabled());
 	}
 
-	/**
-	 * @covers ::exists
-	 * @covers ::flush
-	 */
-	public function testFlush()
+	public function testFlush(): void
 	{
 		$cache = new RedisCache();
 
@@ -96,14 +83,7 @@ class RedisCacheTest extends TestCase
 		$this->assertFalse($cache->exists('c'));
 	}
 
-	/**
-	 * @covers ::exists
-	 * @covers ::key
-	 * @covers ::set
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
-	public function testOperations()
+	public function testOperations(): void
 	{
 		$cache = new RedisCache();
 
@@ -122,15 +102,7 @@ class RedisCacheTest extends TestCase
 		$this->assertFalse($cache->remove('doesnotexist'));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::exists
-	 * @covers ::key
-	 * @covers ::set
-	 * @covers ::retrieve
-	 * @covers ::remove
-	 */
-	public function testOperationsWithPrefix()
+	public function testOperationsWithPrefix(): void
 	{
 		$cache1 = new RedisCache([
 			'prefix' => 'test1:'

--- a/tests/Cache/ValueTest.php
+++ b/tests/Cache/ValueTest.php
@@ -3,17 +3,13 @@
 namespace Kirby\Cache;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use TypeError;
 
-/**
- * @coversDefaultClass \Kirby\Cache\Value
- */
+#[CoversClass(Value::class)]
 class ValueTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::created
-	 */
-	public function testCreated()
+	public function testCreated(): void
 	{
 		$value = new Value('foo');
 		$this->assertSame(time(), $value->created());
@@ -22,10 +18,7 @@ class ValueTest extends TestCase
 		$this->assertSame(1000, $value->created());
 	}
 
-	/**
-	 * @covers ::expires
-	 */
-	public function testExpires()
+	public function testExpires(): void
 	{
 		$value = new Value('foo');
 		$this->assertNull($value->expires());
@@ -46,11 +39,7 @@ class ValueTest extends TestCase
 		$this->assertSame(1234567890, $value->expires());
 	}
 
-	/**
-	 * @covers ::fromArray
-	 * @covers ::toArray
-	 */
-	public function testArrayConversion()
+	public function testArrayConversion(): void
 	{
 		$data = [
 			'created' => 10000,
@@ -106,12 +95,9 @@ class ValueTest extends TestCase
 		], $value->toArray());
 	}
 
-	/**
-	 * @covers ::fromArray
-	 */
-	public function testFromArrayInvalid()
+	public function testFromArrayInvalid(): void
 	{
-		$this->expectException(\TypeError::class);
+		$this->expectException(TypeError::class);
 
 		$data = [
 			'created' => 'invalid',
@@ -121,11 +107,7 @@ class ValueTest extends TestCase
 		$value = Value::fromArray($data);
 	}
 
-	/**
-	 * @covers ::fromJson
-	 * @covers ::toJson
-	 */
-	public function testJsonConversion()
+	public function testJsonConversion(): void
 	{
 		$data = json_encode([
 			'created' => 10000,
@@ -179,10 +161,7 @@ class ValueTest extends TestCase
 		$this->assertNull(Value::fromJson($data));
 	}
 
-	/**
-	 * @covers ::value
-	 */
-	public function testValue()
+	public function testValue(): void
 	{
 		$value = new Value('foo');
 		$this->assertSame('foo', $value->value());


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Cache',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
