### PR TITLE
test: Use PHPUnit attributes for `Kirby\Email`

### DIFF
--- a/tests/Email/BodyTest.php
+++ b/tests/Email/BodyTest.php
@@ -2,12 +2,12 @@
 
 namespace Kirby\Email;
 
-/**
- * @coversDefaultClass \Kirby\Email\Body
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Body::class)]
 class BodyTest extends TestCase
 {
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$body = new Body();
 
@@ -15,7 +15,7 @@ class BodyTest extends TestCase
 		$this->assertSame('', $body->text());
 	}
 
-	public function testConstructParams()
+	public function testConstructParams(): void
 	{
 		$data = [
 			'html' => '<strong>We will never reply</strong>',
@@ -28,7 +28,7 @@ class BodyTest extends TestCase
 		$this->assertSame($data['text'], $body->text());
 	}
 
-	public function testConstructNullParams()
+	public function testConstructNullParams(): void
 	{
 		$body = new Body([
 			'html' => null,

--- a/tests/Email/EmailTest.php
+++ b/tests/Email/EmailTest.php
@@ -5,7 +5,9 @@ namespace Kirby\Email;
 use Exception;
 use Kirby\Exception\InvalidArgumentException;
 use PHPMailer\PHPMailer\PHPMailer as Mailer;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Email::class)]
 class EmailTest extends TestCase
 {
 	protected function _email($props = [], $mailer = Email::class)
@@ -13,7 +15,7 @@ class EmailTest extends TestCase
 		return parent::_email($props, $mailer);
 	}
 
-	public function testProperties()
+	public function testProperties(): void
 	{
 		$email = $this->_email([
 			'from' => $from = 'no-reply@supercompany.com',
@@ -52,7 +54,7 @@ class EmailTest extends TestCase
 		$this->assertSame(['type' => 'mail'], $email->transport());
 	}
 
-	public function testRequiredProperty()
+	public function testRequiredProperty(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('The property "from" is required');
@@ -60,7 +62,7 @@ class EmailTest extends TestCase
 		$this->_email(['from' => null]);
 	}
 
-	public function testOptionalAddresses()
+	public function testOptionalAddresses(): void
 	{
 		$email = $this->_email([
 			'replyTo' => null,
@@ -73,7 +75,7 @@ class EmailTest extends TestCase
 		$this->assertSame([], $email->bcc());
 	}
 
-	public function testInvalidAddress()
+	public function testInvalidAddress(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('"not-valid" is not a valid email address');
@@ -86,7 +88,7 @@ class EmailTest extends TestCase
 		]);
 	}
 
-	public function testIsSent()
+	public function testIsSent(): void
 	{
 		$email = $this->_email([]);
 		$this->assertFalse($email->isSent());
@@ -94,7 +96,7 @@ class EmailTest extends TestCase
 		$this->assertTrue($email->isSent());
 	}
 
-	public function testBody()
+	public function testBody(): void
 	{
 		$email = $this->_email([
 			'body' => $body = [
@@ -110,7 +112,7 @@ class EmailTest extends TestCase
 		$this->assertTrue($email->isHtml());
 	}
 
-	public function testBodyHtmlOnly()
+	public function testBodyHtmlOnly(): void
 	{
 		$email = $this->_email([
 			'body' => $body = [
@@ -125,7 +127,7 @@ class EmailTest extends TestCase
 		$this->assertTrue($email->isHtml());
 	}
 
-	public function testAttachments()
+	public function testAttachments(): void
 	{
 		$email = $this->_email([
 			'attachments' => $attachments = [
@@ -137,7 +139,7 @@ class EmailTest extends TestCase
 		$this->assertSame($attachments, $email->attachments());
 	}
 
-	public function testBeforeSend()
+	public function testBeforeSend(): void
 	{
 		$phpunit = $this;
 		$smtpOptions = [

--- a/tests/Email/PHPMailerTest.php
+++ b/tests/Email/PHPMailerTest.php
@@ -3,7 +3,9 @@
 namespace Kirby\Email;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(PHPMailer::class)]
 class PHPMailerTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/files';
@@ -13,7 +15,7 @@ class PHPMailerTest extends TestCase
 		return parent::_email($props, $mailer);
 	}
 
-	public function testSend()
+	public function testSend(): void
 	{
 		$email = $this->_email([
 			'to' => 'test@test.com'
@@ -23,7 +25,7 @@ class PHPMailerTest extends TestCase
 		$this->assertTrue($email->isSent());
 	}
 
-	public function testProperties()
+	public function testProperties(): void
 	{
 		$phpunit = $this;
 		$fixtures = static::FIXTURES;
@@ -93,7 +95,7 @@ class PHPMailerTest extends TestCase
 		$this->assertTrue($beforeSend);
 	}
 
-	public function testBeforeSendInvalid()
+	public function testBeforeSendInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('"beforeSend" option return should be instance of PHPMailer\PHPMailer\PHPMailer class');
@@ -110,7 +112,7 @@ class PHPMailerTest extends TestCase
 		$email->send(true);
 	}
 
-	public function testSMTPTransportDefaults()
+	public function testSMTPTransportDefaults(): void
 	{
 		$phpunit = $this;
 		$beforeSend = false;
@@ -142,7 +144,7 @@ class PHPMailerTest extends TestCase
 		$this->assertTrue($beforeSend);
 	}
 
-	public function testSMTPTransportSecurity1()
+	public function testSMTPTransportSecurity1(): void
 	{
 		$phpunit = $this;
 		$beforeSend = false;
@@ -171,7 +173,7 @@ class PHPMailerTest extends TestCase
 		$this->assertTrue($beforeSend);
 	}
 
-	public function testSMTPTransportSecurity2()
+	public function testSMTPTransportSecurity2(): void
 	{
 		$phpunit = $this;
 		$beforeSend = false;
@@ -201,7 +203,7 @@ class PHPMailerTest extends TestCase
 		$this->assertTrue($beforeSend);
 	}
 
-	public function testSMTPTransportSecurity3()
+	public function testSMTPTransportSecurity3(): void
 	{
 		$phpunit = $this;
 		$beforeSend = false;
@@ -231,7 +233,7 @@ class PHPMailerTest extends TestCase
 		$this->assertTrue($beforeSend);
 	}
 
-	public function testSMTPTransportSecurityInvalid()
+	public function testSMTPTransportSecurityInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Could not automatically detect the "security" protocol from the "port" option, please set it explicitly to "tls" or "ssl".');


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Email',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
