### PR TITLE
test: Use PHPUnit attributes for `Kirby\Uuid`

### DIFF
--- a/tests/Uuid/BlockUuidTest.tmp
+++ b/tests/Uuid/BlockUuidTest.tmp
@@ -1,81 +1,65 @@
 <?php
 
-// namespace Kirby\Uuid;
+namespace Kirby\Uuid;
 
-// use Generator;
-// use Kirby\Cms\Blocks;
+use Generator;
+use Kirby\Cms\Blocks;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-// /**
-//  * @coversDefaultClass \Kirby\Uuid\BlockUuid
-//  */
-// class BlockUuidTest extends TestCase
-// {
-// 	/**
-// 	 * @covers ::fieldToCollection
-// 	 */
-// 	public function testFieldToCollection()
-// 	{
-// 		$field  = $this->app->page('page-a')->notes();
-// 		$blocks = BlockUuid::fieldToCollection($field);
-// 		$this->assertInstanceOf(Blocks::class, $blocks);
-// 		$this->assertSame(2, $blocks->count());
-// 	}
+#[CoversClass(BlockUuid::class)]
+class BlockUuidTest extends TestCase
+{
+	public function testFieldToCollection(): void
+	{
+		$field  = $this->app->page('page-a')->notes();
+		$blocks = BlockUuid::fieldToCollection($field);
+		$this->assertInstanceOf(Blocks::class, $blocks);
+		$this->assertSame(2, $blocks->count());
+	}
 
-// 	/**
-// 	 * @covers ::findByCache
-// 	 */
-// 	public function testFindByCache()
-// 	{
-// 		$block = $this->app->page('page-a')->notes()->toBlocks()->nth(1);
+	public function testFindByCache(): void
+	{
+		$block = $this->app->page('page-a')->notes()->toBlocks()->nth(1);
 
-// 		// not yet in cache
-// 		$uuid  = new BlockUuid('block://my-block-2');
-// 		$this->assertFalse($uuid->isCached());
-// 		$this->assertNull($uuid->model(true));
+		// not yet in cache
+		$uuid  = new BlockUuid('block://my-block-2');
+		$this->assertFalse($uuid->isCached());
+		$this->assertNull($uuid->model(true));
 
-// 		// fill cache
-// 		$block->uuid()->populate();
+		// fill cache
+		$block->uuid()->populate();
 
-// 		// retrieve from cache
-// 		$this->assertTrue($uuid->isCached());
-// 		$this->assertTrue($block->is($uuid->model(true)));
-// 	}
+		// retrieve from cache
+		$this->assertTrue($uuid->isCached());
+		$this->assertTrue($block->is($uuid->model(true)));
+	}
 
-// 	/**
-// 	 * @covers ::findByIndex
-// 	 */
-// 	public function testFindByIndex()
-// 	{
-// 		$block = $this->app->page('page-a')->notes()->toBlocks()->nth(1);
-// 		$uuid  = new BlockUuid('block://my-block-2');
-// 		$this->assertFalse($uuid->isCached());
-// 		$this->assertNull($uuid->model(true));
-// 		$this->assertTrue($block->is($uuid->model()));
-// 		$this->assertTrue($uuid->isCached());
+	public function testFindByIndex(): void
+	{
+		$block = $this->app->page('page-a')->notes()->toBlocks()->nth(1);
+		$uuid  = new BlockUuid('block://my-block-2');
+		$this->assertFalse($uuid->isCached());
+		$this->assertNull($uuid->model(true));
+		$this->assertTrue($block->is($uuid->model()));
+		$this->assertTrue($uuid->isCached());
 
-// 		// not found
-// 		$uuid = new BlockUuid('block://does-not-exist');
-// 		$this->assertNull($uuid->model());
-// 	}
+		// not found
+		$uuid = new BlockUuid('block://does-not-exist');
+		$this->assertNull($uuid->model());
+	}
 
-// 	/**
-// 	 * @covers ::index
-// 	 */
-// 	public function testIndex()
-// 	{
-// 		$index = BlockUuid::index();
-// 		$this->assertInstanceOf(Generator::class, $index);
-// 		$this->assertInstanceOf(Blocks::class, $index->current());
-// 		$this->assertSame(2, iterator_count($index));
-// 	}
+	public function testIndex(): void
+	{
+		$index = BlockUuid::index();
+		$this->assertInstanceOf(Generator::class, $index);
+		$this->assertInstanceOf(Blocks::class, $index->current());
+		$this->assertSame(2, iterator_count($index));
+	}
 
-// 	/**
-// 	 * @covers ::value
-// 	 */
-// 	public function testValue()
-// 	{
-// 		$block = $this->app->page('page-a')->notes()->toBlocks()->nth(1);
-// 		$uuid  = $block->uuid();
-// 		$this->assertSame('page://my-page/notes/my-block-2', $uuid->value());
-// 	}
-// }
+	public function testValue(): void
+	{
+		$block = $this->app->page('page-a')->notes()->toBlocks()->nth(1);
+		$uuid  = $block->uuid();
+		$this->assertSame('page://my-page/notes/my-block-2', $uuid->value());
+	}
+}

