### PR TITLE
test: Use PHPUnit attributes for `Kirby\Session`

### DIFF
--- a/tests/Session/AutoSessionTest.php
+++ b/tests/Session/AutoSessionTest.php
@@ -5,11 +5,10 @@ namespace Kirby\Session;
 use Kirby\Cms\App;
 use Kirby\Http\Cookie;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClass;
 
-/**
- * @coversDefaultClass \Kirby\Session\AutoSession
- */
+#[CoversClass(AutoSession::class)]
 class AutoSessionTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/store';
@@ -29,10 +28,7 @@ class AutoSessionTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testSessionsOptions()
+	public function testSessionsOptions(): void
 	{
 		$autoSessionReflector = new ReflectionClass(AutoSession::class);
 		$sessionsProperty = $autoSessionReflector->getProperty('sessions');
@@ -68,10 +64,7 @@ class AutoSessionTest extends TestCase
 		$this->assertFalse($this->store->collectedGarbage);
 	}
 
-	/**
-	 * @covers ::get
-	 */
-	public function testGet()
+	public function testGet(): void
 	{
 		Cookie::set('kirby_session', '9999999999.valid.' . $this->store->validKey);
 		$this->setAuthorization('Session 9999999999.valid2.' . $this->store->validKey);
@@ -229,10 +222,7 @@ class AutoSessionTest extends TestCase
 		$session->commit();
 	}
 
-	/**
-	 * @covers ::createManually
-	 */
-	public function testCreateManually()
+	public function testCreateManually(): void
 	{
 		$autoSession = new AutoSession($this->store);
 		$session = $autoSession->createManually(['expiryTime' => 9999999999, 'mode' => 'cookie']);
@@ -242,10 +232,7 @@ class AutoSessionTest extends TestCase
 		$this->assertSame('manual', $session->mode());
 	}
 
-	/**
-	 * @covers ::getManually
-	 */
-	public function testGetManually()
+	public function testGetManually(): void
 	{
 		$autoSession = new AutoSession($this->store);
 
@@ -254,10 +241,7 @@ class AutoSessionTest extends TestCase
 		$this->assertSame('9999999999.valid.' . $this->store->validKey, $session->token());
 	}
 
