### PR TITLE
test: Use PHPUnit attributes for `Kirby\Content`

### DIFF
--- a/tests/Content/ChangesTest.php
+++ b/tests/Content/ChangesTest.php
@@ -6,10 +6,9 @@ use Kirby\Cache\Cache;
 use Kirby\Cms\App;
 use Kirby\TestCase;
 use Kirby\Uuid\Uuids;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\Changes
- */
+#[CoversClass(Changes::class)]
 class ChangesTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.Changes';
@@ -57,21 +56,14 @@ class ChangesTest extends TestCase
 		parent::tearDownTmp();
 	}
 
-	/**
-	 * @covers ::cache
-	 */
-	public function testCache()
+	public function testCache(): void
 	{
 		$cache = $this->app->cache('changes');
 
 		$this->assertInstanceOf(Cache::class, $cache);
 	}
 
-	/**
-	 * @covers ::files
-	 * @covers ::ensure
-	 */
-	public function testFiles()
+	public function testFiles(): void
 	{
 		$this->app->cache('changes')->set('files', $cache = [
 			'file://test'
@@ -99,10 +91,7 @@ class ChangesTest extends TestCase
 		$this->assertSame('test/test.jpg', $changes->files()->first()->id());
 	}
 
-	/**
-	 * @covers ::cacheKey
-	 */
-	public function testCacheKey()
+	public function testCacheKey(): void
 	{
 		$changes = new Changes();
 
@@ -115,11 +104,7 @@ class ChangesTest extends TestCase
 		$this->assertSame('users', $changes->cacheKey($user));
 	}
 
-	/**
-	 * @covers ::cacheExists
-	 * @covers ::generateCache
-	 */
-	public function testGenerateCache()
+	public function testGenerateCache(): void
 	{
 		$changes = new Changes();
 
@@ -150,11 +135,7 @@ class ChangesTest extends TestCase
 		$this->assertSame(['user://test'], $changes->read('users'));
 	}
 
-	/**
-	 * @covers ::pages
-	 * @covers ::ensure
-	 */
-	public function testPages()
+	public function testPages(): void
 	{
 		$this->app->cache('changes')->set('pages', $cache = [
 			'page://test'
@@ -175,10 +156,7 @@ class ChangesTest extends TestCase
 		$this->assertSame('test', $changes->pages()->first()->id());
 	}
 
-	/**
-	 * @covers ::read
-	 */
-	public function testRead()
+	public function testRead(): void
 	{
 		$this->app->cache('changes')->set('files', [
 			'file://test'
@@ -199,10 +177,7 @@ class ChangesTest extends TestCase
 		$this->assertSame(['user://test'], $changes->read('users'));
 	}
 
-	/**
-	 * @covers ::track
-	 */
-	public function testTrack()
+	public function testTrack(): void
 	{
 		$changes = new Changes();
 
@@ -223,10 +198,7 @@ class ChangesTest extends TestCase
 		$this->assertSame('user://test', $users[0]);
 	}
 
-	/**
-	 * @covers ::track
-	 */
-	public function testTrackDisabledUuids()
+	public function testTrackDisabledUuids(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -255,10 +227,7 @@ class ChangesTest extends TestCase
 		$this->assertSame('test', $users[0]);
 	}
 
-	/**
-	 * @covers ::update
-	 */
-	public function testUpdate()
+	public function testUpdate(): void
 	{
 		$changes = new Changes();
 
@@ -287,10 +256,7 @@ class ChangesTest extends TestCase
 		$this->assertCount(0, $changes->read('users'));
 	}
 
-	/**
-	 * @covers ::untrack
-	 */
-	public function testUntrack()
+	public function testUntrack(): void
 	{
 		$changes = new Changes();
 
@@ -311,10 +277,7 @@ class ChangesTest extends TestCase
 		$this->assertCount(0, $changes->read('users'));
 	}
 
-	/**
-	 * @covers ::untrack
-	 */
-	public function testUntrackDisabledUuids()
+	public function testUntrackDisabledUuids(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -343,11 +306,7 @@ class ChangesTest extends TestCase
 		$this->assertCount(0, $changes->read('users'));
 	}
 
-	/**
-	 * @covers ::users
-	 * @covers ::ensure
-	 */
-	public function testUsers()
+	public function testUsers(): void
 	{
 		$this->app->cache('changes')->set('users', $cache = [
 			'user://test'

--- a/tests/Content/ContentConvertToTest.php
+++ b/tests/Content/ContentConvertToTest.php
@@ -13,7 +13,7 @@ class ContentConvertToTest extends TestCase
 		$this->setUpSingleLanguage();
 	}
 
-	public function testConvertToForPage()
+	public function testConvertToForPage(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -77,7 +77,7 @@ class ContentConvertToTest extends TestCase
 		$this->assertSame('keep this', $new['removed']);
 	}
 
-	public function testConvertToForFile()
+	public function testConvertToForFile(): void
 	{
 		$app = $this->app->clone([
 			'site' => [

--- a/tests/Content/ContentTest.php
+++ b/tests/Content/ContentTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(Content::class)]
 class ContentTest extends TestCase
 {
-	public function testCall()
+	public function testCall(): void
 	{
 		$content = new Content([
 			'a' => 'A',
@@ -25,7 +25,7 @@ class ContentTest extends TestCase
 		$this->assertSame('MIXED', $content->mIXEd()->value());
 	}
 
-	public function testData()
+	public function testData(): void
 	{
 		$content = new Content($data = [
 			'a' => 'A',
@@ -35,7 +35,7 @@ class ContentTest extends TestCase
 		$this->assertSame($data, $content->data());
 	}
 
-	public function testFields()
+	public function testFields(): void
 	{
 		$content = new Content([
 			'a' => 'A',
@@ -49,7 +49,7 @@ class ContentTest extends TestCase
 		$this->assertSame('B', $fields['b']->value());
 	}
 
-	public function testGet()
+	public function testGet(): void
 	{
 		$content = new Content([
 			'a' => 'A',
@@ -64,7 +64,7 @@ class ContentTest extends TestCase
 		$this->assertSame(null, $content->get('C')->value(), 'Non-existing field should have a null value');
 	}
 
-	public function testGetWithoutKey()
+	public function testGetWithoutKey(): void
 	{
 		$content = new Content([
 			'a' => 'A',
@@ -78,7 +78,7 @@ class ContentTest extends TestCase
 		$this->assertSame('B', $fields['b']->value());
 	}
 
-	public function testHas()
+	public function testHas(): void
 	{
 		$content = new Content([
 			'a' => 'A',
@@ -93,7 +93,7 @@ class ContentTest extends TestCase
 		$this->assertFalse($content->has('C'));
 	}
 
-	public function testKeys()
+	public function testKeys(): void
 	{
 		$content = new Content([
 			'a' => 'A',
@@ -103,7 +103,7 @@ class ContentTest extends TestCase
 		$this->assertSame(['a', 'b'], $content->keys());
 	}
 
-	public function testKeysNormalized()
+	public function testKeysNormalized(): void
 	{
 		$content = new Content([
 			'a' => 'A',
@@ -113,7 +113,7 @@ class ContentTest extends TestCase
 		$this->assertSame(['a', 'b'], $content->keys());
 	}
 
-	public function testKeysNotNormalized()
+	public function testKeysNotNormalized(): void
 	{
 		$content = new Content(
 			data: [
@@ -126,7 +126,7 @@ class ContentTest extends TestCase
 		$this->assertSame(['a', 'B'], $content->keys());
 	}
 
-	public function testNot()
+	public function testNot(): void
 	{
 		$content = new Content([
 			'a' => 'A',
@@ -141,7 +141,7 @@ class ContentTest extends TestCase
 		$this->assertSame(['a'], $copy->keys());
 	}
 
-	public function testParent()
+	public function testParent(): void
 	{
 		$parent  = new Page(['slug' => 'parent']);
 		$content = new Content([
@@ -152,7 +152,7 @@ class ContentTest extends TestCase
 		$this->assertSame($parent, $content->parent());
 	}
 
-	public function testParentWithoutValue()
+	public function testParentWithoutValue(): void
 	{
 		$content = new Content([
 			'a' => 'A',
@@ -162,7 +162,7 @@ class ContentTest extends TestCase
 		$this->assertNull($content->parent());
 	}
 
-	public function testSetParent()
+	public function testSetParent(): void
 	{
 		$parentA = new Page(['slug' => 'parent-a']);
 		$parentB = new Page(['slug' => 'parent-b']);
@@ -179,7 +179,7 @@ class ContentTest extends TestCase
 		$this->assertSame($parentB, $content->parent());
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$content = new Content($data = [
 			'a' => 'A',
@@ -189,7 +189,7 @@ class ContentTest extends TestCase
 		$this->assertSame($data, $content->toArray());
 	}
 
-	public function testUpdate()
+	public function testUpdate(): void
 	{
 		$content = new Content([
 			'a' => 'A',

--- a/tests/Content/FieldMethodsTest.php
+++ b/tests/Content/FieldMethodsTest.php
@@ -45,69 +45,69 @@ class FieldMethodsTest extends TestCase
 		App::destroy();
 	}
 
-	public function testFieldMethodCaseInsensitivity()
+	public function testFieldMethodCaseInsensitivity(): void
 	{
 		$field = $this->field('test');
 		$this->assertSame('TEST', $field->upper()->value());
 		$this->assertSame('TEST', $field->UPPER()->value());
 	}
 
-	public function testFieldMethodAliasCaseInsensitivity()
+	public function testFieldMethodAliasCaseInsensitivity(): void
 	{
 		$field = $this->field('1');
 		$this->assertSame(1, $field->toInt());
 		$this->assertSame(1, $field->int());
 	}
 
-	public function testFieldMethodCombination()
+	public function testFieldMethodCombination(): void
 	{
 		$field = $this->field('test')->upper()->short(3);
 		$this->assertSame('TES…', $field->value());
 	}
 
-	public function testIsFalse()
+	public function testIsFalse(): void
 	{
 		$this->assertTrue($this->field('false')->isFalse());
 		$this->assertTrue($this->field(false)->isFalse());
 	}
 
-	public function testIsTrue()
+	public function testIsTrue(): void
 	{
 		$this->assertTrue($this->field('true')->isTrue());
 		$this->assertTrue($this->field(true)->isTrue());
 	}
 
-	public function testIsValid()
+	public function testIsValid(): void
 	{
 		$this->assertTrue($this->field('mail@example.com')->isValid('email'));
 		$this->assertTrue($this->field('https://example.com')->isValid('url'));
 	}
 
-	public function testToDataSplit()
+	public function testToDataSplit(): void
 	{
 		$this->assertSame(['a', 'b'], $this->field('a, b')->toData());
 	}
 
-	public function testToDataSplitWithDifferentSeparator()
+	public function testToDataSplitWithDifferentSeparator(): void
 	{
 		$this->assertSame(['a', 'b'], $this->field('a; b')->toData(';'));
 	}
 
-	public function testToDataYaml()
+	public function testToDataYaml(): void
 	{
 		$data = ['a', 'b'];
 
 		$this->assertSame(['a', 'b'], $this->field(Yaml::encode($data))->toData('yaml'));
 	}
 
-	public function testToDataJson()
+	public function testToDataJson(): void
 	{
 		$data = ['a', 'b'];
 
 		$this->assertSame(['a', 'b'], $this->field(json_encode($data))->toData('json'));
 	}
 
-	public function testToBool()
+	public function testToBool(): void
 	{
 		$this->assertTrue($this->field('1')->toBool());
 		$this->assertTrue($this->field('true')->toBool());
@@ -115,7 +115,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertFalse($this->field('false')->toBool());
 	}
 
-	public function testToDate()
+	public function testToDate(): void
 	{
 		$field = $this->field('2012-12-12');
 		$ts    = strtotime('2012-12-12');
@@ -125,7 +125,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($date, $field->toDate('d.m.Y'));
 	}
 
-	public function testToDateWithDateHandler()
+	public function testToDateWithDateHandler(): void
 	{
 		new App([
 			'roots' => [
@@ -144,7 +144,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($date, $field->toDate('%d.%m.%Y'));
 	}
 
-	public function testToDateWithFallback()
+	public function testToDateWithFallback(): void
 	{
 		$field = $this->field(null);
 		$date  = '12.12.2012';
@@ -153,13 +153,13 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame(date('d.m.Y'), $field->toDate('d.m.Y', 'today'));
 	}
 
-	public function testToDateWithEmptyValueAndNoFallback()
+	public function testToDateWithEmptyValueAndNoFallback(): void
 	{
 		$field = $this->field(null);
 		$this->assertNull($field->toDate('d.m.Y'));
 	}
 
-	public function testToEntries()
+	public function testToEntries(): void
 	{
 		$value   = [
 			'Text',
@@ -180,7 +180,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame('Another text', $entries->nth(2)->value());
 	}
 
-	public function testToEntriesDateMethod()
+	public function testToEntriesDateMethod(): void
 	{
 		$value   = ['2012-12-12'];
 		$page    = new Page(['slug' => 'test']);
@@ -195,7 +195,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame('12.12.2012', $entries->first()->toDate('d.m.Y'));
 	}
 
-	public function testToEntriesEmptyValue()
+	public function testToEntriesEmptyValue(): void
 	{
 		$field   = $this->field();
 		$entries = $field->toEntries();
@@ -204,7 +204,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertCount(0, $entries);
 	}
 
-	public function testToFile()
+	public function testToFile(): void
 	{
 		new App([
 			'roots' => [
@@ -230,7 +230,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame('cover.jpg', $page->coverid()->toFile()->filename());
 	}
 
-	public function testToFiles()
+	public function testToFiles(): void
 	{
 		$page = new Page([
 			'content' => [
@@ -246,7 +246,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($page->files()->pluck('filename'), $page->gallery()->toFiles()->pluck('filename'));
 	}
 
-	public function testToFilesFromDifferentPage()
+	public function testToFilesFromDifferentPage(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -278,7 +278,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame(['b.jpg', 'a.jpg'], $page->gallery()->toFiles()->pluck('filename'));
 	}
 
-	public function testToFilesWithoutResults()
+	public function testToFilesWithoutResults(): void
 	{
 		$page = new Page([
 			'content' => [
@@ -292,7 +292,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertInstanceOf(Files::class, $page->gallery()->toFiles());
 	}
 
-	public function testToFloat()
+	public function testToFloat(): void
 	{
 		$field    = $this->field('1.2');
 		$expected = 1.2;
@@ -300,13 +300,13 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $field->toFloat());
 	}
 
-	public function testToInt()
+	public function testToInt(): void
 	{
 		$this->assertSame(1, $this->field('1')->toInt());
 		$this->assertIsInt($this->field('1')->toInt());
 	}
 
-	public function testToLink()
+	public function testToLink(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -320,7 +320,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $page->title()->toLink());
 	}
 
-	public function testToLinkWithHref()
+	public function testToLinkWithHref(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -334,7 +334,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $page->title()->toLink('https://getkirby.com', ['class' => 'test']));
 	}
 
-	public function testToLinkWithActivePage()
+	public function testToLinkWithActivePage(): void
 	{
 		$site = new Site([
 			'children' => [
@@ -353,7 +353,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $page->title()->toLink());
 	}
 
-	public function testToPage()
+	public function testToPage(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -381,7 +381,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($c, $this->field(Yaml::encode(['page://uuid-c', 'b', 'a']))->toPage());
 	}
 
-	public function testToPages()
+	public function testToPages(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -432,7 +432,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame([], $result->data());
 	}
 
-	public function testToQrCode()
+	public function testToQrCode(): void
 	{
 		$field = $this->field($url = 'https://getkirby.com');
 		$qr    = $field->toQrCode();
@@ -443,7 +443,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertNull($this->field()->toQrCode());
 	}
 
-	public function testPermalinksToUrls()
+	public function testPermalinksToUrls(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -476,7 +476,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame('<p>This is a <a href="/a">test</a><img src="/media/pages/a/' . $hash . '/test.jpg"></p>. This should not be <a href="https://getkirby.com">affected</a>.', (string)$result);
 	}
 
-	public function testPermalinksToUrlsWithMissingUUID()
+	public function testPermalinksToUrlsWithMissingUUID(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -490,7 +490,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame('<p>This is a <a href="/@/page/my-page">test</a></p>.', (string)$result);
 	}
 
-	public function testToStructure()
+	public function testToStructure(): void
 	{
 		$data = [
 			['title' => 'a', 'field' => 'c'],
@@ -513,7 +513,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame('d', $structure->last()->content()->field()->value());
 	}
 
-	public function testToStructureWithInvalidData()
+	public function testToStructureWithInvalidData(): void
 	{
 		$data = [
 			['title' => 'a'],
@@ -530,7 +530,7 @@ class FieldMethodsTest extends TestCase
 		$field->toStructure();
 	}
 
-	public function testToTimestamp()
+	public function testToTimestamp(): void
 	{
 		$field = $this->field('2012-12-12');
 		$ts    = strtotime('2012-12-12');
@@ -539,7 +539,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertFalse($this->field(null)->toTimestamp());
 	}
 
-	public function testToDefaultUrl()
+	public function testToDefaultUrl(): void
 	{
 		$field    = $this->field('super/cool');
 		$expected = '/super/cool';
@@ -547,7 +547,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $field->toUrl());
 	}
 
-	public function testToUrlCustom()
+	public function testToUrlCustom(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -564,13 +564,13 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $field->toUrl());
 	}
 
-	public function testToUrlEmpty()
+	public function testToUrlEmpty(): void
 	{
 		$field = $this->field();
 		$this->assertNull($field->toUrl());
 	}
 
-	public function testToUuidUrl()
+	public function testToUuidUrl(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -608,7 +608,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($file->url(), $field->toUrl());
 	}
 
-	public function testToInvalidUuidUrl()
+	public function testToInvalidUuidUrl(): void
 	{
 		$field = $this->field('page://invalid');
 		$this->assertNull($field->toUrl());
@@ -617,7 +617,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertNull($field->toUrl());
 	}
 
-	public function testToUser()
+	public function testToUser(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -642,7 +642,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($b, $this->field(Yaml::encode(['b@company.com', 'a@company.com']))->toUser());
 	}
 
-	public function testToUsers()
+	public function testToUsers(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -671,12 +671,12 @@ class FieldMethodsTest extends TestCase
 		$this->assertInstanceOf(Users::class, $this->field($content)->toUsers());
 	}
 
-	public function testLength()
+	public function testLength(): void
 	{
 		$this->assertSame(3, $this->field('abc')->length());
 	}
 
-	public function testCallback()
+	public function testCallback(): void
 	{
 		$field  = $this->field('Hello world');
 		$result = $field->callback(function ($field) {
@@ -686,12 +686,12 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame('foo', $result->toString());
 	}
 
-	public function testEscape()
+	public function testEscape(): void
 	{
 		$this->assertSame('&lt;script&gt;alert(&quot;hello&quot;)&lt;/script&gt;', $this->field('<script>alert("hello")</script>')->escape()->value());
 	}
 
-	public function testExcerpt()
+	public function testExcerpt(): void
 	{
 		// html
 		$string   = 'This is a long text<br>with some html';
@@ -706,12 +706,12 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $this->field($string)->excerpt(27)->value());
 	}
 
-	public function testHtml()
+	public function testHtml(): void
 	{
 		$this->assertSame('&ouml;', $this->field('ö')->html()->value());
 	}
 
-	public function testInline()
+	public function testInline(): void
 	{
 		$html = '<div><h1>Headline</h1> <p>Subtitle with <a href="#">link</a>.</p></div>';
 		$expected = 'Headline Subtitle with <a href="#">link</a>.';
@@ -720,7 +720,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame('', $this->field(null)->inline()->value());
 	}
 
-	public function testNl2br()
+	public function testNl2br(): void
 	{
 		$input = 'Multiline' . PHP_EOL . 'test' . PHP_EOL . 'string';
 		$expected = 'Multiline<br>' . PHP_EOL . 'test<br>' . PHP_EOL . 'string';
@@ -729,7 +729,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame('', $this->field(null)->nl2br()->value());
 	}
 
-	public function testKirbytext()
+	public function testKirbytext(): void
 	{
 		$kirbytext = '(link: # text: Test)';
 		$expected  = '<p><a href="#">Test</a></p>';
@@ -738,7 +738,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $this->field($kirbytext)->kt()->value());
 	}
 
-	public function testKirbytextWithSafeMode()
+	public function testKirbytextWithSafeMode(): void
 	{
 		$kirbytext = '<h1>Test</h1>';
 		$expected  = '<p>&lt;h1&gt;Test&lt;/h1&gt;</p>';
@@ -746,7 +746,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $this->field($kirbytext)->kirbytext(['markdown' => ['safe' => true]])->value());
 	}
 
-	public function testKirbytextInline()
+	public function testKirbytextInline(): void
 	{
 		$kirbytext = '(link: # text: Test)';
 		$expected  = '<a href="#">Test</a>';
@@ -755,7 +755,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $this->field($kirbytext)->kti()->value());
 	}
 
-	public function testKirbytextInlineWithSafeMode()
+	public function testKirbytextInlineWithSafeMode(): void
 	{
 		$kirbytext = '<b>Test</b>';
 		$expected  = '&lt;b&gt;Test&lt;/b&gt;';
@@ -763,7 +763,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $this->field($kirbytext)->kirbytextInline(['markdown' => ['safe' => true]])->value());
 	}
 
-	public function testKirbytags()
+	public function testKirbytags(): void
 	{
 		$kirbytext = '(link: # text: Test)';
 		$expected  = '<a href="#">Test</a>';
@@ -771,12 +771,12 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $this->field($kirbytext)->kirbytags()->value());
 	}
 
-	public function testLower()
+	public function testLower(): void
 	{
 		$this->assertSame('abc', $this->field('ABC')->lower()->value());
 	}
 
-	public function testMarkdown()
+	public function testMarkdown(): void
 	{
 		$markdown = '**Test**';
 		$expected = '<p><strong>Test</strong></p>';
@@ -784,7 +784,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $this->field($markdown)->markdown()->value());
 	}
 
-	public function testMarkdownWithSafeMode()
+	public function testMarkdownWithSafeMode(): void
 	{
 		$markdown = '<h1>Test</h1>';
 		$expected = '<p>&lt;h1&gt;Test&lt;/h1&gt;</p>';
@@ -792,13 +792,13 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $this->field($markdown)->markdown(['safe' => true])->value());
 	}
 
-	public function testOr()
+	public function testOr(): void
 	{
 		$this->assertSame('field value', $this->field('field value')->or('fallback')->value());
 		$this->assertSame('fallback', $this->field()->or('fallback')->value());
 	}
 
-	public function testQuery()
+	public function testQuery(): void
 	{
 		// with page
 		$page = new Page([
@@ -812,7 +812,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame('Hello world', $page->text()->query()->value());
 	}
 
-	public function testReplace()
+	public function testReplace(): void
 	{
 		// simple replacement
 		$this->assertSame('Hello world', $this->field('Hello {{ message }}')->replace(['message' => 'world'])->value());
@@ -855,12 +855,12 @@ class FieldMethodsTest extends TestCase
 		);
 	}
 
-	public function testShort()
+	public function testShort(): void
 	{
 		$this->assertSame('abc…', $this->field('abcd')->short(3)->value());
 	}
 
-	public function testSmartypants()
+	public function testSmartypants(): void
 	{
 		$text     = '"Test"';
 		$expected = '&#8220;Test&#8221;';
@@ -868,7 +868,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $this->field($text)->smartypants()->value());
 	}
 
-	public function testSmartypantsWithKirbytext()
+	public function testSmartypantsWithKirbytext(): void
 	{
 		new App([
 			'roots' => [
@@ -885,7 +885,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $this->field($text)->kti()->value());
 	}
 
-	public function testSlug()
+	public function testSlug(): void
 	{
 		$text     = 'Ä--Ö--Ü';
 		$expected = 'a-o-u';
@@ -893,7 +893,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $this->field($text)->slug()->value());
 	}
 
-	public function testSplit()
+	public function testSplit(): void
 	{
 		$text = 'a, b, c';
 		$expected = ['a', 'b', 'c'];
@@ -901,30 +901,30 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($expected, $this->field($text)->split());
 	}
 
-	public function testUpper()
+	public function testUpper(): void
 	{
 		$this->assertSame('ABC', $this->field('abc')->upper()->value());
 	}
 
-	public function testWidont()
+	public function testWidont(): void
 	{
 		$this->assertSame('Test&nbsp;Headline', $this->field('Test Headline')->widont()->value());
 		$this->assertSame('Test Headline&nbsp;With&#8209;Dash', $this->field('Test Headline With-Dash')->widont()->value());
 	}
 
-	public function testWords()
+	public function testWords(): void
 	{
 		$text = 'this is an example text';
 		$this->assertSame(5, $this->field($text)->words());
 		$this->assertSame(0, $this->field(null)->words());
 	}
 
-	public function testXml()
+	public function testXml(): void
 	{
 		$this->assertSame('&#246;&#228;&#252;', $this->field('öäü')->xml()->value());
 	}
 
-	public function testYaml()
+	public function testYaml(): void
 	{
 		$data = [
 			'a',
@@ -936,7 +936,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($data, $this->field($yaml)->yaml());
 	}
 
-	public function testToBlocks()
+	public function testToBlocks(): void
 	{
 		$data = [
 			[
@@ -1033,7 +1033,7 @@ class FieldMethodsTest extends TestCase
 		}
 	}
 
-	public function testToBlocksWithInvalidData()
+	public function testToBlocksWithInvalidData(): void
 	{
 		$data = [
 			[
@@ -1052,7 +1052,7 @@ class FieldMethodsTest extends TestCase
 		$field->toBlocks();
 	}
 
-	public function testToLayouts()
+	public function testToLayouts(): void
 	{
 		$data = [
 			[
@@ -1088,7 +1088,7 @@ class FieldMethodsTest extends TestCase
 		$this->assertEquals($field, $block->field());
 	}
 
-	public function testToObject()
+	public function testToObject(): void
 	{
 		$data = [
 			'heading' => 'Heading',

--- a/tests/Content/FieldTest.php
+++ b/tests/Content/FieldTest.php
@@ -4,36 +4,27 @@ namespace Kirby\Content;
 
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use TypeError;
 
-/**
- * @coversDefaultClass \Kirby\Content\Field
- */
+#[CoversClass(Field::class)]
 class FieldTest extends TestCase
 {
-	/**
-	 * @covers ::__debugInfo
-	 */
-	public function test__debugInfo()
+	public function test__debugInfo(): void
 	{
 		$field = new Field(null, 'title', 'Title');
 		$this->assertSame(['title' => 'Title'], $field->__debugInfo());
 	}
 
-	/**
-	 * @covers ::key
-	 */
-	public function testKey()
+	public function testKey(): void
 	{
 		$field = new Field(null, 'title', 'Title');
 		$this->assertSame('title', $field->key());
 	}
 
-	/**
-	 * @covers ::exists
-	 */
-	public function testExists()
+	public function testExists(): void
 	{
 		$parent = new Page([
 			'slug' => 'test',
@@ -46,10 +37,7 @@ class FieldTest extends TestCase
 		$this->assertFalse($parent->b()->exists());
 	}
 
-	/**
-	 * @covers ::model
-	 */
-	public function testModel()
+	public function testModel(): void
 	{
 		$model = new Page(['slug' => 'test']);
 		$field = new Field($model, 'title', 'Title');
@@ -57,10 +45,7 @@ class FieldTest extends TestCase
 		$this->assertSame($model, $field->model());
 	}
 
-	/**
-	 * @covers ::parent
-	 */
-	public function testParent()
+	public function testParent(): void
 	{
 		$parent = new Page(['slug' => 'test']);
 		$field  = new Field($parent, 'title', 'Title');
@@ -68,12 +53,7 @@ class FieldTest extends TestCase
 		$this->assertSame($parent, $field->parent());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::__toString
-	 * @covers ::toString
-	 */
-	public function testToString()
+	public function testToString(): void
 	{
 		$field = new Field(null, 'title', 'Title');
 
@@ -82,28 +62,19 @@ class FieldTest extends TestCase
 		$this->assertSame('Title', (string)$field);
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$field = new Field(null, 'title', 'Title');
 		$this->assertSame(['title' => 'Title'], $field->toArray());
 	}
 
-	/**
-	 * @covers ::value
-	 */
-	public function testValue()
+	public function testValue(): void
 	{
 		$field = new Field(null, 'title', 'Title');
 		$this->assertSame('Title', $field->value());
 	}
 
-	/**
-	 * @covers ::value
-	 */
-	public function testValueSetter()
+	public function testValueSetter(): void
 	{
 		$field = new Field(null, 'title', 'Title');
 		$this->assertSame('Title', $field->value());
@@ -111,10 +82,7 @@ class FieldTest extends TestCase
 		$this->assertSame('Modified', $field->value());
 	}
 
-	/**
-	 * @covers ::value
-	 */
-	public function testValueCallbackSetter()
+	public function testValueCallbackSetter(): void
 	{
 		$field = new Field(null, 'title', 'Title');
 		$this->assertSame('Title', $field->value());
@@ -122,10 +90,7 @@ class FieldTest extends TestCase
 		$this->assertSame('Modified', $field->value());
 	}
 
-	/**
-	 * @covers ::value
-	 */
-	public function testInvalidValueSetter()
+	public function testInvalidValueSetter(): void
 	{
 		$this->expectException(TypeError::class);
 		$this->expectExceptionMessage('Argument #1 ($value) must be of type Closure|string|null, stdClass given');
@@ -135,10 +100,7 @@ class FieldTest extends TestCase
 		$field->value(new stdClass());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
-	public function testCloningInMethods()
+	public function testCloningInMethods(): void
 	{
 		Field::$methods = [
 			'test' => function ($field) {
@@ -174,30 +136,21 @@ class FieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::isEmpty
-	 * @dataProvider emptyDataProvider
-	 */
-	public function testIsEmpty($input, $expected)
+	#[DataProvider('emptyDataProvider')]
+	public function testIsEmpty($input, $expected): void
 	{
 		$field = new Field(null, 'test', $input);
 		$this->assertSame($expected, $field->isEmpty());
 	}
 
-	/**
-	 * @covers ::isNotEmpty
-	 * @dataProvider emptyDataProvider
-	 */
-	public function testIsNotEmpty($input, $expected)
+	#[DataProvider('emptyDataProvider')]
+	public function testIsNotEmpty($input, $expected): void
 	{
 		$field = new Field(null, 'test', $input);
 		$this->assertSame(!$expected, $field->isNotEmpty());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
-	public function testCallNonExistingMethod()
+	public function testCallNonExistingMethod(): void
 	{
 		$field  = new Field(null, 'test', 'value');
 		$result = $field->methodDoesNotExist();
@@ -205,10 +158,7 @@ class FieldTest extends TestCase
 		$this->assertSame($field, $result);
 	}
 
-	/**
-	 * @covers ::or
-	 */
-	public function testOrWithFieldFallback()
+	public function testOrWithFieldFallback(): void
 	{
 		$fallback = new Field(null, 'fallback', 'fallback value');
 		$field    = new Field(null, 'test', '');
@@ -217,10 +167,7 @@ class FieldTest extends TestCase
 		$this->assertSame($fallback, $field->or($fallback));
 	}
 
-	/**
-	 * @covers ::or
-	 */
-	public function testOrWithStringFallback()
+	public function testOrWithStringFallback(): void
 	{
 		$fallback = 'fallback value';
 		$field    = new Field(null, 'test', '');

--- a/tests/Content/ImmutableMemoryStorageTest.php
+++ b/tests/Content/ImmutableMemoryStorageTest.php
@@ -20,7 +20,7 @@ class ImmutableMemoryStorageTest extends TestCase
 		$this->storage = new ImmutableMemoryStorage($this->model);
 	}
 
-	public function testDelete()
+	public function testDelete(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('Storage for the page is immutable and cannot be deleted. Make sure to use the last alteration of the object.');
@@ -28,7 +28,7 @@ class ImmutableMemoryStorageTest extends TestCase
 		$this->storage->delete(VersionId::latest(), Language::ensure());
 	}
 
-	public function testMove()
+	public function testMove(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('Storage for the page is immutable and cannot be moved. Make sure to use the last alteration of the object.');
@@ -40,7 +40,7 @@ class ImmutableMemoryStorageTest extends TestCase
 		);
 	}
 
-	public function testNextModel()
+	public function testNextModel(): void
 	{
 		$model      = new Page(['slug' => 'test']);
 		$nextModel = $model->clone();
@@ -53,7 +53,7 @@ class ImmutableMemoryStorageTest extends TestCase
 		$this->assertSame($nextModel, $storage->nextModel());
 	}
 
-	public function testNextModelWithoutClone()
+	public function testNextModelWithoutClone(): void
 	{
 		$model   = new Page(['slug' => 'test']);
 		$storage = new ImmutableMemoryStorage(
@@ -63,7 +63,7 @@ class ImmutableMemoryStorageTest extends TestCase
 		$this->assertNull($storage->nextModel());
 	}
 
-	public function testTouch()
+	public function testTouch(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('Storage for the page is immutable and cannot be touched. Make sure to use the last alteration of the object.');
@@ -71,7 +71,7 @@ class ImmutableMemoryStorageTest extends TestCase
 		$this->storage->touch(VersionId::latest(), Language::ensure());
 	}
 
-	public function testUpdate()
+	public function testUpdate(): void
 	{
 		$this->storage->create(VersionId::latest(), Language::ensure(), []);
 

--- a/tests/Content/LockTest.php
+++ b/tests/Content/LockTest.php
@@ -6,11 +6,9 @@ use Kirby\Cms\App;
 use Kirby\Cms\Language;
 use Kirby\Cms\User;
 use Kirby\Data\Data;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\Lock
- * @covers ::__construct
- */
+#[CoversClass(Lock::class)]
 class LockTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.LockTest';
@@ -71,10 +69,7 @@ class LockTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::for
-	 */
-	public function testForWithAuthenticatedUser()
+	public function testForWithAuthenticatedUser(): void
 	{
 		$this->app->impersonate('admin');
 
@@ -87,10 +82,7 @@ class LockTest extends TestCase
 		$this->assertSame($this->app->user('admin'), $lock->user());
 	}
 
-	/**
-	 * @covers ::for
-	 */
-	public function testForWithDifferentUser()
+	public function testForWithDifferentUser(): void
 	{
 		// create the version with the admin user
 		$this->app->impersonate('admin');
@@ -108,10 +100,7 @@ class LockTest extends TestCase
 		$this->assertSame($this->app->user('admin'), $lock->user());
 	}
 
-	/**
-	 * @covers ::for
-	 */
-	public function testForWithoutUser()
+	public function testForWithoutUser(): void
 	{
 		// create the version with the admin user
 		$this->app->impersonate('admin');
@@ -122,10 +111,7 @@ class LockTest extends TestCase
 		$this->assertNull($lock->user());
 	}
 
-	/**
-	 * @covers ::for
-	 */
-	public function testForWithLanguageWildcard()
+	public function testForWithLanguageWildcard(): void
 	{
 		$this->app = $this->app->clone([
 			'languages' => [
@@ -156,10 +142,7 @@ class LockTest extends TestCase
 		$this->assertSame('admin', $lock->user()->id());
 	}
 
-	/**
-	 * @covers ::for
-	 */
-	public function testForWithLegacyLock()
+	public function testForWithLegacyLock(): void
 	{
 		$page = $this->app->page('test');
 		$file = $page->root() . '/.lock';
@@ -178,10 +161,7 @@ class LockTest extends TestCase
 		$this->assertTrue($lock->isLocked());
 	}
 
-	/**
-	 * @covers ::isActive
-	 */
-	public function testIsActive()
+	public function testIsActive(): void
 	{
 		// just modified
 		$lock = new Lock(
@@ -191,10 +171,7 @@ class LockTest extends TestCase
 		$this->assertTrue($lock->isActive());
 	}
 
-	/**
-	 * @covers ::isActive
-	 */
-	public function testIsActiveWithOldModificationTimestamp()
+	public function testIsActiveWithOldModificationTimestamp(): void
 	{
 		// create a lock that has not been modified for 20 minutes
 		$lock = new Lock(
@@ -204,28 +181,19 @@ class LockTest extends TestCase
 		$this->assertFalse($lock->isActive());
 	}
 
-	/**
-	 * @covers ::isActive
-	 */
-	public function testIsActiveWithoutModificationTimestamp()
+	public function testIsActiveWithoutModificationTimestamp(): void
 	{
 		// a lock without modification time should also be inactive
 		$lock = new Lock();
 		$this->assertFalse($lock->isActive());
 	}
 
-	/**
-	 * @covers ::isEnabled
-	 */
-	public function testIsEnabled()
+	public function testIsEnabled(): void
 	{
 		$this->assertTrue(Lock::isEnabled());
 	}
 
-	/**
-	 * @covers ::isEnabled
-	 */
-	public function testIsEnabledWhenDisabled()
+	public function testIsEnabledWhenDisabled(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -238,10 +206,7 @@ class LockTest extends TestCase
 		$this->assertFalse(Lock::isEnabled());
 	}
 
-	/**
-	 * @covers ::isLegacy
-	 */
-	public function testIsLegacy()
+	public function testIsLegacy(): void
 	{
 		$lock = new Lock();
 		$this->assertFalse($lock->isLegacy());
@@ -250,19 +215,13 @@ class LockTest extends TestCase
 		$this->assertTrue($lock->isLegacy());
 	}
 
-	/**
-	 * @covers ::isLocked
-	 */
-	public function testIsLocked()
+	public function testIsLocked(): void
 	{
 		$lock = new Lock();
 		$this->assertFalse($lock->isLocked());
 	}
 
-	/**
-	 * @covers ::isLocked
-	 */
-	public function testIsLockedWithCurrentUser()
+	public function testIsLockedWithCurrentUser(): void
 	{
 		$this->app->impersonate('admin');
 
@@ -274,10 +233,7 @@ class LockTest extends TestCase
 		$this->assertFalse($lock->isLocked());
 	}
 
-	/**
-	 * @covers ::isLocked
-	 */
-	public function testIsLockedWithDifferentUser()
+	public function testIsLockedWithDifferentUser(): void
 	{
 		$this->app->impersonate('admin');
 
@@ -289,10 +245,7 @@ class LockTest extends TestCase
 		$this->assertTrue($lock->isLocked());
 	}
 
-	/**
-	 * @covers ::isLocked
-	 */
-	public function testIsLockedWhenDisabled()
+	public function testIsLockedWhenDisabled(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -312,10 +265,7 @@ class LockTest extends TestCase
 		$this->assertFalse($lock->isLocked());
 	}
 
-	/**
-	 * @covers ::isLocked
-	 */
-	public function testIsLockedWithDifferentUserAndOldTimestamp()
+	public function testIsLockedWithDifferentUserAndOldTimestamp(): void
 	{
 		$this->app->impersonate('admin');
 
@@ -327,10 +277,7 @@ class LockTest extends TestCase
 		$this->assertFalse($lock->isLocked());
 	}
 
-	/**
-	 * @covers ::legacy
-	 */
-	public function testLegacy()
+	public function testLegacy(): void
 	{
 		$page = $this->app->page('test');
 		$file = $page->root() . '/.lock';
@@ -353,10 +300,7 @@ class LockTest extends TestCase
 		$this->assertSame($time, $lock->modified());
 	}
 
-	/**
-	 * @covers ::legacy
-	 */
-	public function testLegacyWithoutLockInfo()
+	public function testLegacyWithoutLockInfo(): void
 	{
 		$page = $this->app->page('test');
 		$file = $page->root() . '/.lock';
@@ -367,10 +311,7 @@ class LockTest extends TestCase
 		$this->assertNull($lock);
 	}
 
-	/**
-	 * @covers ::legacy
-	 */
-	public function testLegacyWithOutdatedFile()
+	public function testLegacyWithOutdatedFile(): void
 	{
 		$page = $this->app->page('test');
 		$file = $page->root() . '/.lock';
@@ -390,10 +331,7 @@ class LockTest extends TestCase
 		$this->assertFalse($lock->isLocked());
 	}
 
-	/**
-	 * @covers ::legacy
-	 */
-	public function testLegacyWithUnlockedFile()
+	public function testLegacyWithUnlockedFile(): void
 	{
 		$page = $this->app->page('test');
 		$file = $page->root() . '/.lock';
@@ -412,10 +350,7 @@ class LockTest extends TestCase
 		$this->assertNull($lock);
 	}
 
-	/**
-	 * @covers ::legacyFile
-	 */
-	public function testLegacyFile()
+	public function testLegacyFile(): void
 	{
 		$page = $this->app->page('test');
 		$expected = $page->root() . '/.lock';
@@ -423,10 +358,7 @@ class LockTest extends TestCase
 		$this->assertSame($expected, Lock::legacyFile($page));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
-	public function testModified()
+	public function testModified(): void
 	{
 		$lock = new Lock(
 			modified: $modified = time()
@@ -436,10 +368,7 @@ class LockTest extends TestCase
 		$this->assertSame(date('c', $modified), $lock->modified('c'));
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$lock = new Lock(
 			user: $user = new User([
@@ -460,10 +389,7 @@ class LockTest extends TestCase
 		], $lock->toArray());
 	}
 
-	/**
-	 * @covers ::user
-	 */
-	public function testUser()
+	public function testUser(): void
 	{
 		$lock = new Lock(
 			user: $user = $this->app->user('admin')
@@ -472,10 +398,7 @@ class LockTest extends TestCase
 		$this->assertSame($user, $lock->user());
 	}
 
-	/**
-	 * @covers ::user
-	 */
-	public function testUserWithoutUser()
+	public function testUserWithoutUser(): void
 	{
 		$lock = new Lock();
 		$this->assertNull($lock->user());

--- a/tests/Content/LockedContentExceptionTest.php
+++ b/tests/Content/LockedContentExceptionTest.php
@@ -3,13 +3,12 @@
 namespace Kirby\Content;
 
 use Kirby\Cms\User;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\LockedContentException
- */
+#[CoversClass(LockedContentException::class)]
 class LockedContentExceptionTest extends TestCase
 {
-	public function testException()
+	public function testException(): void
 	{
 		$lock = new Lock(
 			user: new User(['username' => 'test']),
@@ -26,7 +25,7 @@ class LockedContentExceptionTest extends TestCase
 		$this->assertSame('error.content.lock', $exception->getKey());
 	}
 
-	public function testCustomMessage()
+	public function testCustomMessage(): void
 	{
 		$lock = new Lock(
 			user: new User(['username' => 'test']),

--- a/tests/Content/MemoryStorageTest.php
+++ b/tests/Content/MemoryStorageTest.php
@@ -67,7 +67,7 @@ class MemoryStorageTest extends TestCase
 		$this->storage = new MemoryStorage($this->model);
 	}
 
-	public function testCreateAndReadChangesMultiLang()
+	public function testCreateAndReadChangesMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -77,7 +77,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndRead($versionId, $language);
 	}
 
-	public function testCreateAndReadChangesSingleLang()
+	public function testCreateAndReadChangesSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -87,7 +87,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndRead($versionId, $language);
 	}
 
-	public function testCreateAndReadLatestMultiLang()
+	public function testCreateAndReadLatestMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -97,7 +97,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndRead($versionId, $language);
 	}
 
-	public function testCreateAndReadLatestSingleLang()
+	public function testCreateAndReadLatestSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -107,7 +107,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndRead($versionId, $language);
 	}
 
-	public function testDeleteNonExisting()
+	public function testDeleteNonExisting(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -122,7 +122,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertFalse($this->storage->exists($versionId, $language));
 	}
 
-	public function testDeleteChangesMultiLang()
+	public function testDeleteChangesMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -132,7 +132,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndDelete($versionId, $language);
 	}
 
-	public function testDeleteChangesSingleLang()
+	public function testDeleteChangesSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -142,7 +142,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndDelete($versionId, $language);
 	}
 
-	public function testDeleteLatestMultiLang()
+	public function testDeleteLatestMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -152,7 +152,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndDelete($versionId, $language);
 	}
 
-	public function testDeleteLatestSingleLang()
+	public function testDeleteLatestSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -162,7 +162,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndDelete($versionId, $language);
 	}
 
-	public function testExistsMultiLanguage()
+	public function testExistsMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -178,7 +178,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertTrue($this->storage->exists($versionId, $this->app->language('de')));
 	}
 
-	public function testExistsSingleLanguage()
+	public function testExistsSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -192,7 +192,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertTrue($this->storage->exists($versionId, $language));
 	}
 
-	public function testExistsNoneExistingMultiLanguage()
+	public function testExistsNoneExistingMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -200,14 +200,14 @@ class MemoryStorageTest extends TestCase
 		$this->assertFalse($this->storage->exists(VersionId::changes(), $this->app->language('de')));
 	}
 
-	public function testExistsNoneExistingSingleLanguage()
+	public function testExistsNoneExistingSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
 		$this->assertFalse($this->storage->exists(VersionId::changes(), Language::single()));
 	}
 
-	public function testModifiedNoneExistingMultiLanguage()
+	public function testModifiedNoneExistingMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -215,7 +215,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), $this->app->language('en')));
 	}
 
-	public function testModifiedNoneExistingSingleLanguage()
+	public function testModifiedNoneExistingSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -223,7 +223,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), Language::single()));
 	}
 
-	public function testModifiedSomeExistingMultiLanguage()
+	public function testModifiedSomeExistingMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -236,7 +236,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), $language));
 	}
 
-	public function testModifiedSomeExistingSingleLanguage()
+	public function testModifiedSomeExistingSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -249,7 +249,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), $language));
 	}
 
-	public function testMoveToTheSameStorageLocation()
+	public function testMoveToTheSameStorageLocation(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -274,7 +274,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertSame($content, $this->storage->read($versionId, $language), 'The content should still be the same');
 	}
 
-	public function testMoveToTheSameStorageLocationWithAnotherStorageInstance()
+	public function testMoveToTheSameStorageLocationWithAnotherStorageInstance(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -303,7 +303,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertSame($content, $storage->read($versionId, $language));
 	}
 
-	public function testTouchMultiLang()
+	public function testTouchMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -318,7 +318,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($time, $this->storage->modified($versionId, $language));
 	}
 
-	public function testTouchSingleLang()
+	public function testTouchSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -333,7 +333,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($time, $this->storage->modified($versionId, $language));
 	}
 
-	public function testUpdateMultiLang()
+	public function testUpdateMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -343,7 +343,7 @@ class MemoryStorageTest extends TestCase
 		$this->assertCreateAndUpdate($versionId, $language);
 	}
 
-	public function testUpdateSingleLang()
+	public function testUpdateSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 

--- a/tests/Content/PlainTextStorageTest.php
+++ b/tests/Content/PlainTextStorageTest.php
@@ -34,7 +34,7 @@ class PlainTextStorageTest extends TestCase
 		$this->storage = new PlainTextStorage($this->model);
 	}
 
-	public function testCreateChangesMultiLang()
+	public function testCreateChangesMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -47,7 +47,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/_changes/article.en.txt'));
 	}
 
-	public function testCreateChangesSingleLang()
+	public function testCreateChangesSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -60,7 +60,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/_changes/article.txt'));
 	}
 
-	public function testCreateLatestMultiLang()
+	public function testCreateLatestMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -73,7 +73,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/article.en.txt'));
 	}
 
-	public function testCreateLatestSingleLang()
+	public function testCreateLatestSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -86,7 +86,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/article.txt'));
 	}
 
-	public function testDeleteNonExisting()
+	public function testDeleteNonExisting(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -101,7 +101,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertContentFileDoesNotExist($language, $versionId);
 	}
 
-	public function testDeleteChangesMultiLang()
+	public function testDeleteChangesMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -115,7 +115,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryExists($this->model->root());
 	}
 
-	public function testDeleteChangesSingleLang()
+	public function testDeleteChangesSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -128,7 +128,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryDoesNotExist($this->model->root() . '/_changes');
 	}
 
-	public function testDeleteLatestMultiLang()
+	public function testDeleteLatestMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -141,7 +141,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryExists($this->model->root());
 	}
 
-	public function testDeleteLatestMultiLangAndCleanUp()
+	public function testDeleteLatestMultiLangAndCleanUp(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -157,7 +157,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryDoesNotExist($this->model->root());
 	}
 
-	public function testDeleteDraftMultiLangAndCleanUp()
+	public function testDeleteDraftMultiLangAndCleanUp(): void
 	{
 		$this->setUpMultiLanguage([
 			'children' => [
@@ -178,7 +178,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryDoesNotExist(dirname($this->model->root()));
 	}
 
-	public function testDeleteLatestSingleLang()
+	public function testDeleteLatestSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -191,7 +191,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryExists($this->model->root());
 	}
 
-	public function testDeleteLatestSingleLangAndCleanUp()
+	public function testDeleteLatestSingleLangAndCleanUp(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -202,7 +202,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryDoesNotExist($this->model->root());
 	}
 
-	public function testDeleteDraftSingleLangAndCleanUp()
+	public function testDeleteDraftSingleLangAndCleanUp(): void
 	{
 		$this->setUpSingleLanguage([
 			'children' => [
@@ -224,7 +224,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertDirectoryDoesNotExist(dirname($this->model->root()));
 	}
 
-	public function testExistsNoneExistingMultiLanguage()
+	public function testExistsNoneExistingMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -232,14 +232,14 @@ class PlainTextStorageTest extends TestCase
 		$this->assertFalse($this->storage->exists(VersionId::changes(), $this->app->language('de')));
 	}
 
-	public function testExistsNoneExistingSingleLanguage()
+	public function testExistsNoneExistingSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
 		$this->assertFalse($this->storage->exists(VersionId::changes(), Language::single()));
 	}
 
-	public function testModifiedNoneExistingMultiLanguage()
+	public function testModifiedNoneExistingMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -247,7 +247,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), $this->app->language('en')));
 	}
 
-	public function testModifiedNoneExistingSingleLanguage()
+	public function testModifiedNoneExistingSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -255,7 +255,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), Language::single()));
 	}
 
-	public function testModifiedSomeExistingMultiLanguage()
+	public function testModifiedSomeExistingMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -266,7 +266,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), $this->app->language('en')));
 	}
 
-	public function testModifiedSomeExistingSingleLanguage()
+	public function testModifiedSomeExistingSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -277,7 +277,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertNull($this->storage->modified(VersionId::latest(), Language::single()));
 	}
 
-	public function testMove()
+	public function testMove(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -303,7 +303,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertFileExists($this->model->root() . '/_changes/article.txt');
 	}
 
-	public function testMoveNonExistingContentFile()
+	public function testMoveNonExistingContentFile(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -322,7 +322,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertFileExists($this->model->root() . '/_changes/article.txt');
 	}
 
-	public function testMoveToTheSameStorageLocation()
+	public function testMoveToTheSameStorageLocation(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -351,7 +351,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($content, $this->storage->read($versionId, $language), 'The content should still be the same');
 	}
 
-	public function testMoveToTheSameStorageLocationWithAnotherStorageInstance()
+	public function testMoveToTheSameStorageLocationWithAnotherStorageInstance(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -391,7 +391,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($content, $storage->read($versionId, $language));
 	}
 
-	public function testReadChangesMultiLang()
+	public function testReadChangesMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -406,7 +406,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, $this->storage->read(VersionId::changes(), $this->app->language('en')));
 	}
 
-	public function testReadChangesSingleLang()
+	public function testReadChangesSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -421,7 +421,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, $this->storage->read(VersionId::changes(), Language::single()));
 	}
 
-	public function testReadLatestMultiLang()
+	public function testReadLatestMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -435,7 +435,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, $this->storage->read(VersionId::latest(), $this->app->language('en')));
 	}
 
-	public function testReadLatestSingleLang()
+	public function testReadLatestSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -449,7 +449,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, $this->storage->read(VersionId::latest(), Language::single()));
 	}
 
-	public function testTouchChangesMultiLang()
+	public function testTouchChangesMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -467,7 +467,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($minTime, filemtime($root . '/article.en.txt'));
 	}
 
-	public function testTouchChangesSingleLang()
+	public function testTouchChangesSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -485,7 +485,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($minTime, filemtime($root . '/article.txt'));
 	}
 
-	public function testTouchLatestMultiLang()
+	public function testTouchLatestMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -502,7 +502,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($minTime, filemtime($root));
 	}
 
-	public function testTouchLatestSingleLang()
+	public function testTouchLatestSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -519,7 +519,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertGreaterThanOrEqual($minTime, filemtime($root));
 	}
 
-	public function testUpdateChangesMultiLang()
+	public function testUpdateChangesMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -535,7 +535,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/_changes/article.en.txt'));
 	}
 
-	public function testUpdateChangesSingleLang()
+	public function testUpdateChangesSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -551,7 +551,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/_changes/article.txt'));
 	}
 
-	public function testUpdateLatestMultiLang()
+	public function testUpdateLatestMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -566,7 +566,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/article.en.txt'));
 	}
 
-	public function testUpdateLatestSingleLang()
+	public function testUpdateLatestSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -581,7 +581,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($fields, Data::read($this->model->root() . '/article.txt'));
 	}
 
-	public function testUpdateForFileWithMetaData()
+	public function testUpdateForFileWithMetaData(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -599,7 +599,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame($content, Data::read($file->parent()->root() . '/image.jpg.txt'));
 	}
 
-	public function testUpdateForFileWithoutMetaData()
+	public function testUpdateForFileWithoutMetaData(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -614,7 +614,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertFileDoesNotExist($file->parent()->root() . '/image.jpg.txt');
 	}
 
-	public function testUpdateForFileWithoutMetaDataAndFilteredNullValues()
+	public function testUpdateForFileWithoutMetaDataAndFilteredNullValues(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -632,7 +632,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertFileDoesNotExist($file->parent()->root() . '/image.jpg.txt');
 	}
 
-	public function testUpdateForFileWithRemovedMetaFile()
+	public function testUpdateForFileWithRemovedMetaFile(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -655,7 +655,7 @@ class PlainTextStorageTest extends TestCase
 	}
 
 	#[DataProvider('contentFileProviderMultiLang')]
-	public function testContentFileMultiLang(string $type, VersionId $id, string $language, string $expected)
+	public function testContentFileMultiLang(string $type, VersionId $id, string $language, string $expected): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -697,7 +697,7 @@ class PlainTextStorageTest extends TestCase
 	}
 
 	#[DataProvider('contentFileProviderSingleLang')]
-	public function testContentFileSingleLang(string $type, VersionId $id, string $expected)
+	public function testContentFileSingleLang(string $type, VersionId $id, string $expected): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -738,7 +738,7 @@ class PlainTextStorageTest extends TestCase
 		];
 	}
 
-	public function testContentFileDraft()
+	public function testContentFileDraft(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -753,7 +753,7 @@ class PlainTextStorageTest extends TestCase
 		$this->assertSame(static::TMP . '/content/_drafts/a-page/_changes/article.txt', $storage->contentFile(VersionId::changes(), Language::single()));
 	}
 
-	public function testContentFilesChangesMultiLang()
+	public function testContentFilesChangesMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -763,7 +763,7 @@ class PlainTextStorageTest extends TestCase
 		], $this->storage->contentFiles(VersionId::changes()));
 	}
 
-	public function testContentFilesChangesSingleLang()
+	public function testContentFilesChangesSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -772,7 +772,7 @@ class PlainTextStorageTest extends TestCase
 		], $this->storage->contentFiles(VersionId::changes()));
 	}
 
-	public function testContentFilesLatestMultiLang()
+	public function testContentFilesLatestMultiLang(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -782,7 +782,7 @@ class PlainTextStorageTest extends TestCase
 		], $this->storage->contentFiles(VersionId::latest()));
 	}
 
-	public function testContentFilesLatestSingleLang()
+	public function testContentFilesLatestSingleLang(): void
 	{
 		$this->setUpSingleLanguage();
 

--- a/tests/Content/StorageTest.php
+++ b/tests/Content/StorageTest.php
@@ -14,7 +14,7 @@ class StorageTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Content.Storage';
 
-	public function testAllMultiLanguageForFile()
+	public function testAllMultiLanguageForFile(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -46,7 +46,7 @@ class StorageTest extends TestCase
 		$this->assertCount(4, $versions);
 	}
 
-	public function testAllSingleLanguageForFile()
+	public function testAllSingleLanguageForFile(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -73,7 +73,7 @@ class StorageTest extends TestCase
 		$this->assertCount(2, $versions);
 	}
 
-	public function testAllMultiLanguageForPage()
+	public function testAllMultiLanguageForPage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -100,7 +100,7 @@ class StorageTest extends TestCase
 		$this->assertCount(4, $versions);
 	}
 
-	public function testAllSingleLanguageForPage()
+	public function testAllSingleLanguageForPage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -123,7 +123,7 @@ class StorageTest extends TestCase
 		$this->assertCount(2, $versions);
 	}
 
-	public function testCopyMultiLanguage()
+	public function testCopyMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -147,7 +147,7 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler->exists(VersionId::latest(), $de));
 	}
 
