### PR TITLE
test: Use PHPUnit attributes for `Kirby\Option`

### DIFF
--- a/tests/Option/OptionTest.php
+++ b/tests/Option/OptionTest.php
@@ -4,17 +4,12 @@ namespace Kirby\Option;
 
 use Kirby\Cms\Page;
 use Kirby\Field\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Option\Option
- */
+#[CoversClass(Option::class)]
 class OptionTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 * @covers ::id
-	 */
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		// string
 		$option = new Option('test');
@@ -35,10 +30,7 @@ class OptionTest extends TestCase
 		$this->assertSame(1.1, $option->text['en']);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactoryWithJustValue()
+	public function testFactoryWithJustValue(): void
 	{
 		// string
 		$option = Option::factory('test');
@@ -53,10 +45,7 @@ class OptionTest extends TestCase
 		$this->assertSame(1.0, $option->value);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactoryWithValueAndText()
+	public function testFactoryWithValueAndText(): void
 	{
 		// string
 		$option = Option::factory([
@@ -79,10 +68,7 @@ class OptionTest extends TestCase
 		$this->assertSame('Test Option', $option->text['de']);
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRender()
+	public function testRender(): void
 	{
 		$option = Option::factory([
 			'value' => 'test',

--- a/tests/Option/OptionsApiTest.php
+++ b/tests/Option/OptionsApiTest.php
@@ -5,18 +5,14 @@ namespace Kirby\Option;
 use Kirby\Cms\Page;
 use Kirby\Exception\NotFoundException;
 use Kirby\Field\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Option\OptionsApi
- */
+#[CoversClass(OptionsApi::class)]
 class OptionsApiTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$options = new OptionsApi($url = 'https://api.example.com');
 		$this->assertSame($url, $options->url);
@@ -25,10 +21,7 @@ class OptionsApiTest extends TestCase
 		$this->assertNull($options->value);
 	}
 
-	/**
-	 * @covers ::defaults
-	 */
-	public function testDefaults()
+	public function testDefaults(): void
 	{
 		$options = new OptionsApi($url = 'https://api.example.com');
 		$this->assertSame($url, $options->url);
@@ -42,10 +35,7 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('{{ item.key }}', $options->value);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$options = OptionsApi::factory([
 			'url'   => $url = 'https://api.example.com',
@@ -66,10 +56,7 @@ class OptionsApiTest extends TestCase
 		$this->assertNull($options->value);
 	}
 
-	/**
-	 * @covers ::load
-	 */
-	public function testLoadNoJson()
+	public function testLoadNoJson(): void
 	{
 		$model   = new Page(['slug' => 'test']);
 		$options = new OptionsApi(url: 'https://example.com');
@@ -78,10 +65,7 @@ class OptionsApiTest extends TestCase
 		$options->resolve($model);
 	}
 
-	/**
-	 * @covers ::polyfill
-	 */
-	public function testPolyfill()
+	public function testPolyfill(): void
 	{
 		$api = 'https://api.example.com';
 		$this->assertSame(['url' => $api], OptionsApi::polyfill($api));
@@ -93,12 +77,7 @@ class OptionsApiTest extends TestCase
 		$this->assertSame(['query' => 'Companies'], OptionsApi::polyfill($api));
 	}
 
-	/**
-	 * @covers ::load
-	 * @covers ::render
-	 * @covers ::resolve
-	 */
-	public function testResolve()
+	public function testResolve(): void
 	{
 		$model   = new Page(['slug' => 'test']);
 		$options = new OptionsApi(static::FIXTURES . '/data.json');
@@ -110,10 +89,7 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('b', $result[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveSimple()
+	public function testResolveSimple(): void
 	{
 		$model   = new Page(['slug' => 'test']);
 		$options = new OptionsApi(static::FIXTURES . '/data-simple.json');
@@ -125,10 +101,7 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('b', $result[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveCustomKeys()
+	public function testResolveCustomKeys(): void
 	{
 		$model   = new Page(['slug' => 'test']);
 		$options = new OptionsApi(
@@ -144,10 +117,7 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('info@company-b.com', $result[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveQuery()
+	public function testResolveQuery(): void
 	{
 		$model   = new Page(['slug' => 'test']);
 		$options = new OptionsApi(
@@ -162,10 +132,7 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('b', $result[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveCustomKeysAndQuery()
+	public function testResolveCustomKeysAndQuery(): void
 	{
 		$model   = new Page(['slug' => 'test']);
 		$options = new OptionsApi(
@@ -182,10 +149,7 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('info@company-b.com', $result[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveHtmlEscape()
+	public function testResolveHtmlEscape(): void
 	{
 		$model = new Page(['slug' => 'test']);
 
@@ -262,10 +226,7 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('We are <b>better</b>', $result[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveApplyFieldMethods()
+	public function testResolveApplyFieldMethods(): void
 	{
 		$model   = new Page(['slug' => 'test']);
 		$options = new OptionsApi(
@@ -281,10 +242,7 @@ class OptionsApiTest extends TestCase
 		$this->assertSame('company-b', $result[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveSimpleArrays()
+	public function testResolveSimpleArrays(): void
 	{
 		$model   = new Page(['slug' => 'test']);
 		$options = new OptionsApi(

--- a/tests/Option/OptionsQueryTest.php
+++ b/tests/Option/OptionsQueryTest.php
@@ -6,6 +6,8 @@ use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Field\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
 class MyPage extends Page
 {
@@ -33,15 +35,10 @@ class MyPage extends Page
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Option\OptionsQuery
- */
+#[CoversClass(OptionsQuery::class)]
 class OptionsQueryTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$options = new OptionsQuery($query = 'site.children', '{{ page.slug }}');
 		$this->assertSame($query, $options->query);
@@ -49,10 +46,8 @@ class OptionsQueryTest extends TestCase
 		$this->assertNull($options->value);
 	}
 
-	/**
-	 * @coversNothing
-	 */
-	public function testDefaults()
+	#[CoversNothing]
+	public function testDefaults(): void
 	{
 		$options = new OptionsQuery($query = 'site.children');
 		$this->assertSame($query, $options->query);
@@ -60,10 +55,7 @@ class OptionsQueryTest extends TestCase
 		$this->assertNull($options->value);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$options = OptionsQuery::factory([
 			'query' => $query = 'site.children',
@@ -78,10 +70,7 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame($query, $options->query);
 	}
 
-	/**
-	 * @covers ::polyfill
-	 */
-	public function testPolyfill()
+	public function testPolyfill(): void
 	{
 		$query = 'site.children';
 		$this->assertSame(['query' => $query], OptionsQuery::polyfill($query));
@@ -93,11 +82,7 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame(['query' => 'site.children'], OptionsQuery::polyfill($query));
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::itemToDefaults
-	 */
-	public function testResolveForArray()
+	public function testResolveForArray(): void
 	{
 		$model   = new MyPage(['slug' => 'a']);
 		$options = (new OptionsQuery(
@@ -135,11 +120,7 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('tag3', $options[2]['text']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::itemToDefaults
-	 */
-	public function testResolveForStructure()
+	public function testResolveForStructure(): void
 	{
 		$model = new Page([
 			'slug' => 'a',
@@ -171,11 +152,7 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('bar', $options[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::itemToDefaults
-	 */
-	public function testResolveForBlock()
+	public function testResolveForBlock(): void
 	{
 		$model = new Page([
 			'slug' => 'a',
@@ -199,11 +176,7 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('bar', $options[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::itemToDefaults
-	 */
-	public function testResolveForPages()
+	public function testResolveForPages(): void
 	{
 		$app = new App([
 			'site' => [
@@ -228,11 +201,7 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('c', $options[2]['text']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::itemToDefaults
-	 */
-	public function testResolveForFile()
+	public function testResolveForFile(): void
 	{
 		$app = new App([
 			'site' => [
@@ -253,11 +222,7 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('b.pdf', $options[1]['text']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::itemToDefaults
-	 */
-	public function testResolveForUser()
+	public function testResolveForUser(): void
 	{
 		$app = new App([
 			'users' => [
@@ -275,11 +240,7 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('homer', $options[0]['text']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::itemToDefaults
-	 */
-	public function testResolveForOptions()
+	public function testResolveForOptions(): void
 	{
 		$model   = new MyPage(['slug' => 'a']);
 		$options = new OptionsQuery('page.myOptions');
@@ -291,10 +252,7 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('bar', $options[1]['value']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveInvalid()
+	public function testResolveInvalid(): void
 	{
 		$app = new App([
 			'site' => [
@@ -310,10 +268,7 @@ class OptionsQueryTest extends TestCase
 		$options = (new OptionsQuery('site.foo'))->render($app->site());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveHtmlEscape()
+	public function testResolveHtmlEscape(): void
 	{
 		$model   = new MyPage(['slug' => 'a']);
 

--- a/tests/Option/OptionsTest.php
+++ b/tests/Option/OptionsTest.php
@@ -4,16 +4,12 @@ namespace Kirby\Option;
 
 use Kirby\Cms\Page;
 use Kirby\Field\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Option\Options
- */
+#[CoversClass(Options::class)]
 class OptionsTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$options = new Options([
 			new Option('a'),
@@ -27,10 +23,7 @@ class OptionsTest extends TestCase
 		$this->assertSame('b', $options->last()->text['en']);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$options = Options::factory(['a', 'b']);
 
@@ -41,10 +34,7 @@ class OptionsTest extends TestCase
 		$this->assertSame('b', $options->last()->text['en']);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactoryWithAssocArray()
+	public function testFactoryWithAssocArray(): void
 	{
 		$options = Options::factory([
 			'a' => 'Option A',
@@ -58,10 +48,7 @@ class OptionsTest extends TestCase
 		$this->assertSame('Option B', $options->last()->text['en']);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactoryWithOptionArray()
+	public function testFactoryWithOptionArray(): void
 	{
 		$options = Options::factory([
 			['value' => 'a', 'text' => 'Option A'],
@@ -75,10 +62,7 @@ class OptionsTest extends TestCase
 		$this->assertSame('Option B', $options->last()->text['en']);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactoryWithTranslatedOptions()
+	public function testFactoryWithTranslatedOptions(): void
 	{
 		$options = Options::factory([
 			'a' => ['en' => 'Option A', 'de' => 'Variante A'],
@@ -94,10 +78,7 @@ class OptionsTest extends TestCase
 		$this->assertSame('Variante B', $options->last()->text['de']);
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRender()
+	public function testRender(): void
 	{
 		$model = new Page(['slug' => 'test']);
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Option',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