-	/**
-	 * @covers ::collectGarbage
-	 */
-	public function testCollectGarbage()
+	public function testCollectGarbage(): void
 	{
 		$this->store->collectedGarbage = false;
 		$autoSession = new AutoSession($this->store, ['gcInterval' => false]);

--- a/tests/Session/FileSessionStoreTest.php
+++ b/tests/Session/FileSessionStoreTest.php
@@ -8,12 +8,11 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClass;
 use ReflectionProperty;
 
-/**
- * @coversDefaultClass \Kirby\Session\FileSessionStore
- */
+#[CoversClass(FileSessionStore::class)]
 class FileSessionStoreTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Session.FileSessionStore';
@@ -60,10 +59,7 @@ class FileSessionStoreTest extends TestCase
 		$this->assertDirectoryDoesNotExist(static::TMP);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructorNotWritable()
+	public function testConstructorNotWritable(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionCode('error.session.filestore.dirNotWritable');
@@ -74,12 +70,7 @@ class FileSessionStoreTest extends TestCase
 		new FileSessionStore(static::TMP);
 	}
 
-	/**
-	 * @covers ::createId
-	 * @covers ::name
-	 * @covers ::path
-	 */
-	public function testCreateId()
+	public function testCreateId(): void
 	{
 		$id = $this->store->createId(1234567890);
 
@@ -90,12 +81,7 @@ class FileSessionStoreTest extends TestCase
 		$this->assertLocked('1234567890.' . $id);
 	}
 
-	/**
-	 * @covers ::exists
-	 * @covers ::name
-	 * @covers ::path
-	 */
-	public function testExists()
+	public function testExists(): void
 	{
 		$this->assertTrue($this->store->exists(1234567890, 'abcdefghijabcdefghij'));
 		$this->assertTrue($this->store->exists(1357913579, 'abcdefghijabcdefghij'));
@@ -111,12 +97,7 @@ class FileSessionStoreTest extends TestCase
 		$this->assertHandleNotExists('9999999999.abcdefghijabcdefghij');
 	}
 
-	/**
-	 * @covers ::lock
-	 * @covers ::name
-	 * @covers ::path
-	 */
-	public function testLock()
+	public function testLock(): void
 	{
 		$this->store->lock(1234567890, 'abcdefghijabcdefghij');
 		$this->assertLocked('1234567890.abcdefghijabcdefghij');
@@ -128,12 +109,7 @@ class FileSessionStoreTest extends TestCase
 		$this->assertHandleExists('1234567890.abcdefghijabcdefghij');
 	}
 
-	/**
-	 * @covers ::lock
-	 * @covers ::name
-	 * @covers ::path
-	 */
-	public function testLockNonExistingFile()
+	public function testLockNonExistingFile(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionCode('error.session.filestore.notFound');
@@ -141,12 +117,7 @@ class FileSessionStoreTest extends TestCase
 		$this->store->lock(1234567890, 'someotherid');
 	}
 
-	/**
-	 * @covers ::unlock
-	 * @covers ::name
-	 * @covers ::path
-	 */
-	public function testUnlock()
+	public function testUnlock(): void
 	{
 		// unlock an unlocked file
 		$this->assertNotLocked('1234567890.abcdefghijabcdefghij');
@@ -171,12 +142,7 @@ class FileSessionStoreTest extends TestCase
 		$this->assertNotLocked('1357913579.abcdefghijabcdefghij');
 	}
 
-	/**
-	 * @covers ::get
-	 * @covers ::name
-	 * @covers ::path
-	 */
-	public function testGet()
+	public function testGet(): void
 	{
 		$this->assertSame('1234567890', $this->store->get(1234567890, 'abcdefghijabcdefghij'));
 		$this->assertHandleExists('1234567890.abcdefghijabcdefghij');
@@ -184,12 +150,7 @@ class FileSessionStoreTest extends TestCase
 		$this->assertSame('', $this->store->get(8888888888, 'abcdefghijabcdefghij'));
 	}
 
-	/**
-	 * @covers ::get
-	 * @covers ::name
-	 * @covers ::path
-	 */
-	public function testGetNonExistingFile()
+	public function testGetNonExistingFile(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionCode('error.session.filestore.notFound');
@@ -197,13 +158,7 @@ class FileSessionStoreTest extends TestCase
 		$this->store->get(1234567890, 'someotherid');
 	}
 
-	/**
-	 * @covers ::get
-	 * @covers ::name
-	 * @covers ::path
-	 * @covers ::handle
-	 */
-	public function testGetUnreadableFile()
+	public function testGetUnreadableFile(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionCode('error.session.filestore.notOpened');
@@ -213,12 +168,7 @@ class FileSessionStoreTest extends TestCase
 		$this->store->get(1234567890, 'abcdefghijabcdefghij');
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::name
-	 * @covers ::path
-	 */
-	public function testSet()
+	public function testSet(): void
 	{
 		$this->assertSame('1234567890', $this->store->get(1234567890, 'abcdefghijabcdefghij'));
 
@@ -231,12 +181,7 @@ class FileSessionStoreTest extends TestCase
 		$this->assertSame('some other data', $this->store->get(1234567890, 'abcdefghijabcdefghij'));
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::name
-	 * @covers ::path
-	 */
-	public function testSetNonExistingFile()
+	public function testSetNonExistingFile(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionCode('error.session.filestore.notFound');
@@ -244,12 +189,7 @@ class FileSessionStoreTest extends TestCase
 		$this->store->set(1234567890, 'someotherid', 'some other data');
 	}
 
-	/**
-	 * @covers ::set
-	 * @covers ::name
-	 * @covers ::path
-	 */
-	public function testSetWithoutLock()
+	public function testSetWithoutLock(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionCode('error.session.filestore.notLocked');
@@ -259,13 +199,7 @@ class FileSessionStoreTest extends TestCase
 		$this->store->set(1234567890, 'abcdefghijabcdefghij', 'some other data');
 	}
 
-	/**
-	 * @covers ::destroy
-	 * @covers ::name
-	 * @covers ::path
-	 * @covers ::closeHandle
-	 */
-	public function testDestroy()
+	public function testDestroy(): void
 	{
 		$this->assertFileExists(static::TMP . '/1234567890.abcdefghijabcdefghij.sess');
 		$this->assertNotLocked('1234567890.abcdefghijabcdefghij');
@@ -278,13 +212,7 @@ class FileSessionStoreTest extends TestCase
 		$this->assertHandleNotExists('1234567890.abcdefghijabcdefghij');
 	}
 
-	/**
-	 * @covers ::destroy
-	 * @covers ::name
-	 * @covers ::path
-	 * @covers ::closeHandle
-	 */
-	public function testDestroyAlreadyDestroyed()
+	public function testDestroyAlreadyDestroyed(): void
 	{
 		// make sure we get a handle
 		$this->assertSame('1234567890', $this->store->get(1234567890, 'abcdefghijabcdefghij'));
@@ -297,12 +225,7 @@ class FileSessionStoreTest extends TestCase
 		$this->store->destroy(1234567890, 'abcdefghijabcdefghij');
 	}
 
-	/**
-	 * @covers ::handle
-	 * @covers ::name
-	 * @covers ::path
-	 */
-	public function testAccessAfterDestroy()
+	public function testAccessAfterDestroy(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionCode('error.session.filestore.notFound');
@@ -319,10 +242,7 @@ class FileSessionStoreTest extends TestCase
 		$this->store->set(1234567890, 'abcdefghijabcdefghij', 'something else');
 	}
 
-	/**
-	 * @covers ::collectGarbage
-	 */
-	public function testCollectGarbage()
+	public function testCollectGarbage(): void
 	{
 		$this->assertFileExists(static::TMP . '/.gitignore');
 		$this->assertFileExists(static::TMP . '/1234567890.abcdefghijabcdefghij.sess');

--- a/tests/Session/SessionDataTest.php
+++ b/tests/Session/SessionDataTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Session;
 
 use Kirby\Exception\LogicException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Session\SessionData
- */
+#[CoversClass(SessionData::class)]
 class SessionDataTest extends TestCase
 {
 	protected Session $session;
@@ -27,10 +26,7 @@ class SessionDataTest extends TestCase
 		unset($this->session, $this->sessionData);
 	}
 
-	/**
-	 * @covers ::set
-	 */
-	public function testSet()
+	public function testSet(): void
 	{
 		// string as key
 		$this->session->ensuredToken = false;
@@ -60,10 +56,7 @@ class SessionDataTest extends TestCase
 		$this->assertSame('someValue2', $this->sessionData->get('someKey2'));
 	}
 
-	/**
-	 * @covers ::increment
-	 */
-	public function testIncrement()
+	public function testIncrement(): void
 	{
 		$this->session->ensuredToken = false;
 		$this->session->preparedForWriting = false;
@@ -88,10 +81,7 @@ class SessionDataTest extends TestCase
 		$this->assertSame(155, $this->sessionData->get('someInt'));
 	}
 
-	/**
-	 * @covers ::increment
-	 */
-	public function testIncrementNonIntValue()
+	public function testIncrementNonIntValue(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionCode('error.session.data.increment.nonInt');
@@ -99,10 +89,7 @@ class SessionDataTest extends TestCase
 		$this->sessionData->increment('someString', 10);
 	}
 
-	/**
-	 * @covers ::decrement
-	 */
-	public function testDecrement()
+	public function testDecrement(): void
 	{
 		$this->session->ensuredToken = false;
 		$this->session->preparedForWriting = false;
@@ -127,10 +114,7 @@ class SessionDataTest extends TestCase
 		$this->assertSame(85, $this->sessionData->get('someInt'));
 	}
 
-	/**
-	 * @covers ::decrement
-	 */
-	public function testDecrementNonIntValue()
+	public function testDecrementNonIntValue(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionCode('error.session.data.decrement.nonInt');
@@ -138,10 +122,7 @@ class SessionDataTest extends TestCase
 		$this->sessionData->decrement('someString', 10);
 	}
 
-	/**
-	 * @covers ::get
-	 */
-	public function testGet()
+	public function testGet(): void
 	{
 		// string as key
 		$this->assertSame('someValue', $this->sessionData->get('someString', 'someDefault'));
@@ -156,10 +137,7 @@ class SessionDataTest extends TestCase
 		], $this->sessionData->get());
 	}
 
-	/**
-	 * @covers ::pull
-	 */
-	public function testPull()
+	public function testPull(): void
 	{
 		$this->session->ensuredToken = false;
 		$this->session->preparedForWriting = false;
@@ -172,10 +150,7 @@ class SessionDataTest extends TestCase
 		$this->assertSame('someDefault', $this->sessionData->pull('someOtherString', 'someDefault'));
 	}
 
-	/**
-	 * @covers ::remove
-	 */
-	public function testRemove()
+	public function testRemove(): void
 	{
 		// string as key
 		$this->session->ensuredToken = false;
@@ -194,10 +169,7 @@ class SessionDataTest extends TestCase
 		$this->assertSame([], $this->sessionData->get());
 	}
 
-	/**
-	 * @covers ::clear
-	 */
-	public function testClear()
+	public function testClear(): void
 	{
 		$this->session->ensuredToken = false;
 		$this->session->preparedForWriting = false;
@@ -207,10 +179,7 @@ class SessionDataTest extends TestCase
 		$this->assertSame([], $this->sessionData->get());
 	}
 
-	/**
-	 * @covers ::reload
-	 */
-	public function testReload()
+	public function testReload(): void
 	{
 		$newData = ['someOtherString' => 'someOtherValue'];
 

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -3,17 +3,13 @@
 namespace Kirby\Session;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClass;
 
-/**
- * @coversDefaultClass \Kirby\Session\SessionStore
- */
+#[CoversClass(SessionStore::class)]
 class SessionStoreTest extends TestCase
 {
-	/**
-	 * @covers ::generateId
-	 */
-	public function testGenerateId()
+	public function testGenerateId(): void
 	{
 		// get a reference to the protected method
 		$reflector = new ReflectionClass(SessionStore::class);

--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -11,12 +11,11 @@ use Kirby\TestCase;
 use Kirby\Toolkit\Obj;
 use Kirby\Toolkit\Str;
 use Kirby\Toolkit\SymmetricCrypto;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClass;
 use TypeError;
 
-/**
- * @coversDefaultClass \Kirby\Session\Session
- */
+#[CoversClass(Session::class)]
 class SessionTest extends TestCase
 {
 	protected SessionStore $store;
@@ -35,25 +34,14 @@ class SessionTest extends TestCase
 		unset($this->sessions, $this->store);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructInvalidToken()
+	public function testConstructInvalidToken(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
 		new Session($this->sessions, 123, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 * @covers ::destroy
-	 * @covers ::ensureToken
-	 */
-	public function testCreate()
+	public function testCreate(): void
 	{
 		$reflector = new ReflectionClass(Session::class);
 		$activityProperty = $reflector->getProperty('lastActivity');
@@ -118,10 +106,7 @@ class SessionTest extends TestCase
 		$this->assertTrue(isset($this->store->sessions[$token[0] . '.' . $token[1]]));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testCreateInvalidExpiry()
+	public function testCreateInvalidExpiry(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
@@ -131,10 +116,7 @@ class SessionTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testCreateInvalidDuration()
+	public function testCreateInvalidDuration(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
@@ -144,10 +126,7 @@ class SessionTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testCreateInvalidTimeout()
+	public function testCreateInvalidTimeout(): void
 	{
 		$this->expectException(TypeError::class);
 
@@ -156,10 +135,7 @@ class SessionTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testCreateInvalidRenewable()
+	public function testCreateInvalidRenewable(): void
 	{
 		$this->expectException(TypeError::class);
 
@@ -168,10 +144,7 @@ class SessionTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::mode
-	 */
-	public function testMode()
+	public function testMode(): void
 	{
 		$session = new Session($this->sessions, null, [
 			'mode' => 'manual'
@@ -182,11 +155,7 @@ class SessionTest extends TestCase
 		$this->assertSame('cookie', $session->mode());
 	}
 
-	/**
-	 * @covers ::mode
-	 * @covers ::data
-	 */
-	public function testModeStartedSession()
+	public function testModeStartedSession(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
@@ -199,14 +168,7 @@ class SessionTest extends TestCase
 		$session->mode('cookie');
 	}
 
-	/**
-	 * @covers ::expiryTime
-	 * @covers ::token
-	 * @covers ::commit
-	 * @covers ::regenerateToken
-	 * @covers ::regenerateTokenIfNotNew
-	 */
-	public function testExpiryTime()
+	public function testExpiryTime(): void
 	{
 		$session = new Session($this->sessions, null, [
 			'startTime'  => 1000000000,
@@ -231,10 +193,7 @@ class SessionTest extends TestCase
 		$this->assertNotSame($originalToken, $session->token());
 	}
 
-	/**
-	 * @covers ::expiryTime
-	 */
-	public function testExpiryTimeInvalidType()
+	public function testExpiryTimeInvalidType(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
@@ -245,10 +204,7 @@ class SessionTest extends TestCase
 		$session->expiryTime(false);
 	}
 
-	/**
-	 * @covers ::expiryTime
-	 */
-	public function testExpiryTimeInvalidString()
+	public function testExpiryTimeInvalidString(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
@@ -259,10 +215,7 @@ class SessionTest extends TestCase
 		$session->expiryTime('some gibberish that is definitely no valid time');
 	}
 
-	/**
-	 * @covers ::expiryTime
-	 */
-	public function testExpiryTimeInvalidTime1()
+	public function testExpiryTimeInvalidTime1(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
@@ -273,10 +226,7 @@ class SessionTest extends TestCase
 		$session->expiryTime(time() - 1);
 	}
 
-	/**
-	 * @covers ::expiryTime
-	 */
-	public function testExpiryTimeInvalidTime2()
+	public function testExpiryTimeInvalidTime2(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
@@ -287,14 +237,7 @@ class SessionTest extends TestCase
 		$session->expiryTime(time());
 	}
 
-	/**
-	 * @covers ::duration
-	 * @covers ::token
-	 * @covers ::commit
-	 * @covers ::regenerateToken
-	 * @covers ::regenerateTokenIfNotNew
-	 */
-	public function testDuration()
+	public function testDuration(): void
 	{
 		$session = new Session($this->sessions, null, [
 			'startTime'  => 1000000000,
@@ -314,10 +257,7 @@ class SessionTest extends TestCase
 		$this->assertNotSame($originalToken, $session->token());
 	}
 
-	/**
-	 * @covers ::duration
-	 */
-	public function testDurationInvalidTime1()
+	public function testDurationInvalidTime1(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
@@ -328,10 +268,7 @@ class SessionTest extends TestCase
 		$session->duration(-1);
 	}
 
-	/**
-	 * @covers ::duration
-	 */
-	public function testDurationInvalidTime2()
+	public function testDurationInvalidTime2(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
@@ -342,12 +279,7 @@ class SessionTest extends TestCase
 		$session->duration(0);
 	}
 
-	/**
-	 * @covers ::timeout
-	 * @covers ::commit
-	 * @covers ::regenerateToken
-	 */
-	public function testTimeout()
+	public function testTimeout(): void
 	{
 		$reflector = new ReflectionClass(Session::class);
 		$activityProperty = $reflector->getProperty('lastActivity');
@@ -371,10 +303,7 @@ class SessionTest extends TestCase
 		$this->assertWriteMode(true, $session);
 	}
 
-	/**
-	 * @covers ::timeout
-	 */
-	public function testTimeoutInvalidType()
+	public function testTimeoutInvalidType(): void
 	{
 		$this->expectException(TypeError::class);
 
@@ -384,10 +313,7 @@ class SessionTest extends TestCase
 		$session->timeout('after an hour');
 	}
 
-	/**
-	 * @covers ::timeout
-	 */
-	public function testTimeoutInvalidTimeout1()
+	public function testTimeoutInvalidTimeout1(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
@@ -397,10 +323,7 @@ class SessionTest extends TestCase
 		$session->timeout(-10);
 	}
 
-	/**
-	 * @covers ::timeout
-	 */
-	public function testTimeoutInvalidTimeout2()
+	public function testTimeoutInvalidTimeout2(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
@@ -410,15 +333,7 @@ class SessionTest extends TestCase
 		$session->timeout(0);
 	}
 
-	/**
-	 * @covers ::renewable
-	 * @covers ::token
-	 * @covers ::commit
-	 * @covers ::regenerateToken
-	 * @covers ::autoRenew
-	 * @covers ::needsRenewal
-	 */
-	public function testRenewable()
+	public function testRenewable(): void
 	{
 		$session = new Session($this->sessions, null, [
 			'expiryTime' => '+ 1 minute',
@@ -459,11 +374,7 @@ class SessionTest extends TestCase
 		$this->assertSame($newToken, $session->token());
 	}
 
-	/**
-	 * @covers ::__call
-	 * @covers ::data
-	 */
-	public function testDataMethods()
+	public function testDataMethods(): void
 	{
 		$session = new Session($this->sessions, null, []);
 		$session->data()->reload(['someString' => 'someValue', 'someInt' => 123]);
@@ -499,10 +410,7 @@ class SessionTest extends TestCase
 		$this->assertSame([], $session->get());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
-	public function testInvalidMethod()
+	public function testInvalidMethod(): void
 	{
 		$this->expectException(BadMethodCallException::class);
 
@@ -510,12 +418,7 @@ class SessionTest extends TestCase
 		$session->someGibberish();
 	}
 
-	/**
-	 * @covers ::commit
-	 * @covers ::data
-	 * @covers ::commit
-	 */
-	public function testCommit()
+	public function testCommit(): void
 	{
 		$token = '9999999999.valid.' . $this->store->validKey;
 		$session = new Session($this->sessions, $token, []);
@@ -587,13 +490,7 @@ class SessionTest extends TestCase
 		], $this->store->sessions['9999999999.valid']);
 	}
 
-	/**
-	 * @covers ::destroy
-	 * @covers ::data
-	 * @covers ::commit
-	 * @covers ::regenerateToken
-	 */
-	public function testDestroy()
+	public function testDestroy(): void
 	{
 		$token = '9999999999.valid2.' . $this->store->validKey;
 		Cookie::set('kirby_session', $token);
@@ -622,14 +519,7 @@ class SessionTest extends TestCase
 		$this->assertFalse(isset($this->store->sessions['9999999999.valid']));
 	}
 
-	/**
-	 * @covers ::renew
-	 * @covers ::token
-	 * @covers ::commit
-	 * @covers ::regenerateToken
-	 * @covers ::regenerateTokenIfNotNew
-	 */
-	public function testRenew()
+	public function testRenew(): void
 	{
 		$session = new Session($this->sessions, null, [
 			'startTime'  => 1000000000,
@@ -667,10 +557,7 @@ class SessionTest extends TestCase
 		$this->assertSame($expected, $actual);
 	}
 
-	/**
-	 * @covers ::renew
-	 */
-	public function testRenewNotRenewable()
+	public function testRenewNotRenewable(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionCode('error.session.notRenewable');
@@ -681,12 +568,7 @@ class SessionTest extends TestCase
 		$session->renew();
 	}
 
-	/**
-	 * @covers ::regenerateToken
-	 * @covers ::token
-	 * @covers ::startTime
-	 */
-	public function testRegenerateToken()
+	public function testRegenerateToken(): void
 	{
 		$sessionsReflector = new ReflectionClass(Sessions::class);
 		$cache = $sessionsReflector->getProperty('cache');
@@ -733,11 +615,7 @@ class SessionTest extends TestCase
 		$this->assertSame($session, $cache->getValue($this->sessions)[$newToken]);
 	}
 
-	/**
-	 * @covers ::regenerateToken
-	 * @covers ::needsRetransmission
-	 */
-	public function testRegenerateTokenHeaderMode()
+	public function testRegenerateTokenHeaderMode(): void
 	{
 		$sessionsReflector = new ReflectionClass(Sessions::class);
 		$cache = $sessionsReflector->getProperty('cache');
@@ -758,11 +636,7 @@ class SessionTest extends TestCase
 		$this->assertSame($session, $cache->getValue($this->sessions)[$newToken]);
 	}
 
-	/**
-	 * @covers ::__destruct
-	 * @covers ::data
-	 */
-	public function testDestruct()
+	public function testDestruct(): void
 	{
 		$token = '9999999999.valid.' . $this->store->validKey;
 		$session = new Session($this->sessions, $token, []);
@@ -776,11 +650,7 @@ class SessionTest extends TestCase
 		$this->assertSame(1, $this->store->sessions['9999999999.valid']['data']['someId']);
 	}
 
-	/**
-	 * @covers ::prepareForWriting
-	 * @covers ::data
-	 */
-	public function testPrepareForWriting()
+	public function testPrepareForWriting(): void
 	{
 		$token = '9999999999.valid.' . $this->store->validKey;
 		$session = new Session($this->sessions, $token, []);
@@ -802,11 +672,7 @@ class SessionTest extends TestCase
 		$this->assertSame(124, $session->data()->get('someId'));
 	}
 
-	/**
-	 * @covers ::prepareForWriting
-	 * @covers ::data
-	 */
-	public function testPrepareForWritingReadonly()
+	public function testPrepareForWritingReadonly(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionCode('error.session.readonly');
@@ -817,11 +683,7 @@ class SessionTest extends TestCase
 		$session->data()->set('someId', 1);
 	}
 
-	/**
-	 * @covers ::parseToken
-	 * @covers ::token
-	 */
-	public function testParseToken()
+	public function testParseToken(): void
 	{
 		$reflector = new ReflectionClass(Session::class);
 		$parseToken = $reflector->getMethod('parseToken');
@@ -843,10 +705,7 @@ class SessionTest extends TestCase
 		$this->assertNull($tokenKey->getValue($session));
 	}
 
-	/**
-	 * @covers ::parseToken
-	 */
-	public function testParseTokenInvalidToken1()
+	public function testParseTokenInvalidToken1(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
@@ -854,10 +713,7 @@ class SessionTest extends TestCase
 		$session = new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::parseToken
-	 */
-	public function testParseTokenInvalidToken2()
+	public function testParseTokenInvalidToken2(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
@@ -865,11 +721,7 @@ class SessionTest extends TestCase
 		$session = new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::parseToken
-	 * @covers ::token
-	 */
-	public function testParseTokenInvalidToken3()
+	public function testParseTokenInvalidToken3(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
@@ -883,10 +735,7 @@ class SessionTest extends TestCase
 		$parseToken->invoke($session, '1234567890.thisIsMyAwesomeId.' . $this->store->validKey, true);
 	}
 
-	/**
-	 * @covers ::timeToTimestamp
-	 */
-	public function testTimeToTimestamp()
+	public function testTimeToTimestamp(): void
 	{
 		$reflector = new ReflectionClass(Session::class);
 		$timeToTimestamp = $reflector->getMethod('timeToTimestamp');
@@ -899,10 +748,7 @@ class SessionTest extends TestCase
 		$this->assertSame(strtotime('tomorrow', 1357924680), $timeToTimestamp->invoke(null, 'tomorrow', 1357924680));
 	}
 
-	/**
-	 * @covers ::timeToTimestamp
-	 */
-	public function testTimeToTimestampInvalidParam()
+	public function testTimeToTimestampInvalidParam(): void
 	{
 		$this->expectException(TypeError::class);
 
@@ -913,10 +759,7 @@ class SessionTest extends TestCase
 		$timeToTimestamp->invoke(null, ['tomorrow']);
 	}
 
-	/**
-	 * @covers ::timeToTimestamp
-	 */
-	public function testTimeToTimestampInvalidTimeString()
+	public function testTimeToTimestampInvalidTimeString(): void
 	{
 		$this->expectException(TypeError::class);
 
@@ -927,16 +770,7 @@ class SessionTest extends TestCase
 		$timeToTimestamp->invoke(null, ['some gibberish that is definitely no valid time']);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 * @covers ::autoRenew
-	 * @covers ::needsRenewal
-	 */
-	public function testInit()
+	public function testInit(): void
 	{
 		$token = '9999999999.valid.' . $this->store->validKey;
 
@@ -950,13 +784,7 @@ class SessionTest extends TestCase
 		$this->assertSame('valid', $session->data()->get('id'));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::data
-	 * @covers ::commit
-	 */
-	public function testInitSerializedObject()
+	public function testInitSerializedObject(): void
 	{
 		$token = '9999999999.valid.' . $this->store->validKey;
 
@@ -981,11 +809,7 @@ class SessionTest extends TestCase
 		$this->assertFalse($obj === $session->data()->get('obj'));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
-	public function testInitNonExisting()
+	public function testInitNonExisting(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionCode('error.session.notFound');
@@ -994,11 +818,7 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
-	public function testInitWrongKey()
+	public function testInitWrongKey(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionCode('error.session.invalid');
@@ -1007,11 +827,7 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
-	public function testInitMissingKey()
+	public function testInitMissingKey(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid argument "$token" in method "Session::parseToken"');
@@ -1020,11 +836,7 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
-	public function testInitInvalidSerialization()
+	public function testInitInvalidSerialization(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionCode('error.session.invalid');
@@ -1033,11 +845,7 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
-	public function testInitInvalidStructure()
+	public function testInitInvalidStructure(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionCode('error.session.invalid');
@@ -1046,11 +854,7 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
-	public function testInitExpired()
+	public function testInitExpired(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionCode('error.session.invalid');
@@ -1059,11 +863,7 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
-	public function testInitNotStarted()
+	public function testInitNotStarted(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionCode('error.session.invalid');
@@ -1072,14 +872,7 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
-	public function testInitMoved()
+	public function testInitMoved(): void
 	{
 		// moved session: data should be identical to the actual one
 		$token = '9999999999.moved.' . $this->store->validKey;
@@ -1094,14 +887,7 @@ class SessionTest extends TestCase
 		$this->assertSame('valid', $session->data()->get('id'));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
-	public function testInitMovedRenewal()
+	public function testInitMovedRenewal(): void
 	{
 		// moved session: data should be identical to the actual one
 		$token = '9999999999.movedRenewal.' . $this->store->validKey;
@@ -1119,11 +905,7 @@ class SessionTest extends TestCase
 		$this->assertWriteMode(false, $session);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
-	public function testInitMovedManualRenewal()
+	public function testInitMovedManualRenewal(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionCode('error.session.readonly');
@@ -1134,13 +916,7 @@ class SessionTest extends TestCase
 		$session->renew();
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
-	public function testInitMovedRenewalWithKey()
+	public function testInitMovedRenewalWithKey(): void
 	{
 		if (SymmetricCrypto::isAvailable() !== true) {
 			$this->markTestSkipped('PHP sodium extension is not available');
@@ -1161,14 +937,7 @@ class SessionTest extends TestCase
 		$this->assertWriteMode(true, $session);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
-	public function testInitTimeoutActivity()
+	public function testInitTimeoutActivity(): void
 	{
 		// moved session: data should be identical to the actual one
 		$token = '9999999999.movedTimeoutActivity.' . $this->store->validKey;
@@ -1186,13 +955,7 @@ class SessionTest extends TestCase
 		$this->assertWriteMode(false, $session);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
-	public function testInitTimeoutActivityWithKey()
+	public function testInitTimeoutActivityWithKey(): void
 	{
 		if (SymmetricCrypto::isAvailable() !== true) {
 			$this->markTestSkipped('PHP sodium extension is not available');
@@ -1213,11 +976,7 @@ class SessionTest extends TestCase
 		$this->assertWriteMode(true, $session);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
-	public function testInitMovedExpired()
+	public function testInitMovedExpired(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionCode('error.session.invalid');
@@ -1226,11 +985,7 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
-	public function testInitMovedInvalid()
+	public function testInitMovedInvalid(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionCode('error.session.notFound');
@@ -1239,11 +994,7 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
-	public function testInitMovedWrongKey()
+	public function testInitMovedWrongKey(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionCode('error.session.invalid');
@@ -1252,11 +1003,7 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 */
-	public function testInitExpiredTimeout()
+	public function testInitExpiredTimeout(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionCode('error.session.invalid');
@@ -1265,14 +1012,7 @@ class SessionTest extends TestCase
 		new Session($this->sessions, $token, []);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
-	public function testInitAutoActivity1()
+	public function testInitAutoActivity1(): void
 	{
 		$token = '9999999999.timeoutActivity1.' . $this->store->validKey;
 
@@ -1291,14 +1031,7 @@ class SessionTest extends TestCase
 		$this->assertSame($session->data()->get('expectedActivity'), $activityProperty->getValue($session));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
-	public function testInitAutoActivity2()
+	public function testInitAutoActivity2(): void
 	{
 		$token = '9999999999.timeoutActivity2.' . $this->store->validKey;
 
@@ -1319,14 +1052,7 @@ class SessionTest extends TestCase
 		$this->assertLessThan($session->data()->get('expectedActivity') + 5, $newActivity);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
-	public function testInitAutoRenew()
+	public function testInitAutoRenew(): void
 	{
 		$token = '.renewal.' . $this->store->validKey;
 
@@ -1343,14 +1069,7 @@ class SessionTest extends TestCase
 		$this->assertSame('renewal', $session->data()->get('id'));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::init
-	 * @covers ::token
-	 * @covers ::startTime
-	 * @covers ::data
-	 */
-	public function testInitNonRenewable()
+	public function testInitNonRenewable(): void
 	{
 		$token = '2000000000.nonRenewable.' . $this->store->validKey;
 

--- a/tests/Session/SessionsTest.php
+++ b/tests/Session/SessionsTest.php
@@ -8,12 +8,11 @@ use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Http\Cookie;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionClass;
 use TypeError;
 
-/**
- * @coversDefaultClass \Kirby\Session\Sessions
- */
+#[CoversClass(Sessions::class)]
 class SessionsTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/store';
@@ -35,11 +34,7 @@ class SessionsTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::store
-	 */
-	public function testConstructorStores()
+	public function testConstructorStores(): void
 	{
 		// mock store
 		$this->assertSame($this->store, $this->sessions->store());
@@ -59,20 +54,13 @@ class SessionsTest extends TestCase
 		$this->assertSame($path, $pathProperty->getValue($sessions->store()));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructorInvalidStore()
+	public function testConstructorInvalidStore(): void
 	{
 		$this->expectException(TypeError::class);
 		new Sessions(new InvalidSessionStore());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::cookieName
-	 */
-	public function testConstructorOptions()
+	public function testConstructorOptions(): void
 	{
 		$sessions = new Sessions(static::FIXTURES, [
 			'mode'       => 'header',
@@ -87,30 +75,21 @@ class SessionsTest extends TestCase
 		$this->assertSame('header', $modeProperty->getValue($sessions));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructorInvalidMode()
+	public function testConstructorInvalidMode(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
 		new Sessions(static::FIXTURES, ['mode' => 'invalid']);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructorInvalidCookieName()
+	public function testConstructorInvalidCookieName(): void
 	{
 		$this->expectException(TypeError::class);
 
 		new Sessions(static::FIXTURES, ['cookieName' => ['foo']]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructorGarbageCollector()
+	public function testConstructorGarbageCollector(): void
 	{
 		// collect garbage every time
 		$this->store->collectedGarbage = false;
@@ -123,20 +102,14 @@ class SessionsTest extends TestCase
 		$this->assertFalse($this->store->collectedGarbage);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructorInvalidGcInterval()
+	public function testConstructorInvalidGcInterval(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
 		new Sessions(static::FIXTURES, ['gcInterval' => 0]);
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreate()
+	public function testCreate(): void
 	{
 		$sessions = new Sessions($this->store, ['mode' => 'header']);
 		$session = $sessions->create();
@@ -164,10 +137,7 @@ class SessionsTest extends TestCase
 		$this->assertFalse($session->renewable());
 	}
 
-	/**
-	 * @covers ::get
-	 */
-	public function testGet()
+	public function testGet(): void
 	{
 		$sessions = new Sessions($this->store, ['mode' => 'header']);
 		$session = $sessions->get('9999999999.valid.' . $this->store->validKey);
@@ -184,10 +154,7 @@ class SessionsTest extends TestCase
 		$this->assertSame('someValue', $session2->data()->get('someKey'));
 	}
 
-	/**
-	 * @covers ::get
-	 */
-	public function testGetInvalid()
+	public function testGetInvalid(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionCode('error.session.notFound');
@@ -195,10 +162,7 @@ class SessionsTest extends TestCase
 		$this->sessions->get('9999999999.doesNotExist.' . $this->store->validKey);
 	}
 
-	/**
-	 * @covers ::current
-	 */
-	public function testCurrent()
+	public function testCurrent(): void
 	{
 		Cookie::set('kirby_session', '9999999999.valid.' . $this->store->validKey);
 		$this->setAuthorization('Session 9999999999.valid2.' . $this->store->validKey);
@@ -226,10 +190,7 @@ class SessionsTest extends TestCase
 		$this->assertSame('9999999999.valid2.' . $this->store->validKey, $session->token());
 	}
 
-	/**
-	 * @covers ::current
-	 */
-	public function testCurrentManualMode()
+	public function testCurrentManualMode(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionCode('error.session.sessions.manualMode');
@@ -238,10 +199,7 @@ class SessionsTest extends TestCase
 		$sessions->current();
 	}
 
-	/**
-	 * @covers ::currentDetected
-	 */
-	public function testCurrentDetected()
+	public function testCurrentDetected(): void
 	{
 		Cookie::set('kirby_session', '9999999999.valid.' . $this->store->validKey);
 		$this->setAuthorization('Session 9999999999.valid2.' . $this->store->validKey);
@@ -269,20 +227,14 @@ class SessionsTest extends TestCase
 		$this->assertSame('9999999999.valid2.' . $this->store->validKey, $session->token());
 	}
 
-	/**
-	 * @covers ::collectGarbage
-	 */
-	public function testCollectGarbage()
+	public function testCollectGarbage(): void
 	{
 		$this->store->collectedGarbage = false;
 		$this->sessions->collectGarbage();
 		$this->assertTrue($this->store->collectedGarbage);
 	}
 
-	/**
-	 * @covers ::updateCache
-	 */
-	public function testUpdateCache()
+	public function testUpdateCache(): void
 	{
 		$sessionsReflector = new ReflectionClass(Sessions::class);
 		$cache = $sessionsReflector->getProperty('cache');
@@ -302,10 +254,7 @@ class SessionsTest extends TestCase
 		$this->assertSame($session, $cache->getValue($sessions)['9999999999.valid.new-key']);
 	}
 
-	/**
-	 * @covers ::tokenFromCookie
-	 */
-	public function testTokenFromCookie()
+	public function testTokenFromCookie(): void
 	{
 		$reflector = new ReflectionClass(Sessions::class);
 		$tokenFromCookie = $reflector->getMethod('tokenFromCookie');
@@ -320,10 +269,7 @@ class SessionsTest extends TestCase
 		Cookie::remove('kirby_session');
 	}
 
-	/**
-	 * @covers ::tokenFromHeader
-	 */
-	public function testTokenFromHeader()
+	public function testTokenFromHeader(): void
 	{
 		$reflector = new ReflectionClass(Sessions::class);
 		$tokenFromHeader = $reflector->getMethod('tokenFromHeader');


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Session',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