-	public function testCopySingleLanguage()
+	public function testCopySingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -168,7 +168,7 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler->exists(VersionId::changes(), Language::single()));
 	}
 
-	public function testCopyToAnotherStorage()
+	public function testCopyToAnotherStorage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -190,7 +190,7 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler2->exists(VersionId::latest(), Language::single()));
 	}
 
-	public function testCopyToTheSameStorageLocation()
+	public function testCopyToTheSameStorageLocation(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -218,7 +218,7 @@ class StorageTest extends TestCase
 		$this->assertSame($content, $handler->read($versionId, $language), 'The content should still be the same');
 	}
 
-	public function testCopyAll()
+	public function testCopyAll(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -241,7 +241,7 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler2->exists(VersionId::changes(), Language::single()));
 	}
 
-	public function testDeleteLanguageMultiLanguage()
+	public function testDeleteLanguageMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -260,7 +260,7 @@ class StorageTest extends TestCase
 		$this->assertFalse($handler->exists(VersionId::changes(), $this->app->language('de')));
 	}
 
-	public function testDeleteLanguageSingleLanguage()
+	public function testDeleteLanguageSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -283,7 +283,7 @@ class StorageTest extends TestCase
 		$this->assertFalse($handler->exists(VersionId::changes(), $language));
 	}
 
