### PR TITLE
test: Use PHPUnit attributes for `Kirby\Api`

### DIFF
--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -22,7 +22,7 @@ class ExtendedModel extends stdClass
 
 class ApiTest extends TestCase
 {
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$api = new Api([]);
 
@@ -36,7 +36,7 @@ class ApiTest extends TestCase
 		$this->assertSame([], $api->routes());
 	}
 
-	public function test__call()
+	public function test__call(): void
 	{
 		$api = new Api([
 			'data' => [
@@ -47,7 +47,7 @@ class ApiTest extends TestCase
 		$this->assertSame('bar', $api->foo());
 	}
 
-	public function testAuthentication()
+	public function testAuthentication(): void
 	{
 		$phpunit = $this;
 
@@ -64,7 +64,7 @@ class ApiTest extends TestCase
 		$api->authenticate();
 	}
 
-	public function testCall()
+	public function testCall(): void
 	{
 		$api = new Api([
 			'routes' => [
@@ -112,7 +112,7 @@ class ApiTest extends TestCase
 		$this->assertEquals(new Response('test', 'text/plain', 201), $result); // cannot use strict assertion (test for object contents)
 	}
 
-	public function testCallLocale()
+	public function testCallLocale(): void
 	{
 		$originalLocale = setlocale(LC_CTYPE, 0);
 
@@ -145,7 +145,7 @@ class ApiTest extends TestCase
 		$this->assertSame($originalLocale, setlocale(LC_CTYPE, 0));
 	}
 
-	public function testCollections()
+	public function testCollections(): void
 	{
 		$api = new Api([
 			'models' => [
@@ -185,7 +185,7 @@ class ApiTest extends TestCase
 		$api->collection('not-available', $instance);
 	}
 
-	public function testData()
+	public function testData(): void
 	{
 		$api = new Api([
 			'data' => $data = [
@@ -206,7 +206,7 @@ class ApiTest extends TestCase
 		$api->data('d');
 	}
 
-	public function testDebug()
+	public function testDebug(): void
 	{
 		$api = new Api([
 			'debug' => true
@@ -215,7 +215,7 @@ class ApiTest extends TestCase
 		$this->assertTrue($api->debug());
 	}
 
-	public function testModels()
+	public function testModels(): void
 	{
 		$api = new Api([
 			'models' => [
@@ -242,7 +242,7 @@ class ApiTest extends TestCase
 		$api->model('not-available', $instance);
 	}
 
-	public function testModelResolver()
+	public function testModelResolver(): void
 	{
 		$api = new Api([
 			'models' => [
@@ -268,7 +268,7 @@ class ApiTest extends TestCase
 		$this->assertInstanceOf(Model::class, $result);
 	}
 
-	public function testModelResolverWithMissingModel()
+	public function testModelResolverWithMissingModel(): void
 	{
 		$this->expectException(NotFoundException::class);
 
@@ -276,7 +276,7 @@ class ApiTest extends TestCase
 		$api->resolve(new MockModel());
 	}
 
-	public function testRequestData()
+	public function testRequestData(): void
 	{
 		$api = new Api([
 			'requestData' => $requestData = [
@@ -318,7 +318,7 @@ class ApiTest extends TestCase
 		$this->assertSame('fallback', $api->requestHeaders('x', 'fallback'));
 	}
 
-	public function testRenderString()
+	public function testRenderString(): void
 	{
 		$api = new Api([
 			'routes' => [
@@ -333,7 +333,7 @@ class ApiTest extends TestCase
 		$this->assertSame('test', $api->render('test', 'POST'));
 	}
 
-	public function testRenderArray()
+	public function testRenderArray(): void
 	{
 		$api = new Api([
 			'routes' => [
@@ -351,7 +351,7 @@ class ApiTest extends TestCase
 		$this->assertSame(json_encode(['a' => 'A']), $result->body());
 	}
 
-	public function testRenderTrue()
+	public function testRenderTrue(): void
 	{
 		$api = new Api([
 			'routes' => [
@@ -375,7 +375,7 @@ class ApiTest extends TestCase
 		$this->assertSame(json_encode($expected), $result->body());
 	}
 
-	public function testRenderFalse()
+	public function testRenderFalse(): void
 	{
 		$api = new Api([
 			'routes' => [
@@ -399,7 +399,7 @@ class ApiTest extends TestCase
 		$this->assertSame(json_encode($expected), $result->body());
 	}
 
-	public function testRenderNull()
+	public function testRenderNull(): void
 	{
 		$api = new Api([
 			'routes' => [
@@ -423,7 +423,7 @@ class ApiTest extends TestCase
 		$this->assertSame(json_encode($expected), $result->body());
 	}
 
-	public function testRenderException()
+	public function testRenderException(): void
 	{
 		$api = new Api([
 			'routes' => [
@@ -451,7 +451,7 @@ class ApiTest extends TestCase
 		$this->assertSame(json_encode($expected), $result->body());
 	}
 
-	public function testRenderExceptionWithDebugging()
+	public function testRenderExceptionWithDebugging(): void
 	{
 		$api = new Api([
 			'debug' => true,
@@ -489,7 +489,7 @@ class ApiTest extends TestCase
 		unset($_SERVER['DOCUMENT_ROOT']);
 	}
 
-	public function testRenderKirbyException()
+	public function testRenderKirbyException(): void
 	{
 		$api = new Api([
 			'routes' => [
@@ -521,7 +521,7 @@ class ApiTest extends TestCase
 		$this->assertSame(json_encode($expected), $result->body());
 	}
 
-	public function testRenderKirbyExceptionWithDebugging()
+	public function testRenderKirbyExceptionWithDebugging(): void
 	{
 		$api = new Api([
 			'debug' => true,
@@ -563,7 +563,7 @@ class ApiTest extends TestCase
 		unset($_SERVER['DOCUMENT_ROOT']);
 	}
 
-	public function testRenderWithSanitizedErrorCode()
+	public function testRenderWithSanitizedErrorCode(): void
 	{
 		$api = new Api([
 			'routes' => [
@@ -582,7 +582,7 @@ class ApiTest extends TestCase
 		$this->assertSame(500, $result->code());
 	}
 
-	public function testRequestMethod()
+	public function testRequestMethod(): void
 	{
 		$api = new Api([
 			'requestMethod' => 'POST',
@@ -591,7 +591,7 @@ class ApiTest extends TestCase
 		$this->assertSame('POST', $api->requestMethod());
 	}
 
-	public function testRoutes()
+	public function testRoutes(): void
 	{
 		$api = new Api([
 			'routes' => $routes = [
@@ -605,7 +605,7 @@ class ApiTest extends TestCase
 		$this->assertSame($routes, $api->routes());
 	}
 
-	public function testUpload()
+	public function testUpload(): void
 	{
 		$api = new Api([
 			'requestMethod' => 'POST',

--- a/tests/Api/CollectionTest.php
+++ b/tests/Api/CollectionTest.php
@@ -9,7 +9,7 @@ use Kirby\TestCase;
 
 class CollectionTest extends TestCase
 {
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$api = new Api([]);
 		$collection = new Collection($api, [], []);
@@ -17,7 +17,7 @@ class CollectionTest extends TestCase
 		$this->assertInstanceOf(Collection::class, $collection);
 	}
 
-	public function testSelect()
+	public function testSelect(): void
 	{
 		$api = new Api([
 			'models' => [
@@ -52,7 +52,7 @@ class CollectionTest extends TestCase
 		$collection->select(0)->toArray();
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$api = new Api([
 			'models' => [
@@ -79,7 +79,7 @@ class CollectionTest extends TestCase
 		$this->assertSame(['value' => 'C'], $result[2]);
 	}
 
-	public function testToResponse()
+	public function testToResponse(): void
 	{
 		$api = new Api([
 			'models' => [

--- a/tests/Api/Controller/ChangesTest.php
+++ b/tests/Api/Controller/ChangesTest.php
@@ -41,7 +41,7 @@ class ChangesTest extends TestCase
 		$this->tearDownTmp();
 	}
 
-	public function testDiscard()
+	public function testDiscard(): void
 	{
 		Data::write($file = $this->page->root() . '/_changes/article.txt', []);
 
@@ -52,7 +52,7 @@ class ChangesTest extends TestCase
 		$this->assertFileDoesNotExist($file);
 	}
 
-	public function testPublish()
+	public function testPublish(): void
 	{
 		$this->app->impersonate('kirby');
 
@@ -88,7 +88,7 @@ class ChangesTest extends TestCase
 		], $published);
 	}
 
-	public function testSave()
+	public function testSave(): void
 	{
 		Data::write($this->page->root() . '/article.txt', [
 			// title and uuid should be passed through
@@ -120,7 +120,7 @@ class ChangesTest extends TestCase
 		], $changes);
 	}
 
-	public function testSaveWithNoDiff()
+	public function testSaveWithNoDiff(): void
 	{
 		Data::write($this->page->root() . '/article.txt', [
 			// title and uuid should be passed through
@@ -148,7 +148,7 @@ class ChangesTest extends TestCase
 	 * @todo We want to ignore undefined fields later in v6. This needs to be
 	 * refactored at that point to make sure that undefined fields are not saved.
 	 */
-	public function testSaveWithUndefinedField()
+	public function testSaveWithUndefinedField(): void
 	{
 		Data::write($this->page->root() . '/article.txt', [
 			// title and uuid should be passed through

--- a/tests/Api/ModelTest.php
+++ b/tests/Api/ModelTest.php
@@ -8,13 +8,13 @@ use stdClass;
 
 class ModelTest extends TestCase
 {
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$model = new Model(new Api([]), [], []);
 
 		$this->assertInstanceOf(Model::class, $model);
 	}
-	public function testConstructInvalidModel()
+	public function testConstructInvalidModel(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Invalid model type "stdClass" expected: "nonexists"');
@@ -22,7 +22,7 @@ class ModelTest extends TestCase
 		new Model(new Api([]), new stdClass(), ['type' => 'nonexists']);
 	}
 
-	public function testConstructMissingModel()
+	public function testConstructMissingModel(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Missing model data');
@@ -30,7 +30,7 @@ class ModelTest extends TestCase
 		new Model(new Api([]), null, []);
 	}
 
-	public function testSelectInvalidKeys()
+	public function testSelectInvalidKeys(): void
 	{
 		$model = new Model(new Api([]), [], []);
 
@@ -39,7 +39,7 @@ class ModelTest extends TestCase
 		$model->select(0);
 	}
 
-	public function testSelection()
+	public function testSelection(): void
 	{
 		$api = new Api([
 			'models' => [

--- a/tests/Api/UploadTest.php
+++ b/tests/Api/UploadTest.php
@@ -11,10 +11,9 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Api\Upload
- */
+#[CoversClass(Upload::class)]
 class UploadTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Api.Upload';
@@ -59,10 +58,7 @@ class UploadTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::chunkId
-	 */
-	public function testChunkId()
+	public function testChunkId(): void
 	{
 		$this->assertSame('abcd', Upload::chunkId('abcd'));
 		$this->assertSame('abcd', Upload::chunkId('ab/cd'));
@@ -70,20 +66,14 @@ class UploadTest extends TestCase
 		$this->assertSame('abcd', Upload::chunkId('a-b/../cd.'));
 	}
 
-	/**
-	 * @covers ::chunkId
-	 */
-	public function testChunkIdInvalid()
+	public function testChunkIdInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Chunk ID must at least be 3 characters long');
 		Upload::chunkId('a-b-');
 	}
 
-	/**
-	 * @covers ::chunkSize
-	 */
-	public function testChunkSize()
+	public function testChunkSize(): void
 	{
 		ini_set('upload_max_filesize', '10M');
 		ini_set('post_max_size', '20M');
@@ -104,10 +94,7 @@ class UploadTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::cleanTmpDir
-	 */
-	public function testCleanTmpDir()
+	public function testCleanTmpDir(): void
 	{
 		$dir = static::TMP . '/site/cache/.uploads';
 		F::write($a = $dir . '/abcd-a.md', '');
@@ -133,30 +120,21 @@ class UploadTest extends TestCase
 		$this->assertFileDoesNotExist($b);
 	}
 
-	/**
-	 * @covers ::error
-	 */
-	public function testError()
+	public function testError(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('No file was uploaded');
 		Upload::error(UPLOAD_ERR_NO_FILE);
 	}
 
-	/**
-	 * @covers ::error
-	 */
-	public function testErrorUnknown()
+	public function testErrorUnknown(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('The file could not be uploaded');
 		Upload::error(999);
 	}
 
-	/**
-	 * @covers ::filename
-	 */
-	public function testFilename()
+	public function testFilename(): void
 	{
 		$this->assertSame('foo.md', Upload::filename(['name' => 'foo.md']));
 		$this->assertSame('foo.jpg', Upload::filename([
@@ -165,10 +143,7 @@ class UploadTest extends TestCase
 		]));
 	}
 
-	/**
-	 * @covers ::process
-	 */
-	public function testProcessSingle()
+	public function testProcessSingle(): void
 	{
 		$upload = $this->upload([
 			'requestMethod' => 'POST',
@@ -202,10 +177,7 @@ class UploadTest extends TestCase
 		], $data);
 	}
 
-	/**
-	 * @covers ::process
-	 */
-	public function testProcessMultiple()
+	public function testProcessMultiple(): void
 	{
 		$upload = $this->upload([
 			'requestMethod' => 'POST',
@@ -245,10 +217,7 @@ class UploadTest extends TestCase
 		], $data);
 	}
 
-	/**
-	 * @covers ::process
-	 */
-	public function testProcessError()
+	public function testProcessError(): void
 	{
 		$upload = $this->upload([
 			'requestMethod' => 'POST',
@@ -274,10 +243,7 @@ class UploadTest extends TestCase
 		], $data);
 	}
 
-	/**
-	 * @covers ::process
-	 */
-	public function testProcessException()
+	public function testProcessException(): void
 	{
 		$upload = $this->upload([
 			'requestMethod' => 'POST',
@@ -309,10 +275,7 @@ class UploadTest extends TestCase
 		$this->assertFalse(F::exists($tmp));
 	}
 
-	/**
-	 * @covers ::process
-	 */
-	public function testProcessWithChunk()
+	public function testProcessWithChunk(): void
 	{
 		$source = static::TMP . '/test.md';
 		F::write($source, 'abcdef');
@@ -346,10 +309,7 @@ class UploadTest extends TestCase
 		$this->assertFileExists($dir . '/abcd-test.md');
 	}
 
-	/**
-	 * @covers ::processChunk
-	 */
-	public function testProcessChunkFirstChunkFullLength()
+	public function testProcessChunkFirstChunkFullLength(): void
 	{
 		$source = static::TMP . '/test.md';
 		F::write($source, 'abcdef');
@@ -372,10 +332,7 @@ class UploadTest extends TestCase
 		$this->assertFileDoesNotExist('abcd-' . $file);
 	}
 
-	/**
-	 * @covers ::processChunk
-	 */
-	public function testProcessChunkFirstChunkPartialLength()
+	public function testProcessChunkFirstChunkPartialLength(): void
 	{
 		$source = static::TMP . '/test.md';
 		F::write($source, 'abcdef');
@@ -395,10 +352,7 @@ class UploadTest extends TestCase
 		$this->assertFileExists($dir . '/abcd-test.md');
 	}
 
-	/**
-	 * @covers ::processChunk
-	 */
-	public function testProcessChunkIdRemoveUnallowedCharacters()
+	public function testProcessChunkIdRemoveUnallowedCharacters(): void
 	{
 		$source = static::TMP . '/test.md';
 		F::write($source, 'abcdef');
@@ -418,10 +372,7 @@ class UploadTest extends TestCase
 		$this->assertFileExists($dir . '/abcd-test.md');
 	}
 
-	/**
-	 * @covers ::processChunk
-	 */
-	public function testProcessChunkFilenameNoDirectoryTraversal()
+	public function testProcessChunkFilenameNoDirectoryTraversal(): void
 	{
 		$source = static::TMP . '/test.md';
 		F::write($source, 'abcdef');
@@ -441,10 +392,7 @@ class UploadTest extends TestCase
 		$this->assertFileExists($dir . '/abcd-test.md');
 	}
 
-	/**
-	 * @covers ::processChunk
-	 */
-	public function testProcessChunkSuccesfulAll()
+	public function testProcessChunkSuccesfulAll(): void
 	{
 		$source = static::TMP . '/test.md';
 		F::write($source, 'abc');
@@ -479,10 +427,7 @@ class UploadTest extends TestCase
 		$this->assertSame('abcdef', F::read($file));
 	}
 
-	/**
-	 * @covers ::response
-	 */
-	public function testResponse()
+	public function testResponse(): void
 	{
 		// nothing
 		$response = Upload::response([], []);
@@ -516,10 +461,7 @@ class UploadTest extends TestCase
 	}
 
 
-	/**
-	 * @covers ::validateChunk
-	 */
-	public function testValidateChunkDuplicate()
+	public function testValidateChunkDuplicate(): void
 	{
 		$source = static::TMP . '/test.md';
 		F::write($source, 'abcdef');
@@ -539,10 +481,7 @@ class UploadTest extends TestCase
 		$upload->processChunk($source, basename($source));
 	}
 
-	/**
-	 * @covers ::validateChunk
-	 */
-	public function testValidateChunkSubsequentInvalidOffset()
+	public function testValidateChunkSubsequentInvalidOffset(): void
 	{
 		$source = static::TMP . '/a.md';
 		F::write($source, 'abcdef');
@@ -573,10 +512,7 @@ class UploadTest extends TestCase
 		$upload->processChunk($source, basename($source));
 	}
 
-	/**
-	 * @covers ::validateChunk
-	 */
-	public function testValidateChunkSubsequentNoFirst()
+	public function testValidateChunkSubsequentNoFirst(): void
 	{
 		$source = static::TMP . '/a.md';
 		F::write($source, 'abcdef');
@@ -595,10 +531,7 @@ class UploadTest extends TestCase
 		$upload->processChunk($source, basename($source));
 	}
 
-	/**
-	 * @covers ::validateChunk
-	 */
-	public function testValidateChunkInvalidExtension()
+	public function testValidateChunkInvalidExtension(): void
 	{
 		$source = static::TMP . '/a.php';
 		$upload = $this->upload([
@@ -616,10 +549,7 @@ class UploadTest extends TestCase
 		$upload->processChunk($source, basename($source));
 	}
 
-	/**
-	 * @covers ::validateChunk
-	 */
-	public function testValidateChunkTooLargeTotal()
+	public function testValidateChunkTooLargeTotal(): void
 	{
 		$source = static::TMP . '/a.md';
 		$app    = $this->app->clone([
@@ -648,10 +578,7 @@ class UploadTest extends TestCase
 		$upload->processChunk($source, basename($source));
 	}
 
-	/**
-	 * @covers ::validateChunk
-	 */
-	public function testValidateChunkTooLargeCurrentChunk()
+	public function testValidateChunkTooLargeCurrentChunk(): void
 	{
 		$dir    = static::TMP . '/site/cache/.uploads';
 		$source = static::TMP . '/a.md';
@@ -684,10 +611,7 @@ class UploadTest extends TestCase
 		$upload->processChunk($source, basename($source));
 	}
 
-	/**
-	 * @covers ::validateFiles
-	 */
-	public function testValidateFilesEmpty()
+	public function testValidateFilesEmpty(): void
 	{
 		ini_set('upload_max_filesize', '10M');
 		ini_set('post_max_size', '20M');


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Api',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
