### PR TITLE
test: Use PHPUnit attributes for `Kirby\Filesystem`

### DIFF
--- a/tests/Filesystem/AssetTest.php
+++ b/tests/Filesystem/AssetTest.php
@@ -25,12 +25,12 @@ class AssetTest extends TestCase
 		]);
 	}
 
-	protected function _asset($file = 'images/logo.svg')
+	protected function _asset($file = 'images/logo.svg'): Asset
 	{
 		return new Asset($file);
 	}
 
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$asset = $this->_asset($file = 'images/logo.svg');
 
@@ -53,7 +53,7 @@ class AssetTest extends TestCase
 		$this->assertSame('images', $asset->path());
 	}
 
-	public function testCall()
+	public function testCall(): void
 	{
 		$asset = $this->_asset($file = 'images/logo.svg');
 
@@ -72,7 +72,7 @@ class AssetTest extends TestCase
 		$asset->foo();
 	}
 
-	public function testMedia()
+	public function testMedia(): void
 	{
 		$asset = $this->_asset();
 
@@ -93,13 +93,13 @@ class AssetTest extends TestCase
 		$this->assertSame(dirname($mediaUrl) . '/test.jpg', $asset->mediaUrl('test.jpg'));
 	}
 
-	public function testToString()
+	public function testToString(): void
 	{
 		$asset = $this->_asset();
 		$this->assertSame('<img alt="" src="https://getkirby.com/images/logo.svg">', $asset->__toString());
 	}
 
-	public function testNonExistingMethod()
+	public function testNonExistingMethod(): void
 	{
 		$asset = $this->_asset();
 		$this->expectException(BadMethodCallException::class);

--- a/tests/Filesystem/DirTest.php
+++ b/tests/Filesystem/DirTest.php
@@ -8,10 +8,9 @@ use Kirby\Cms\Page;
 use Kirby\TestCase;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Filesystem\Dir
- */
+#[CoversClass(Dir::class)]
 class DirTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/dir';
@@ -37,10 +36,7 @@ class DirTest extends TestCase
 		return Dir::inventory(static::TMP, ...$args);
 	}
 
-	/**
-	 * @covers ::copy
-	 */
-	public function testCopy()
+	public function testCopy(): void
 	{
 		$src    = static::FIXTURES . '/copy';
 		$target = static::TMP . '/copy';
@@ -54,10 +50,7 @@ class DirTest extends TestCase
 		$this->assertFileDoesNotExist($target . '/subfolder/.gitignore');
 	}
 
-	/**
-	 * @covers ::copy
-	 */
-	public function testCopyNonRecursive()
+	public function testCopyNonRecursive(): void
 	{
 		$src    = static::FIXTURES . '/copy';
 		$target = static::TMP . '/copy';
@@ -71,10 +64,7 @@ class DirTest extends TestCase
 		$this->assertFileDoesNotExist($target . '/subfolder/.gitignore');
 	}
 
-	/**
-	 * @covers ::copy
-	 */
-	public function testCopyIgnore()
+	public function testCopyIgnore(): void
 	{
 		$src    = static::FIXTURES . '/copy';
 		$target = static::TMP . '/copy';
@@ -89,10 +79,7 @@ class DirTest extends TestCase
 		$this->assertFileDoesNotExist($target . '/subfolder/.gitignore');
 	}
 
-	/**
-	 * @covers ::copy
-	 */
-	public function testCopyNoIgnore()
+	public function testCopyNoIgnore(): void
 	{
 		$src    = static::FIXTURES . '/copy';
 		$target = static::TMP . '/copy';
@@ -107,10 +94,7 @@ class DirTest extends TestCase
 		$this->assertFileExists($target . '/subfolder/.gitignore');
 	}
 
-	/**
-	 * @covers ::copy
-	 */
-	public function testCopyMissingSource()
+	public function testCopyMissingSource(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('The directory "/does-not-exist" does not exist');
@@ -121,10 +105,7 @@ class DirTest extends TestCase
 		Dir::copy($src, $target);
 	}
 
-	/**
-	 * @covers ::copy
-	 */
-	public function testCopyExistingTarget()
+	public function testCopyExistingTarget(): void
 	{
 		$src    = static::FIXTURES . '/copy';
 		$target = static::FIXTURES . '/copy';
@@ -135,10 +116,7 @@ class DirTest extends TestCase
 		Dir::copy($src, $target);
 	}
 
-	/**
-	 * @covers ::copy
-	 */
-	public function testCopyInvalidTarget()
+	public function testCopyInvalidTarget(): void
 	{
 		$src    = static::FIXTURES . '/copy';
 		$target = '';
@@ -149,20 +127,14 @@ class DirTest extends TestCase
 		Dir::copy($src, $target);
 	}
 
-	/**
-	 * @covers ::exists
-	 */
-	public function testExists()
+	public function testExists(): void
 	{
 		$this->assertFalse(Dir::exists(static::TMP));
 		Dir::make(static::TMP);
 		$this->assertTrue(Dir::exists(static::TMP));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
-	public function testExistsIn()
+	public function testExistsIn(): void
 	{
 		$test = static::TMP . '/test';
 
@@ -174,10 +146,7 @@ class DirTest extends TestCase
 		$this->assertFalse(Dir::exists($test, static::FIXTURES));
 	}
 
-	/**
-	 * @covers ::index
-	 */
-	public function testIndex()
+	public function testIndex(): void
 	{
 		Dir::make($dir = static::TMP);
 		Dir::make(static::TMP . '/sub');
@@ -194,10 +163,7 @@ class DirTest extends TestCase
 		$this->assertSame($expected, Dir::index($dir));
 	}
 
-	/**
-	 * @covers ::index
-	 */
-	public function testIndexRecursive()
+	public function testIndexRecursive(): void
 	{
 		Dir::make($dir = static::TMP);
 		Dir::make(static::TMP . '/sub');
@@ -218,10 +184,7 @@ class DirTest extends TestCase
 		$this->assertSame($expected, Dir::index($dir, true));
 	}
 
-	/**
-	 * @covers ::index
-	 */
-	public function testIndexIgnore()
+	public function testIndexIgnore(): void
 	{
 		Dir::$ignore = ['z.txt'];
 
@@ -276,20 +239,14 @@ class DirTest extends TestCase
 		]));
 	}
 
-	/**
-	 * @covers ::isWritable
-	 */
-	public function testIsWritable()
+	public function testIsWritable(): void
 	{
 		Dir::make(static::TMP);
 
 		$this->assertSame(is_writable(static::TMP), Dir::isWritable(static::TMP));
 	}
 