-	public function testFrom()
+	public function testFrom(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -324,7 +324,7 @@ class StorageTest extends TestCase
 		$this->assertSame($changesDE, $handlerB->read($versionChanges, $de));
 	}
 
-	public function testIsSameStorageLocation()
+	public function testIsSameStorageLocation(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -338,7 +338,7 @@ class StorageTest extends TestCase
 		));
 	}
 
-	public function testIsSameStorageLocationWithDifferentVersionIds()
+	public function testIsSameStorageLocationWithDifferentVersionIds(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -352,7 +352,7 @@ class StorageTest extends TestCase
 		));
 	}
 
-	public function testIsSameStorageLocationWithDifferentLanguages()
+	public function testIsSameStorageLocationWithDifferentLanguages(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -366,7 +366,7 @@ class StorageTest extends TestCase
 		));
 	}
 
-	public function testIsSameStorageLocationWithDifferentStorageInstances()
+	public function testIsSameStorageLocationWithDifferentStorageInstances(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -382,7 +382,7 @@ class StorageTest extends TestCase
 		));
 	}
 
-	public function testModel()
+	public function testModel(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -391,7 +391,7 @@ class StorageTest extends TestCase
 		$this->assertSame($this->model, $handler->model());
 	}
 
-	public function testMoveMultiLanguage()
+	public function testMoveMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -415,7 +415,7 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler->exists(VersionId::latest(), $de));
 	}
 
