### PR TITLE
test: Use PHPUnit attributes for `Kirby\Exception`

### DIFF
--- a/tests/Exception/AuthExceptionTest.php
+++ b/tests/Exception/AuthExceptionTest.php
@@ -3,13 +3,12 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 class AuthExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
-	public function testDefaults()
+	#[CoversNothing]
+	public function testDefaults(): void
 	{
 		$exception = new AuthException();
 		$this->assertSame('error.auth', $exception->getKey());

--- a/tests/Exception/BadMethodCallExceptionTest.php
+++ b/tests/Exception/BadMethodCallExceptionTest.php
@@ -3,13 +3,12 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 class BadMethodCallExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
-	public function testDefaults()
+	#[CoversNothing]
+	public function testDefaults(): void
 	{
 		$exception = new BadMethodCallException();
 		$this->assertSame('error.invalidMethod', $exception->getKey());
@@ -18,10 +17,8 @@ class BadMethodCallExceptionTest extends TestCase
 		$this->assertSame(['method' => null], $exception->getData());
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testPlaceholders()
+	#[CoversNothing]
+	public function testPlaceholders(): void
 	{
 		$exception = new BadMethodCallException(data: [
 			'method' => 'get'
@@ -30,10 +27,8 @@ class BadMethodCallExceptionTest extends TestCase
 		$this->assertSame(['method' => 'get'], $exception->getData());
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testPlaceholdersWithNamedArguments()
+	#[CoversNothing]
+	public function testPlaceholdersWithNamedArguments(): void
 	{
 		$exception = new BadMethodCallException(
 			data: ['method' => 'get']

--- a/tests/Exception/DuplicateExceptionTest.php
+++ b/tests/Exception/DuplicateExceptionTest.php
@@ -3,13 +3,12 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 class DuplicateExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
-	public function testDefaults()
+	#[CoversNothing]
+	public function testDefaults(): void
 	{
 		$exception = new DuplicateException();
 		$this->assertSame('error.duplicate', $exception->getKey());

--- a/tests/Exception/ErrorPageExceptionTest.php
+++ b/tests/Exception/ErrorPageExceptionTest.php
@@ -3,13 +3,12 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 class ErrorPageExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
-	public function testDefaults()
+	#[CoversNothing]
+	public function testDefaults(): void
 	{
 		$exception = new ErrorPageException();
 		$this->assertSame('error.errorPage', $exception->getKey());

--- a/tests/Exception/ExceptionTest.php
+++ b/tests/Exception/ExceptionTest.php
@@ -6,18 +6,17 @@ use Kirby\Cms\App;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
 use Kirby\Toolkit\I18n;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class WillFail
 {
-	public function fail()
+	public function fail(): void
 	{
 		throw new Exception(key: 'key.unique');
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Exception\Exception
- */
+#[CoversClass(Exception::class)]
 class ExceptionTest extends TestCase
 {
 	public function tearDown(): void
@@ -25,15 +24,7 @@ class ExceptionTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::getKey
-	 * @covers ::getHttpCode
-	 * @covers ::getData
-	 * @covers ::getDetails
-	 * @covers ::isTranslated
-	 */
-	public function testException()
+	public function testException(): void
 	{
 		$exception = new Exception([
 			'key' => 'page.slug.invalid',
@@ -54,15 +45,7 @@ class ExceptionTest extends TestCase
 		$this->assertFalse($exception->isTranslated());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::getKey
-	 * @covers ::getHttpCode
-	 * @covers ::getData
-	 * @covers ::getDetails
-	 * @covers ::isTranslated
-	 */
-	public function testExceptionWithNamedArguments()
+	public function testExceptionWithNamedArguments(): void
 	{
 		$exception = new Exception(
 			key: 'page.slug.invalid',
@@ -83,10 +66,7 @@ class ExceptionTest extends TestCase
 		$this->assertFalse($exception->isTranslated());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testDefaults()
+	public function testDefaults(): void
 	{
 		$exception = new Exception();
 
@@ -98,10 +78,7 @@ class ExceptionTest extends TestCase
 		$this->assertSame([], $exception->getDetails());
 	}
 
-	/**
-	 * @covers ::getDetails
-	 */
-	public function testGetDetails()
+	public function testGetDetails(): void
 	{
 		$exception = new Exception(
 			details: $details = [
@@ -115,10 +92,7 @@ class ExceptionTest extends TestCase
 		$this->assertSame($details, $exception->getDetails());
 	}
 
-	/**
-	 * @covers ::getDetails
-	 */
-	public function testGetDetailsWithExceptions()
+	public function testGetDetailsWithExceptions(): void
 	{
 		$exception = new Exception(
 			details: [
@@ -136,10 +110,7 @@ class ExceptionTest extends TestCase
 		$this->assertSame($expected, $exception->getDetails());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testJustMessage()
+	public function testJustMessage(): void
 	{
 		$exception = new Exception('Another error occurred');
 
@@ -150,10 +121,7 @@ class ExceptionTest extends TestCase
 		$this->assertSame([], $exception->getData());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testJustMessageWithNamedArgument()
+	public function testJustMessageWithNamedArgument(): void
 	{
 		$exception = new Exception(message: 'Another error occurred');
 
@@ -164,10 +132,7 @@ class ExceptionTest extends TestCase
 		$this->assertSame([], $exception->getData());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testPrevious()
+	public function testPrevious(): void
 	{
 		$previous  = new Exception(message: 'Previous');
 		$exception = new Exception(previous: $previous);
@@ -176,10 +141,7 @@ class ExceptionTest extends TestCase
 		$this->assertSame($previous, $exception->getPrevious());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testPreviousWithNamedArgument()
+	public function testPreviousWithNamedArgument(): void
 	{
 		$previous  = new Exception(message: 'Previous');
 		$exception = new Exception(previous: $previous);
@@ -188,10 +150,7 @@ class ExceptionTest extends TestCase
 		$this->assertSame($previous, $exception->getPrevious());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testPHPUnitTesting()
+	public function testPHPUnitTesting(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionCode('error.key.unique');
@@ -200,10 +159,7 @@ class ExceptionTest extends TestCase
 		$class->fail();
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testTranslation()
+	public function testTranslation(): void
 	{
 		I18n::$locale = 'test';
 		I18n::$translations = [
@@ -269,10 +225,7 @@ class ExceptionTest extends TestCase
 		$this->assertFalse($exception->isTranslated());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testTranslationWithNamedArguments()
+	public function testTranslationWithNamedArguments(): void
 	{
 		I18n::$locale = 'test';
 		I18n::$translations = [
@@ -338,10 +291,7 @@ class ExceptionTest extends TestCase
 		$this->assertFalse($exception->isTranslated());
 	}
 
-	/**
-	 * @covers ::getFileRelative
-	 */
-	public function testGetFileRelative()
+	public function testGetFileRelative(): void
 	{
 		$exception = new Exception();
 		$this->assertSame(__FILE__, $exception->getFileRelative());
@@ -363,10 +313,7 @@ class ExceptionTest extends TestCase
 		$this->assertSame(F::filename(__FILE__), $exception->getFileRelative());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$exception = new Exception();
 		$expected = [

--- a/tests/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/Exception/InvalidArgumentExceptionTest.php
@@ -3,13 +3,12 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 class InvalidArgumentExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
-	public function testDefaults()
+	#[CoversNothing]
+	public function testDefaults(): void
 	{
 		$exception = new InvalidArgumentException();
 		$this->assertSame('error.invalidArgument', $exception->getKey());
@@ -18,10 +17,8 @@ class InvalidArgumentExceptionTest extends TestCase
 		$this->assertSame(['argument' => null, 'method' => null], $exception->getData());
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testPlaceholders()
+	#[CoversNothing]
+	public function testPlaceholders(): void
 	{
 		$exception = new InvalidArgumentException(data: [
 			'argument' => 'key',
@@ -34,10 +31,8 @@ class InvalidArgumentExceptionTest extends TestCase
 		], $exception->getData());
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testPlaceholdersWithNamedArguments()
+	#[CoversNothing]
+	public function testPlaceholdersWithNamedArguments(): void
 	{
 		$exception = new InvalidArgumentException(
 			data: [

--- a/tests/Exception/LogicExceptionTest.php
+++ b/tests/Exception/LogicExceptionTest.php
@@ -3,13 +3,12 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 class LogicExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
-	public function testDefaults()
+	#[CoversNothing]
+	public function testDefaults(): void
 	{
 		$exception = new LogicException();
 		$this->assertSame('error.logic', $exception->getKey());

--- a/tests/Exception/NotFoundExceptionTest.php
+++ b/tests/Exception/NotFoundExceptionTest.php
@@ -3,13 +3,12 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 class NotFoundExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
-	public function testDefaults()
+	#[CoversNothing]
+	public function testDefaults(): void
 	{
 		$exception = new NotFoundException();
 		$this->assertSame('error.notFound', $exception->getKey());

--- a/tests/Exception/PermissionExceptionTest.php
+++ b/tests/Exception/PermissionExceptionTest.php
@@ -3,13 +3,12 @@
 namespace Kirby\Exception;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 class PermissionExceptionTest extends TestCase
 {
-	/**
-	 * @coversNothing
-	 */
-	public function testDefaults()
+	#[CoversNothing]
+	public function testDefaults(): void
 	{
 		$exception = new PermissionException();
 		$this->assertSame('error.permission', $exception->getKey());


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Exception',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
