### PR TITLE
test: Use PHPUnit attributes for `Kirby\Database`

### DIFF
--- a/tests/Database/DatabaseTest.php
+++ b/tests/Database/DatabaseTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Database;
 use Kirby\Exception\InvalidArgumentException;
 use PDO;
 use PDOException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Database\Database
- */
+#[CoversClass(Database::class)]
 class DatabaseTest extends TestCase
 {
 	public function setUp(): void
@@ -61,12 +60,12 @@ class DatabaseTest extends TestCase
 		Database::$connections = [];
 	}
 
-	public function testInstance()
+	public function testInstance(): void
 	{
 		$this->assertSame($this->database, Database::instance());
 	}
 
-	public function testInstances()
+	public function testInstances(): void
 	{
 		// create another instance
 		$secondInstance = new Database([
@@ -80,19 +79,13 @@ class DatabaseTest extends TestCase
 		], array_values(Database::instances()));
 	}
 
-	/**
-	 * @covers ::affected
-	 */
-	public function testAffected()
+	public function testAffected(): void
 	{
 		$this->database->table('users')->delete();
 		$this->assertSame(3, $this->database->affected());
 	}
 
-	/**
-	 * @covers ::lastId
-	 */
-	public function testLastId()
+	public function testLastId(): void
 	{
 		$id = $this->database->table('users')->insert([
 			'username' => 'ringo',
@@ -106,26 +99,20 @@ class DatabaseTest extends TestCase
 		$this->assertSame($id, $this->database->lastId());
 	}
 
-	/**
-	 * @covers ::lastResult
-	 */
-	public function testLastResult()
+	public function testLastResult(): void
 	{
 		$result = $this->database->table('users')->select('*')->all();
 		$this->assertSame($result, $this->database->lastResult());
 	}
 
-	/**
-	 * @covers ::lastError
-	 */
-	public function testLastError()
+	public function testLastError(): void
 	{
 		$this->assertNull($this->database->lastError());
 		$this->database->table('users')->select('nonexisting')->all();
 		$this->assertInstanceOf(PDOException::class, $this->database->lastError());
 	}
 
-	public function testConnect()
+	public function testConnect(): void
 	{
 		$db = new Database([
 			'database' => ':memory:',
@@ -141,12 +128,12 @@ class DatabaseTest extends TestCase
 		]);
 	}
 
-	public function testConnectConnection()
+	public function testConnectConnection(): void
 	{
 		$this->assertInstanceOf(PDO::class, $this->database->connection());
 	}
 
-	public function testFail()
+	public function testFail(): void
 	{
 		$this->expectException(PDOException::class);
 
@@ -155,7 +142,7 @@ class DatabaseTest extends TestCase
 			->table('users')->select('nonexisting')->all();
 	}
 
-	public function testDropTable()
+	public function testDropTable(): void
 	{
 		$this->assertTrue($this->database->dropTable('users'));
 
@@ -163,39 +150,39 @@ class DatabaseTest extends TestCase
 		$this->database->fail()->dropTable('nonexisting');
 	}
 
-	public function testValidateTable()
+	public function testValidateTable(): void
 	{
 		$this->database->validateTable('users');
 		$this->assertTrue($this->database->dropTable('users'));
 	}
 
-	public function testMagicCall()
+	public function testMagicCall(): void
 	{
 		$this->assertCount(3, $this->database->users()->all());
 	}
 
-	public function testType()
+	public function testType(): void
 	{
 		$this->assertSame('sqlite', $this->database->type());
 	}
 
-	public function testEscape()
+	public function testEscape(): void
 	{
 		$this->assertSame("sql''inject", $this->database->escape("sql'inject"));
 	}
 
-	public function testLastQuery()
+	public function testLastQuery(): void
 	{
 		$this->database->users()->all();
 		$this->assertSame('SELECT * FROM "users"', $this->database->lastQuery());
 	}
 
-	public function testName()
+	public function testName(): void
 	{
 		$this->assertSame(':memory:', $this->database->name());
 	}
 
-	public function testCreateTable()
+	public function testCreateTable(): void
 	{
 		$this->assertFalse($this->database->createTable('test'));
 		$this->assertTrue($this->database->createTable('test', [
@@ -206,7 +193,7 @@ class DatabaseTest extends TestCase
 		]));
 	}
 
-	public function testMysqlConnector()
+	public function testMysqlConnector(): void
 	{
 		$dsn = Database::$types['mysql']['dsn'];
 		$this->assertInstanceOf('Closure', $dsn);
@@ -224,7 +211,7 @@ class DatabaseTest extends TestCase
 		$this->assertSame($expected, $connectionString);
 	}
 
-	public function testMysqlConnectorNoSocketHost()
+	public function testMysqlConnectorNoSocketHost(): void
 	{
 		$dsn = Database::$types['mysql']['dsn'];
 
@@ -234,7 +221,7 @@ class DatabaseTest extends TestCase
 		$dsn([]);
 	}
 
-	public function testMysqlConnectorNoDatabase()
+	public function testMysqlConnectorNoDatabase(): void
 	{
 		$dsn = Database::$types['mysql']['dsn'];
 
@@ -244,7 +231,7 @@ class DatabaseTest extends TestCase
 		$dsn(['host' => 'localhost']);
 	}
 
-	public function testSqliteConnector()
+	public function testSqliteConnector(): void
 	{
 		$dsn = Database::$types['sqlite']['dsn'];
 		$this->assertInstanceOf('Closure', $dsn);

--- a/tests/Database/DbTest.php
+++ b/tests/Database/DbTest.php
@@ -3,11 +3,11 @@
 namespace Kirby\Database;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use ReflectionProperty;
 
-/**
- * @coversDefaultClass \Kirby\Database\Db
- */
+#[CoversClass(Db::class)]
 class DbTest extends TestCase
 {
 	public function setUp(): void
@@ -59,10 +59,7 @@ class DbTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::connect
-	 */
-	public function testConnect()
+	public function testConnect(): void
 	{
 		$db = Db::connect();
 		$this->assertInstanceOf(Database::class, $db);
@@ -88,18 +85,12 @@ class DbTest extends TestCase
 		$this->assertSame($db, Db::connect());
 	}
 
-	/**
-	 * @covers ::connection
-	 */
-	public function testConnection()
+	public function testConnection(): void
 	{
 		$this->assertInstanceOf(Database::class, Db::connection());
 	}
 
-	/**
-	 * @covers ::table
-	 */
-	public function testTable()
+	public function testTable(): void
 	{
 		$tableProp = new ReflectionProperty(Query::class, 'table');
 		$tableProp->setAccessible(true);
@@ -109,19 +100,13 @@ class DbTest extends TestCase
 		$this->assertSame('users', $tableProp->getValue($query));
 	}
 
-	/**
-	 * @covers ::query
-	 */
-	public function testQuery()
+	public function testQuery(): void
 	{
 		$result = Db::query('SELECT * FROM users WHERE username = :username', ['username' => 'paul'], ['fetch' => 'array', 'iterator' => 'array']);
 		$this->assertSame('paul', $result[0]['username']);
 	}
 
-	/**
-	 * @covers ::execute
-	 */
-	public function testExecute()
+	public function testExecute(): void
 	{
 		$result = Db::query('SELECT * FROM users WHERE username = :username', ['username' => 'paul'], ['fetch' => 'array', 'iterator' => 'array']);
 		$this->assertSame('paul', $result[0]['username']);
@@ -133,10 +118,7 @@ class DbTest extends TestCase
 		$this->assertEmpty($result);
 	}
 
-	/**
-	 * @covers ::__callStatic
-	 */
-	public function testCallStatic()
+	public function testCallStatic(): void
 	{
 		Db::connect([
 			'database' => ':memory:',
@@ -152,10 +134,7 @@ class DbTest extends TestCase
 		$this->assertSame('myprefix_', Db::prefix());
 	}
 
-	/**
-	 * @covers ::__callStatic
-	 */
-	public function testCallStaticInvalid()
+	public function testCallStaticInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid static Db method: thisIsInvalid');
@@ -163,10 +142,8 @@ class DbTest extends TestCase
 		Db::thisIsInvalid();
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testSelect()
+	#[CoversNothing]
+	public function testSelect(): void
 	{
 		$result = Db::select('users');
 		$this->assertCount(3, $result);
@@ -184,10 +161,8 @@ class DbTest extends TestCase
 		$this->assertSame('george', $result->first()->username());
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testFirst()
+	#[CoversNothing]
+	public function testFirst(): void
 	{
 		$result = Db::first('users');
 		$this->assertSame('john', $result->username());
@@ -205,10 +180,8 @@ class DbTest extends TestCase
 		$this->assertSame('john', $result->username());
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testColumn()
+	#[CoversNothing]
+	public function testColumn(): void
 	{
 		$result = Db::column('users', 'username');
 		$this->assertSame(['john', 'paul', 'george'], $result->toArray());
@@ -223,10 +196,8 @@ class DbTest extends TestCase
 		$this->assertSame(['john'], $result->toArray());
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testInsert()
+	#[CoversNothing]
+	public function testInsert(): void
 	{
 		$result = Db::insert('users', [
 			'username' => 'ringo',
@@ -241,10 +212,8 @@ class DbTest extends TestCase
 		$this->assertSame('0', Db::row('users', '*', ['username' => 'ringo'])->active());
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testUpdate()
+	#[CoversNothing]
+	public function testUpdate(): void
 	{
 		$result = Db::update('users', ['email' => 'john@gmail.com'], ['username' => 'john']);
 		$this->assertTrue($result);
@@ -257,10 +226,8 @@ class DbTest extends TestCase
 		$this->assertSame('1', Db::row('users', '*', ['username' => 'paul'])->active());
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testDelete()
+	#[CoversNothing]
+	public function testDelete(): void
 	{
 		$result = Db::delete('users', ['username' => 'john']);
 		$this->assertTrue($result);
@@ -268,42 +235,32 @@ class DbTest extends TestCase
 		$this->assertSame(2, Db::count('users'));
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testCount()
+	#[CoversNothing]
+	public function testCount(): void
 	{
 		$this->assertSame(3, Db::count('users'));
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testMin()
+	#[CoversNothing]
+	public function testMin(): void
 	{
 		$this->assertSame(1.0, Db::min('users', 'id'));
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testMax()
+	#[CoversNothing]
+	public function testMax(): void
 	{
 		$this->assertSame(3.0, Db::max('users', 'id'));
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testAvg()
+	#[CoversNothing]
+	public function testAvg(): void
 	{
 		$this->assertSame(2.0, Db::avg('users', 'id'));
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testSum()
+	#[CoversNothing]
+	public function testSum(): void
 	{
 		$this->assertSame(6.0, Db::sum('users', 'id'));
 	}

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -6,10 +6,9 @@ use InvalidArgumentException;
 use Kirby\Toolkit\Collection;
 use Kirby\Toolkit\Pagination;
 use PDOException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Database\Database
- */
+#[CoversClass(Query::class)]
 class QueryTest extends TestCase
 {
 	public function setUp(): void
@@ -111,7 +110,7 @@ class QueryTest extends TestCase
 		]);
 	}
 
-	public function testJoin()
+	public function testJoin(): void
 	{
 		$user = $this->database
 			->table('users')
@@ -124,7 +123,7 @@ class QueryTest extends TestCase
 		$this->assertSame('admin', $user->role());
 	}
 
-	public function testInnerJoin()
+	public function testInnerJoin(): void
 	{
 		$user = $this->database
 			->table('users')
@@ -137,7 +136,7 @@ class QueryTest extends TestCase
 		$this->assertSame('admin', $user->role());
 	}
 
-	public function testLeftJoin()
+	public function testLeftJoin(): void
 	{
 		$user = $this->database
 			->table('users')
@@ -150,7 +149,7 @@ class QueryTest extends TestCase
 		$this->assertSame('admin', $user->role());
 	}
 
-	public function testRightJoin()
+	public function testRightJoin(): void
 	{
 		$query = $this->database
 			->table('users')
@@ -165,7 +164,7 @@ class QueryTest extends TestCase
 		$this->assertSame($expected, $query['query']);
 	}
 
-	public function testOrder()
+	public function testOrder(): void
 	{
 		$user = $this->database
 			->table('users')
@@ -175,7 +174,7 @@ class QueryTest extends TestCase
 		$this->assertSame('paul', $user->username());
 	}
 
-	public function testGroup()
+	public function testGroup(): void
 	{
 		$sum = $this->database
 			->table('users')
@@ -188,7 +187,7 @@ class QueryTest extends TestCase
 		$this->assertSame((float)150, $sum);
 	}
 
-	public function testSum()
+	public function testSum(): void
 	{
 		$sum = $this->database
 			->table('users')
@@ -197,7 +196,7 @@ class QueryTest extends TestCase
 		$this->assertSame((float)470, $sum);
 	}
 
-	public function testAggregateAndDebug()
+	public function testAggregateAndDebug(): void
 	{
 		$result = $this->database
 			->table('users')
@@ -210,7 +209,7 @@ class QueryTest extends TestCase
 		$this->assertArrayHasKey('options', $result);
 	}
 
-	public function testAvg()
+	public function testAvg(): void
 	{
 		$balance = $this->database
 			->table('users')
@@ -223,7 +222,7 @@ class QueryTest extends TestCase
 		$this->assertSame((float)75, $balance);
 	}
 
-	public function testCount()
+	public function testCount(): void
 	{
 		$count = $this->database
 			->table('users')
@@ -235,7 +234,7 @@ class QueryTest extends TestCase
 		$this->assertSame(2, $count);
 	}
 
-	public function testQuery()
+	public function testQuery(): void
 	{
 		$result = $this->database
 			->query('SELECT * FROM users WHERE role_id = :role', ['role' => 3]);
@@ -243,7 +242,7 @@ class QueryTest extends TestCase
 		$this->assertCount(2, $result->data());
 	}
 
-	public function testUpdate()
+	public function testUpdate(): void
 	{
 		// update
 		$update = $this->database
@@ -261,7 +260,7 @@ class QueryTest extends TestCase
 		$this->assertSame('250', $user->balance());
 	}
 
-	public function testDelete()
+	public function testDelete(): void
 	{
 		$delete = $this->database
 			->table('users')
@@ -276,7 +275,7 @@ class QueryTest extends TestCase
 		$this->assertCount(4, $users);
 	}
 
-	public function testMagicCall()
+	public function testMagicCall(): void
 	{
 		$user = $this->database
 			->table('users')
@@ -285,7 +284,7 @@ class QueryTest extends TestCase
 		$this->assertSame('george', $user->username());
 	}
 
-	public function testFail()
+	public function testFail(): void
 	{
 		// should not throw an exception
 		$this->database
@@ -305,7 +304,7 @@ class QueryTest extends TestCase
 			->one();
 	}
 
-	public function testFetch()
+	public function testFetch(): void
 	{
 		$query = $this->database
 			->table('users')
@@ -355,7 +354,7 @@ class QueryTest extends TestCase
 		return $row['fname'] . ' ' . $row['lname'];
 	}
 
-	public function testFind()
+	public function testFind(): void
 	{
 		$user = $this->database
 			->table('users')
@@ -364,7 +363,7 @@ class QueryTest extends TestCase
 		$this->assertSame('paul', $user->username());
 	}
 
-	public function testDistinct()
+	public function testDistinct(): void
 	{
 		$users = $this->database
 			->table('users')
@@ -376,7 +375,7 @@ class QueryTest extends TestCase
 		$this->assertCount(2, $users);
 	}
 
-	public function testMin()
+	public function testMin(): void
 	{
 		$balance = $this->database
 			->table('users')
@@ -385,7 +384,7 @@ class QueryTest extends TestCase
 		$this->assertSame((float)-30, $balance);
 	}
 
-	public function testMax()
+	public function testMax(): void
 	{
 		$balance = $this->database
 			->table('users')
@@ -394,7 +393,7 @@ class QueryTest extends TestCase
 		$this->assertSame((float)200, $balance);
 	}
 
-	public function testPrimaryKeyName()
+	public function testPrimaryKeyName(): void
 	{
 		$user = $this->database
 			->table('users')
@@ -404,7 +403,7 @@ class QueryTest extends TestCase
 		$this->assertSame('paul', $user->username());
 	}
 
-	public function testFirst()
+	public function testFirst(): void
 	{
 		$query = $this->database
 			->table('users')
@@ -417,7 +416,7 @@ class QueryTest extends TestCase
 		$this->assertSame('John', $query->One()->fname());
 	}
 
-	public function testColumn()
+	public function testColumn(): void
 	{
 		$users = $this->database
 			->table('users')
@@ -431,7 +430,7 @@ class QueryTest extends TestCase
 		$this->assertSame(['george', 'mark'], $users->data());
 	}
 
-	public function testBindings()
+	public function testBindings(): void
 	{
 		$query = $this->database
 			->table('users')
@@ -440,7 +439,7 @@ class QueryTest extends TestCase
 		$this->assertSame(['role' => 3], $query->bindings());
 	}
 
-	public function testHaving()
+	public function testHaving(): void
 	{
 		$users = $this->database
 			->table('users')
@@ -459,7 +458,7 @@ class QueryTest extends TestCase
 		$this->assertCount(2, $users);
 	}
 
-	public function testWhere()
+	public function testWhere(): void
 	{
 		// numeric comparison
 		$count = $this->database
@@ -558,7 +557,7 @@ class QueryTest extends TestCase
 		$this->assertSame(1, $count);
 	}
 
-	public function testWhereInvalidPredicate()
+	public function testWhereInvalidPredicate(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid predicate INV');
@@ -569,7 +568,7 @@ class QueryTest extends TestCase
 			->count();
 	}
 
-	public function testWhereInvalidPredicateOperator()
+	public function testWhereInvalidPredicateOperator(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid predicate/operator <!>');
@@ -580,7 +579,7 @@ class QueryTest extends TestCase
 			->count();
 	}
 
-	public function testAndWhere()
+	public function testAndWhere(): void
 	{
 		$count = $this->database
 			->table('users')
@@ -613,7 +612,7 @@ class QueryTest extends TestCase
 		$this->assertSame(1, $count);
 	}
 
-	public function testOrWhere()
+	public function testOrWhere(): void
 	{
 		$count = $this->database
 			->table('users')
@@ -646,7 +645,7 @@ class QueryTest extends TestCase
 		$this->assertSame(4, $count);
 	}
 
-	public function testWhereCallback()
+	public function testWhereCallback(): void
 	{
 		$count = $this->database
 			->table('users')
@@ -657,7 +656,7 @@ class QueryTest extends TestCase
 		$this->assertSame(1, $count);
 	}
 
-	public function testPage()
+	public function testPage(): void
 	{
 		$query = $this->database->table('users');
 
@@ -704,7 +703,7 @@ class QueryTest extends TestCase
 		$this->assertSame(3, $pagination->limit());
 	}
 
-	public function testTable()
+	public function testTable(): void
 	{
 		// should not throw an exception
 		$this->database->table('users');

--- a/tests/Database/Sql/MysqlTest.php
+++ b/tests/Database/Sql/MysqlTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Database\Sql;
 
 use Kirby\Database\Database;
 use Kirby\Toolkit\A;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Database\Sql\Mysql
- */
+#[CoversClass(Mysql::class)]
 class MysqlTest extends TestCase
 {
 	public function setUp(): void
@@ -22,30 +21,21 @@ class MysqlTest extends TestCase
 		$this->sql = new Mysql($this->database);
 	}
 
-	/**
-	 * @covers ::columns
-	 */
-	public function testColumns()
+	public function testColumns(): void
 	{
 		$result = $this->sql->columns('test');
 		$this->assertSame(':memory:', A::first($result['bindings']));
 		$this->assertSame('test', A::last($result['bindings']));
 	}
 
-	/**
-	 * @covers ::tables
-	 */
-	public function testTables()
+	public function testTables(): void
 	{
 		$result = $this->sql->tables();
 		$this->assertStringStartsWith('SELECT TABLE_NAME AS name FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ', $result['query']);
 		$this->assertSame(':memory:', A::first($result['bindings']));
 	}
 
-	/**
-	 * @covers ::tables
-	 */
-	public function testValidateTable()
+	public function testValidateTable(): void
 	{
 		$this->assertTrue($this->database->validateTable('test'));
 		$this->assertTrue($this->database->validateTable('view_test'));

--- a/tests/Database/Sql/SqliteTest.php
+++ b/tests/Database/Sql/SqliteTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Database\Sql;
 use Kirby\Database\Database;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\A;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Database\Sql\Sqlite
- */
+#[CoversClass(Sqlite::class)]
 class SqliteTest extends TestCase
 {
 	public function setUp(): void
@@ -23,19 +22,13 @@ class SqliteTest extends TestCase
 		$this->sql = new Sqlite($this->database);
 	}
 
-	/**
-	 * @covers ::columns
-	 */
-	public function testColumns()
+	public function testColumns(): void
 	{
 		$result = $this->sql->columns('test');
 		$this->assertSame('PRAGMA table_info("test")', $result['query']);
 	}
 
-	/**
-	 * @covers ::columns
-	 */
-	public function testColumnsInvalidTable()
+	public function testColumnsInvalidTable(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid table does-not-exist');
@@ -43,10 +36,7 @@ class SqliteTest extends TestCase
 		$this->sql->columns('does-not-exist');
 	}
 
-	/**
-	 * @covers ::combineIdentifier
-	 */
-	public function testCombineIdentifier()
+	public function testCombineIdentifier(): void
 	{
 		$this->assertSame('"test"."id"', $this->sql->combineIdentifier('test', 'id'));
 		$this->assertSame('"test".*', $this->sql->combineIdentifier('test', '*'));
@@ -56,10 +46,7 @@ class SqliteTest extends TestCase
 		$this->assertSame('"id"', $this->sql->combineIdentifier('test', 'id', true));
 	}
 
-	/**
-	 * @covers ::createTable
-	 */
-	public function testCreateTable()
+	public function testCreateTable(): void
 	{
 		// basic example
 		$table = $this->sql->createTable('table', [
@@ -138,10 +125,7 @@ class SqliteTest extends TestCase
 		$this->assertSame([], $table['bindings']);
 	}
 
-	/**
-	 * @covers ::quoteIdentifier
-	 */
-	public function testQuoteIdentifier()
+	public function testQuoteIdentifier(): void
 	{
 		$this->assertSame('*', $this->sql->quoteIdentifier('*'));
 		$this->assertSame('"test"', $this->sql->quoteIdentifier('test'));
@@ -150,20 +134,14 @@ class SqliteTest extends TestCase
 		$this->assertSame('"another\'test"', $this->sql->quoteIdentifier("another'test"));
 	}
 
-	/**
-	 * @covers ::tables
-	 */
-	public function testTables()
+	public function testTables(): void
 	{
 		$result = $this->sql->tables();
 		$this->assertSame('SELECT name FROM sqlite_master WHERE type = \'table\' OR type = \'view\'', $result['query']);
 		$this->assertSame([], $result['bindings']);
 	}
 
-	/**
-	 * @covers ::tables
-	 */
-	public function testValidateTable()
+	public function testValidateTable(): void
 	{
 		$this->assertTrue($this->database->validateTable('test'));
 		$this->assertTrue($this->database->validateTable('view_test'));

--- a/tests/Database/SqlTest.php
+++ b/tests/Database/SqlTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Database;
 use Kirby\Database\Sql\Sqlite;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\A;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Database\Sql
- */
+#[CoversClass(Sql::class)]
 class SqlTest extends TestCase
 {
 	protected Sql $sql;
@@ -25,10 +24,7 @@ class SqlTest extends TestCase
 		$this->sql = new MockSql($this->database);
 	}
 
-	/**
-	 * @covers ::bindingName
-	 */
-	public function testBindingName()
+	public function testBindingName(): void
 	{
 		$result = $this->sql->bindingName('test_binding1');
 		$this->assertMatchesRegularExpression('/^:test_binding1_[a-zA-Z0-9]{8}$/', $result);
@@ -40,10 +36,7 @@ class SqlTest extends TestCase
 		$this->assertMatchesRegularExpression('/^:invalid_[a-zA-Z0-9]{8}$/', $result);
 	}
 
-	/**
-	 * @covers ::columnDefault
-	 */
-	public function testColumnDefault()
+	public function testColumnDefault(): void
 	{
 		$this->assertSame([
 			'query'    => null,
@@ -55,10 +48,7 @@ class SqlTest extends TestCase
 		$this->assertSame('amazing default', A::first($result['bindings']));
 	}
 
-	/**
-	 * @covers ::columnName
-	 */
-	public function testColumnName()
+	public function testColumnName(): void
 	{
 		// test with the SQLite class because of its more
 		// complex `combineIdentifier()` implementation
@@ -71,10 +61,7 @@ class SqlTest extends TestCase
 		$this->assertNull($sql->columnName('test', 'invalid.id', true));
 	}
 
-	/**
-	 * @covers ::combineIdentifier
-	 */
-	public function testCombineIdentifier()
+	public function testCombineIdentifier(): void
 	{
 		$this->assertSame('`test`.`id`', $this->sql->combineIdentifier('test', 'id'));
 		$this->assertSame('`test`.*', $this->sql->combineIdentifier('test', '*'));
@@ -82,10 +69,7 @@ class SqlTest extends TestCase
 		$this->assertSame('`test`.`id`', $this->sql->combineIdentifier('test', 'id', true));
 	}
 
-	/**
-	 * @covers ::createColumn
-	 */
-	public function testCreateColumn()
+	public function testCreateColumn(): void
 	{
 		// basic example
 		$column = $this->sql->createColumn('test', [
@@ -202,10 +186,7 @@ class SqlTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::createColumn
-	 */
-	public function testCreateColumnNoType()
+	public function testCreateColumnNoType(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('No column type given for column test');
@@ -213,10 +194,7 @@ class SqlTest extends TestCase
 		$this->sql->createColumn('test', []);
 	}
 
-	/**
-	 * @covers ::createColumn
-	 */
-	public function testCreateColumnInvalidType()
+	public function testCreateColumnInvalidType(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Unsupported column type: invalid');
@@ -224,7 +202,7 @@ class SqlTest extends TestCase
 		$this->sql->createColumn('test', ['type' => 'invalid']);
 	}
 
-	public function testCreateTableInner()
+	public function testCreateTableInner(): void
 	{
 		// basic example
 		$inner = $this->sql->createTableInner([
@@ -279,7 +257,7 @@ class SqlTest extends TestCase
 		$this->assertSame(['test' => true], $inner['unique']);
 	}
 
-	public function testCreateTable()
+	public function testCreateTable(): void
 	{
 		// basic example
 		$table = $this->sql->createTable('table', [
@@ -423,10 +401,7 @@ class SqlTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::quoteIdentifier
-	 */
-	public function testQuoteIdentifier()
+	public function testQuoteIdentifier(): void
 	{
 		$this->assertSame('*', $this->sql->quoteIdentifier('*'));
 		$this->assertSame('`test`', $this->sql->quoteIdentifier('test'));
@@ -435,10 +410,7 @@ class SqlTest extends TestCase
 		$this->assertSame("`another'test`", $this->sql->quoteIdentifier("another'test"));
 	}
 
-	/**
-	 * @covers ::splitIdentifier
-	 */
-	public function testSplitIdentifier()
+	public function testSplitIdentifier(): void
 	{
 		$result = $this->sql->splitIdentifier('table', 'table.column');
 		$this->assertSame(['table', 'column'], $result);
@@ -474,10 +446,7 @@ class SqlTest extends TestCase
 		$this->assertSame(['table.name', 'column.name'], $result);
 	}
 
-	/**
-	 * @covers ::splitIdentifier
-	 */
-	public function testSplitIdentifierInvalid()
+	public function testSplitIdentifierInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid identifier table.column.invalid');
@@ -485,7 +454,7 @@ class SqlTest extends TestCase
 		$this->sql->splitIdentifier('table', 'table.column.invalid');
 	}
 
-	public function testFrom()
+	public function testFrom(): void
 	{
 		$this->database->createTable('users', [
 			'test' => ['type' => 'varchar']
@@ -497,7 +466,7 @@ class SqlTest extends TestCase
 		], $this->sql->from('users'));
 	}
 
-	public function testGroup()
+	public function testGroup(): void
 	{
 		$this->database->createTable('users', [
 			'test' => ['type' => 'varchar']
@@ -509,7 +478,7 @@ class SqlTest extends TestCase
 		], $this->sql->group('test'));
 	}
 
-	public function testHaving()
+	public function testHaving(): void
 	{
 		$this->database->createTable('users', [
 			'test' => ['type' => 'varchar']
@@ -521,7 +490,7 @@ class SqlTest extends TestCase
 		], $this->sql->having('test < :value'));
 	}
 
-	public function testValueSet()
+	public function testValueSet(): void
 	{
 		$this->database->createTable('users', [
 			'name' => ['type' => 'varchar']
@@ -538,7 +507,7 @@ class SqlTest extends TestCase
 		$this->assertSame('John Doe', current($values['bindings']));
 	}
 
-	public function testValueList()
+	public function testValueList(): void
 	{
 		$this->database->createTable('users', [
 			'name' => ['type' => 'varchar']

--- a/tests/Database/TestCase.php
+++ b/tests/Database/TestCase.php
@@ -7,5 +7,4 @@ use Kirby\TestCase as BaseTestCase;
 class TestCase extends BaseTestCase
 {
 	protected Database $database;
-
 }


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

> [!CAUTION]
> Code coverage drops a bit. But this is actually more accurate as we are indeed missing tests, especially for the `Sql` abstract class

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Database',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