-	public function testMoveSingleLanguage()
+	public function testMoveSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -437,7 +437,7 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler->exists(VersionId::changes(), Language::single()));
 	}
 
-	public function testMoveToTheSameStorageLocation()
+	public function testMoveToTheSameStorageLocation(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -465,7 +465,7 @@ class StorageTest extends TestCase
 		$this->assertSame($content, $handler->read($versionId, $language), 'The content should still be the same');
 	}
 
-	public function testMoveToAnotherStorage()
+	public function testMoveToAnotherStorage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -487,7 +487,7 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler2->exists(VersionId::latest(), Language::single()));
 	}
 
-	public function testMoveAll()
+	public function testMoveAll(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -510,7 +510,7 @@ class StorageTest extends TestCase
 		$this->assertTrue($handler2->exists(VersionId::changes(), Language::single()));
 	}
 
-	public function testMoveSingleLanguageToMultiLanguage()
+	public function testMoveSingleLanguageToMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -536,7 +536,7 @@ class StorageTest extends TestCase
 		$this->assertFileExists($this->model->root() . '/_changes/article.en.txt');
 	}
 
-	public function testMoveMultiLanguageToSingleLanguage()
+	public function testMoveMultiLanguageToSingleLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -563,7 +563,7 @@ class StorageTest extends TestCase
 		$this->assertFileExists($this->model->root() . '/_changes/article.txt');
 	}
 
