### PR TITLE
test: Use PHPUnit attributes for `Kirby\Image`

### DIFF
--- a/tests/Image/CameraTest.php
+++ b/tests/Image/CameraTest.php
@@ -3,7 +3,9 @@
 namespace Kirby\Image;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Camera::class)]
 class CameraTest extends TestCase
 {
 	protected function _exif(): array
@@ -14,7 +16,7 @@ class CameraTest extends TestCase
 		];
 	}
 
-	public function testSetup()
+	public function testSetup(): void
 	{
 		$exif   = $this->_exif();
 		$camera = new Camera($exif);
@@ -22,7 +24,7 @@ class CameraTest extends TestCase
 		$this->assertSame($exif['Model'], $camera->model());
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$exif   = $this->_exif();
 		$camera = new Camera($exif);
@@ -30,7 +32,7 @@ class CameraTest extends TestCase
 		$this->assertSame(array_change_key_case($exif), $camera->__debugInfo());
 	}
 
-	public function testToString()
+	public function testToString(): void
 	{
 		$exif   = $this->_exif();
 		$camera = new Camera($exif);

--- a/tests/Image/Darkroom/GdLibTest.php
+++ b/tests/Image/Darkroom/GdLibTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Image\Darkroom;
 use claviska\SimpleImage;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionMethod;
 
 class SimpleImageMock extends SimpleImage
@@ -19,9 +20,7 @@ class SimpleImageMock extends SimpleImage
 }
 
 
-/**
- * @coversDefaultClass \Kirby\Image\Darkroom\GdLib
- */
+#[CoversClass(GdLib::class)]
 class GdLibTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/../fixtures/image';
@@ -37,7 +36,7 @@ class GdLibTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testProcess()
+	public function testProcess(): void
 	{
 		$gd = new GdLib();
 
@@ -59,20 +58,14 @@ class GdLibTest extends TestCase
 		], $gd->process($file));
 	}
 
-	/**
-	 * @covers ::mime
-	 */
-	public function testProcessWithFormat()
+	public function testProcessWithFormat(): void
 	{
 		$gd = new GdLib(['format' => 'webp']);
 		copy(static::FIXTURES . '/cat.jpg', $file = static::TMP . '/cat.jpg');
 		$this->assertSame('webp', $gd->process($file)['format']);
 	}
 
-	/**
-	 * @covers ::sharpen
-	 */
-	public function testSharpen()
+	public function testSharpen(): void
 	{
 		$gd = new GdLib();
 
@@ -88,10 +81,7 @@ class GdLibTest extends TestCase
 		$this->assertSame(50, $result->sharpen);
 	}
 
-	/**
-	 * @covers ::sharpen
-	 */
-	public function testSharpenWithoutValue()
+	public function testSharpenWithoutValue(): void
 	{
 		$gd = new GdLib();
 

--- a/tests/Image/Darkroom/ImageMagickTest.php
+++ b/tests/Image/Darkroom/ImageMagickTest.php
@@ -5,11 +5,11 @@ namespace Kirby\Image\Darkroom;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 use Kirby\Toolkit\F;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionMethod;
 
-/**
- * @coversDefaultClass \Kirby\Image\Darkroom\ImageMagick
- */
+#[CoversClass(ImageMagick::class)]
 class ImageMagickTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/../fixtures/image';
@@ -25,7 +25,7 @@ class ImageMagickTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testProcess()
+	public function testProcess(): void
 	{
 		$im = new ImageMagick();
 
@@ -50,10 +50,7 @@ class ImageMagickTest extends TestCase
 		], $im->process($file));
 	}
 
-	/**
-	 * @covers ::sharpen
-	 */
-	public function testSharpen()
+	public function testSharpen(): void
 	{
 		$im = new ImageMagick();
 
@@ -67,10 +64,7 @@ class ImageMagickTest extends TestCase
 		$this->assertSame("-sharpen '0x0.5'", $result);
 	}
 
-	/**
-	 * @covers ::sharpen
-	 */
-	public function testSharpenWithoutValue()
+	public function testSharpenWithoutValue(): void
 	{
 		$im = new ImageMagick();
 
@@ -84,10 +78,7 @@ class ImageMagickTest extends TestCase
 		$this->assertNull($result);
 	}
 
