### PR TITLE
test: Use PHPUnit attributes for `Kirby\Parsley`

### DIFF
--- a/tests/Parsley/ElementTest.php
+++ b/tests/Parsley/ElementTest.php
@@ -4,16 +4,12 @@ namespace Kirby\Parsley;
 
 use Kirby\TestCase;
 use Kirby\Toolkit\Dom;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Parsley\Element
- */
+#[CoversClass(Element::class)]
 class ElementTest extends TestCase
 {
-	/**
-	 * @covers ::attr
-	 */
-	public function testAttr()
+	public function testAttr(): void
 	{
 		$dom     = new Dom('<p class="test">test</p>');
 		$p       = $dom->query('//p')[0];
@@ -22,10 +18,7 @@ class ElementTest extends TestCase
 		$this->assertSame('test', $element->attr('class'));
 	}
 
-	/**
-	 * @covers ::children
-	 */
-	public function testChildren()
+	public function testChildren(): void
 	{
 		$dom     = new Dom('<p class="test"><span>A</span><span>B</span></p>');
 		$p       = $dom->query('//p')[0];
@@ -36,10 +29,7 @@ class ElementTest extends TestCase
 		$this->assertCount(2, $children);
 	}
 
-	/**
-	 * @covers ::classList
-	 */
-	public function testClassList()
+	public function testClassList(): void
 	{
 		$dom     = new Dom('<p class="a b">test</p>');
 		$p       = $dom->query('//p')[0];
@@ -48,10 +38,7 @@ class ElementTest extends TestCase
 		$this->assertSame(['a', 'b'], $element->classList());
 	}
 
-	/**
-	 * @covers ::className
-	 */
-	public function testClassName()
+	public function testClassName(): void
 	{
 		$dom     = new Dom('<p class="a b">test</p>');
 		$p       = $dom->query('//p')[0];
@@ -60,10 +47,7 @@ class ElementTest extends TestCase
 		$this->assertSame('a b', $element->className());
 	}
 
-	/**
-	 * @covers ::element
-	 */
-	public function testElement()
+	public function testElement(): void
 	{
 		$dom     = new Dom('test');
 		$body    = $dom->body();
@@ -72,10 +56,7 @@ class ElementTest extends TestCase
 		$this->assertSame($body, $element->element());
 	}
 
-	/**
-	 * @covers ::filter
-	 */
-	public function testFilter()
+	public function testFilter(): void
 	{
 		$dom     = new Dom('<p><i>Italic</i><b>Bold</b></p>');
 		$p       = $dom->query('//p')[0];
@@ -86,10 +67,7 @@ class ElementTest extends TestCase
 		$this->assertSame('Bold', $children[0]->innerText());
 	}
 
-	/**
-	 * @covers ::find
-	 */
-	public function testFind()
+	public function testFind(): void
 	{
 		$dom     = new Dom('<p><i>Italic</i><b>Bold</b></p>');
 		$p       = $dom->query('//p')[0];
@@ -99,10 +77,7 @@ class ElementTest extends TestCase
 		$this->assertSame('Bold', $child->innerText());
 	}
 
-	/**
-	 * @covers ::find
-	 */
-	public function testFindWithoutResult()
+	public function testFindWithoutResult(): void
 	{
 		$dom     = new Dom('<p><i>Italic</i><b>Bold</b></p>');
 		$p       = $dom->query('//p')[0];
@@ -111,10 +86,7 @@ class ElementTest extends TestCase
 		$this->assertNull($element->find('//a'));
 	}
 
-	/**
-	 * @covers ::innerHtml
-	 */
-	public function testInnerHtml()
+	public function testInnerHtml(): void
 	{
 		$dom     = new Dom('<p><i>Italic</i><b>Bold</b></p>');
 		$p       = $dom->query('//p')[0];
@@ -123,10 +95,7 @@ class ElementTest extends TestCase
 		$this->assertSame('ItalicBold', $element->innerHtml());
 	}
 
-	/**
-	 * @covers ::innerHtml
-	 */
-	public function testInnerHtmlWithMarks()
+	public function testInnerHtmlWithMarks(): void
 	{
 		$marks = [
 			['tag' => 'i'],
@@ -150,10 +119,7 @@ class ElementTest extends TestCase
 		$this->assertSame('<i>Italic</i><b>Bold</b>', $element->innerHtml());
 	}
 
-	/**
-	 * @covers ::innerText
-	 */
-	public function testInnerText()
+	public function testInnerText(): void
 	{
 		$dom     = new Dom('<p><i>Italic</i><b>Bold</b></p>');
 		$p       = $dom->query('//p')[0];
@@ -162,10 +128,7 @@ class ElementTest extends TestCase
 		$this->assertSame('ItalicBold', $element->innerText());
 	}
 
-	/**
-	 * @covers ::outerHtml
-	 */
-	public function testOuterHtml()
+	public function testOuterHtml(): void
 	{
 		$dom     = new Dom('<p><i>Italic</i><b>Bold</b></p>');
 		$p       = $dom->query('//p')[0];
@@ -174,10 +137,7 @@ class ElementTest extends TestCase
 		$this->assertSame('<p><i>Italic</i><b>Bold</b></p>', $element->outerHtml());
 	}
 
-	/**
-	 * @covers ::query
-	 */
-	public function testQuery()
+	public function testQuery(): void
 	{
 		$dom = new Dom('<p><i>Italic</i><b>Bold</b></p>');
 
@@ -186,10 +146,7 @@ class ElementTest extends TestCase
 		$this->assertSame('b', $dom->query('//p/b')[0]->tagName);
 	}
 
-	/**
-	 * @covers ::remove
-	 */
-	public function testRemove()
+	public function testRemove(): void
 	{
 		$dom     = new Dom('<p><i>Italic</i><b>Bold</b></p>');
 		$i       = $dom->query('//p/i')[0];
@@ -199,10 +156,7 @@ class ElementTest extends TestCase
 		$this->assertNull($dom->query('//p/i')[0]);
 	}
 
-	/**
-	 * @covers ::tagName
-	 */
-	public function testTagName()
+	public function testTagName(): void
 	{
 		$dom     = new Dom('<p>Test</p>');
 		$p       = $dom->query('//p')[0];

--- a/tests/Parsley/InlineTest.php
+++ b/tests/Parsley/InlineTest.php
@@ -2,18 +2,15 @@
 
 namespace Kirby\Parsley;
 
+use DOMDocument;
 use Kirby\TestCase;
 use Kirby\Toolkit\Dom;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Parsley\Inline
- */
+#[CoversClass(Inline::class)]
 class InlineTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructTrim()
+	public function testConstructTrim(): void
 	{
 		$dom    = new Dom('<span> Test </span>');
 		$dom    = $dom->query('//span')[0];
@@ -26,10 +23,7 @@ class InlineTest extends TestCase
 		$this->assertSame(' ', $inline->innerHtml());
 	}
 
-	/**
-	 * @covers ::parseAttrs
-	 */
-	public function testParseAttrs()
+	public function testParseAttrs(): void
 	{
 		$dom    = new Dom('<b class="foo">Test</b>');
 		$b      = $dom->query('//b')[0];
@@ -42,10 +36,7 @@ class InlineTest extends TestCase
 		$this->assertSame(['class' => 'foo'], $attrs);
 	}
 
-	/**
-	 * @covers ::parseAttrs
-	 */
-	public function testParseAttrsWithDefaults()
+	public function testParseAttrsWithDefaults(): void
 	{
 		$dom    = new Dom('<b>Test</b>');
 		$b      = $dom->query('//b')[0];
@@ -59,10 +50,7 @@ class InlineTest extends TestCase
 		$this->assertSame(['class' => 'foo'], $attrs);
 	}
 
-	/**
-	 * @covers ::parseAttrs
-	 */
-	public function testParseAttrsWithIgnoredAttrs()
+	public function testParseAttrsWithIgnoredAttrs(): void
 	{
 		$dom    = new Dom('<b class="foo">Test</b>');
 		$b      = $dom->query('//b')[0];
@@ -73,10 +61,7 @@ class InlineTest extends TestCase
 		$this->assertSame([], $attrs);
 	}
 
-	/**
-	 * @covers ::parseInnerHtml
-	 */
-	public function testParseInnerHtml()
+	public function testParseInnerHtml(): void
 	{
 		$dom    = new Dom('<p><b>Bold</b> <i>Italic</i></p>');
 		$p      = $dom->query('//p')[0];
@@ -88,10 +73,7 @@ class InlineTest extends TestCase
 		$this->assertSame('<b>Bold</b> <i>Italic</i>', $html);
 	}
 
-	/**
-	 * @covers ::parseInnerHtml
-	 */
-	public function testParseInnerHtmlWithEmptyParagraph()
+	public function testParseInnerHtmlWithEmptyParagraph(): void
 	{
 		$dom  = new Dom('<p> </p>');
 		$p    = $dom->query('//p')[0];
@@ -100,12 +82,9 @@ class InlineTest extends TestCase
 		$this->assertNull($html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
-	public function testParseNodeWithComment()
+	public function testParseNodeWithComment(): void
 	{
-		$dom = new \DOMDocument();
+		$dom = new DOMDocument();
 		$dom->loadHTML('<!-- comment -->');
 
 		$comment = $dom->childNodes[1];
@@ -114,10 +93,7 @@ class InlineTest extends TestCase
 		$this->assertNull($html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
-	public function testParseNodeWithEmptyParagraph()
+	public function testParseNodeWithEmptyParagraph(): void
 	{
 		$dom  = new Dom('<p> </p>');
 		$p    = $dom->query('//p')[0];
@@ -128,10 +104,7 @@ class InlineTest extends TestCase
 		$this->assertNull($html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
-	public function testParseNodeWithKnownMarks()
+	public function testParseNodeWithKnownMarks(): void
 	{
 		$dom  = new Dom('<p><b>Test</b> <i>Test</i></p>');
 		$p    = $dom->query('//p')[0];
@@ -143,10 +116,7 @@ class InlineTest extends TestCase
 		$this->assertSame('<b>Test</b> <i>Test</i>', $html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
-	public function testParseNodeWithKnownMarksWithAttrs()
+	public function testParseNodeWithKnownMarksWithAttrs(): void
 	{
 		$dom  = new Dom('<p><a href="https://getkirby.com">Test</a></p>');
 		$p    = $dom->query('//p')[0];
@@ -159,10 +129,7 @@ class InlineTest extends TestCase
 		$this->assertSame('<a href="https://getkirby.com">Test</a>', $html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
-	public function testParseNodeWithKnownMarksWithAttrDefaults()
+	public function testParseNodeWithKnownMarksWithAttrDefaults(): void
 	{
 		$dom  = new Dom('<p><a href="https://getkirby.com">Test</a></p>');
 		$p    = $dom->query('//p')[0];
@@ -178,10 +145,7 @@ class InlineTest extends TestCase
 		$this->assertSame('<a href="https://getkirby.com" rel="test">Test</a>', $html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
-	public function testParseNodeWithUnkownMarks()
+	public function testParseNodeWithUnkownMarks(): void
 	{
 		$dom     = new Dom('<p><b>Test</b> <i>Test</i></p>');
 		$p       = $dom->query('//p')[0];
@@ -190,10 +154,7 @@ class InlineTest extends TestCase
 		$this->assertSame('Test Test', $html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
-	public function testParseNodeWithSelfClosingElement()
+	public function testParseNodeWithSelfClosingElement(): void
 	{
 		$dom  = new Dom('<p><br></p>');
 		$p    = $dom->query('//p')[0];
@@ -204,10 +165,7 @@ class InlineTest extends TestCase
 		$this->assertSame('<br />', $html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
-	public function testParseNodeWithText()
+	public function testParseNodeWithText(): void
 	{
 		$dom  = new Dom('Test');
 		$text = $dom->query('//text()')[0];
@@ -216,10 +174,7 @@ class InlineTest extends TestCase
 		$this->assertSame('Test', $html);
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
-	public function testParseNodeWithTextEncoded()
+	public function testParseNodeWithTextEncoded(): void
 	{
 		$dom  = new Dom('Test & Test');
 		$text = $dom->query('//text()')[0];

--- a/tests/Parsley/ParsleyTest.php
+++ b/tests/Parsley/ParsleyTest.php
@@ -2,23 +2,24 @@
 
 namespace Kirby\Parsley;
 
+use DOMDocument;
 use Kirby\Filesystem\F;
 use Kirby\Parsley\Schema\Blocks;
 use Kirby\TestCase;
 use Kirby\Toolkit\Dom;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class TestableParsley extends Parsley
 {
-	public function setBlocks(array $blocks)
+	public function setBlocks(array $blocks): void
 	{
 		$this->blocks = $blocks;
 	}
 }
 
 
-/**
- * @coversDefaultClass \Kirby\Parsley\Parsley
- */
+#[CoversClass(Parsley::class)]
 class ParsleyTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -28,13 +29,7 @@ class ParsleyTest extends TestCase
 		return new TestableParsley($html, new Blocks());
 	}
 
-	/**
-	 * @covers ::blocks
-	 * @covers ::endInlineBlock
-	 * @covers ::fallback
-	 * @covers ::mergeOrAppend
-	 */
-	public function testBlocks()
+	public function testBlocks(): void
 	{
 		$examples = glob(static::FIXTURES . '/*.html');
 
@@ -59,11 +54,8 @@ class ParsleyTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider containsBlockProvider
-	 * @covers ::containsBlock
-	 */
-	public function testContainsBlock($html, $query, $expected)
+	#[DataProvider('containsBlockProvider')]
+	public function testContainsBlock($html, $query, $expected): void
 	{
 		$dom     = new Dom($html);
 		$element = $dom->query($query)[0];
@@ -71,10 +63,7 @@ class ParsleyTest extends TestCase
 		$this->assertSame($expected, $this->parser()->containsBlock($element));
 	}
 
-	/**
-	 * @covers ::containsBlock
-	 */
-	public function testContainsBlockWithText()
+	public function testContainsBlockWithText(): void
 	{
 		$dom     = new Dom('Test');
 		$element = $dom->query('//body')[0]->childNodes[0];
@@ -90,19 +79,13 @@ class ParsleyTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
-	public function testFallbackWithEmptyInput()
+	public function testFallbackWithEmptyInput(): void
 	{
 		$this->assertNull($this->parser()->fallback(''));
 	}
 
-	/**
-	 * @dataProvider isBlockProvider
-	 * @covers ::isBlock
-	 */
-	public function testIsBlock($html, $query, $expected)
+	#[DataProvider('isBlockProvider')]
+	public function testIsBlock($html, $query, $expected): void
 	{
 		$dom     = new Dom($html);
 		$element = $dom->query($query)[0];
@@ -120,11 +103,8 @@ class ParsleyTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider isInlineProvider
-	 * @covers ::isInline
-	 */
-	public function testIsInline($html, $query, $expected)
+	#[DataProvider('isInlineProvider')]
+	public function testIsInline($html, $query, $expected): void
 	{
 		$dom     = new Dom($html);
 		$element = $dom->query($query)[0];
@@ -132,10 +112,7 @@ class ParsleyTest extends TestCase
 		$this->assertSame($expected, $this->parser()->isInline($element));
 	}
 
-	/**
-	 * @covers ::isInline
-	 */
-	public function testIsInlineWithComment()
+	public function testIsInlineWithComment(): void
 	{
 		$dom     = new Dom('<p><!-- test --></p>');
 		$comment = $dom->query('/html/body/p')[0]->childNodes[0];
@@ -143,10 +120,7 @@ class ParsleyTest extends TestCase
 		$this->assertFalse($this->parser()->isInline($comment));
 	}
 
-	/**
-	 * @covers ::mergeOrAppend
-	 */
-	public function testMergeOrAppendExpectMerge()
+	public function testMergeOrAppendExpectMerge(): void
 	{
 		$parser = $this->parser();
 
@@ -174,10 +148,7 @@ class ParsleyTest extends TestCase
 		$this->assertSame($expected, $parser->blocks());
 	}
 
-	/**
-	 * @covers ::mergeOrAppend
-	 */
-	public function testMergeOrAppendExpectAppend()
+	public function testMergeOrAppendExpectAppend(): void
 	{
 		$parser = $this->parser();
 
@@ -211,10 +182,7 @@ class ParsleyTest extends TestCase
 		$this->assertSame($expected, $parser->blocks());
 	}
 
-	/**
-	 * @covers ::mergeOrAppend
-	 */
-	public function testMergeOrAppendWithoutBlocks()
+	public function testMergeOrAppendWithoutBlocks(): void
 	{
 		$parser = $this->parser();
 
@@ -237,10 +205,7 @@ class ParsleyTest extends TestCase
 		$this->assertSame($expected, $parser->blocks());
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
-	public function testParseNodeWithBlock()
+	public function testParseNodeWithBlock(): void
 	{
 		$dom = new Dom('<p>Test</p>');
 		$p   = $dom->query('/html/body/p')[0];
@@ -249,12 +214,9 @@ class ParsleyTest extends TestCase
 		$this->assertTrue($this->parser()->parseNode($p));
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
-	public function testParseNodeWithComment()
+	public function testParseNodeWithComment(): void
 	{
-		$dom = new \DOMDocument();
+		$dom = new DOMDocument();
 		$dom->loadHTML('<!-- comment -->');
 
 		$comment = $dom->childNodes[1];
@@ -263,21 +225,15 @@ class ParsleyTest extends TestCase
 		$this->assertFalse($this->parser()->parseNode($comment));
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
-	public function testParseNodeWithDoctype()
+	public function testParseNodeWithDoctype(): void
 	{
-		$dom = new \DOMDocument();
+		$dom = new DOMDocument();
 		$dom->loadHTML('<!doctype html>');
 
 		$this->assertFalse($this->parser()->parseNode($dom->doctype));
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
-	public function testParseNodeWithSkippableElement()
+	public function testParseNodeWithSkippableElement(): void
 	{
 		$dom    = new Dom('<script src="/test.js"></script>');
 		$script = $dom->query('/html/body/script')[0];
@@ -286,10 +242,7 @@ class ParsleyTest extends TestCase
 		$this->assertFalse($this->parser()->parseNode($script));
 	}
 
-	/**
-	 * @covers ::parseNode
-	 */
-	public function testParseNodeWithText()
+	public function testParseNodeWithText(): void
 	{
 		$dom = new Dom('Test');
 
@@ -300,7 +253,7 @@ class ParsleyTest extends TestCase
 		$this->assertTrue($this->parser()->parseNode($text));
 	}
 
-	public function testSkipXmlExtension()
+	public function testSkipXmlExtension(): void
 	{
 		Parsley::$useXmlExtension = false;
 

--- a/tests/Parsley/Schema/BlocksTest.php
+++ b/tests/Parsley/Schema/BlocksTest.php
@@ -3,26 +3,30 @@
 namespace Kirby\Parsley\Schema;
 
 use Kirby\Parsley\Element;
+use Kirby\Parsley\Schema;
 use Kirby\Toolkit\Dom;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Parsley\Schema\Blocks
- */
+#[CoversClass(Blocks::class)]
 class BlocksTest extends TestCase
 {
+	/** @var \Kirby\Parsley\Schema\Blocks */
+	protected Schema $schema;
+
 	public function setUp(): void
 	{
 		$this->schema = new Blocks();
 	}
 
-	protected function element($html, $query)
+	protected function element($html, $query): Element
 	{
 		$dom  = new Dom($html);
 		$node = $dom->query($query)[0];
 		return new Element($node);
 	}
 
-	public function testBlockquote()
+	public function testBlockquote(): void
 	{
 		$html = <<<HTML
 			<blockquote>
@@ -39,10 +43,10 @@ class BlocksTest extends TestCase
 			'type' => 'quote',
 		];
 
-		return $this->assertSame($expected, $this->schema->blockquote($element));
+		$this->assertSame($expected, $this->schema->blockquote($element));
 	}
 
-	public function testBlockquoteWithMarks()
+	public function testBlockquoteWithMarks(): void
 	{
 		$html = <<<HTML
 			<blockquote>
@@ -59,10 +63,10 @@ class BlocksTest extends TestCase
 			'type' => 'quote',
 		];
 
-		return $this->assertSame($expected, $this->schema->blockquote($element));
+		$this->assertSame($expected, $this->schema->blockquote($element));
 	}
 
-	public function testBlockquoteWithParagraphs()
+	public function testBlockquoteWithParagraphs(): void
 	{
 		$html = <<<HTML
 			<blockquote>
@@ -80,10 +84,10 @@ class BlocksTest extends TestCase
 			'type' => 'quote',
 		];
 
-		return $this->assertSame($expected, $this->schema->blockquote($element));
+		$this->assertSame($expected, $this->schema->blockquote($element));
 	}
 
-	public function testBlockquoteWithFooter()
+	public function testBlockquoteWithFooter(): void
 	{
 		$html = <<<HTML
 			<blockquote>
@@ -101,13 +105,10 @@ class BlocksTest extends TestCase
 			'type' => 'quote',
 		];
 
-		return $this->assertSame($expected, $this->schema->blockquote($element));
+		$this->assertSame($expected, $this->schema->blockquote($element));
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
-	public function testFallback()
+	public function testFallback(): void
 	{
 		$expected = [
 			'content' => [
@@ -116,13 +117,10 @@ class BlocksTest extends TestCase
 			'type' => 'text',
 		];
 
-		return $this->assertSame($expected, $this->schema->fallback('Test'));
+		$this->assertSame($expected, $this->schema->fallback('Test'));
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
-	public function testFallbackForDomElement()
+	public function testFallbackForDomElement(): void
 	{
 		$dom = new Dom('<p><b>Bold</b> <i>Italic</i></p>');
 		$p        = $dom->query('//p')[0];
@@ -143,10 +141,7 @@ class BlocksTest extends TestCase
 		$this->assertSame($expected, $fallback);
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
-	public function testFallbackForDomElementWithParagraphs()
+	public function testFallbackForDomElementWithParagraphs(): void
 	{
 		$dom = new Dom('<div><p>A</p><p>B</p></div>');
 		$p        = $dom->query('//div')[0];
@@ -167,23 +162,17 @@ class BlocksTest extends TestCase
 		$this->assertSame($expected, $fallback);
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
-	public function testFallbackForEmptyContent()
+	public function testFallbackForEmptyContent(): void
 	{
-		return $this->assertNull($this->schema->fallback(''));
+		$this->assertNull($this->schema->fallback(''));
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
-	public function testFallbackForInvalidContent()
+	public function testFallbackForInvalidContent(): void
 	{
-		return $this->assertNull($this->schema->fallback(''));
+		$this->assertNull($this->schema->fallback(''));
 	}
 
-	public function testHeading()
+	public function testHeading(): void
 	{
 		$html = <<<HTML
 			<h1>
@@ -200,7 +189,7 @@ class BlocksTest extends TestCase
 			'type' => 'heading',
 		];
 
-		return $this->assertSame($expected, $this->schema->heading($element));
+		$this->assertSame($expected, $this->schema->heading($element));
 	}
 
 	public static function headingLevelProvider(): array
@@ -210,10 +199,8 @@ class BlocksTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider headingLevelProvider
-	 */
-	public function testHeadingLevel($level)
+	#[DataProvider('headingLevelProvider')]
+	public function testHeadingLevel($level): void
 	{
 		$html = <<<HTML
 			<$level>
@@ -230,10 +217,10 @@ class BlocksTest extends TestCase
 			'type' => 'heading',
 		];
 
-		return $this->assertSame($expected, $this->schema->heading($element));
+		$this->assertSame($expected, $this->schema->heading($element));
 	}
 
-	public function testHeadingId()
+	public function testHeadingId(): void
 	{
 		$html = <<<HTML
 			<h1 id="test">
@@ -251,10 +238,10 @@ class BlocksTest extends TestCase
 			'type' => 'heading',
 		];
 
-		return $this->assertSame($expected, $this->schema->heading($element));
+		$this->assertSame($expected, $this->schema->heading($element));
 	}
 
-	public function testIframe()
+	public function testIframe(): void
 	{
 		$html = <<<HTML
 			<iframe src="https://getkirby.com"></iframe>
@@ -268,10 +255,10 @@ class BlocksTest extends TestCase
 			'type' => 'markdown',
 		];
 
-		return $this->assertSame($expected, $this->schema->iframe($element));
+		$this->assertSame($expected, $this->schema->iframe($element));
 	}
 
-	public function testIframeWithVimeoVideo()
+	public function testIframeWithVimeoVideo(): void
 	{
 		$html = <<<HTML
 			<iframe src="https://player.vimeo.com/video/1"></iframe>
@@ -286,10 +273,10 @@ class BlocksTest extends TestCase
 			'type' => 'video',
 		];
 
-		return $this->assertSame($expected, $this->schema->iframe($element));
+		$this->assertSame($expected, $this->schema->iframe($element));
 	}
 
-	public function testIframeWithYoutubeVideo()
+	public function testIframeWithYoutubeVideo(): void
 	{
 		$html = <<<HTML
 			<iframe src="https://youtube.com/embed/1"></iframe>
@@ -304,10 +291,10 @@ class BlocksTest extends TestCase
 			'type' => 'video',
 		];
 
-		return $this->assertSame($expected, $this->schema->iframe($element));
+		$this->assertSame($expected, $this->schema->iframe($element));
 	}
 
-	public function testIframeWithYoutubeNoCookieVideo()
+	public function testIframeWithYoutubeNoCookieVideo(): void
 	{
 		$html = <<<HTML
 			<iframe src="https://youtube-nocookie.com/embed/1"></iframe>
@@ -322,10 +309,10 @@ class BlocksTest extends TestCase
 			'type' => 'video',
 		];
 
-		return $this->assertSame($expected, $this->schema->iframe($element));
+		$this->assertSame($expected, $this->schema->iframe($element));
 	}
 
-	public function testIframeWithCaption()
+	public function testIframeWithCaption(): void
 	{
 		$html = <<<HTML
 			<figure>
@@ -343,10 +330,10 @@ class BlocksTest extends TestCase
 			'type' => 'video',
 		];
 
-		return $this->assertSame($expected, $this->schema->iframe($element));
+		$this->assertSame($expected, $this->schema->iframe($element));
 	}
 
-	public function testIframeWithCaptionAndMarks()
+	public function testIframeWithCaptionAndMarks(): void
 	{
 		$html = <<<HTML
 			<figure>
@@ -364,10 +351,10 @@ class BlocksTest extends TestCase
 			'type' => 'video',
 		];
 
-		return $this->assertSame($expected, $this->schema->iframe($element));
+		$this->assertSame($expected, $this->schema->iframe($element));
 	}
 
-	public function testImg()
+	public function testImg(): void
 	{
 		$html = <<<HTML
 			<img src="https://getkirby.com/image.jpg">
@@ -385,10 +372,10 @@ class BlocksTest extends TestCase
 			'type' => 'image',
 		];
 
-		return $this->assertSame($expected, $this->schema->img($element));
+		$this->assertSame($expected, $this->schema->img($element));
 	}
 
-	public function testImgWithAlt()
+	public function testImgWithAlt(): void
 	{
 		$html = <<<HTML
 			<img src="https://getkirby.com/image.jpg" alt="Test">
@@ -406,10 +393,10 @@ class BlocksTest extends TestCase
 			'type' => 'image',
 		];
 
-		return $this->assertSame($expected, $this->schema->img($element));
+		$this->assertSame($expected, $this->schema->img($element));
 	}
 
-	public function testImgWithLink()
+	public function testImgWithLink(): void
 	{
 		$html = <<<HTML
 			<a href="https://getkirby.com">
@@ -429,10 +416,10 @@ class BlocksTest extends TestCase
 			'type' => 'image',
 		];
 
-		return $this->assertSame($expected, $this->schema->img($element));
+		$this->assertSame($expected, $this->schema->img($element));
 	}
 
-	public function testImgWithCaption()
+	public function testImgWithCaption(): void
 	{
 		$html = <<<HTML
 			<figure>
@@ -453,10 +440,10 @@ class BlocksTest extends TestCase
 			'type' => 'image',
 		];
 
-		return $this->assertSame($expected, $this->schema->img($element));
+		$this->assertSame($expected, $this->schema->img($element));
 	}
 
-	public function testImgWithLinkAndCaption()
+	public function testImgWithLinkAndCaption(): void
 	{
 		$html = <<<HTML
 			<figure>
@@ -479,10 +466,10 @@ class BlocksTest extends TestCase
 			'type' => 'image',
 		];
 
-		return $this->assertSame($expected, $this->schema->img($element));
+		$this->assertSame($expected, $this->schema->img($element));
 	}
 
-	public function testList()
+	public function testList(): void
 	{
 		$html = <<<HTML
 			<ul>
@@ -495,10 +482,10 @@ class BlocksTest extends TestCase
 		$element  = $this->element($html, '//ul');
 		$expected = '<ul><li>A</li><li>B</li><li>C</li></ul>';
 
-		return $this->assertSame($expected, $this->schema->list($element));
+		$this->assertSame($expected, $this->schema->list($element));
 	}
 
-	public function testListWithMarks()
+	public function testListWithMarks(): void
 	{
 		$html = <<<HTML
 			<ul>
@@ -509,10 +496,10 @@ class BlocksTest extends TestCase
 		$element  = $this->element($html, '//ul');
 		$expected = '<ul><li><b>Bold</b><i>Italic</i></li></ul>';
 
-		return $this->assertSame($expected, $this->schema->list($element));
+		$this->assertSame($expected, $this->schema->list($element));
 	}
 
-	public function testListNested()
+	public function testListNested(): void
 	{
 		$html = <<<HTML
 			<ul>
@@ -531,10 +518,10 @@ class BlocksTest extends TestCase
 		$element  = $this->element($html, '//ul');
 		$expected = '<ul><li>A</li><li><ol><li>1</li><li>2</li><li>3</li></ol></li><li>C</li></ul>';
 
-		return $this->assertSame($expected, $this->schema->list($element));
+		$this->assertSame($expected, $this->schema->list($element));
 	}
 
-	public function testPre()
+	public function testPre(): void
 	{
 		$html = <<<HTML
 			<pre>Code</pre>
@@ -549,10 +536,10 @@ class BlocksTest extends TestCase
 			'type' => 'code',
 		];
 
-		return $this->assertSame($expected, $this->schema->pre($element));
+		$this->assertSame($expected, $this->schema->pre($element));
 	}
 
-	public function testPreWithCode()
+	public function testPreWithCode(): void
 	{
 		$html = <<<HTML
 			<pre><code>Code</code></pre>
@@ -567,10 +554,10 @@ class BlocksTest extends TestCase
 			'type' => 'code',
 		];
 
-		return $this->assertSame($expected, $this->schema->pre($element));
+		$this->assertSame($expected, $this->schema->pre($element));
 	}
 
-	public function testPreWithLanguage()
+	public function testPreWithLanguage(): void
 	{
 		$html = <<<HTML
 			<pre><code class="language-php">Code</code></pre>
@@ -585,15 +572,12 @@ class BlocksTest extends TestCase
 			'type' => 'code',
 		];
 
-		return $this->assertSame($expected, $this->schema->pre($element));
+		$this->assertSame($expected, $this->schema->pre($element));
 	}
 
-	/**
-	 * @covers ::skip
-	 */
-	public function testSkip()
+	public function testSkip(): void
 	{
-		return $this->assertSame([
+		$this->assertSame([
 			'base',
 			'link',
 			'meta',
@@ -603,7 +587,7 @@ class BlocksTest extends TestCase
 		], $this->schema->skip());
 	}
 
-	public function testTable()
+	public function testTable(): void
 	{
 		$html = <<<HTML
 			<table></table>
@@ -617,6 +601,6 @@ class BlocksTest extends TestCase
 			'type' => 'markdown',
 		];
 
-		return $this->assertSame($expected, $this->schema->table($element));
+		$this->assertSame($expected, $this->schema->table($element));
 	}
 }

--- a/tests/Parsley/Schema/PlainTest.php
+++ b/tests/Parsley/Schema/PlainTest.php
@@ -3,22 +3,22 @@
 namespace Kirby\Parsley\Schema;
 
 use Kirby\Parsley\Element;
+use Kirby\Parsley\Schema;
 use Kirby\Toolkit\Dom;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Parsley\Schema\Plain
- */
+#[CoversClass(Plain::class)]
 class PlainTest extends TestCase
 {
+	/** @var \Kirby\Parsley\Schema\Plain */
+	protected Schema $schema;
+
 	public function setUp(): void
 	{
 		$this->schema = new Plain();
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
-	public function testFallback()
+	public function testFallback(): void
 	{
 		$expected = [
 			'content' => [
@@ -27,21 +27,15 @@ class PlainTest extends TestCase
 			'type' => 'text',
 		];
 
-		return $this->assertSame($expected, $this->schema->fallback('Test'));
+		$this->assertSame($expected, $this->schema->fallback('Test'));
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
-	public function testFallbackForEmptyContent()
+	public function testFallbackForEmptyContent(): void
 	{
-		return $this->assertNull($this->schema->fallback(''));
+		$this->assertNull($this->schema->fallback(''));
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
-	public function testFallbackForDomElement()
+	public function testFallbackForDomElement(): void
 	{
 		$dom      = new Dom('<p>Test</p>');
 		$p        = $dom->query('//p')[0];
@@ -58,36 +52,24 @@ class PlainTest extends TestCase
 		$this->assertSame($expected, $fallback);
 	}
 
-	/**
-	 * @covers ::fallback
-	 */
-	public function testFallbackForInvalidContent()
+	public function testFallbackForInvalidContent(): void
 	{
 		$this->assertNull($this->schema->fallback(''));
 	}
 
-	/**
-	 * @covers ::marks
-	 */
-	public function testMarks()
+	public function testMarks(): void
 	{
-		return $this->assertSame([], $this->schema->marks());
+		$this->assertSame([], $this->schema->marks());
 	}
 
-	/**
-	 * @covers ::nodes
-	 */
-	public function testNodes()
+	public function testNodes(): void
 	{
-		return $this->assertSame([], $this->schema->nodes());
+		$this->assertSame([], $this->schema->nodes());
 	}
 
-	/**
-	 * @covers ::skip
-	 */
-	public function testSkip()
+	public function testSkip(): void
 	{
-		return $this->assertSame([
+		$this->assertSame([
 			'base',
 			'link',
 			'meta',

--- a/tests/Parsley/SchemaTest.php
+++ b/tests/Parsley/SchemaTest.php
@@ -3,42 +3,29 @@
 namespace Kirby\Parsley;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Parsley\Schema
- */
+#[CoversClass(Schema::class)]
 class SchemaTest extends TestCase
 {
-	/**
-	 * @covers ::fallback
-	 */
 	public function testFallback()
 	{
 		$schema = new Schema();
 		return $this->assertNull($schema->fallback('test'));
 	}
 
-	/**
-	 * @covers ::marks
-	 */
 	public function testMarks()
 	{
 		$schema = new Schema();
 		return $this->assertSame([], $schema->marks());
 	}
 
-	/**
-	 * @covers ::nodes
-	 */
 	public function testNodes()
 	{
 		$schema = new Schema();
 		return $this->assertSame([], $schema->nodes());
 	}
 
-	/**
-	 * @covers ::skip
-	 */
 	public function testSkip()
 	{
 		$schema = new Schema();


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Parsley',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