-	public function testReplaceStrings()
+	public function testReplaceStrings(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -590,7 +590,7 @@ class StorageTest extends TestCase
 		$this->assertSame($expected, $handler->read($versionId, $language));
 	}
 
-	public function testReplaceStringsWithNullValues()
+	public function testReplaceStringsWithNullValues(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -611,7 +611,7 @@ class StorageTest extends TestCase
 		], $handler->read(VersionId::latest(), Language::single()));
 	}
 
-	public function testTouchLanguageMultiLanguage()
+	public function testTouchLanguageMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 

--- a/tests/Content/TestCase.php
+++ b/tests/Content/TestCase.php
@@ -14,12 +14,12 @@ class TestCase extends BaseTestCase
 
 	protected ModelWithContent $model;
 
-	public function assertContentFileExists(string|null $language = null, VersionId|null $versionId = null)
+	public function assertContentFileExists(string|null $language = null, VersionId|null $versionId = null): void
 	{
 		$this->assertFileExists($this->contentFile($language, $versionId));
 	}
 
-	public function assertContentFileDoesNotExist(string|null $language = null, VersionId|null $versionId = null)
+	public function assertContentFileDoesNotExist(string|null $language = null, VersionId|null $versionId = null): void
 	{
 		$this->assertFileDoesNotExist($this->contentFile($language, $versionId));
 	}