-	/**
-	 * @covers ::inventory
-	 */
-	public function testInventory()
+	public function testInventory(): void
 	{
 		$inventory = $this->create([
 			'1_project-a',
@@ -315,10 +272,7 @@ class DirTest extends TestCase
 		$this->assertSame('projects', $inventory['template']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 */
-	public function testInventoryWithSkippedFiles()
+	public function testInventoryWithSkippedFiles(): void
 	{
 		$inventory = $this->create([
 			'valid.jpg',
@@ -334,10 +288,7 @@ class DirTest extends TestCase
 		$this->assertSame($expected, A::pluck($inventory['files'], 'filename'));
 	}
 
-	/**
-	 * @covers ::inventory
-	 */
-	public function testInventoryChildSorting()
+	public function testInventoryChildSorting(): void
 	{
 		$inventory = $this->create([
 			'1_project-c',
@@ -350,10 +301,7 @@ class DirTest extends TestCase
 		$this->assertSame('project-a', $inventory['children'][2]['slug']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 */
-	public function testInventoryChildWithLeadingZero()
+	public function testInventoryChildWithLeadingZero(): void
 	{
 		$inventory = $this->create([
 			'01_project-c',
@@ -371,10 +319,7 @@ class DirTest extends TestCase
 		$this->assertSame(3, $inventory['children'][2]['num']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 */
-	public function testInventoryFileSorting()
+	public function testInventoryFileSorting(): void
 	{
 		$inventory = $this->create([
 			'1-c.jpg',
@@ -389,11 +334,7 @@ class DirTest extends TestCase
 		$this->assertSame('11-a.jpg', $files[2]['filename']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 * @covers ::inventoryTemplate
-	 */
-	public function testInventoryMissingTemplate()
+	public function testInventoryMissingTemplate(): void
 	{
 		$inventory = $this->create([
 			'cover.jpg',
@@ -404,11 +345,7 @@ class DirTest extends TestCase
 		$this->assertSame('default', $inventory['template']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 * @covers ::inventoryTemplate
-	 */
-	public function testInventoryTemplateWithDotInFilename()
+	public function testInventoryTemplateWithDotInFilename(): void
 	{
 		$inventory = $this->create([
 			'cover.jpg',
@@ -420,11 +357,7 @@ class DirTest extends TestCase
 		$this->assertSame('article.video', $inventory['template']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 * @covers ::inventoryTemplate
-	 */
-	public function testInventoryExtension()
+	public function testInventoryExtension(): void
 	{
 		$inventory = $this->create([
 			'cover.jpg',
@@ -436,11 +369,7 @@ class DirTest extends TestCase
 		$this->assertSame('article', $inventory['template']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 * @covers ::inventoryTemplate
-	 */
-	public function testInventoryIgnore()
+	public function testInventoryIgnore(): void
 	{
 		$inventory = $this->create([
 			'cover.jpg',
@@ -451,11 +380,7 @@ class DirTest extends TestCase
 		$this->assertSame('article', $inventory['template']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 * @covers ::inventoryTemplate
-	 */
-	public function testInventoryMultilang()
+	public function testInventoryMultilang(): void
 	{
 		$inventory = $this->create([
 			'cover.jpg',
@@ -468,11 +393,7 @@ class DirTest extends TestCase
 		$this->assertSame('article', $inventory['template']);
 	}
 
-	/**
-	 * @covers ::inventory
-	 * @covers ::inventoryChild
-	 */
-	public function testInventoryChildModels()
+	public function testInventoryChildModels(): void
 	{
 		Page::$models = [
 			'a' => 'A',
@@ -492,11 +413,7 @@ class DirTest extends TestCase
 		Page::$models = [];
 	}
 
-	/**
-	 * @covers ::inventory
-	 * @covers ::inventoryChild
-	 */
-	public function testInventoryChildMultilangModels()
+	public function testInventoryChildMultilangModels(): void
 	{
 		new App([
 			'roots' => [
@@ -536,19 +453,13 @@ class DirTest extends TestCase
 		Page::$models = [];
 	}
 
-	/**
-	 * @covers ::make
-	 */
-	public function testMake()
+	public function testMake(): void
 	{
 		$this->assertTrue(Dir::make(static::TMP));
 		$this->assertFalse(Dir::make(''));
 	}
 
-	/**
-	 * @covers ::make
-	 */
-	public function testMakeFileExists()
+	public function testMakeFileExists(): void
 	{
 		$test = static::TMP . '/test';
 
@@ -559,38 +470,26 @@ class DirTest extends TestCase
 		Dir::make($test);
 	}
 
-	/**
-	 * @covers ::modified
-	 */
-	public function testModified()
+	public function testModified(): void
 	{
 		Dir::make(static::TMP);
 
 		$this->assertIsInt(Dir::modified(static::TMP));
 	}
 
-	/**
-	 * @covers ::move
-	 */
-	public function testMove()
+	public function testMove(): void
 	{
 		Dir::make(static::TMP . '/1');
 
 		$this->assertTrue(Dir::move(static::TMP . '/1', static::TMP . '/2'));
 	}
 
-	/**
-	 * @covers ::move
-	 */
-	public function testMoveNonExisting()
+	public function testMoveNonExisting(): void
 	{
 		$this->assertFalse(Dir::move('/does-not-exist', static::TMP . '/2'));
 	}
 
-	/**
-	 * @covers ::link
-	 */
-	public function testLink()
+	public function testLink(): void
 	{
 		$source = static::TMP . '/source';
 		$link   = static::TMP . '/link';
@@ -601,10 +500,7 @@ class DirTest extends TestCase
 		$this->assertTrue(is_link($link));
 	}
 
-	/**
-	 * @covers ::link
-	 */
-	public function testLinkExistingLink()
+	public function testLinkExistingLink(): void
 	{
 		$source = static::TMP . '/source';
 		$link   = static::TMP . '/link';
@@ -615,10 +511,7 @@ class DirTest extends TestCase
 		$this->assertTrue(Dir::link($source, $link));
 	}
 
-	/**
-	 * @covers ::link
-	 */
-	public function testLinkWithoutSource()
+	public function testLinkWithoutSource(): void
 	{
 		$source = static::TMP . '/source';
 		$link   = static::TMP . '/link';
@@ -629,10 +522,7 @@ class DirTest extends TestCase
 		Dir::link($source, $link);
 	}
 
-	/**
-	 * @covers ::read
-	 */
-	public function testRead()
+	public function testRead(): void
 	{
 		Dir::make(static::TMP);
 
@@ -670,19 +560,13 @@ class DirTest extends TestCase
 		$this->assertSame($expected, $files);
 	}
 
-	/**
-	 * @covers ::realpath
-	 */
-	public function testRealpath()
+	public function testRealpath(): void
 	{
 		$path = Dir::realpath(__DIR__ . '/../Filesystem');
 		$this->assertSame(__DIR__, $path);
 	}
 
-	/**
-	 * @covers ::realpath
-	 */
-	public function testRealpathToMissingFile()
+	public function testRealpathToMissingFile(): void
 	{
 		$path = __DIR__ . '/../does-not-exist';
 
@@ -692,10 +576,7 @@ class DirTest extends TestCase
 		Dir::realpath($path);
 	}
 
-	/**
-	 * @covers ::realpath
-	 */
-	public function testRealpathToParent()
+	public function testRealpathToParent(): void
 	{
 		$parent = __DIR__ . '/..';
 		$dir    = $parent . '/Filesystem';
@@ -704,10 +585,7 @@ class DirTest extends TestCase
 		$this->assertSame(__DIR__, $path);
 	}
 
-	/**
-	 * @covers ::realpath
-	 */
-	public function testRealpathToNonExistingParent()
+	public function testRealpathToNonExistingParent(): void
 	{
 		$parent = __DIR__ . '/../does-not-exist';
 		$dir    = __DIR__ . '/../Filesystem';
@@ -718,10 +596,7 @@ class DirTest extends TestCase
 		Dir::realpath($dir, $parent);
 	}
 
-	/**
-	 * @covers ::realpath
-	 */
-	public function testRealpathToInvalidParent()
+	public function testRealpathToInvalidParent(): void
 	{
 		$parent = __DIR__ . '/../Cms';
 		$dir    = __DIR__ . '/../Filesystem';
@@ -732,10 +607,7 @@ class DirTest extends TestCase
 		Dir::realpath($dir, $parent);
 	}
 
-	/**
-	 * @covers ::remove
-	 */
-	public function testRemove()
+	public function testRemove(): void
 	{
 		Dir::make(static::TMP);
 
@@ -744,21 +616,14 @@ class DirTest extends TestCase
 		$this->assertDirectoryDoesNotExist(static::TMP);
 	}
 
-	/**
-	 * @covers ::isReadable
-	 */
-	public function testIsReadable()
+	public function testIsReadable(): void
 	{
 		Dir::make(static::TMP);
 
 		$this->assertSame(is_readable(static::TMP), Dir::isReadable(static::TMP));
 	}
 
-	/**
-	 * @covers ::dirs
-	 * @covers ::files
-	 */
-	public function testReadDirsAndFiles()
+	public function testReadDirsAndFiles(): void
 	{
 		Dir::make(static::TMP);
 		Dir::make(static::TMP . '/a');
@@ -807,11 +672,7 @@ class DirTest extends TestCase
 		$this->assertSame($expected, $files);
 	}
 
-	/**
-	 * @covers ::size
-	 * @covers ::niceSize
-	 */
-	public function testSize()
+	public function testSize(): void
 	{
 		Dir::make(static::TMP);
 
@@ -826,10 +687,7 @@ class DirTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::size
-	 */
-	public function testSizeWithNestedFolders()
+	public function testSizeWithNestedFolders(): void
 	{
 		Dir::make(static::TMP);
 		Dir::make(static::TMP . '/sub');
@@ -846,18 +704,12 @@ class DirTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::size
-	 */
-	public function testSizeOfNonExistingDir()
+	public function testSizeOfNonExistingDir(): void
 	{
 		$this->assertFalse(Dir::size('/does-not-exist'));
 	}
 
-	/**
-	 * @covers ::wasModifiedAfter
-	 */
-	public function testWasModifiedAfter()
+	public function testWasModifiedAfter(): void
 	{
 		$time = time();
 

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -8,10 +8,10 @@ use Kirby\Http\HeadersSent;
 use Kirby\TestCase;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
+use stdClass;
 
-/**
- * @coversDefaultClass \Kirby\Filesystem\F
- */
+#[CoversClass(F::class)]
 class FTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/f';
@@ -42,19 +42,13 @@ class FTest extends TestCase
 		HeadersSent::$value = false;
 	}
 
-	/**
-	 * @covers ::append
-	 */
-	public function testAppend()
+	public function testAppend(): void
 	{
 		F::copy($this->sample, $this->test);
 		$this->assertTrue(F::append($this->test, ' is awesome'));
 	}
 
-	/**
-	 * @covers ::base64
-	 */
-	public function testBase64()
+	public function testBase64(): void
 	{
 		F::write($this->test, 'test');
 		$expected = base64_encode('test');
@@ -62,10 +56,7 @@ class FTest extends TestCase
 		$this->assertSame($expected, F::base64($this->test));
 	}
 
-	/**
-	 * @covers ::copy
-	 */
-	public function testCopy()
+	public function testCopy(): void
 	{
 		$origin = static::TMP . '/a.txt';
 		F::write($origin, 'test');
@@ -75,28 +66,19 @@ class FTest extends TestCase
 		$this->assertFileExists($this->test);
 	}
 
-	/**
-	 * @covers ::dirname
-	 */
-	public function testDirname()
+	public function testDirname(): void
 	{
 		$this->assertSame(dirname($this->test), F::dirname($this->test));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
-	public function testExists()
+	public function testExists(): void
 	{
 		$this->assertFalse(F::exists($this->test));
 		touch($this->test);
 		$this->assertTrue(F::exists($this->test));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
-	public function testExistsIn()
+	public function testExistsIn(): void
 	{
 		$this->assertFalse(F::exists($this->test, static::TMP));
 		touch($this->test);
@@ -106,46 +88,31 @@ class FTest extends TestCase
 		$this->assertFalse(F::exists($this->test, static::FIXTURES));
 	}
 
-	/**
-	 * @covers ::extension
-	 */
-	public function testExtension()
+	public function testExtension(): void
 	{
 		$this->assertSame('php', F::extension(__FILE__));
 		$this->assertSame('test.jpg', F::extension($this->sample, 'jpg'));
 	}
 
-	/**
-	 * @covers ::extensionToType
-	 */
-	public function testExtensionToType()
+	public function testExtensionToType(): void
 	{
 		$this->assertSame('image', F::extensionToType('jpg'));
 		$this->assertFalse(F::extensionToType('something'));
 	}
 
-	/**
-	 * @covers ::extensions
-	 */
-	public function testExtensions()
+	public function testExtensions(): void
 	{
 		$this->assertSame(array_keys(Mime::types()), F::extensions());
 		$this->assertSame(F::$types['image'], F::extensions('image'));
 		$this->assertSame([], F::extensions('unknown-type'));
 	}
 
-	/**
-	 * @covers ::filename
-	 */
-	public function testFilename()
+	public function testFilename(): void
 	{
 		$this->assertSame('test.txt', F::filename($this->sample));
 	}
 
-	/**
-	 * @covers ::is
-	 */
-	public function testIs()
+	public function testIs(): void
 	{
 		F::write($this->test, 'test');
 
@@ -155,28 +122,19 @@ class FTest extends TestCase
 		$this->assertFalse(F::is($this->test, 'no-clue'));
 	}
 
-	/**
-	 * @covers ::isReadable
-	 */
-	public function testIsReadable()
+	public function testIsReadable(): void
 	{
 		F::write($this->test, 'test');
 		$this->assertSame(is_readable($this->test), F::isReadable($this->test));
 	}
 
-	/**
-	 * @covers ::isWritable
-	 */
-	public function testIsWritable()
+	public function testIsWritable(): void
 	{
 		F::write($this->test, 'test');
 		$this->assertSame(is_writable($this->test), F::isWritable($this->test));
 	}
 
-	/**
-	 * @covers ::link
-	 */
-	public function testLink()
+	public function testLink(): void
 	{
 		$src  = static::TMP . '/a.txt';
 		$link = static::TMP . '/b.txt';
@@ -187,19 +145,13 @@ class FTest extends TestCase
 		$this->assertFileExists($link);
 	}
 
-	/**
-	 * @covers ::realpath
-	 */
-	public function testRealpath()
+	public function testRealpath(): void
 	{
 		$path = F::realpath(__DIR__ . '/../Filesystem/FTest.php');
 		$this->assertSame(__FILE__, $path);
 	}
 
-	/**
-	 * @covers ::realpath
-	 */
-	public function testRealpathToMissingFile()
+	public function testRealpathToMissingFile(): void
 	{
 		$path = __DIR__ . '/../does-not-exist.php';
 
@@ -209,10 +161,7 @@ class FTest extends TestCase
 		F::realpath($path);
 	}
 
-	/**
-	 * @covers ::realpath
-	 */
-	public function testRealpathToParent()
+	public function testRealpathToParent(): void
 	{
 		$parent = __DIR__ . '/..';
 		$file   = $parent . '/Filesystem/FTest.php';
@@ -221,10 +170,7 @@ class FTest extends TestCase
 		$this->assertSame(__FILE__, $path);
 	}
 
-	/**
-	 * @covers ::realpath
-	 */
-	public function testRealpathToNonExistingParent()
+	public function testRealpathToNonExistingParent(): void
 	{
 		$parent = __DIR__ . '/../does-not-exist';
 		$file   = __DIR__ . '/../Filesystem/FTest.php';
@@ -235,10 +181,7 @@ class FTest extends TestCase
 		F::realpath($file, $parent);
 	}
 
-	/**
-	 * @covers ::realpath
-	 */
-	public function testRealpathToInvalidParent()
+	public function testRealpathToInvalidParent(): void
 	{
 		$parent = __DIR__ . '/../Cms';
 		$file   = __DIR__ . '/../Filesystem/FTest.php';
@@ -249,10 +192,7 @@ class FTest extends TestCase
 		F::realpath($file, $parent);
 	}
 
-	/**
-	 * @covers ::relativepath
-	 */
-	public function testRelativePath()
+	public function testRelativePath(): void
 	{
 		$path = F::relativepath(__FILE__, __DIR__);
 		$this->assertSame('/' . basename(__FILE__), $path);
@@ -261,10 +201,7 @@ class FTest extends TestCase
 		$this->assertSame('/' . basename(__FILE__), $path);
 	}
 
-	/**
-	 * @covers ::relativepath
-	 */
-	public function testRelativePathWithEmptyBase()
+	public function testRelativePathWithEmptyBase(): void
 	{
 		$path = F::relativepath(__FILE__, '');
 		$this->assertSame(basename(__FILE__), $path);
@@ -273,10 +210,7 @@ class FTest extends TestCase
 		$this->assertSame(basename(__FILE__), $path);
 	}
 
-	/**
-	 * @covers ::relativepath
-	 */
-	public function testRelativePathWithUnrelatedBase()
+	public function testRelativePathWithUnrelatedBase(): void
 	{
 		$path = F::relativepath(__DIR__ . '/fruits/apples/fuji.txt', __DIR__ . '/fruits/pineapples');
 		$this->assertSame('../apples/fuji.txt', $path);
@@ -303,10 +237,7 @@ class FTest extends TestCase
 		$this->assertSame('../path-extra/file.txt', $path);
 	}
 
-	/**
-	 * @covers ::relativepath
-	 */
-	public function testRelativePathOnWindows()
+	public function testRelativePathOnWindows(): void
 	{
 		$file = 'C:\xampp\htdocs\index.php';
 		$in   = 'C:/xampp/htdocs';
@@ -315,10 +246,7 @@ class FTest extends TestCase
 		$this->assertSame('/index.php', $path);
 	}
 
-	/**
-	 * @covers ::link
-	 */
-	public function testLinkSymlink()
+	public function testLinkSymlink(): void
 	{
 		$src  = static::TMP . '/a.txt';
 		$link = static::TMP . '/b.txt';
@@ -329,10 +257,7 @@ class FTest extends TestCase
 		$this->assertTrue(is_link($link));
 	}
 
-	/**
-	 * @covers ::link
-	 */
-	public function testLinkExistingLink()
+	public function testLinkExistingLink(): void
 	{
 		$src  = static::TMP . '/a.txt';
 		$link = static::TMP . '/b.txt';
@@ -343,10 +268,7 @@ class FTest extends TestCase
 		$this->assertTrue(F::link($src, $link));
 	}
 
-	/**
-	 * @covers ::link
-	 */
-	public function testLinkWithMissingSource()
+	public function testLinkWithMissingSource(): void
 	{
 		$src  = static::TMP . '/a.txt';
 		$link = static::TMP . '/b.txt';
@@ -357,10 +279,7 @@ class FTest extends TestCase
 		F::link($src, $link);
 	}
 
-	/**
-	 * @covers ::load
-	 */
-	public function testLoad()
+	public function testLoad(): void
 	{
 		// basic behavior
 		F::write($file = static::TMP . '/test.php', '<?php return "foo";');
@@ -398,10 +317,7 @@ class FTest extends TestCase
 		$this->assertSame('foo', F::load($file));
 	}
 
-	/**
-	 * @covers ::load
-	 */
-	public function testLoadAccidentalOutput()
+	public function testLoadAccidentalOutput(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('Disallowed output from file file.php:123, possible accidental whitespace?');
@@ -411,10 +327,7 @@ class FTest extends TestCase
 		F::load($file, allowOutput: false);
 	}
 
-	/**
-	 * @covers ::loadClasses
-	 */
-	public function testLoadClasses()
+	public function testLoadClasses(): void
 	{
 		F::loadClasses([
 			'ftest\\a' => static::FIXTURES . '/load/a/a.php',
@@ -434,10 +347,7 @@ class FTest extends TestCase
 		class_exists('FTest\\Output');
 	}
 
-	/**
-	 * @covers ::loadOnce
-	 */
-	public function testLoadOnce()
+	public function testLoadOnce(): void
 	{
 		// basic behavior
 		F::write($file = static::TMP . '/test1.php', '<?php return "foo";');
@@ -455,10 +365,7 @@ class FTest extends TestCase
 		$this->assertTrue(F::loadOnce($file));
 	}
 
-	/**
-	 * @covers ::loadOnce
-	 */
-	public function testLoadOnceAccidentalOutput()
+	public function testLoadOnceAccidentalOutput(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('Disallowed output from file file.php:123, possible accidental whitespace?');
@@ -468,10 +375,7 @@ class FTest extends TestCase
 		F::loadOnce($file, allowOutput: false);
 	}
 
-	/**
-	 * @covers ::move
-	 */
-	public function testMove()
+	public function testMove(): void
 	{
 		F::write($origin = static::TMP . '/a.txt', 'test');
 
@@ -499,10 +403,7 @@ class FTest extends TestCase
 		$this->assertSame('test', file_get_contents($origin));
 	}
 
-	/**
-	 * @covers ::move
-	 */
-	public function testMoveAcrossDevices()
+	public function testMoveAcrossDevices(): void
 	{
 		// try to find a suitable path on a different device (filesystem)
 		if (is_dir('/dev/shm') === true) {
@@ -546,54 +447,36 @@ class FTest extends TestCase
 		$this->assertSame('test', file_get_contents($origin));
 	}
 
-	/**
-	 * @covers ::mime
-	 */
-	public function testMime()
+	public function testMime(): void
 	{
 		F::write($this->test, 'test');
 		$this->assertSame('text/plain', F::mime($this->test));
 	}
 
-	/**
-	 * @covers ::mimeToExtension
-	 */
-	public function testMimeToExtension()
+	public function testMimeToExtension(): void
 	{
 		$this->assertSame('jpg', F::mimeToExtension('image/jpeg'));
 		$this->assertFalse(F::mimeToExtension('image/something'));
 	}
 
-	/**
-	 * @covers ::mimeToType
-	 */
-	public function testMimeToType()
+	public function testMimeToType(): void
 	{
 		$this->assertSame('image', F::mimeToType('image/jpeg'));
 		$this->assertFalse(F::mimeToType('image/something'));
 	}
 
-	/**
-	 * @covers ::modified
-	 */
-	public function testModified()
+	public function testModified(): void
 	{
 		F::write($this->test, 'test');
 		$this->assertSame(filemtime($this->test), F::modified($this->test));
 	}
 
-	/**
-	 * @covers ::name
-	 */
-	public function testName()
+	public function testName(): void
 	{
 		$this->assertSame('test', F::name($this->sample));
 	}
 
-	/**
-	 * @covers ::niceSize
-	 */
-	public function testNiceSize()
+	public function testNiceSize(): void
 	{
 		$locale = I18n::$locale;
 
@@ -630,36 +513,24 @@ class FTest extends TestCase
 		I18n::$locale = $locale;
 	}
 
-	/**
-	 * @covers ::read
-	 */
-	public function testRead()
+	public function testRead(): void
 	{
 		file_put_contents($this->test, $content = 'my content is awesome');
 
 		$this->assertSame($content, F::read($this->test));
 	}
 
-	/**
-	 * @covers ::read
-	 */
-	public function testReadInvalidFile()
+	public function testReadInvalidFile(): void
 	{
 		$this->assertFalse(F::read('invalid file'));
 	}
 
-	/**
-	 * @covers ::read
-	 */
-	public function testReadRemoteFile()
+	public function testReadRemoteFile(): void
 	{
 		$this->assertFalse(F::read('https://example.com/some-file.jpg'));
 	}
 
-	/**
-	 * @covers ::remove
-	 */
-	public function testRemove()
+	public function testRemove(): void
 	{
 		F::write($a = static::TMP . '/a.jpg', '');
 
@@ -670,10 +541,7 @@ class FTest extends TestCase
 		$this->assertFileDoesNotExist($a);
 	}
 
-	/**
-	 * @covers ::remove
-	 */
-	public function testRemoveAlreadyRemoved()
+	public function testRemoveAlreadyRemoved(): void
 	{
 		$this->assertFileDoesNotExist($a = static::TMP . '/a.jpg');
 
@@ -682,10 +550,7 @@ class FTest extends TestCase
 		$this->assertFileDoesNotExist($a);
 	}
 
-	/**
-	 * @covers ::remove
-	 */
-	public function testRemoveDirectory()
+	public function testRemoveDirectory(): void
 	{
 		Dir::make($a = static::TMP . '/a');
 
@@ -696,10 +561,7 @@ class FTest extends TestCase
 		$this->assertDirectoryExists($a);
 	}
 
-	/**
-	 * @covers ::remove
-	 */
-	public function testRemoveLink()
+	public function testRemoveLink(): void
 	{
 		F::write($a = static::TMP . '/a.jpg', '');
 		symlink($a, $b = static::TMP . '/b.jpg');
@@ -713,10 +575,7 @@ class FTest extends TestCase
 		$this->assertTrue(is_link($b));
 	}
 
-	/**
-	 * @covers ::remove
-	 */
-	public function testRemoveGlob()
+	public function testRemoveGlob(): void
 	{
 		F::write($a = static::TMP . '/a.jpg', '');
 		F::write($b = static::TMP . '/a.1234.jpg', '');
@@ -733,10 +592,7 @@ class FTest extends TestCase
 		$this->assertFileDoesNotExist($c);
 	}
 
-	/**
-	 * @covers ::rename
-	 */
-	public function testRename()
+	public function testRename(): void
 	{
 		F::write($origin = static::TMP . '/a.txt', 'test');
 
@@ -773,10 +629,7 @@ class FTest extends TestCase
 		$this->assertFileExists($origin);
 	}
 
-	/**
-	 * @covers ::safeName
-	 */
-	public function testSafeName()
+	public function testSafeName(): void
 	{
 		// make sure no language rules are still set
 		Str::$language = [];
@@ -803,10 +656,7 @@ class FTest extends TestCase
 		$this->assertSame('file.a@b_c-d.jpg', F::safeName('file.a@b_c-d.jpg'));
 	}
 
-	/**
-	 * @covers ::safeBasename
-	 */
-	public function testSafeBasename()
+	public function testSafeBasename(): void
 	{
 		// make sure no language rules are still set
 		Str::$language = [];
@@ -823,10 +673,7 @@ class FTest extends TestCase
 		$this->assertSame('super', F::safeBasename('-super.jpg'));
 	}
 
-	/**
-	 * @covers ::safeExtension
-	 */
-	public function testSafeExtension()
+	public function testSafeExtension(): void
 	{
 		// make sure no language rules are still set
 		Str::$language = [];
@@ -838,10 +685,7 @@ class FTest extends TestCase
 		$this->assertSame('jpg', F::safeExtension('-super.jpg'));
 	}
 
-	/**
-	 * @covers ::size
-	 */
-	public function testSize()
+	public function testSize(): void
 	{
 		F::write($a = static::TMP . '/a.txt', 'test');
 		F::write($b = static::TMP . '/b.txt', 'test');
@@ -851,10 +695,7 @@ class FTest extends TestCase
 		$this->assertSame(8, F::size([$a, $b]));
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testType()
+	public function testType(): void
 	{
 		$this->assertSame('image', F::type('jpg'));
 		$this->assertSame('document', F::type('pdf'));
@@ -867,10 +708,7 @@ class FTest extends TestCase
 		$this->assertNull(F::type('tmp'));
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeWithoutExtension()
+	public function testTypeWithoutExtension(): void
 	{
 		F::write($file = static::TMP . '/test', '<?php echo "foo"; ?>');
 
@@ -878,10 +716,7 @@ class FTest extends TestCase
 		$this->assertSame('code', F::type($file));
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeWithTmpExtension()
+	public function testTypeWithTmpExtension(): void
 	{
 		F::write($file = static::TMP . '/test.tmp', '<?php echo "foo"; ?>');
 
@@ -889,20 +724,14 @@ class FTest extends TestCase
 		$this->assertSame('code', F::type($file));
 	}
 
-	/**
-	 * @covers ::typeToExtensions
-	 */
-	public function testTypeToExtensions()
+	public function testTypeToExtensions(): void
 	{
 		$this->assertSame(F::$types['audio'], F::typeToExtensions('audio'));
 		$this->assertSame(F::$types['document'], F::typeToExtensions('document'));
 		$this->assertNull(F::typeToExtensions('invalid'));
 	}
 
-	/**
-	 * @covers ::unlink
-	 */
-	public function testUnlink()
+	public function testUnlink(): void
 	{
 		touch(static::TMP . '/file');
 		symlink(static::TMP . '/file', static::TMP . '/link-exists');
@@ -917,18 +746,12 @@ class FTest extends TestCase
 		$this->assertFalse(is_link(static::TMP . '/link-invalid'));
 	}
 
-	/**
-	 * @covers ::unlink
-	 */
-	public function testUnlinkAlredyDeleted()
+	public function testUnlinkAlredyDeleted(): void
 	{
 		$this->assertTrue(F::unlink(static::TMP . '/does-not-exist'));
 	}
 
-	/**
-	 * @covers ::unlink
-	 */
-	public function testUnlinkFolder()
+	public function testUnlinkFolder(): void
 	{
 		$this->hasErrorHandler = true;
 
@@ -954,10 +777,7 @@ class FTest extends TestCase
 		$this->assertTrue($called);
 	}
 
-	/**
-	 * @covers ::uri
-	 */
-	public function testURI()
+	public function testURI(): void
 	{
 		F::write($this->test, 'test');
 
@@ -968,26 +788,17 @@ class FTest extends TestCase
 		$this->assertSame($expected, F::uri($this->test));
 	}
 
-	/**
-	 * @covers ::uri
-	 */
-	public function testUriOfNonExistingFile()
+	public function testUriOfNonExistingFile(): void
 	{
 		$this->assertFalse(F::uri('/does-not-exist'));
 	}
 
-	/**
-	 * @covers ::write
-	 */
-	public function testWrite()
+	public function testWrite(): void
 	{
 		$this->assertTrue(F::write($this->test, 'my content'));
 	}
 
-	/**
-	 * @covers ::write
-	 */
-	public function testWriteArray()
+	public function testWriteArray(): void
 	{
 		$input = ['a' => 'a'];
 
@@ -997,12 +808,9 @@ class FTest extends TestCase
 		$this->assertSame($input, $result);
 	}
 
-	/**
-	 * @covers ::write
-	 */
-	public function testWriteObject()
+	public function testWriteObject(): void
 	{
-		$input = new \stdClass([
+		$input = new stdClass([
 			'a' => 'b'
 		]);
 
@@ -1012,10 +820,7 @@ class FTest extends TestCase
 		$this->assertEquals($input, $result); // cannot use strict assertion (serialization)
 	}
 
-	/**
-	 * @covers ::similar
-	 */
-	public function testSimilar()
+	public function testSimilar(): void
 	{
 		F::write($a = static::TMP . '/a.jpg', '');
 		F::write($b = static::TMP . '/a.1234.jpg', '');

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -11,15 +11,14 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Http\Response;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class InvalidFileModel
 {
 	public string $foo = 'bar';
 }
 
-/**
- * @coversDefaultClass \Kirby\Filesystem\File
- */
+#[CoversClass(\Kirby\Filesystem\File::class)]
 class FileTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/files';
@@ -53,12 +52,7 @@ class FileTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::root
-	 * @covers ::url
-	 */
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$file = new File([
 			'root' => '/dev/null/test.pdf',
@@ -73,12 +67,7 @@ class FileTest extends TestCase
 		$this->assertNull($file->url());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::root
-	 * @covers ::url
-	 */
-	public function testLegacyConstruct()
+	public function testLegacyConstruct(): void
 	{
 		$file = new File(
 			'/dev/null/test.pdf',
@@ -88,20 +77,14 @@ class FileTest extends TestCase
 		$this->assertSame('https://home.io/test.pdf', $file->url());
 	}
 
-	/**
-	 * @covers ::base64
-	 */
-	public function testBase64()
+	public function testBase64(): void
 	{
 		$file   = $this->_file('real.svg');
 		$base64 = file_get_contents(static::TMP . '/real.svg.base64');
 		$this->assertSame($base64, $file->base64());
 	}
 
-	/**
-	 * @covers ::copy
-	 */
-	public function testCopy()
+	public function testCopy(): void
 	{
 		$oldRoot = static::TMP . '/test.txt';
 		$newRoot = static::TMP . '/awesome.txt';
@@ -121,10 +104,7 @@ class FileTest extends TestCase
 		$this->assertSame($newRoot, $new->root());
 	}
 
-	/**
-	 * @covers ::copy
-	 */
-	public function testCopyToExisting()
+	public function testCopyToExisting(): void
 	{
 		$this->expectException(GlobalException::class);
 		$this->expectExceptionMessage('could not be copied');
@@ -133,10 +113,7 @@ class FileTest extends TestCase
 		$file->copy(static::TMP . '/folder/b.txt');
 	}
 
-	/**
-	 * @covers ::copy
-	 */
-	public function testCopyNonExisting()
+	public function testCopyNonExisting(): void
 	{
 		$this->expectException(GlobalException::class);
 		$this->expectExceptionMessage('could not be copied');
@@ -145,10 +122,7 @@ class FileTest extends TestCase
 		$file->copy(static::TMP . '/b.txt');
 	}
 
-	/**
-	 * @covers ::copy
-	 */
-	public function testCopyFail()
+	public function testCopyFail(): void
 	{
 		$this->expectException(GlobalException::class);
 		$this->expectExceptionMessage('could not be copied');
@@ -158,30 +132,21 @@ class FileTest extends TestCase
 		$file->copy(static::TMP . '/copied.txt');
 	}
 
-	/**
-	 * @covers ::dataUri
-	 */
-	public function testDataUri()
+	public function testDataUri(): void
 	{
 		$file = $this->_file('real.svg');
 		$base64 = file_get_contents(static::TMP . '/real.svg.base64');
 		$this->assertSame('data:image/svg+xml;base64,' . $base64, $file->dataUri());
 	}
 
-	/**
-	 * @covers ::dataUri
-	 */
-	public function testDataUriRaw()
+	public function testDataUriRaw(): void
 	{
 		$file = $this->_file('real.svg');
 		$encoded = rawurlencode($file->read());
 		$this->assertSame('data:image/svg+xml,' . $encoded, $file->dataUri(false));
 	}
 
-	/**
-	 * @covers ::delete
-	 */
-	public function testDelete()
+	public function testDelete(): void
 	{
 		$file = new File(static::TMP . '/test.txt');
 
@@ -192,20 +157,14 @@ class FileTest extends TestCase
 		$this->assertFalse($file->exists());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
-	public function testDeleteNotExisting()
+	public function testDeleteNotExisting(): void
 	{
 		$file = new File('test.txt');
 		$this->assertFalse($file->exists());
 		$this->assertTrue($file->delete());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
-	public function testDeleteFail()
+	public function testDeleteFail(): void
 	{
 		$this->expectException(GlobalException::class);
 		$this->expectExceptionMessage('could not be deleted');
@@ -215,20 +174,14 @@ class FileTest extends TestCase
 		$file->delete();
 	}
 
-	/**
-	 * @covers ::download
-	 */
-	public function testDownload()
+	public function testDownload(): void
 	{
 		$file = $this->_file();
 		$this->assertIsString($file->download());
 		$this->assertIsString($file->download('meow.jpg'));
 	}
 
-	/**
-	 * @covers ::exists
-	 */
-	public function testExists()
+	public function testExists(): void
 	{
 		$file = $this->_file();
 		$this->assertTrue($file->exists());
@@ -237,55 +190,37 @@ class FileTest extends TestCase
 		$this->assertFalse($file->exists());
 	}
 
-	/**
-	 * @covers ::extension
-	 */
-	public function testExtension()
+	public function testExtension(): void
 	{
 		$file = $this->_file();
 		$this->assertSame('js', $file->extension());
 	}
 
-	/**
-	 * @covers ::filename
-	 */
-	public function testFilename()
+	public function testFilename(): void
 	{
 		$file = $this->_file();
 		$this->assertSame('test.js', $file->filename());
 	}
 
-	/**
-	 * @covers ::hash
-	 */
-	public function testHash()
+	public function testHash(): void
 	{
 		$file = $this->_file();
 		$this->assertIsString($file->hash());
 	}
 
-	/**
-	 * @covers ::header
-	 */
-	public function testHeader()
+	public function testHeader(): void
 	{
 		$file = $this->_file();
 		$this->assertInstanceOf(Response::class, $file->header(false));
 	}
 
-	/**
-	 * @covers ::header
-	 */
-	public function testHeaderSend()
+	public function testHeaderSend(): void
 	{
 		$file = $this->_file();
 		$this->assertNull($file->header());
 	}
 
-	/**
-	 * @covers ::html
-	 */
-	public function testHtml()
+	public function testHtml(): void
 	{
 		$file = new File([
 			'root' => static::TMP . '/blank.pdf',
@@ -294,10 +229,7 @@ class FileTest extends TestCase
 		$this->assertSame('<a href="https://foo.bar/blank.pdf">foo.bar/blank.pdf</a>', $file->html());
 	}
 
-	/**
-	 * @covers ::is
-	 */
-	public function testIs()
+	public function testIs(): void
 	{
 		$file = $this->_file();
 		$this->assertTrue($file->is('text/plain'));
@@ -307,37 +239,25 @@ class FileTest extends TestCase
 		$this->assertFalse($file->is('jpg'));
 	}
 
-	/**
-	 * @covers ::isReadable
-	 */
-	public function testIsReadable()
+	public function testIsReadable(): void
 	{
 		$file = $this->_file();
 		$this->assertSame(is_readable($file->root()), $file->isReadable());
 	}
 
-	/**
-	 * @covers ::isResizable
-	 */
-	public function testIsResizable()
+	public function testIsResizable(): void
 	{
 		$file = $this->_file();
 		$this->assertFalse($file->isResizable());
 	}
 
-	/**
-	 * @covers ::isViewable
-	 */
-	public function testIsViewable()
+	public function testIsViewable(): void
 	{
 		$file = $this->_file();
 		$this->assertFalse($file->isViewable());
 	}
 
-	/**
-	 * @covers ::isWritable
-	 */
-	public function testIsWritable()
+	public function testIsWritable(): void
 	{
 		$file = $this->_file();
 		$this->assertTrue($file->isWritable());
@@ -349,10 +269,7 @@ class FileTest extends TestCase
 		$this->assertFalse($file->isWritable());
 	}
 
-	/**
-	 * @covers ::kirby
-	 */
-	public function testKirby()
+	public function testKirby(): void
 	{
 		$file = $this->_file();
 
@@ -362,10 +279,7 @@ class FileTest extends TestCase
 		$this->assertInstanceOf(App::class, $file->kirby());
 	}
 
-	/**
-	 * @covers ::match
-	 */
-	public function testMatch()
+	public function testMatch(): void
 	{
 		$rules = [
 			'miMe'        => ['image/png', 'image/jpeg', 'application/pdf'],
@@ -378,10 +292,7 @@ class FileTest extends TestCase
 		$this->assertTrue($this->_file('cat.jpg')->match($rules));
 	}
 
-	/**
-	 * @covers ::match
-	 */
-	public function testMatchMimeMissing()
+	public function testMatchMimeMissing(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('The media type for "doesnotexist.invalid" cannot be detected');
@@ -389,10 +300,7 @@ class FileTest extends TestCase
 		$this->_file('doesnotexist.invalid')->match(['mime' => ['image/png', 'application/pdf']]);
 	}
 
-	/**
-	 * @covers ::match
-	 */
-	public function testMatchMimeInvalid()
+	public function testMatchMimeInvalid(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Invalid mime type: text/plain');
@@ -403,10 +311,7 @@ class FileTest extends TestCase
 		$this->_file()->match(['mime' => ['image/png', 'application/pdf']]);
 	}
 
-	/**
-	 * @covers ::match
-	 */
-	public function testMatchExtensionException()
+	public function testMatchExtensionException(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Invalid extension: js');
@@ -417,10 +322,7 @@ class FileTest extends TestCase
 		$this->_file()->match(['extension' => ['png', 'pdf']]);
 	}
 
-	/**
-	 * @covers ::match
-	 */
-	public function testMatchTypeException()
+	public function testMatchTypeException(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Invalid file type: code');
@@ -431,19 +333,13 @@ class FileTest extends TestCase
 		$this->_file()->match(['type' => ['document', 'video']]);
 	}
 
-	/**
-	 * @covers ::mime
-	 */
-	public function testMime()
+	public function testMime(): void
 	{
 		$file = $this->_file();
 		$this->assertSame('text/plain', $file->mime());
 	}
 
-	/**
-	 * @covers ::model
-	 */
-	public function testModel()
+	public function testModel(): void
 	{
 		$parent = Page::factory(['slug' => 'test']);
 		$model = CmsFile::factory([
@@ -460,10 +356,7 @@ class FileTest extends TestCase
 		$this->assertSame($model, $file->model());
 	}
 
-	/**
-	 * @covers ::model
-	 */
-	public function testParentModel()
+	public function testParentModel(): void
 	{
 		$parent = Page::factory([
 			'slug' => 'test',
@@ -483,10 +376,7 @@ class FileTest extends TestCase
 		$this->assertSame($file->root(), $asset->root());
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testInvalidModel()
+	public function testInvalidModel(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The model object must use the "Kirby\Filesystem\IsFile" trait');
@@ -497,10 +387,7 @@ class FileTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::modified
-	 */
-	public function testModified()
+	public function testModified(): void
 	{
 		// existing file
 		$file = $this->_file();
@@ -513,10 +400,7 @@ class FileTest extends TestCase
 		$this->assertFalse($file->modified());
 	}
 
-	/**
-	 * @covers ::move
-	 */
-	public function testMove()
+	public function testMove(): void
 	{
 		$oldRoot = static::TMP . '/test.txt';
 		$newRoot = static::TMP . '/awesome.txt';
@@ -535,10 +419,7 @@ class FileTest extends TestCase
 		$this->assertSame($newRoot, $moved->root());
 	}
 
-	/**
-	 * @covers ::move
-	 */
-	public function testMoveToExisting()
+	public function testMoveToExisting(): void
 	{
 		$this->expectException(GlobalException::class);
 		$this->expectExceptionMessage('could not be moved');
@@ -547,10 +428,7 @@ class FileTest extends TestCase
 		$file->move(static::TMP . '/folder/b.txt');
 	}
 
-	/**
-	 * @covers ::move
-	 */
-	public function testMoveNonExisting()
+	public function testMoveNonExisting(): void
 	{
 		$this->expectException(GlobalException::class);
 		$this->expectExceptionMessage('could not be moved');
@@ -559,10 +437,7 @@ class FileTest extends TestCase
 		$file->move(static::TMP . '/b.txt');
 	}
 
-	/**
-	 * @covers ::move
-	 */
-	public function testMoveFail()
+	public function testMoveFail(): void
 	{
 		$this->expectException(GlobalException::class);
 		$this->expectExceptionMessage('could not be moved');
@@ -572,19 +447,13 @@ class FileTest extends TestCase
 		$file->move(static::TMP . '/moved.txt');
 	}
 
-	/**
-	 * @covers ::name
-	 */
-	public function testName()
+	public function testName(): void
 	{
 		$file = $this->_file();
 		$this->assertSame('test', $file->name());
 	}
 
-	/**
-	 * @covers ::niceSize
-	 */
-	public function testNiceSize()
+	public function testNiceSize(): void
 	{
 		// existing file
 		$file = $this->_file('test.js');
@@ -595,28 +464,19 @@ class FileTest extends TestCase
 		$this->assertSame('0 KB', $file->niceSize());
 	}
 
-	/**
-	 * @covers ::read
-	 */
-	public function testRead()
+	public function testRead(): void
 	{
 		$file = $this->_file();
 		$this->assertSame(file_get_contents($file->root()), $file->read());
 	}
 
-	/**
-	 * @covers ::read
-	 */
-	public function testReadNotExist()
+	public function testReadNotExist(): void
 	{
 		$file = $this->_file('missing.txt');
 		$this->assertFalse($file->read());
 	}
 
-	/**
-	 * @covers ::rename
-	 */
-	public function testRename()
+	public function testRename(): void
 	{
 		$file = new File(static::TMP . '/test.js');
 		$file->write('test');
@@ -626,10 +486,7 @@ class FileTest extends TestCase
 		$this->assertSame('awesome', $renamed->name());
 	}
 
-	/**
-	 * @covers ::rename
-	 */
-	public function testRenameFail()
+	public function testRenameFail(): void
 	{
 		$this->expectException(GlobalException::class);
 		$this->expectExceptionMessage('The file: "' . static::TMP . '/test.js" could not be renamed to: "awesome"');
@@ -639,10 +496,7 @@ class FileTest extends TestCase
 		$renamed = $file->rename('awesome');
 	}
 
-	/**
-	 * @covers ::rename
-	 */
-	public function testRenameSameRoot()
+	public function testRenameSameRoot(): void
 	{
 		$file = new File(static::TMP . '/test.txt');
 		$file->write('test');
@@ -652,21 +506,14 @@ class FileTest extends TestCase
 		$this->assertSame(static::TMP . '/test.txt', $file->root());
 	}
 
-	/**
-	 * @covers ::root
-	 * @covers ::realpath
-	 */
-	public function testRoot()
+	public function testRoot(): void
 	{
 		$file = $this->_file();
 		$this->assertSame(static::TMP . '/test.js', $file->root());
 		$this->assertSame(static::TMP . '/test.js', $file->realpath());
 	}
 
-	/**
-	 * @covers ::sanitizeContents
-	 */
-	public function testSanitizeContentsValid()
+	public function testSanitizeContentsValid(): void
 	{
 		$fixture = static::TMP . '/clean.svg';
 		$tmp     = static::TMP . '/clean.svg';
@@ -680,10 +527,7 @@ class FileTest extends TestCase
 		$this->assertFileEquals($fixture, $tmp);
 	}
 
-	/**
-	 * @covers ::sanitizeContents
-	 */
-	public function testSanitizeContentsWrongType()
+	public function testSanitizeContentsWrongType(): void
 	{
 		$fixture = static::TMP . '/real.svg';
 		$tmp     = static::TMP . '/real.svg';
@@ -695,10 +539,7 @@ class FileTest extends TestCase
 		$this->assertFileEquals(static::TMP . '/real.sanitized.svg', $tmp);
 	}
 
-	/**
-	 * @covers ::sanitizeContents
-	 */
-	public function testSanitizeContentsMissingHandler()
+	public function testSanitizeContentsMissingHandler(): void
 	{
 		$file = new File(static::TMP . '/test.js');
 
@@ -712,29 +553,19 @@ class FileTest extends TestCase
 		$file->sanitizeContents();
 	}
 
-	/**
-	 * @covers ::size
-	 */
-	public function testSize()
+	public function testSize(): void
 	{
 		$file = $this->_file('test.js');
 		$this->assertSame(14, $file->size());
 	}
 
-	/**
-	 * @covers ::sha1
-	 */
-	public function testSha1()
+	public function testSha1(): void
 	{
 		$file = $this->_file('test.js');
 		$this->assertSame('25f2d6df4f2a30f29f6f80da1e95011044b0b8f7', $file->sha1());
 	}
 
-	/**
-	 * @covers ::toArray
-	 * @covers ::__debugInfo
-	 */
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$file = $this->_file('blank.pdf');
 		$this->assertSame('blank.pdf', $file->toArray()['filename']);
@@ -744,20 +575,14 @@ class FileTest extends TestCase
 		$this->assertSame($file->toArray(), $file->__debugInfo());
 	}
 
-	/**
-	 * @covers ::toJson
-	 */
-	public function testToJson()
+	public function testToJson(): void
 	{
 		$file = $this->_file();
 		$this->assertIsString($json = $file->toJson());
 		$this->assertSame('test.js', json_decode($json)->filename);
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
-	public function testToString()
+	public function testToString(): void
 	{
 		$file = new File([
 			'root' => static::TMP . '/blank.pdf',
@@ -780,28 +605,19 @@ class FileTest extends TestCase
 		$this->assertSame('', $file->__toString());
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testType()
+	public function testType(): void
 	{
 		$file = $this->_file();
 		$this->assertSame('code', $file->type());
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeUnknown()
+	public function testTypeUnknown(): void
 	{
 		$file = $this->_file('test.kirby');
 		$this->assertNull($file->type());
 	}
 
-	/**
-	 * @covers ::validateContents
-	 */
-	public function testValidateContentsValid()
+	public function testValidateContentsValid(): void
 	{
 		$file = new File(static::TMP . '/real.svg');
 		$this->assertNull($file->validateContents());
@@ -809,10 +625,7 @@ class FileTest extends TestCase
 		$this->assertNull($file->validateContents(false));
 	}
 
-	/**
-	 * @covers ::validateContents
-	 */
-	public function testValidateContentsWrongType()
+	public function testValidateContentsWrongType(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The namespace "http://www.w3.org/2000/svg" is not allowed (around line 2)');
@@ -821,10 +634,7 @@ class FileTest extends TestCase
 		$file->validateContents('xml');
 	}
 
-	/**
-	 * @covers ::validateContents
-	 */
-	public function testValidateContentsMissingHandler()
+	public function testValidateContentsMissingHandler(): void
 	{
 		$file = new File(static::TMP . '/test.js');
 
@@ -838,10 +648,7 @@ class FileTest extends TestCase
 		$file->validateContents();
 	}
 
-	/**
-	 * @covers ::write
-	 */
-	public function testWrite()
+	public function testWrite(): void
 	{
 		$root = static::TMP . '/test.txt';
 
@@ -853,10 +660,7 @@ class FileTest extends TestCase
 		$this->assertSame('test', file_get_contents($file->root()));
 	}
 
-	/**
-	 * @covers ::write
-	 */
-	public function testWriteUnwritable()
+	public function testWriteUnwritable(): void
 	{
 		$this->expectException(GlobalException::class);
 		$this->expectExceptionMessage('is not writable');
@@ -867,10 +671,7 @@ class FileTest extends TestCase
 		$file->write('kirby');
 	}
 
-	/**
-	 * @covers ::write
-	 */
-	public function testWriteFail()
+	public function testWriteFail(): void
 	{
 		$this->expectException(GlobalException::class);
 		$this->expectExceptionMessage('could not be written');

--- a/tests/Filesystem/FilenameTest.php
+++ b/tests/Filesystem/FilenameTest.php
@@ -3,16 +3,13 @@
 namespace Kirby\Filesystem;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Filesystem\Filename
- */
+#[CoversClass(Filename::class)]
 class FilenameTest extends TestCase
 {
-	/**
-	 * @covers ::attributesToArray
-	 */
-	public function testAttributesToArray()
+	public function testAttributesToArray(): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
 			'width'     => 300,
@@ -78,21 +75,15 @@ class FilenameTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::attributesToString
-	 * @dataProvider attributesToStringProvider
-	 */
-	public function testAttributesToString($expected, $options)
+	#[DataProvider('attributesToStringProvider')]
+	public function testAttributesToString($expected, $options): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', $options);
 
 		$this->assertSame($expected, $name->attributesToString('-'));
 	}
 
-	/**
-	 * @covers ::attributesToString
-	 */
-	public function testAttributesToStringWithoutAttrs()
+	public function testAttributesToStringWithoutAttrs(): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', []);
 		$this->assertSame('', $name->attributesToString());
@@ -109,11 +100,8 @@ class FilenameTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::blur
-	 * @dataProvider blurOptionProvider
-	 */
-	public function testBlur($value, $expected)
+	#[DataProvider('blurOptionProvider')]
+	public function testBlur($value, $expected): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
 			'blur' => $value
@@ -137,11 +125,8 @@ class FilenameTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::crop
-	 * @dataProvider cropAnchorProvider
-	 */
-	public function testCrop($anchor, $expected)
+	#[DataProvider('cropAnchorProvider')]
+	public function testCrop($anchor, $expected): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
 			'crop' => $anchor
@@ -150,19 +135,13 @@ class FilenameTest extends TestCase
 		$this->assertSame($expected, $name->crop());
 	}
 
-	/**
-	 * @covers ::crop
-	 */
-	public function testCropEmpty()
+	public function testCropEmpty(): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}');
 		$this->assertFalse($name->crop());
 	}
 
-	/**
-	 * @covers ::crop
-	 */
-	public function testCropDisabled()
+	public function testCropDisabled(): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
 			'crop' => false
@@ -171,10 +150,7 @@ class FilenameTest extends TestCase
 		$this->assertFalse($name->crop());
 	}
 
-	/**
-	 * @covers ::crop
-	 */
-	public function testCropCustom()
+	public function testCropCustom(): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
 			'crop' => 'something'
@@ -183,10 +159,7 @@ class FilenameTest extends TestCase
 		$this->assertSame('something', $name->crop());
 	}
 
-	/**
-	 * @covers ::dimensions
-	 */
-	public function testDimensions()
+	public function testDimensions(): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', $dimensions = [
 			'width'  => 300,
@@ -196,20 +169,14 @@ class FilenameTest extends TestCase
 		$this->assertSame($dimensions, $name->dimensions());
 	}
 
-	/**
-	 * @covers ::dimensions
-	 */
-	public function testDimensionsEmpty()
+	public function testDimensionsEmpty(): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}');
 
 		$this->assertSame([], $name->dimensions());
 	}
 
-	/**
-	 * @covers ::dimensions
-	 */
-	public function testDimensionsWithoutWidth()
+	public function testDimensionsWithoutWidth(): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
 			'height' => 300
@@ -221,10 +188,7 @@ class FilenameTest extends TestCase
 		], $name->dimensions());
 	}
 
-	/**
-	 * @covers ::dimensions
-	 */
-	public function testDimensionsWithoutHeight()
+	public function testDimensionsWithoutHeight(): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
 			'width' => 300
@@ -236,28 +200,19 @@ class FilenameTest extends TestCase
 		], $name->dimensions());
 	}
 
-	/**
-	 * @covers ::extension
-	 */
-	public function testExtension()
+	public function testExtension(): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}');
 		$this->assertSame('jpg', $name->extension());
 	}
 
-	/**
-	 * @covers ::extension
-	 */
-	public function testExtensionUppercase()
+	public function testExtensionUppercase(): void
 	{
 		$name = new Filename('/test/some-file.JPG', '{{ name }}.{{ extension }}');
 		$this->assertSame('jpg', $name->extension());
 	}
 
-	/**
-	 * @covers ::extension
-	 */
-	public function testExtensionJpeg()
+	public function testExtensionJpeg(): void
 	{
 		$name = new Filename('/test/some-file.jpeg', '{{ name }}.{{ extension }}');
 		$this->assertSame('jpg', $name->extension());
@@ -275,11 +230,8 @@ class FilenameTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::grayscale
-	 * @dataProvider grayscaleOptionProvider
-	 */
-	public function testGrayscale($prop, $value, $expected)
+	#[DataProvider('grayscaleOptionProvider')]
+	public function testGrayscale($prop, $value, $expected): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}', [
 			$prop => $value
@@ -288,31 +240,19 @@ class FilenameTest extends TestCase
 		$this->assertSame($expected, $name->grayscale());
 	}
 
-	/**
-	 * @covers ::name
-	 * @covers ::sanitizeName
-	 */
-	public function testName()
+	public function testName(): void
 	{
 		$name = new Filename('/var/www/some-file.jpg', '{{ name }}.{{ extension }}');
 		$this->assertSame('some-file', $name->name());
 	}
 
-	/**
-	 * @covers ::name
-	 * @covers ::sanitizeName
-	 */
-	public function testNameSanitization()
+	public function testNameSanitization(): void
 	{
 		$name = new Filename('/var/www/söme file.jpg', '{{ name }}.{{ extension }}');
 		$this->assertSame('some-file', $name->name());
 	}
 
-	/**
-	 * @covers ::name
-	 * @covers ::sanitizeName
-	 */
-	public function testNameSanitizationWithLanguageRules()
+	public function testNameSanitizationWithLanguageRules(): void
 	{
 		$name = new Filename(
 			filename: '/var/www/안녕하세요.pdf',
@@ -334,11 +274,8 @@ class FilenameTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::quality
-	 * @dataProvider qualityOptionProvider
-	 */
-	public function testQuality($value, $expected)
+	#[DataProvider('qualityOptionProvider')]
+	public function testQuality($value, $expected): void
 	{
 		$name = new Filename('/test/some-file.jpg', 'some-file.jpg', [
 			'quality' => $value
@@ -347,12 +284,8 @@ class FilenameTest extends TestCase
 		$this->assertSame($expected, $name->quality());
 	}
 
-	/**
-	 * @covers ::toString
-	 * @covers ::__toString
-	 * @dataProvider attributesToStringProvider
-	 */
-	public function testToString($expected, $attributes)
+	#[DataProvider('attributesToStringProvider')]
+	public function testToString($expected, $attributes): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}{{ attributes }}.{{ extension }}', $attributes);
 
@@ -361,10 +294,9 @@ class FilenameTest extends TestCase
 	}
 
 	/**
-	 * @covers ::toString
 	 * @ocvers ::__toString
 	 */
-	public function testToStringWithFalsyAttributes()
+	public function testToStringWithFalsyAttributes(): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}{{ attributes }}.{{ extension }}', [
 			'width'     => false,
@@ -381,10 +313,9 @@ class FilenameTest extends TestCase
 	}
 
 	/**
-	 * @covers ::toString
 	 * @ocvers ::__toString
 	 */
-	public function testToStringWithoutAttributes()
+	public function testToStringWithoutAttributes(): void
 	{
 		$name = new Filename('/test/some-file.jpg', '{{ name }}.{{ extension }}');
 		$this->assertSame('some-file.jpg', $name->toString());

--- a/tests/Filesystem/IsFileTest.php
+++ b/tests/Filesystem/IsFileTest.php
@@ -6,6 +6,7 @@ use Kirby\Cms\App;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\Image\Image;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class AFile
 {
@@ -14,9 +15,7 @@ class AFile
 	public string $foo = 'bar';
 }
 
-/**
- * @coversDefaultClass \Kirby\Filesystem\IsFile
- */
+#[CoversClass(IsFile::class)]
 class IsFileTest extends TestCase
 {
 	protected function _asset($file = 'blank.pdf')
@@ -27,12 +26,7 @@ class IsFileTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::root
-	 * @covers ::url
-	 */
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$asset = $this->_asset();
 
@@ -40,10 +34,7 @@ class IsFileTest extends TestCase
 		$this->assertSame('https://foo.bar/blank.pdf', $asset->url());
 	}
 
-	/**
-	 * @covers ::asset
-	 */
-	public function testAsset()
+	public function testAsset(): void
 	{
 		$asset = $this->_asset();
 		$file = $asset->asset();
@@ -52,10 +43,7 @@ class IsFileTest extends TestCase
 		$this->assertSame($file, $asset->asset());
 	}
 
-	/**
-	 * @covers ::asset
-	 */
-	public function testAssetStringProp()
+	public function testAssetStringProp(): void
 	{
 		$asset = $this->_asset();
 		$file =  $asset->asset('/dev/null/blank.pdf');
@@ -64,46 +52,31 @@ class IsFileTest extends TestCase
 		$this->assertSame('/dev/null/blank.pdf', $file->root());
 	}
 
-	/**
-	 * @covers ::asset
-	 */
-	public function testAssetImage()
+	public function testAssetImage(): void
 	{
 		$asset = $this->_asset('cat.jpg');
 		$this->assertInstanceOf(Image::class, $asset->asset());
 	}
 
-	/**
-	 * @covers ::kirby
-	 */
-	public function testKirby()
+	public function testKirby(): void
 	{
 		$asset = $this->_asset();
 		$this->assertInstanceOf(App::class, $asset->kirby());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
-	public function testCall()
+	public function testCall(): void
 	{
 		$asset = $this->_asset();
 		$this->assertSame('pdf', $asset->extension());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
-	public function testCallPublicProperty()
+	public function testCallPublicProperty(): void
 	{
 		$asset = $this->_asset();
 		$this->assertSame('bar', $asset->foo());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
-	public function testCallNotExisting()
+	public function testCallNotExisting(): void
 	{
 		$asset = $this->_asset();
 		$this->expectException(BadMethodCallException::class);

--- a/tests/Filesystem/MimeTest.php
+++ b/tests/Filesystem/MimeTest.php
@@ -3,82 +3,57 @@
 namespace Kirby\Filesystem;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Filesystem\Mime
- */
+#[CoversClass(Mime::class)]
 class MimeTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/mime';
 
-	/**
-	 * @covers ::fix
-	 */
-	public function testFixCss()
+	public function testFixCss(): void
 	{
 		$this->assertSame('text/css', Mime::fix('something.css', 'text/x-asm', 'css'));
 		$this->assertSame('text/css', Mime::fix('something.css', 'text/plain', 'css'));
 	}
 
-	/**
-	 * @covers ::fix
-	 */
-	public function testFixMjs()
+	public function testFixMjs(): void
 	{
 		$this->assertSame('text/javascript', Mime::fix('something.mjs', 'text/x-java', 'mjs'));
 		$this->assertSame('text/javascript', Mime::fix('something.mjs', 'text/plain', 'mjs'));
 	}
 
-	/**
-	 * @covers ::fix
-	 */
-	public function testFixSvg()
+	public function testFixSvg(): void
 	{
 		$this->assertSame('image/svg+xml', Mime::fix('something.svg', 'image/svg', 'svg'));
 		$this->assertSame('image/svg+xml', Mime::fix(static::FIXTURES . '/optimized.svg', 'text/html', 'svg'));
 		$this->assertSame('image/svg+xml', Mime::fix(static::FIXTURES . '/unoptimized.svg', 'text/html', 'svg'));
 	}
 
-	/**
-	 * @covers ::fromExtension
-	 */
-	public function testFromExtension()
+	public function testFromExtension(): void
 	{
 		$mime = Mime::fromExtension('jpg');
 		$this->assertSame('image/jpeg', $mime);
 	}
 
-	/**
-	 * @covers ::fromMimeContentType
-	 */
-	public function testFromMimeContentType()
+	public function testFromMimeContentType(): void
 	{
 		$mime = Mime::fromMimeContentType(__FILE__);
 		$this->assertSame('text/x-php', $mime);
 	}
 
-	/**
-	 * @covers ::fromSvg
-	 */
-	public function testFromSvg()
+	public function testFromSvg(): void
 	{
 		$mime = Mime::fromSvg(static::FIXTURES . '/optimized.svg');
 		$this->assertSame('image/svg+xml', $mime);
 	}
 
-	/**
-	 * @covers ::fromSvg
-	 */
-	public function testFromSvgNonExistingFile()
+	public function testFromSvgNonExistingFile(): void
 	{
 		$mime = Mime::fromSvg(__DIR__ . '/imaginary.svg');
 		$this->assertFalse($mime);
 	}
 
-	/**
-	 * @covers ::isAccepted
-	 */
-	public function testIsAccepted()
+	public function testIsAccepted(): void
 	{
 		$pattern = 'text/html,text/plain;q=0.8,application/*;q=0.7';
 
@@ -90,10 +65,7 @@ class MimeTest extends TestCase
 		$this->assertFalse(Mime::isAccepted('text/xml', $pattern));
 	}
 
-	/**
-	 * @covers ::matches
-	 */
-	public function testMatches()
+	public function testMatches(): void
 	{
 		$this->assertTrue(Mime::matches('text/plain', 'text/plain'));
 		$this->assertTrue(Mime::matches('text/plain', 'text/*'));
@@ -108,10 +80,7 @@ class MimeTest extends TestCase
 		$this->assertFalse(Mime::matches('text/xml', '*/plain'));
 	}
 
-	/**
-	 * @covers ::toExtension
-	 */
-	public function testToExtension()
+	public function testToExtension(): void
 	{
 		$extension = Mime::toExtension('image/jpeg');
 		$this->assertSame('jpg', $extension);
@@ -120,10 +89,7 @@ class MimeTest extends TestCase
 		$this->assertSame('css', $extensions);
 	}
 
-	/**
-	 * @covers ::toExtensions
-	 */
-	public function testToExtensions()
+	public function testToExtensions(): void
 	{
 		$extensions = Mime::toExtensions('image/jpeg');
 		$this->assertSame(['jpg', 'jpeg', 'jpe'], $extensions);
@@ -132,10 +98,7 @@ class MimeTest extends TestCase
 		$this->assertSame(['css'], $extensions);
 	}
 
-	/**
-	 * @covers ::toExtensions
-	 */
-	public function testToExtensionsMatchWildcards()
+	public function testToExtensionsMatchWildcards(): void
 	{
 		// matchWildcards: false (default value)
 		$extensions = Mime::toExtensions('image/*');
@@ -159,37 +122,25 @@ class MimeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeWithOptimizedSvg()
+	public function testTypeWithOptimizedSvg(): void
 	{
 		$mime = Mime::type(static::FIXTURES . '/optimized.svg');
 		$this->assertSame('image/svg+xml', $mime);
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeWithUnoptimizedSvg()
+	public function testTypeWithUnoptimizedSvg(): void
 	{
 		$mime = Mime::type(static::FIXTURES . '/unoptimized.svg');
 		$this->assertSame('image/svg+xml', $mime);
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeWithJson()
+	public function testTypeWithJson(): void
 	{
 		$mime = Mime::type(static::FIXTURES . '/something.json');
 		$this->assertSame('application/json', $mime);
 	}
 
-	/**
-	 * @covers ::types
-	 */
-	public function testTypes()
+	public function testTypes(): void
 	{
 		$this->assertSame(Mime::$types, Mime::types());
 	}


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Filesystem',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