--- a/tests/Uuid/FileUuidTest.php
+++ b/tests/Uuid/FileUuidTest.php
@@ -4,18 +4,15 @@ namespace Kirby\Uuid;
 
 use Generator;
 use Kirby\Cms\App;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Uuid\FileUuid
- */
+#[CoversClass(FileUuid::class)]
 class FileUuidTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.FileUuid';
 
-	/**
-	 * @covers ::findByCache
-	 */
-	public function testFindByCache()
+	public function testFindByCache(): void
 	{
 		$file = $this->app->file('page-a/test.pdf');
 
@@ -32,10 +29,7 @@ class FileUuidTest extends TestCase
 		$this->assertIsFile($file, $uuid->model(true));
 	}
 
-	/**
-	 * @covers ::findByIndex
-	 */
-	public function testFindByIndex()
+	public function testFindByIndex(): void
 	{
 		$file = $this->app->file('page-a/test.pdf');
 		$uuid  = new FileUuid('file://my-file');
@@ -49,19 +43,13 @@ class FileUuidTest extends TestCase
 		$this->assertNull($uuid->model());
 	}
 
-	/**
-	 * @covers ::id
-	 */
-	public function testId()
+	public function testId(): void
 	{
 		$uuid = new FileUuid('file://just-a-file');
 		$this->assertSame('just-a-file', $uuid->id());
 	}
 