--- a/tests/Content/TranslationTest.php
+++ b/tests/Content/TranslationTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(Translation::class)]
 class TranslationTest extends TestCase
 {
-	public function testCodeAndId()
+	public function testCodeAndId(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -35,7 +35,7 @@ class TranslationTest extends TestCase
 		$this->assertSame('de', $translationDE->id());
 	}
 
-	public function testContentMultiLanguage()
+	public function testContentMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -57,7 +57,7 @@ class TranslationTest extends TestCase
 		$this->assertSame($expected['de']['content'], $translationDE->content());
 	}
 
-	public function testContentSingleLanguage()
+	public function testContentSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -72,7 +72,7 @@ class TranslationTest extends TestCase
 		$this->assertSame($expected['content'], $translation->content());
 	}
 
-	public function testContentFileMultiLanguage()
+	public function testContentFileMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -85,7 +85,7 @@ class TranslationTest extends TestCase
 		$this->assertSame($this->model->root() . '/article.en.txt', $translation->version()->contentFile());
 	}
 
-	public function testContentFileSingleLanguage()
+	public function testContentFileSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -98,7 +98,7 @@ class TranslationTest extends TestCase
 		$this->assertSame($this->model->root() . '/article.txt', $translation->version()->contentFile());
 	}
 
-	public function testCreate()
+	public function testCreate(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -118,7 +118,7 @@ class TranslationTest extends TestCase
 		$this->assertTrue($translation->exists());
 	}
 