-	/**
-	 * @covers ::save
-	 */
-	public function testSaveWithFormat()
+	public function testSaveWithFormat(): void
 	{
 		$im = new ImageMagick(['format' => 'webp']);
 
@@ -97,10 +88,8 @@ class ImageMagickTest extends TestCase
 		$this->assertTrue(F::exists($webp));
 	}
 
-	/**
-	 * @dataProvider keepColorProfileStripMetaProvider
-	 */
-	public function testKeepColorProfileStripMeta(string $basename, bool $crop)
+	#[DataProvider('keepColorProfileStripMetaProvider')]
+	public function testKeepColorProfileStripMeta(string $basename, bool $crop): void
 	{
 		$im = new ImageMagick([
 			'bin' => 'convert',

--- a/tests/Image/DarkroomTest.php
+++ b/tests/Image/DarkroomTest.php
@@ -3,8 +3,12 @@
 namespace Kirby\Image;
 
 use Exception;
+use Kirby\Image\Darkroom\GdLib;
+use Kirby\Image\Darkroom\ImageMagick;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Darkroom::class)]
 class DarkroomTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -18,16 +22,16 @@ class DarkroomTest extends TestCase
 		return static::FIXTURES . '/image/cat.jpg';
 	}
 
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$instance = Darkroom::factory('gd');
-		$this->assertInstanceOf(Darkroom\GdLib::class, $instance);
+		$this->assertInstanceOf(GdLib::class, $instance);
 
 		$instance = Darkroom::factory('im');
-		$this->assertInstanceOf(Darkroom\ImageMagick::class, $instance);
+		$this->assertInstanceOf(ImageMagick::class, $instance);
 	}
 
-	public function testFactoryWithInvalidType()
+	public function testFactoryWithInvalidType(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Invalid Darkroom type');
@@ -35,7 +39,7 @@ class DarkroomTest extends TestCase
 		Darkroom::factory('does-not-exist');
 	}
 
