### PR TITLE
test: Use PHPUnit attributes for `Kirby\Field`

### DIFF
--- a/tests/Field/FieldOptionsTest.php
+++ b/tests/Field/FieldOptionsTest.php
@@ -6,18 +6,14 @@ use Kirby\Cms\Page;
 use Kirby\Option\Options;
 use Kirby\Option\OptionsApi;
 use Kirby\Option\OptionsQuery;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Field\FieldOptions
- */
+#[CoversClass(FieldOptions::class)]
 class FieldOptionsTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/../Option/fixtures';
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$options = FieldOptions::factory([
 			'type' => 'api',
@@ -52,10 +48,7 @@ class FieldOptionsTest extends TestCase
 		$this->assertSame($query, $options->options->query);
 	}
 
-	/**
-	 * @covers ::polyfill
-	 */
-	public function testPolyfill()
+	public function testPolyfill(): void
 	{
 		$props = FieldOptions::polyfill(['options' => 'site.children']);
 		$this->assertSame(['type' => 'query', 'query' => 'site.children'], $props['options']);
@@ -79,11 +72,7 @@ class FieldOptionsTest extends TestCase
 		$this->assertSame(['options' => ['type' => 'array', 'options' => $options]], $props);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::render
-	 */
-	public function testResolveRender()
+	public function testResolveRender(): void
 	{
 		$model = new Page(['slug' => 'test']);
 		$options = FieldOptions::factory(['type'  => 'array', 'options' => ['a', 'b']]);


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Field',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