-	public function testCreateWithSlug()
+	public function testCreateWithSlug(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -136,7 +136,7 @@ class TranslationTest extends TestCase
 		$this->assertSame('foo', $translation->slug());
 	}
 
-	public function testExistsMultiLanguage()
+	public function testExistsMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -166,7 +166,7 @@ class TranslationTest extends TestCase
 		$this->assertTrue($translationDE->exists());
 	}
 
-	public function testExistsSingleLanguage()
+	public function testExistsSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -180,7 +180,7 @@ class TranslationTest extends TestCase
 		$this->assertTrue($translation->exists());
 	}
 
-	public function testIsDefault()
+	public function testIsDefault(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -200,7 +200,7 @@ class TranslationTest extends TestCase
 		$this->assertFalse($de->language()->isDefault());
 	}
 
-	public function testLanguage()
+	public function testLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -220,7 +220,7 @@ class TranslationTest extends TestCase
 		$this->assertSame($languageDE, $translationDE->language());
 	}
 
-	public function testModel()
+	public function testModel(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -233,7 +233,7 @@ class TranslationTest extends TestCase
 		$this->assertSame($this->model, $translation->model());
 	}
 
-	public function testParent()
+	public function testParent(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -249,7 +249,7 @@ class TranslationTest extends TestCase
 		$translation->parent();
 	}
 
-	public function testSlugExists()
+	public function testSlugExists(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -267,7 +267,7 @@ class TranslationTest extends TestCase
 		$this->assertSame('german-slug', $translation->slug());
 	}
 
-	public function testSlugNotExists()
+	public function testSlugNotExists(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -284,7 +284,7 @@ class TranslationTest extends TestCase
 		$this->assertNull($translation->slug());
 	}
 
-	public function testUpdate()
+	public function testUpdate(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -300,7 +300,7 @@ class TranslationTest extends TestCase
 		$translation->update();
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -320,7 +320,7 @@ class TranslationTest extends TestCase
 		$this->assertSame($expected, $translation->toArray());
 	}
 
-	public function testVersion()
+	public function testVersion(): void
 	{
 		$this->setUpMultiLanguage();
 

--- a/tests/Content/TranslationsTest.php
+++ b/tests/Content/TranslationsTest.php
@@ -3,17 +3,12 @@
 namespace Kirby\Content;
 
 use Kirby\Exception\NotFoundException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\Translations
- * @covers ::__construct
- */
+#[CoversClass(Translations::class)]
 class TranslationsTest extends TestCase
 {
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateMultiLanguage()
+	public function testCreateMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -41,10 +36,7 @@ class TranslationsTest extends TestCase
 		$this->assertSame('de', $translations->last()->language()->code());
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateSingleLanguage()
+	public function testCreateSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -73,10 +65,7 @@ class TranslationsTest extends TestCase
 		$this->assertTrue($translations->first()->language()->isSingle());
 	}
 
-	/**
-	 * @covers ::findByKey
-	 */
-	public function testFindByKeyMultiLanguage()
+	public function testFindByKeyMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -91,10 +80,7 @@ class TranslationsTest extends TestCase
 		$this->assertSame('de', $translations->findByKey('de')->language()->code());
 	}
 
-	/**
-	 * @covers ::findByKey
-	 */
-	public function testFindByKeySingleLanguage()
+	public function testFindByKeySingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -108,10 +94,7 @@ class TranslationsTest extends TestCase
 		$this->assertSame('en', $translations->findByKey('current')->language()->code());
 	}
 
-	/**
-	 * @covers ::findByKey
-	 */
-	public function testFindByKeyWithInvalidLanguage()
+	public function testFindByKeyWithInvalidLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -126,10 +109,7 @@ class TranslationsTest extends TestCase
 		$translations->findByKey('fr');
 	}
 
-	/**
-	 * @covers ::load
-	 */
-	public function testLoadMultiLanguage()
+	public function testLoadMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -143,10 +123,7 @@ class TranslationsTest extends TestCase
 		$this->assertSame('de', $translations->last()->language()->code());
 	}
 