-	/**
-	 * @covers ::id
-	 */
-	public function testIdGenerate()
+	public function testIdGenerate(): void
 	{
 		$file = $this->app->file('page-b/foo.pdf');
 
@@ -70,10 +58,7 @@ class FileUuidTest extends TestCase
 		$this->assertSame($uuid->id(), $file->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::id
-	 */
-	public function testIdGenerateExistingButEmpty()
+	public function testIdGenerateExistingButEmpty(): void
 	{
 		$file = $this->app->file('page-b/foo.pdf');
 		$file->version()->save(['uuid' => '']);
@@ -83,10 +68,7 @@ class FileUuidTest extends TestCase
 		$this->assertSame($uuid->id(), $file->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::index
-	 */
-	public function testIndex()
+	public function testIndex(): void
 	{
 		$index = FileUuid::index();
 		$this->assertInstanceOf(Generator::class, $index);
@@ -94,29 +76,20 @@ class FileUuidTest extends TestCase
 		$this->assertSame(4, iterator_count($index));
 	}
 
-	/**
-	 * @covers ::retrieveId
-	 */
-	public function testRetrieveId()
+	public function testRetrieveId(): void
 	{
 		$file = $this->app->file('page-a/test.pdf');
 		$this->assertSame('my-file', ModelUuid::retrieveId($file));
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrl()
+	public function testUrl(): void
 	{
 		$file = $this->app->file('page-a/test.pdf');
 		$url  = 'https://getkirby.com/@/file/my-file';
 		$this->assertSame($url, $file->uuid()->url());
 	}
 
-	/**
-	 * @covers ::value
-	 */
-	public function testValue()
+	public function testValue(): void
 	{
 		$file = $this->app->file('page-a/test.pdf');
 		$uuid = $file->uuid();
@@ -132,11 +105,8 @@ class FileUuidTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider multilangProvider
-	 * @covers ::id
-	 */
-	public function testMultilang(string $language, string $title)
+	#[DataProvider('multilangProvider')]
+	public function testMultilang(string $language, string $title): void
 	{
 		$app = new App([
 			'roots' => [

--- a/tests/Uuid/HasUuidsTest.php
+++ b/tests/Uuid/HasUuidsTest.php
@@ -6,7 +6,7 @@ class HasUuidsTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.HasUuids';
 
-	public function testfindByUuid()
+	public function testfindByUuid(): void
 	{
 		$app = $this->app->clone([
 			'site' => [

--- a/tests/Uuid/IdentifiableModelActionsTest.php
+++ b/tests/Uuid/IdentifiableModelActionsTest.php
@@ -6,7 +6,7 @@ class IdentifiableModelActionsTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.IdentifiableModelActions';
 
-	public function testFileChangeName()
+	public function testFileChangeName(): void
 	{
 		$file = $this->app->file('page-a/test.pdf');
 		$uuid = $file->uuid();
@@ -19,7 +19,7 @@ class IdentifiableModelActionsTest extends TestCase
 		$this->assertFalse($uuid->isCached());
 	}
 
-	public function testFileDelete()
+	public function testFileDelete(): void
 	{
 		$file = $this->app->file('page-a/test.pdf');
 		$uuid = $file->uuid();
@@ -32,7 +32,7 @@ class IdentifiableModelActionsTest extends TestCase
 		$this->assertFalse($uuid->isCached());
 	}
 
-	public function testPageChangeSlug()
+	public function testPageChangeSlug(): void
 	{
 		$page = $this->app->page('page-a');
 		$uuid = $page->uuid();
@@ -45,7 +45,7 @@ class IdentifiableModelActionsTest extends TestCase
 		$this->assertFalse($uuid->isCached());
 	}
 
-	public function testPageDelete()
+	public function testPageDelete(): void
 	{
 		$page = $this->app->page('page-b');
 		$uuid = $page->uuid();

--- a/tests/Uuid/PageUuidTest.php
+++ b/tests/Uuid/PageUuidTest.php
@@ -4,18 +4,15 @@ namespace Kirby\Uuid;
 
 use Generator;
 use Kirby\Cms\App;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Uuid\PageUuid
- */
+#[CoversClass(PageUuid::class)]
 class PageUuidTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.PageUuid';
 
-	/**
-	 * @covers ::findByCache
-	 */
-	public function testFindByCache()
+	public function testFindByCache(): void
 	{
 		$page = $this->app->page('page-a');
 
@@ -32,10 +29,7 @@ class PageUuidTest extends TestCase
 		$this->assertIsPage($page, $uuid->model(true));
 	}
 
-	/**
-	 * @covers ::findByIndex
-	 */
-	public function testFindByIndex()
+	public function testFindByIndex(): void
 	{
 		$page = $this->app->page('page-a');
 		$uuid  = new PageUuid('page://my-page');
@@ -49,19 +43,13 @@ class PageUuidTest extends TestCase
 		$this->assertNull($uuid->model());
 	}
 
-	/**
-	 * @covers ::id
-	 */
-	public function testId()
+	public function testId(): void
 	{
 		$uuid = new PageUuid('page://just-a-file');
 		$this->assertSame('just-a-file', $uuid->id());
 	}
 
-	/**
-	 * @covers ::id
-	 */
-	public function testIdGenerate()
+	public function testIdGenerate(): void
 	{
 		$page = $this->app->page('page-b');
 
@@ -70,10 +58,7 @@ class PageUuidTest extends TestCase
 		$this->assertSame($uuid->id(), $page->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::id
-	 */
-	public function testIdGenerateExistingButEmpty()
+	public function testIdGenerateExistingButEmpty(): void
 	{
 		$page = $this->app->page('page-b');
 		$page->version()->save(['uuid' => '']);
@@ -83,10 +68,7 @@ class PageUuidTest extends TestCase
 		$this->assertSame($uuid->id(), $page->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::index
-	 */
-	public function testIndex()
+	public function testIndex(): void
 	{
 		$index = PageUuid::index();
 		$this->assertInstanceOf(Generator::class, $index);
@@ -94,19 +76,13 @@ class PageUuidTest extends TestCase
 		$this->assertSame(3, iterator_count($index));
 	}
 
-	/**
-	 * @covers ::retrieveId
-	 */
-	public function testRetrieveId()
+	public function testRetrieveId(): void
 	{
 		$page = $this->app->page('page-a');
 		$this->assertSame('my-page', ModelUuid::retrieveId($page));
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrl()
+	public function testUrl(): void
 	{
 		$page = $this->app->page('page-a');
 		$url  = 'https://getkirby.com/@/page/my-page';
@@ -121,12 +97,8 @@ class PageUuidTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider multilangProvider
-	 * @covers ::id
-	 * @covers ::url
-	 */
-	public function testMultilang(string $language, string $title)
+	#[DataProvider('multilangProvider')]
+	public function testMultilang(string $language, string $title): void
 	{
 		$app = new App([
 			'roots' => [

--- a/tests/Uuid/PermalinksTest.php
+++ b/tests/Uuid/PermalinksTest.php
@@ -6,7 +6,7 @@ class PermalinksTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.Permalinks';
 
-	public function testRoute()
+	public function testRoute(): void
 	{
 		$app = $this->app->clone([
 			'site' => [

--- a/tests/Uuid/SiteUuidTest.php
+++ b/tests/Uuid/SiteUuidTest.php
@@ -3,27 +3,20 @@
 namespace Kirby\Uuid;
 
 use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Uuid\SiteUuid
- */
+#[CoversClass(SiteUuid::class)]
 class SiteUuidTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.SiteUuid';
 
-	/**
-	 * @covers ::id
-	 */
-	public function testId()
+	public function testId(): void
 	{
 		$site = $this->app->site();
 		$this->assertSame('', $site->uuid()->id());
 	}
 
-	/**
-	 * @covers ::index
-	 */
-	public function testIndex()
+	public function testIndex(): void
 	{
 		$index = SiteUuid::index();
 		$this->assertInstanceOf(Generator::class, $index);
@@ -31,29 +24,19 @@ class SiteUuidTest extends TestCase
 		$this->assertSame(1, iterator_count($index));
 	}
 
-	/**
-	 * @covers ::model
-	 */
-	public function testModel()
+	public function testModel(): void
 	{
 		$site = $this->app->site();
 		$this->assertIsSite($site, Uuid::for('site://')->model());
 	}
 
-	/**
-	 * @covers ::populate
-	 */
-	public function testPopulate()
+	public function testPopulate(): void
 	{
 		$uuid = $this->app->site()->uuid();
 		$this->assertTrue($uuid->populate());
 	}
 
-	/**
-	 * @covers ::toString
-	 * @covers ::__toString
-	 */
-	public function testToString()
+	public function testToString(): void
 	{
 		$uuid = $this->app->site()->uuid();
 		$this->assertSame('site://', $uuid->toString());

--- a/tests/Uuid/StructureUuidTest.tmp
+++ b/tests/Uuid/StructureUuidTest.tmp
@@ -1,82 +1,65 @@
 <?php
 
-// namespace Kirby\Uuid;
+namespace Kirby\Uuid;
 
-// use Generator;
-// use Kirby\Cms\Structure;
+use Generator;
+use Kirby\Cms\Structure;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-// /**
-//  * @coversDefaultClass \Kirby\Uuid\StructureUuid
-//  */
-// class StructureUuidTest extends TestCase
-// {
+#[CoversClass(StructureUuid::class)]
+class StructureUuidTest extends TestCase
+{
+	public function testFieldToCollection(): void
+	{
+		$field     = $this->app->page('page-a')->authors();
+		$structure = StructureUuid::fieldToCollection($field);
+		$this->assertInstanceOf(Structure::class, $structure);
+		$this->assertSame(2, $structure->count());
+	}
 
-// 	/**
-// 	 * @covers ::fieldToCollection
-// 	 */
-// 	public function testFieldToCollection()
-// 	{
-// 		$field     = $this->app->page('page-a')->authors();
-// 		$structure = StructureUuid::fieldToCollection($field);
-// 		$this->assertInstanceOf(Structure::class, $structure);
-// 		$this->assertSame(2, $structure->count());
-// 	}
+	public function testFindByCache(): void
+	{
+		$struct = $this->app->page('page-a')->authors()->toStructure()->first();
 
-// 	/**
-// 	 * @covers ::findByCache
-// 	 */
-// 	public function testFindByCache()
-// 	{
-// 		$struct = $this->app->page('page-a')->authors()->toStructure()->first();
+		// not yet in cache
+		$uuid  = new StructureUuid('struct://my-struct');
+		$this->assertFalse($uuid->isCached());
+		$this->assertNull($uuid->model(true));
 
-// 		// not yet in cache
-// 		$uuid  = new StructureUuid('struct://my-struct');
-// 		$this->assertFalse($uuid->isCached());
-// 		$this->assertNull($uuid->model(true));
+		// fill cache
+		$struct->uuid()->populate();
 
-// 		// fill cache
-// 		$struct->uuid()->populate();
+		// retrieve from cache
+		$this->assertTrue($uuid->isCached());
+		$this->assertTrue($struct->is($uuid->model(true)));
+	}
 
-// 		// retrieve from cache
-// 		$this->assertTrue($uuid->isCached());
-// 		$this->assertTrue($struct->is($uuid->model(true)));
-// 	}
+	public function testFindByIndex(): void
+	{
+		$struct = $this->app->page('page-a')->authors()->toStructure()->first();
+		$uuid   = new StructureUuid('struct://my-struct');
+		$this->assertFalse($uuid->isCached());
+		$this->assertNull($uuid->model(true));
+		$this->assertTrue($struct->is($uuid->model()));
+		$this->assertTrue($uuid->isCached());
 
-// 	/**
-// 	 * @covers ::findByIndex
-// 	 */
-// 	public function testFindByIndex()
-// 	{
-// 		$struct = $this->app->page('page-a')->authors()->toStructure()->first();
-// 		$uuid   = new StructureUuid('struct://my-struct');
-// 		$this->assertFalse($uuid->isCached());
-// 		$this->assertNull($uuid->model(true));
-// 		$this->assertTrue($struct->is($uuid->model()));
-// 		$this->assertTrue($uuid->isCached());
+		// not found
+		$uuid = new StructureUuid('struct://does-not-exist');
+		$this->assertNull($uuid->model());
+	}
 
-// 		// not found
-// 		$uuid = new StructureUuid('struct://does-not-exist');
-// 		$this->assertNull($uuid->model());
-// 	}
+	public function testIndex(): void
+	{
+		$index = StructureUuid::index();
+		$this->assertInstanceOf(Generator::class, $index);
+		$this->assertInstanceOf(Structure::class, $index->current());
+		$this->assertSame(2, iterator_count($index));
+	}
 
-// 	/**
-// 	 * @covers ::index
-// 	 */
-// 	public function testIndex()
-// 	{
-// 		$index = StructureUuid::index();
-// 		$this->assertInstanceOf(Generator::class, $index);
-// 		$this->assertInstanceOf(Structure::class, $index->current());
-// 		$this->assertSame(2, iterator_count($index));
-// 	}
-
-// 	/**
-// 	 * @covers ::value
-// 	 */
-// 	public function testValue()
-// 	{
-// 		$struct = $this->app->page('page-a')->authors()->toStructure()->first();
-// 		$uuid   = $struct->uuid();
-// 		$this->assertSame('page://my-page/authors/my-struct', $uuid->value());
-// 	}
-// }
+	public function testValue(): void
+	{
+		$struct = $this->app->page('page-a')->authors()->toStructure()->first();
+		$uuid   = $struct->uuid();
+		$this->assertSame('page://my-page/authors/my-struct', $uuid->value());
+	}
+}

--- a/tests/Uuid/UriTest.php
+++ b/tests/Uuid/UriTest.php
@@ -2,9 +2,10 @@
 
 namespace Kirby\Uuid;
 
-/**
- * @coversDefaultClass \Kirby\Uuid\Uri
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(Uri::class)]
 class UriTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.Uri';
@@ -36,30 +37,21 @@ class UriTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::domain
-	 * @dataProvider provider
-	 */
-	public function testDomain(string $input, string $scheme, string|null $domain)
+	#[DataProvider('provider')]
+	public function testDomain(string $input, string $scheme, string|null $domain): void
 	{
 		$uri = new Uri($input);
 		$this->assertSame($domain, $uri->domain());
 	}
 
-	/**
-	 * @covers ::host
-	 * @dataProvider provider
-	 */
-	public function testHost(string $input, string $scheme, string|null $domain, string|null $path)
+	#[DataProvider('provider')]
+	public function testHost(string $input, string $scheme, string|null $domain, string|null $path): void
 	{
 		$uri = new Uri($input);
 		$this->assertSame($domain ?? '', $uri->host());
 	}
 
-	/**
-	 * @covers ::host
-	 */
-	public function testHostSet()
+	public function testHostSet(): void
 	{
 		$uri = new Uri('page://my-id');
 		$this->assertSame('my-id', $uri->host());
@@ -68,32 +60,22 @@ class UriTest extends TestCase
 		$this->assertSame('page://my-other-id', $uri->toString());
 	}
 
-	/**
-	 * @dataProvider provider
-	 */
-	public function testPath(string $input, string $scheme, string|null $domain, string|null $path)
+	#[DataProvider('provider')]
+	public function testPath(string $input, string $scheme, string|null $domain, string|null $path): void
 	{
 		$uri = new Uri($input);
 		$this->assertSame($path ?? '', $uri->path()->toString());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::base
-	 * @covers ::toString
-	 * @dataProvider provider
-	 */
-	public function testToString(string $input)
+	#[DataProvider('provider')]
+	public function testToString(string $input): void
 	{
 		$uri = new Uri($input);
 		$this->assertSame($input, $uri->toString());
 	}
 
-	/**
-	 * @covers ::type
-	 * @dataProvider provider
-	 */
-	public function testType(string $input, string $scheme)
+	#[DataProvider('provider')]
+	public function testType(string $input, string $scheme): void
 	{
 		$uri = new Uri($input);
 		$this->assertSame($scheme, $uri->type());

--- a/tests/Uuid/UserUuidTest.php
+++ b/tests/Uuid/UserUuidTest.php
@@ -3,18 +3,14 @@
 namespace Kirby\Uuid;
 
 use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Uuid\UserUuid
- */
+#[CoversClass(UserUuid::class)]
 class UserUuidTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.UserUuid';
 
-	/**
-	 * @covers ::index
-	 */
-	public function testIndex()
+	public function testIndex(): void
 	{
 		$index = UserUuid::index();
 		$this->assertInstanceOf(Generator::class, $index);
@@ -22,19 +18,13 @@ class UserUuidTest extends TestCase
 		$this->assertSame(1, iterator_count($index));
 	}
 
-	/**
-	 * @covers ::model
-	 */
-	public function testModel()
+	public function testModel(): void
 	{
 		$user = $this->app->user('my-user');
 		$this->assertIsUser($user, Uuid::for('user://my-user')->model());
 	}
 
-	/**
-	 * @covers ::populate
-	 */
-	public function testPopulate()
+	public function testPopulate(): void
 	{
 		$uuid = $this->app->user('my-user')->uuid();
 		$this->assertTrue($uuid->populate());

--- a/tests/Uuid/UuidTest.php
+++ b/tests/Uuid/UuidTest.php
@@ -7,6 +7,7 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class TestUuid extends Uuid
 {
@@ -16,17 +17,12 @@ class TestUuid extends Uuid
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Uuid\Uuid
- */
+#[CoversClass(Uuid::class)]
 class UuidTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.Uuid';
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructUuidString()
+	public function testConstructUuidString(): void
 	{
 		$uuid = new TestUuid($uri = 'page://my-page-uuid');
 		$this->assertInstanceOf(Uri::class, $uuid->uri);
@@ -35,10 +31,7 @@ class UuidTest extends TestCase
 		$this->assertNull($uuid->context);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructModel()
+	public function testConstructModel(): void
 	{
 		$app      = $this->app;
 		$page     = $app->page('page-a');
@@ -53,10 +46,7 @@ class UuidTest extends TestCase
 		$this->assertSame($siblings, $uuid->context);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructModelStringNoMatch()
+	public function testConstructModelStringNoMatch(): void
 	{
 		$app  = $this->app;
 		$page = $app->page('page-a');
@@ -75,10 +65,7 @@ class UuidTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructConfigDisabled()
+	public function testConstructConfigDisabled(): void
 	{
 		$this->app->clone(['options' => ['content' => ['uuid' => false]]]);
 		$this->expectException(LogicException::class);
@@ -86,12 +73,7 @@ class UuidTest extends TestCase
 		new TestUuid('page://my-page-uuid');
 	}
 
-	/**
-	 * @covers ::clear
-	 * @covers ::isCached
-	 * @covers ::populate
-	 */
-	public function testCache()
+	public function testCache(): void
 	{
 		$page    = $this->app->page('page-a');
 		$subpage = $page->children()->find('subpage-a');
@@ -121,10 +103,7 @@ class UuidTest extends TestCase
 		$this->assertFalse($subpage->isCached());
 	}
 
-	/**
-	 * @covers ::clear
-	 */
-	public function testClearNotGenerate()
+	public function testClearNotGenerate(): void
 	{
 		$page = $this->app->page('page-b');
 		$uuid = $page->uuid();
@@ -134,10 +113,7 @@ class UuidTest extends TestCase
 		$this->assertNull($page->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::context
-	 */
-	public function testContext()
+	public function testContext(): void
 	{
 		$uuid = $this->app->page('page-a')->uuid();
 		$this->assertInstanceOf(Generator::class, $uuid->context());
@@ -151,10 +127,7 @@ class UuidTest extends TestCase
 		$this->assertSame(2, iterator_count($uuid->context()));
 	}
 
-	/**
-	 * @covers ::for
-	 */
-	public function testForUuidString()
+	public function testForUuidString(): void
 	{
 		$this->assertInstanceOf(PageUuid::class, Uuid::for('page://my-id'));
 		$this->assertInstanceOf(FileUuid::class, Uuid::for('file://my-id'));
@@ -165,49 +138,34 @@ class UuidTest extends TestCase
 		// $this->assertInstanceOf(StructureUuid::class, Uuid::for('struct://my-id'));
 	}
 
-	/**
-	 * @covers ::for
-	 */
-	public function testForUuidStringInvalid()
+	public function testForUuidStringInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid UUID URI: foo://my-id');
 		Uuid::for('foo://my-id');
 	}
 
-	/**
-	 * @covers ::for
-	 */
-	public function testForPermalinkString()
+	public function testForPermalinkString(): void
 	{
 		$this->assertInstanceOf(PageUuid::class, Uuid::for('/@/page/my-id'));
 		$this->assertInstanceOf(FileUuid::class, Uuid::for('/@/file/my-id'));
 	}
 
-	/**
-	 * @covers ::for
-	 */
-	public function testForPermalinkStringInvalid()
+	public function testForPermalinkStringInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid UUID URI: foo://my-id');
 		Uuid::for('/@/foo/my-id');
 	}
 
-	/**
-	 * @covers ::for
-	 */
-	public function testForStringInvalid()
+	public function testForStringInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid UUID string: foo˜bar');
 		Uuid::for('foo˜bar');
 	}
 
-	/**
-	 * @covers ::for
-	 */
-	public function testForObject()
+	public function testForObject(): void
 	{
 		$site   = $this->app->site();
 		$page   = $site->find('page-a');
@@ -225,19 +183,13 @@ class UuidTest extends TestCase
 		// $this->assertInstanceOf(StructureUuid::class, Uuid::for($struct));
 	}
 
-	/**
-	 * @covers ::for
-	 */
-	public function testForConfigDisabled()
+	public function testForConfigDisabled(): void
 	{
 		$this->app->clone(['options' => ['content' => ['uuid' => false]]]);
 		$this->assertNull(Uuid::for('page://my-page-uuid'));
 	}
 
-	/**
-	 * @covers ::generate
-	 */
-	public function testGenerate()
+	public function testGenerate(): void
 	{
 		// default length
 		$id = Uuid::generate();
@@ -280,10 +232,7 @@ class UuidTest extends TestCase
 		Uuid::$generator = null;
 	}
 
-	/**
-	 * @covers ::id
-	 */
-	public function testId()
+	public function testId(): void
 	{
 		$uuid = new TestUuid('page://my-uuid-id');
 		$this->assertSame('my-uuid-id', $uuid->id());
@@ -293,19 +242,13 @@ class UuidTest extends TestCase
 	}
 
 
-	/**
-	 * @covers ::index
-	 */
-	public function testIndex()
+	public function testIndex(): void
 	{
 		$this->assertInstanceOf(Generator::class, Uuid::index());
 		$this->assertSame(0, iterator_count(Uuid::index()));
 	}
 
-	/**
-	 * @covers ::indexes
-	 */
-	public function testIndexes()
+	public function testIndexes(): void
 	{
 		$uuid = new TestUuid('page://my-uuid');
 		$this->assertInstanceOf(Generator::class, $uuid->indexes());
@@ -319,10 +262,7 @@ class UuidTest extends TestCase
 		$this->assertSame(2, iterator_count($uuid->indexes()));
 	}
 
-	/**
-	 * @covers ::is
-	 */
-	public function testIs()
+	public function testIs(): void
 	{
 		$this->assertTrue(Uuid::is('site://'));
 		$this->assertTrue(Uuid::is('page://something'));
@@ -357,10 +297,7 @@ class UuidTest extends TestCase
 		$this->assertFalse(Uuid::is('not a page://something'));
 	}
 
-	/**
-	 * @covers ::isCached
-	 */
-	public function testIsCachedNotGenerate()
+	public function testIsCachedNotGenerate(): void
 	{
 		$page = $this->app->page('page-b');
 		$uuid = $page->uuid();
@@ -370,10 +307,7 @@ class UuidTest extends TestCase
 		$this->assertNull($page->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::is
-	 */
-	public function testIsConfigDisabled()
+	public function testIsConfigDisabled(): void
 	{
 		$this->app->clone(['options' => ['content' => ['uuid' => false]]]);
 		$this->assertFalse(Uuid::is('site://'));
@@ -383,19 +317,13 @@ class UuidTest extends TestCase
 		$this->assertFalse(Uuid::is('file://something/else'));
 	}
 
-	/**
-	 * @covers ::key
-	 */
-	public function testKey()
+	public function testKey(): void
 	{
 		$uuid = $this->app->page('page-a')->uuid();
 		$this->assertSame('page/my/-page', $uuid->key());
 	}
 
-	/**
-	 * @covers ::key
-	 */
-	public function testKeyGenerate()
+	public function testKeyGenerate(): void
 	{
 		$page = $this->app->page('page-b');
 		$uuid = $page->uuid();
@@ -404,10 +332,7 @@ class UuidTest extends TestCase
 		$this->assertSame($key, $uuid->key());
 	}
 
-	/**
-	 * @covers ::model
-	 */
-	public function testModel()
+	public function testModel(): void
 	{
 		// for Uuid that was constructed from model
 		$page = $this->app->page('page-a');
@@ -431,20 +356,14 @@ class UuidTest extends TestCase
 		$this->assertTrue($uuid->isCached());
 	}
 
-	/**
-	 * @covers ::model
-	 */
-	public function testModelNotFound()
+	public function testModelNotFound(): void
 	{
 		$this->assertNull(Uuid::for('page://something')->model());
 		$this->assertNull(Uuid::for('user://something')->model());
 		$this->assertNull(Uuid::for('file://something')->model());
 	}
 
-	/**
-	 * @covers ::model
-	 */
-	public function testModelNotFoundIndexLookupDisabled()
+	public function testModelNotFoundIndexLookupDisabled(): void
 	{
 		$this->app->clone(['options' => ['content' => ['uuid' => ['index' => false]]]]);
 		$this->expectException(NotFoundException::class);
@@ -452,10 +371,7 @@ class UuidTest extends TestCase
 		Uuid::for('page://something')->model();
 	}
 
-	/**
-	 * @covers ::isCached
-	 */
-	public function testPopulateGenerate()
+	public function testPopulateGenerate(): void
 	{
 		$page = $this->app->page('page-b');
 		$uuid = $page->uuid();
@@ -464,21 +380,13 @@ class UuidTest extends TestCase
 		$this->assertNotNull($page->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::retrieveId
-	 */
-	public function testRetrieveId()
+	public function testRetrieveId(): void
 	{
 		$page = $this->app->page('page-a');
 		$this->assertSame('page-a', Uuid::retrieveId($page));
 	}
 
-	/**
-	 * @covers ::id
-	 * @covers ::toString
-	 * @covers ::__toString
-	 */
-	public function testToString()
+	public function testToString(): void
 	{
 		// with ID already stored in content
 		$uuid = $this->app->page('page-a')->uuid();
@@ -492,20 +400,13 @@ class UuidTest extends TestCase
 		$this->assertSame(Str::after($id, '://'), $this->app->page('page-b')->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::value
-	 */
-	public function testValue()
+	public function testValue(): void
 	{
 		$page = $this->app->page($dir = 'page-a/subpage-a');
 		$this->assertSame($dir, $page->uuid()->value());
 	}
 
-	/**
-	 * @covers ::model
-	 * @covers ::populate
-	 */
-	public function testCacheInvalidModelId()
+	public function testCacheInvalidModelId(): void
 	{
 		$page = $this->app->page('page-a');
 		$key  = 'page/my/-page';

--- a/tests/Uuid/UuidsTest.php
+++ b/tests/Uuid/UuidsTest.php
@@ -6,18 +6,14 @@ use Kirby\Cache\Cache;
 use Kirby\Cache\MemoryCache;
 use Kirby\Cache\NullCache;
 use Kirby\Exception\LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Uuid\Uuids
- */
+#[CoversClass(Uuids::class)]
 class UuidsTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.Uuids';
 
-	/**
-	 * @covers ::cache
-	 */
-	public function testCache()
+	public function testCache(): void
 	{
 		$this->assertInstanceOf(Cache::class, Uuids::cache());
 
@@ -40,10 +36,7 @@ class UuidsTest extends TestCase
 		$this->assertInstanceOf(NullCache::class, Uuids::cache());
 	}
 
-	/**
-	 * @covers ::each
-	 */
-	public function testEach()
+	public function testEach(): void
 	{
 		$models = 0;
 		Uuids::each(function ($model) use (&$models) {
@@ -52,20 +45,14 @@ class UuidsTest extends TestCase
 		$this->assertSame(7, $models);
 	}
 
-	/**
-	 * @covers ::enabled
-	 */
-	public function testEnabled()
+	public function testEnabled(): void
 	{
 		$this->assertTrue(Uuids::enabled());
 		$this->app->clone(['options' => ['content' => ['uuid' => false]]]);
 		$this->assertFalse(Uuids::enabled());
 	}
 
-	/**
-	 * @covers ::generate
-	 */
-	public function testGenerate()
+	public function testGenerate(): void
 	{
 		$page = $this->app->page('page-b');
 		$file = $this->app->file('page-b/foo.pdf');
@@ -80,10 +67,7 @@ class UuidsTest extends TestCase
 		$this->assertNotNull($file->content()->get('uuid')->value());
 	}
 
-	/**
-	 * @covers ::generate
-	 */
-	public function testGenerateIfDisabled()
+	public function testGenerateIfDisabled(): void
 	{
 		$this->app->clone(['options' => ['content' => ['uuid' => false]]]);
 
@@ -93,10 +77,7 @@ class UuidsTest extends TestCase
 		Uuids::generate();
 	}
 
-	/**
-	 * @covers ::populate
-	 */
-	public function testPopulate()
+	public function testPopulate(): void
 	{
 		$page     = $this->app->page('page-a');
 		$pageFile = $this->app->file('page-a/test.pdf');
@@ -199,10 +180,7 @@ class UuidsTest extends TestCase
 		Uuids::cache()->flush();
 	}
 
-	/**
-	 * @covers ::populate
-	 */
-	public function testPopulateIfDisabled()
+	public function testPopulateIfDisabled(): void
 	{
 		$this->app->clone(['options' => ['content' => ['uuid' => false]]]);
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Uuid',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