-	public function testCropWithoutPosition()
+	public function testCropWithoutPosition(): void
 	{
 		$darkroom = new Darkroom();
 		$options  = $darkroom->preprocess($this->file(), [
@@ -46,7 +50,7 @@ class DarkroomTest extends TestCase
 		$this->assertSame('center', $options['crop']);
 	}
 
-	public function testBlurWithoutPosition()
+	public function testBlurWithoutPosition(): void
 	{
 		$darkroom = new Darkroom();
 		$options  = $darkroom->preprocess($this->file(), [
@@ -56,7 +60,7 @@ class DarkroomTest extends TestCase
 		$this->assertSame(10, $options['blur']);
 	}
 
-	public function testQualityWithoutValue()
+	public function testQualityWithoutValue(): void
 	{
 		$darkroom = new Darkroom();
 		$options  = $darkroom->preprocess($this->file(), [
@@ -66,7 +70,7 @@ class DarkroomTest extends TestCase
 		$this->assertSame(90, $options['quality']);
 	}
 
-	public function testSharpenWithoutValue()
+	public function testSharpenWithoutValue(): void
 	{
 		$darkroom = new Darkroom();
 		$options  = $darkroom->preprocess($this->file(), [
@@ -77,7 +81,7 @@ class DarkroomTest extends TestCase
 		$this->assertSame(50, $options['sharpen']);
 	}
 
-	public function testDefaults()
+	public function testDefaults(): void
 	{
 		$darkroom = new Darkroom();
 		$options  = $darkroom->preprocess('/dev/null');
@@ -90,7 +94,7 @@ class DarkroomTest extends TestCase
 		$this->assertSame(0, $options['width']);
 	}
 
-	public function testGlobalOptions()
+	public function testGlobalOptions(): void
 	{
 		$darkroom = new Darkroom([
 			'quality' => 20
@@ -101,7 +105,7 @@ class DarkroomTest extends TestCase
 		$this->assertSame(20, $options['quality']);
 	}
 
-	public function testPassedOptions()
+	public function testPassedOptions(): void
 	{
 		$darkroom = new Darkroom([
 			'quality' => 20
@@ -114,7 +118,7 @@ class DarkroomTest extends TestCase
 		$this->assertSame(30, $options['quality']);
 	}
 
-	public function testProcess()
+	public function testProcess(): void
 	{
 		$darkroom = new Darkroom([
 			'quality' => 20
@@ -127,7 +131,7 @@ class DarkroomTest extends TestCase
 		$this->assertSame(30, $options['quality']);
 	}
 
-	public function testGrayscaleFixes()
+	public function testGrayscaleFixes(): void
 	{
 		$darkroom = new Darkroom();
 

--- a/tests/Image/DimensionsTest.php
+++ b/tests/Image/DimensionsTest.php
@@ -3,30 +3,22 @@
 namespace Kirby\Image;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Image\Dimensions
- */
+#[CoversClass(Dimensions::class)]
 class DimensionsTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::width
-	 * @covers ::height
-	 */
-	public function testDimensions()
+	public function testDimensions(): void
 	{
 		$dimensions = new Dimensions(1200, 768);
 		$this->assertSame(1200, $dimensions->width());
 		$this->assertSame(768, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::crop
-	 */
-	public function testCrop()
+	public function testCrop(): void
 	{
 		$dimensions = new Dimensions(1200, 768);
 		$dimensions->crop(1000, 500);
@@ -39,10 +31,7 @@ class DimensionsTest extends TestCase
 		$this->assertSame(500, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::fit
-	 */
-	public function testFit()
+	public function testFit(): void
 	{
 		// zero dimensions
 		$dimensions = new Dimensions(0, 0);
@@ -75,10 +64,7 @@ class DimensionsTest extends TestCase
 		$this->assertSame(200, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::fit
-	 */
-	public function testFitForce()
+	public function testFitForce(): void
 	{
 		// wider than tall
 		$dimensions = new Dimensions(1200, 768);
@@ -93,10 +79,7 @@ class DimensionsTest extends TestCase
 		$this->assertSame(2000, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::fitWidth
-	 */
-	public function testFitWidth()
+	public function testFitWidth(): void
 	{
 		$dimensions = new Dimensions(1200, 768);
 		$dimensions->fitWidth(0);
@@ -121,10 +104,7 @@ class DimensionsTest extends TestCase
 		$this->assertSame(1280, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::fitHeight
-	 */
-	public function testFitHeight()
+	public function testFitHeight(): void
 	{
 		$dimensions = new Dimensions(1200, 768);
 		$dimensions->fitHeight(0);
@@ -149,10 +129,7 @@ class DimensionsTest extends TestCase
 		$this->assertSame(2000, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::fitWidthAndHeight
-	 */
-	public function testFitWidthAndHeight()
+	public function testFitWidthAndHeight(): void
 	{
 		$dimensions = new Dimensions(1200, 768);
 		$dimensions->fitWidthAndHeight(1000, 500);
@@ -165,10 +142,7 @@ class DimensionsTest extends TestCase
 		$this->assertSame(781, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::forImage
-	 */
-	public function testForImage()
+	public function testForImage(): void
 	{
 		$image = new Image([
 			'root' => __DIR__ . '/fixtures/image/onigiri-adobe-rgb-gps.jpg'
@@ -220,15 +194,12 @@ class DimensionsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider imageOrientationProvider
-	 * @covers ::forImage
-	 */
+	#[DataProvider('imageOrientationProvider')]
 	public function testForImageOrientation(
 		string $filename,
 		int $width,
 		int $height
-	) {
+	): void {
 		$image = new Image([
 			'root' => __DIR__ . '/fixtures/orientation/' . $filename
 		]);
@@ -238,10 +209,7 @@ class DimensionsTest extends TestCase
 		$this->assertSame($height, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::forSvg
-	 */
-	public function testForSvg()
+	public function testForSvg(): void
 	{
 		$dimensions = Dimensions::forSvg(static::FIXTURES . '/dimensions/circle.svg');
 		$this->assertSame(50, $dimensions->width());
@@ -256,10 +224,7 @@ class DimensionsTest extends TestCase
 		$this->assertSame(25, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::orientation
-	 */
-	public function testOrientation()
+	public function testOrientation(): void
 	{
 		$dimensions = new Dimensions(1200, 768);
 		$this->assertSame('landscape', $dimensions->orientation());
@@ -275,10 +240,7 @@ class DimensionsTest extends TestCase
 		$this->assertFalse($dimensions->orientation());
 	}
 
-	/**
-	 * @covers ::ratio
-	 */
-	public function testRatio()
+	public function testRatio(): void
 	{
 		$dimensions = new Dimensions(1200, 768);
 		$this->assertSame(1.5625, $dimensions->ratio());
@@ -290,10 +252,7 @@ class DimensionsTest extends TestCase
 		$this->assertSame(0.0, $dimensions->ratio());
 	}
 
-	/**
-	 * @covers ::resize
-	 */
-	public function testResize()
+	public function testResize(): void
 	{
 		$dimensions = new Dimensions(1200, 768);
 		$dimensions->resize(2000, 800, true);
@@ -301,11 +260,7 @@ class DimensionsTest extends TestCase
 		$this->assertSame(800, $dimensions->height());
 	}
 
-	/**
-	 * @covers ::toArray
-	 * @covers ::__debugInfo
-	 */
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$dimensions = new Dimensions(1200, 768);
 		$array = [
@@ -318,10 +273,7 @@ class DimensionsTest extends TestCase
 		$this->assertSame($array, $dimensions->__debugInfo());
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
-	public function testToString()
+	public function testToString(): void
 	{
 		$dimensions = new Dimensions(1200, 768);
 		$this->assertSame('1200 × 768', (string)$dimensions);

--- a/tests/Image/ExifTest.php
+++ b/tests/Image/ExifTest.php
@@ -2,8 +2,10 @@
 
 namespace Kirby\Image;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClass;
 
+#[CoversClass(Exif::class)]
 class ExifTest extends TestCase
 {
 	protected function _exif($filename = 'image/cat.jpg')
@@ -12,7 +14,7 @@ class ExifTest extends TestCase
 		return new Exif($image);
 	}
 
-	public function testData()
+	public function testData(): void
 	{
 		$exif  = $this->_exif();
 		$this->assertSame([
@@ -31,7 +33,7 @@ class ExifTest extends TestCase
 		], $exif->data());
 	}
 
-	public function testCamera()
+	public function testCamera(): void
 	{
 		$exif = $this->_exif();
 		$this->assertInstanceOf(Camera::class, $exif->camera());
@@ -40,7 +42,7 @@ class ExifTest extends TestCase
 		$this->assertInstanceOf(Camera::class, $exif->camera());
 	}
 
-	public function testLocation()
+	public function testLocation(): void
 	{
 		$exif = $this->_exif();
 		$this->assertInstanceOf(Location::class, $exif->location());
@@ -49,49 +51,49 @@ class ExifTest extends TestCase
 		$this->assertInstanceOf(Location::class, $exif->location());
 	}
 
-	public function testTimestamp()
+	public function testTimestamp(): void
 	{
 		$exif  = $this->_exif();
 		$this->assertSame((string)exif_read_data(static::FIXTURES . '/image/cat.jpg')['FileDateTime'], $exif->timestamp());
 	}
 
-	public function testExposure()
+	public function testExposure(): void
 	{
 		$exif  = $this->_exif();
 		$this->assertNull($exif->exposure());
 	}
 
-	public function testAperture()
+	public function testAperture(): void
 	{
 		$exif  = $this->_exif();
 		$this->assertNull($exif->aperture());
 	}
 
-	public function testIso()
+	public function testIso(): void
 	{
 		$exif  = $this->_exif();
 		$this->assertNull($exif->iso());
 	}
 
-	public function testIsColor()
+	public function testIsColor(): void
 	{
 		$exif  = $this->_exif();
 		$this->assertTrue($exif->isColor());
 	}
 
-	public function testIsBw()
+	public function testIsBw(): void
 	{
 		$exif  = $this->_exif();
 		$this->assertFalse($exif->isBw());
 	}
 
-	public function testFocalLength()
+	public function testFocalLength(): void
 	{
 		$exif  = $this->_exif();
 		$this->assertNull($exif->focalLength());
 	}
 
-	public function testOrientation()
+	public function testOrientation(): void
 	{
 		$exif  = $this->_exif('orientation/Landscape_0.jpg');
 		$this->assertSame(0, $exif->orientation());
@@ -100,7 +102,7 @@ class ExifTest extends TestCase
 		$this->assertSame(6, $exif->orientation());
 	}
 
-	public function testParseTimestampDateTimeOriginal()
+	public function testParseTimestampDateTimeOriginal(): void
 	{
 		$exif = $this->_exif();
 
@@ -119,7 +121,7 @@ class ExifTest extends TestCase
 		$this->assertSame((string)strtotime('11.12.2016 11:13:14'), $parse->invoke($exif));
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$exif  = $this->_exif();
 		$this->assertIsArray($exif->toArray());

--- a/tests/Image/FocusTest.php
+++ b/tests/Image/FocusTest.php
@@ -3,16 +3,12 @@
 namespace Kirby\Image;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Image\Focus
- */
+#[CoversClass(Focus::class)]
 class FocusTest extends TestCase
 {
-	/**
-	 * @covers ::coords
-	 */
-	public function testCoords()
+	public function testCoords(): void
 	{
 		$options = [
 			'sourceWidth'  => 1200,
@@ -99,10 +95,7 @@ class FocusTest extends TestCase
 		$this->assertSame(906, $focus['y2']);
 	}
 
-	/**
-	 * @covers ::coords
-	 */
-	public function testCoordsSameRatio()
+	public function testCoordsSameRatio(): void
 	{
 		$options = [
 			'sourceWidth'  => 1200,
@@ -115,10 +108,7 @@ class FocusTest extends TestCase
 		$this->assertNull(Focus::coords(...$options));
 	}
 
-	/**
-	 * @covers ::parse
-	 */
-	public function testParse()
+	public function testParse(): void
 	{
 		$this->assertSame([0.7, 0.3], Focus::parse('70%, 30%'));
 		$this->assertSame([0.7, 0.3], Focus::parse('70%,30%'));
@@ -129,10 +119,7 @@ class FocusTest extends TestCase
 		$this->assertSame([0.7, 0.3], Focus::parse('{"x":0.7,"y":0.3}'));
 	}
 
-	/**
-	 * @covers ::ratio
-	 */
-	public function testRatio()
+	public function testRatio(): void
 	{
 		$this->assertSame(0.5, Focus::ratio(200, 400));
 		$this->assertSame(2.0, Focus::ratio(400, 200));

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -7,10 +7,9 @@ use Kirby\Cms\Page;
 use Kirby\Exception\Exception;
 use Kirby\Exception\LogicException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Image\Image
- */
+#[CoversClass(Image::class)]
 class ImageTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -23,10 +22,7 @@ class ImageTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::dimensions
-	 */
-	public function testDimensions()
+	public function testDimensions(): void
 	{
 		// jpg
 		$file = $this->_image();
@@ -56,10 +52,7 @@ class ImageTest extends TestCase
 		$this->assertInstanceOf(Dimensions::class, $file->dimensions());
 	}
 
-	/**
-	 * @covers ::exif
-	 */
-	public function testExif()
+	public function testExif(): void
 	{
 		$file = $this->_image();
 		$this->assertInstanceOf(Exif::class, $file->exif());
@@ -67,19 +60,13 @@ class ImageTest extends TestCase
 		$this->assertInstanceOf(Exif::class, $file->exif());
 	}
 
-	/**
-	 * @covers ::height
-	 */
-	public function testHeight()
+	public function testHeight(): void
 	{
 		$file = $this->_image();
 		$this->assertSame(500, $file->height());
 	}
 
-	/**
-	 * @covers ::html
-	 */
-	public function testHtml()
+	public function testHtml(): void
 	{
 		$file = $this->_image();
 		$this->assertSame('<img alt="" src="https://foo.bar/cat.jpg">', $file->html());
@@ -99,10 +86,7 @@ class ImageTest extends TestCase
 		$this->assertSame('<img alt="Test text" src="https://foo.bar/cat.jpg">', $image->html());
 	}
 
-	/**
-	 * @covers ::html
-	 */
-	public function testHtmlWithoutUrl()
+	public function testHtmlWithoutUrl(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('Calling Image::html() requires that the URL property is not null');
@@ -110,47 +94,32 @@ class ImageTest extends TestCase
 		$file->html();
 	}
 
-	/**
-	 * @covers ::imagesize
-	 */
-	public function testImagesize()
+	public function testImagesize(): void
 	{
 		$file = $this->_image();
 		$this->assertIsArray($file->imagesize());
 		$this->assertSame(500, $file->imagesize()[0]);
 	}
 
-	/**
-	 * @covers ::isPortrait
-	 */
-	public function testIsPortrait()
+	public function testIsPortrait(): void
 	{
 		$file = $this->_image();
 		$this->assertFalse($file->isPortrait());
 	}
 
-	/**
-	 * @covers ::isLandscape
-	 */
-	public function testIsLandscape()
+	public function testIsLandscape(): void
 	{
 		$file = $this->_image();
 		$this->assertFalse($file->isLandscape());
 	}
 
-	/**
-	 * @covers ::isSquare
-	 */
-	public function testIsSquare()
+	public function testIsSquare(): void
 	{
 		$file = $this->_image();
 		$this->assertTrue($file->isSquare());
 	}
 
-	/**
-	 * @covers ::isResizable
-	 */
-	public function testIsResizable()
+	public function testIsResizable(): void
 	{
 		$file = $this->_image();
 		$this->assertTrue($file->isResizable());
@@ -159,10 +128,7 @@ class ImageTest extends TestCase
 		$this->assertFalse($file->isResizable());
 	}
 
-	/**
-	 * @covers ::isViewable
-	 */
-	public function testIsViewable()
+	public function testIsViewable(): void
 	{
 		$file = $this->_image();
 		$this->assertTrue($file->isResizable());
@@ -171,10 +137,7 @@ class ImageTest extends TestCase
 		$this->assertFalse($file->isResizable());
 	}
 
-	/**
-	 * @covers ::match
-	 */
-	public function testMatch()
+	public function testMatch(): void
 	{
 		$rules = [
 			'miMe'        => ['image/png', 'image/jpeg', 'application/pdf'],
@@ -192,10 +155,7 @@ class ImageTest extends TestCase
 		$this->assertTrue($this->_image()->match($rules));
 	}
 
-	/**
-	 * @covers ::match
-	 */
-	public function testMatchOrientationException()
+	public function testMatchOrientationException(): void
 	{
 		// Make sure i18n files are loaded
 		$kirby = kirby();
@@ -206,28 +166,19 @@ class ImageTest extends TestCase
 		$this->_image()->match(['orientation' => 'portrait']);
 	}
 
-	/**
-	 * @covers ::orientation
-	 */
-	public function testOrientation()
+	public function testOrientation(): void
 	{
 		$file = $this->_image();
 		$this->assertSame('square', $file->orientation());
 	}
 
-	/**
-	 * @covers ::ratio
-	 */
-	public function testRatio()
+	public function testRatio(): void
 	{
 		$image  = $this->_image();
 		$this->assertSame(1.0, $image->ratio());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$file = $this->_image();
 		$this->assertSame('cat.jpg', $file->toArray()['filename']);
@@ -235,10 +186,7 @@ class ImageTest extends TestCase
 		$this->assertIsArray($file->toArray()['dimensions']);
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
-	public function testToString()
+	public function testToString(): void
 	{
 		$file = $this->_image();
 		$expected = '<img alt="" src="https://foo.bar/cat.jpg">';
@@ -246,10 +194,7 @@ class ImageTest extends TestCase
 		$this->assertSame($expected, (string)$file);
 	}
 
-	/**
-	 * @covers ::width
-	 */
-	public function testWidth()
+	public function testWidth(): void
 	{
 		$file = $this->_image();
 		$this->assertSame(500, $file->width());

--- a/tests/Image/LocationTest.php
+++ b/tests/Image/LocationTest.php
@@ -3,7 +3,9 @@
 namespace Kirby\Image;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Location::class)]
 class LocationTest extends TestCase
 {
 	protected function _exif(): array
@@ -16,14 +18,14 @@ class LocationTest extends TestCase
 		];
 	}
 
-	public function testLatLng()
+	public function testLatLng(): void
 	{
 		$camera = new Location($this->_exif());
 		$this->assertSame(50.819053333333336, $camera->lat());
 		$this->assertSame(-0.016666666666666666, $camera->lng());
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$camera = new Location($this->_exif());
 		$array  = [
@@ -34,7 +36,7 @@ class LocationTest extends TestCase
 		$this->assertSame($array, $camera->__debugInfo());
 	}
 
-	public function testToString()
+	public function testToString(): void
 	{
 		$camera = new Location($this->_exif());
 		$this->assertStringContainsString('50.8190533333', (string)$camera);

--- a/tests/Image/QrCodeTest.php
+++ b/tests/Image/QrCodeTest.php
@@ -6,10 +6,9 @@ use GdImage;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Image\QrCode
- */
+#[CoversClass(QrCode::class)]
 class QrCodeTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/qr';
@@ -20,7 +19,7 @@ class QrCodeTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testToDataUri()
+	public function testToDataUri(): void
 	{
 		$qr = new QrCode('12345678');
 		$expected = F::read(static::FIXTURES . '/num.txt');
@@ -43,7 +42,7 @@ class QrCodeTest extends TestCase
 		$this->assertSame($expected, $qr->toDataUri());
 	}
 
-	public function testToImage()
+	public function testToImage(): void
 	{
 		$qr       = new QrCode('https://getkirby.com');
 		$image    = $qr->toImage();
@@ -54,7 +53,7 @@ class QrCodeTest extends TestCase
 		$this->assertSame($expected, $data);
 	}
 
-	public function testToImageSize()
+	public function testToImageSize(): void
 	{
 		$qr       = new QrCode('https://getkirby.com');
 		$image    = $qr->toImage(750);
@@ -63,7 +62,7 @@ class QrCodeTest extends TestCase
 		$this->assertSame($expected, $data);
 	}
 
-	public function testToImageColors()
+	public function testToImageColors(): void
 	{
 		$qr       = new QrCode('https://getkirby.com');
 		$image    = $qr->toImage(null, '#00ff00', '#0000ff');
@@ -72,7 +71,7 @@ class QrCodeTest extends TestCase
 		$this->assertSame($expected, $data);
 	}
 
-	public function testToImageBorder()
+	public function testToImageBorder(): void
 	{
 		$qr       = new QrCode('https://getkirby.com');
 		$image    = $qr->toImage(null, '#000000', '#ffffff', 0);
@@ -81,7 +80,7 @@ class QrCodeTest extends TestCase
 		$this->assertSame($expected, $data);
 	}
 
-	public function testToSvg()
+	public function testToSvg(): void
 	{
 		$qr = new QrCode('12345678');
 		$expected = F::read(static::FIXTURES . '/num.svg');
@@ -104,7 +103,7 @@ class QrCodeTest extends TestCase
 		$this->assertSame($expected, $qr->toSvg());
 	}
 
-	public function testToSvgColors()
+	public function testToSvgColors(): void
 	{
 		$qr = new QrCode('https://getkirby.com');
 		$svg = $qr->toSvg(
@@ -116,19 +115,13 @@ class QrCodeTest extends TestCase
 		$this->assertStringContainsString('<rect width="100%" height="100%" fill="#00ff00"/>', $svg);
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
-	public function testToString()
+	public function testToString(): void
 	{
 		$qr = new QrCode('https://getkirby.com');
 		$this->assertSame($qr->toSvg(), (string)$qr);
 	}
 
-	/**
-	 * @covers ::write
-	 */
-	public function testWrite()
+	public function testWrite(): void
 	{
 		Dir::make(static::TMP);
 
@@ -171,10 +164,7 @@ class QrCodeTest extends TestCase
 		$this->assertSame($expectedJpeg, $actualJpeg);
 	}
 
-	/**
-	 * @covers ::write
-	 */
-	public function testWriteInvalidFormat()
+	public function testWriteInvalidFormat(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Cannot write QR code as docx');


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Image',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