-	/**
-	 * @covers ::load
-	 */
-	public function testLoadSingleLanguage()
+	public function testLoadSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 

--- a/tests/Content/VersionCacheTest.php
+++ b/tests/Content/VersionCacheTest.php
@@ -16,7 +16,7 @@ class VersionCacheTest extends TestCase
 		$this->setUpMultiLanguage();
 	}
 
-	public function testGetSetAndRemove()
+	public function testGetSetAndRemove(): void
 	{
 		$model    = new Page(['slug' => 'test']);
 		$version  = $model->version();
@@ -44,7 +44,7 @@ class VersionCacheTest extends TestCase
 		$this->assertNull(VersionCache::get($version, $language));
 	}
 
-	public function testGetSetAndRemoveWithDifferentModels()
+	public function testGetSetAndRemoveWithDifferentModels(): void
 	{
 		$page = new Page(['slug' => 'test1']);
 		$file = new File(['filename' => 'test2.jpg', 'parent' => $page]);
@@ -79,7 +79,7 @@ class VersionCacheTest extends TestCase
 		$this->assertNull(VersionCache::get($versionFile, $language));
 	}
 
-	public function testGetSetAndRemoveWithDifferentStorage()
+	public function testGetSetAndRemoveWithDifferentStorage(): void
 	{
 		$model    = new Page(['slug' => 'test']);
 		$version  = $model->version();
@@ -103,7 +103,7 @@ class VersionCacheTest extends TestCase
 		$this->assertNull(VersionCache::get($version, $language));
 	}
 
-	public function testGetSetAndRemoveWithClonedModel()
+	public function testGetSetAndRemoveWithClonedModel(): void
 	{
 		$model    = new Page(['slug' => 'test']);
 		$version  = $model->version();
@@ -133,7 +133,7 @@ class VersionCacheTest extends TestCase
 		$this->assertNull(VersionCache::get($clonedVersion, $language));
 	}
 
-	public function testGetSetAndRemoveWithDifferentLanguages()
+	public function testGetSetAndRemoveWithDifferentLanguages(): void
 	{
 		$model    = new Page(['slug' => 'test']);
 		$version  = $model->version();
@@ -166,7 +166,7 @@ class VersionCacheTest extends TestCase
 		$this->assertNull(VersionCache::get($version, $de));
 	}
 
-	public function testGetSetAndRemoveWithDifferentVersions()
+	public function testGetSetAndRemoveWithDifferentVersions(): void
 	{
 		$model        = new Page(['slug' => 'test']);
 		$latest       = $model->version('latest');
@@ -199,7 +199,7 @@ class VersionCacheTest extends TestCase
 		$this->assertNull(VersionCache::get($changes, $language));
 	}
 
-	public function testReset()
+	public function testReset(): void
 	{
 		$model    = new Page(['slug' => 'test']);
 		$version  = $model->version();
@@ -216,5 +216,4 @@ class VersionCacheTest extends TestCase
 
 		$this->assertNull(VersionCache::get($version, $language));
 	}
-
 }

--- a/tests/Content/VersionIdTest.php
+++ b/tests/Content/VersionIdTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Content;
 use Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Content\VersionId
- */
+#[CoversClass(VersionId::class)]
 class VersionIdTest extends TestCase
 {
 	public function tearDown(): void
@@ -18,21 +17,14 @@ class VersionIdTest extends TestCase
 		VersionId::$render = null;
 	}
 
-	/**
-	 * @covers ::changes
-	 * @covers ::value
-	 */
-	public function testChanges()
+	public function testChanges(): void
 	{
 		$version = VersionId::changes();
 
 		$this->assertSame('changes', $version->value());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructWithInvalidId()
+	public function testConstructWithInvalidId(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid Version ID');
@@ -40,30 +32,19 @@ class VersionIdTest extends TestCase
 		new VersionId('foo');
 	}
 
-	/**
-	 * @covers ::from
-	 * @covers ::value
-	 */
-	public function testFromString()
+	public function testFromString(): void
 	{
 		$version = VersionId::from('latest');
 		$this->assertSame('latest', $version->value());
 	}
 
-	/**
-	 * @covers ::from
-	 * @covers ::value
-	 */
-	public function testFromInstance()
+	public function testFromInstance(): void
 	{
 		$version = VersionId::from(VersionId::latest());
 		$this->assertSame('latest', $version->value());
 	}
 
-	/**
-	 * @covers ::is
-	 */
-	public function testIs()
+	public function testIs(): void
 	{
 		$version = VersionId::latest();
 
@@ -75,21 +56,14 @@ class VersionIdTest extends TestCase
 		$this->assertFalse($version->is(VersionId::changes()));
 	}
 
-	/**
-	 * @covers ::latest
-	 * @covers ::value
-	 */
-	public function testLatest()
+	public function testLatest(): void
 	{
 		$version = VersionId::latest();
 
 		$this->assertSame('latest', $version->value());
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderString()
+	public function testRenderString(): void
 	{
 		$executed = 0;
 
@@ -117,10 +91,7 @@ class VersionIdTest extends TestCase
 		$this->assertSame(3, $executed);
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderInstance()
+	public function testRenderInstance(): void
 	{
 		$executed = 0;
 
@@ -148,10 +119,7 @@ class VersionIdTest extends TestCase
 		$this->assertSame(3, $executed);
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderPreviousValue()
+	public function testRenderPreviousValue(): void
 	{
 		$executed = 0;
 
@@ -169,10 +137,7 @@ class VersionIdTest extends TestCase
 		$this->assertSame(1, $executed);
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderException()
+	public function testRenderException(): void
 	{
 		$executed = 0;
 
@@ -194,10 +159,7 @@ class VersionIdTest extends TestCase
 		$this->assertSame(3, $executed);
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
-	public function testToString()
+	public function testToString(): void
 	{
 		$this->assertSame('latest', (string)VersionId::latest());
 		$this->assertSame('changes', (string)VersionId::changes());

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -483,7 +483,7 @@ class VersionTest extends TestCase
 		$this->assertSame($id, $version->id());
 	}
 
-	public function testIsIdenticalMultiLanguage()
+	public function testIsIdenticalMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -518,7 +518,7 @@ class VersionTest extends TestCase
 		$this->assertFalse($a->isIdentical(VersionId::changes(), 'de'));
 	}
 
-	public function testIsIdenticalSingleLanguage()
+	public function testIsIdenticalSingleLanguage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -545,7 +545,7 @@ class VersionTest extends TestCase
 		$this->assertFalse($a->isIdentical('changes'));
 	}
 
-	public function testIsIdenticalWithoutChanges()
+	public function testIsIdenticalWithoutChanges(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -572,7 +572,7 @@ class VersionTest extends TestCase
 		$this->assertTrue($a->isIdentical('changes'));
 	}
 
-	public function testIsIdenticalWithSameVersion()
+	public function testIsIdenticalWithSameVersion(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -778,7 +778,7 @@ class VersionTest extends TestCase
 	}
 
 	#[DataProvider('previewTokenIndexUrlProvider')]
-	public function testPreviewToken(string $indexUrl)
+	public function testPreviewToken(string $indexUrl): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -816,7 +816,7 @@ class VersionTest extends TestCase
 		$this->assertSame($expected, $version->previewToken());
 	}
 
-	public function testPreviewTokenCustomSalt()
+	public function testPreviewTokenCustomSalt(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -837,7 +837,7 @@ class VersionTest extends TestCase
 		$this->assertSame($expected, $version->previewToken());
 	}
 
-	public function testPreviewTokenCustomSaltCallback()
+	public function testPreviewTokenCustomSaltCallback(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -862,7 +862,7 @@ class VersionTest extends TestCase
 		$this->assertSame($expected, $version->previewToken());
 	}
 
-	public function testPreviewTokenInvalidModel()
+	public function testPreviewTokenInvalidModel(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('Invalid model type');
@@ -877,7 +877,7 @@ class VersionTest extends TestCase
 		$version->previewToken();
 	}
 
-	public function testPreviewTokenMissingHomePage()
+	public function testPreviewTokenMissingHomePage(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('The home page does not exist');
@@ -896,7 +896,7 @@ class VersionTest extends TestCase
 		$version->previewToken();
 	}
 
-	public function testPublish()
+	public function testPublish(): void
 	{
 		$this->setUpSingleLanguage();
 		$this->app->impersonate('kirby');
@@ -924,7 +924,7 @@ class VersionTest extends TestCase
 		$this->assertSame('Title changes', Data::read($fileLatest)['title']);
 	}
 
-	public function testPublishAlreadyLatestVersion()
+	public function testPublishAlreadyLatestVersion(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -1490,7 +1490,7 @@ class VersionTest extends TestCase
 		$this->assertArrayNotHasKey('date', $version->read('de'));
 	}
 
-	public function testUrlPage()
+	public function testUrlPage(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -1505,7 +1505,7 @@ class VersionTest extends TestCase
 		$this->assertSame('/a-page', $version->url());
 	}
 
-	public function testUrlPageUnauthenticated()
+	public function testUrlPageUnauthenticated(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -1634,7 +1634,7 @@ class VersionTest extends TestCase
 		$this->assertSame($expected, $version->url());
 	}
 
-	public function testUrlSite()
+	public function testUrlSite(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -1649,7 +1649,7 @@ class VersionTest extends TestCase
 		$this->assertSame('/', $version->url());
 	}
 
-	public function testUrlSiteUnauthenticated()
+	public function testUrlSiteUnauthenticated(): void
 	{
 		$this->setUpSingleLanguage();
 
@@ -1752,7 +1752,7 @@ class VersionTest extends TestCase
 		$this->assertSame($expected, $version->url());
 	}
 
-	public function testUrlInvalidModel()
+	public function testUrlInvalidModel(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('Only pages and the site have a content preview URL');


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Content',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
