### PR TITLE
test: Use PHPUnit attributes for `Kirby\Form`

### DIFF
--- a/tests/Form/Field/BlocksFieldTest.php
+++ b/tests/Form/Field/BlocksFieldTest.php
@@ -10,7 +10,7 @@ use Kirby\Form\Fields;
 
 class BlocksFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('blocks', []);
 
@@ -22,7 +22,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testGroups()
+	public function testGroups(): void
 	{
 		$field = $this->field('blocks', [
 			'group'     => 'test',
@@ -58,7 +58,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertSame(['image', 'video'], $groups['media']['sets']);
 	}
 
-	public function testMax()
+	public function testMax(): void
 	{
 		$field = $this->field('blocks', [
 			'value' => [
@@ -83,7 +83,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertSame($field->errors()['blocks'], 'You must not add more than one block');
 	}
 
-	public function testMin()
+	public function testMin(): void
 	{
 		$field = $this->field('blocks', [
 			'value' => [
@@ -100,7 +100,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertSame($field->errors()['blocks'], 'You must add at least 2 blocks');
 	}
 
-	public function testPretty()
+	public function testPretty(): void
 	{
 		$value = [
 			[
@@ -135,7 +135,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertSame($pretty, $field->toStoredValue());
 	}
 
-	public function testProps()
+	public function testProps(): void
 	{
 		$field = $this->field('blocks');
 
@@ -168,7 +168,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertSame('1/1', $props['width']);
 	}
 
-	public function testRequired()
+	public function testRequired(): void
 	{
 		$field = $this->field('blocks', [
 			'required' => true
@@ -177,7 +177,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertTrue($field->required());
 	}
 
-	public function testRequiredInvalid()
+	public function testRequiredInvalid(): void
 	{
 		$field = $this->field('blocks', [
 			'required' => true
@@ -186,7 +186,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertFalse($field->isValid());
 	}
 
-	public function testRequiredValid()
+	public function testRequiredValid(): void
 	{
 		$field = $this->field('blocks', [
 			'value' => [
@@ -203,7 +203,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertTrue($field->isValid());
 	}
 
-	public function testRoutes()
+	public function testRoutes(): void
 	{
 		$field = $this->field('blocks');
 
@@ -213,7 +213,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertCount(4, $routes);
 	}
 
-	public function testRouteUUID()
+	public function testRouteUUID(): void
 	{
 		$field = $this->field('blocks');
 		$route = $field->routes()[0];
@@ -224,7 +224,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertArrayHasKey('uuid', $response);
 	}
 
-	public function testRoutePaste()
+	public function testRoutePaste(): void
 	{
 		$this->app = $this->app->clone([
 			'request' => [
@@ -245,7 +245,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertSame('text', $response[0]['type']);
 	}
 
-	public function testRoutePasteFieldsets()
+	public function testRoutePasteFieldsets(): void
 	{
 		$this->app = $this->app->clone([
 			'request' => [
@@ -267,7 +267,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertSame('heading', $response[1]['type']);
 	}
 
-	public function testRouteFieldset()
+	public function testRouteFieldset(): void
 	{
 		$field = $this->field('blocks');
 		$route = $field->routes()[2];
@@ -280,7 +280,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertSame('text', $response['type']);
 	}
 
-	public function testToStoredValue()
+	public function testToStoredValue(): void
 	{
 		$value = [
 			[
@@ -321,7 +321,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertSame('', $field->toStoredValue());
 	}
 
-	public function testTranslateField()
+	public function testTranslateField(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -374,7 +374,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertTrue($field->fields('heading')['text']['disabled']);
 	}
 
-	public function testTranslateFieldset()
+	public function testTranslateFieldset(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -429,7 +429,7 @@ class BlocksFieldTest extends TestCase
 		$field->fieldset('not-exists');
 	}
 
-	public function testValidations()
+	public function testValidations(): void
 	{
 		$field = $this->field('blocks', [
 			'value' => [
@@ -452,7 +452,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertTrue($field->isValid());
 	}
 
-	public function testValidationsInvalid()
+	public function testValidationsInvalid(): void
 	{
 		$field = $this->field('blocks', [
 			'value' => [
@@ -478,7 +478,7 @@ class BlocksFieldTest extends TestCase
 		], $field->errors());
 	}
 
-	public function testValidationsWithInvalidBlockType()
+	public function testValidationsWithInvalidBlockType(): void
 	{
 		$field = $this->field('blocks', [
 			'value' => [
@@ -492,7 +492,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertSame([], $field->errors());
 	}
 
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$field = $this->field('blocks', [
 			'empty' => $value = 'Custom empty text'
@@ -501,7 +501,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertSame($value, $field->empty());
 	}
 
-	public function testWhen()
+	public function testWhen(): void
 	{
 		$page = new Page(['slug' => 'test']);
 
@@ -552,7 +552,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertSame($expected, $field->errors());
 	}
 
-	public function testDefault()
+	public function testDefault(): void
 	{
 		$field = $this->field('blocks', [
 			'default' => [
@@ -571,7 +571,7 @@ class BlocksFieldTest extends TestCase
 		$this->assertArrayHasKey('id', $default[0]);
 	}
 
-	public function testInvalidType()
+	public function testInvalidType(): void
 	{
 		$field = $this->field('blocks', [
 			'value' => [

--- a/tests/Form/Field/CheckboxesFieldTest.php
+++ b/tests/Form/Field/CheckboxesFieldTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Field;
 
 class CheckboxesFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('checkboxes');
 
@@ -15,7 +15,7 @@ class CheckboxesFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testValue()
+	public function testValue(): void
 	{
 		$field = $this->field('checkboxes', [
 			'value'   => 'a,b,c',
@@ -29,14 +29,14 @@ class CheckboxesFieldTest extends TestCase
 		$this->assertSame($expected, $field->value());
 	}
 
-	public function testEmptyValue()
+	public function testEmptyValue(): void
 	{
 		$field = $this->field('checkboxes');
 
 		$this->assertSame([], $field->value());
 	}
 
-	public function testDefaultValueWithInvalidOptions()
+	public function testDefaultValueWithInvalidOptions(): void
 	{
 		$field = $this->field('checkboxes', [
 			'default' => 'a,b,d',
@@ -51,7 +51,7 @@ class CheckboxesFieldTest extends TestCase
 		$this->assertSame('a, b', $field->data(true));
 	}
 
-	public function testStringConversion()
+	public function testStringConversion(): void
 	{
 		$field = $this->field('checkboxes', [
 			'options' => [
@@ -65,7 +65,7 @@ class CheckboxesFieldTest extends TestCase
 		$this->assertSame('a, b, c', $field->data());
 	}
 
-	public function testIgnoreInvalidOptions()
+	public function testIgnoreInvalidOptions(): void
 	{
 		$field = $this->field('checkboxes', [
 			'options' => [
@@ -79,7 +79,7 @@ class CheckboxesFieldTest extends TestCase
 		$this->assertSame(['a', 'b'], $field->value());
 	}
 
-	public function testMin()
+	public function testMin(): void
 	{
 		$field = $this->field('checkboxes', [
 			'value'   => 'a',
@@ -92,7 +92,7 @@ class CheckboxesFieldTest extends TestCase
 		$this->assertArrayHasKey('min', $field->errors());
 	}
 
-	public function testMax()
+	public function testMax(): void
 	{
 		$field = $this->field('checkboxes', [
 			'value'   => 'a, b',
@@ -104,7 +104,7 @@ class CheckboxesFieldTest extends TestCase
 		$this->assertArrayHasKey('max', $field->errors());
 	}
 
-	public function testRequiredProps()
+	public function testRequiredProps(): void
 	{
 		$field = $this->field('checkboxes', [
 			'options'  => ['a', 'b', 'c'],
@@ -115,7 +115,7 @@ class CheckboxesFieldTest extends TestCase
 		$this->assertSame(1, $field->min());
 	}
 
-	public function testRequiredInvalid()
+	public function testRequiredInvalid(): void
 	{
 		$field = $this->field('checkboxes', [
 			'options'  => ['a', 'b', 'c'],
@@ -126,7 +126,7 @@ class CheckboxesFieldTest extends TestCase
 		$this->assertFalse($field->isValid());
 	}
 
-	public function testRequiredValid()
+	public function testRequiredValid(): void
 	{
 		$field = $this->field('checkboxes', [
 			'options'  => ['a', 'b', 'c'],

--- a/tests/Form/Field/ColorFieldTest.php
+++ b/tests/Form/Field/ColorFieldTest.php
@@ -7,7 +7,7 @@ use Kirby\Exception\InvalidArgumentException;
 
 class ColorFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('color');
 
@@ -20,7 +20,7 @@ class ColorFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testEmptyColor()
+	public function testEmptyColor(): void
 	{
 		$field = $this->field('color', [
 			'value' => null
@@ -30,7 +30,7 @@ class ColorFieldTest extends TestCase
 		$this->assertNull($field->toString());
 	}
 
-	public function testDefault()
+	public function testDefault(): void
 	{
 		$field = $this->field('color', [
 			'default' => '#fff',
@@ -39,19 +39,19 @@ class ColorFieldTest extends TestCase
 		$this->assertSame('#fff', $field->default());
 	}
 
-	public function testFormatInvalid()
+	public function testFormatInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->field('color', ['format' => 'foo']);
 	}
 
-	public function testModeInvalid()
+	public function testModeInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->field('color', ['mode' => 'foo']);
 	}
 
-	public function testOptions()
+	public function testOptions(): void
 	{
 		// Only values
 		$field = $this->field('color', [
@@ -80,7 +80,7 @@ class ColorFieldTest extends TestCase
 		], $field->options());
 	}
 
-	public function testOptionsFromQuery()
+	public function testOptionsFromQuery(): void
 	{
 		// Only values
 		$this->app = new App([

--- a/tests/Form/Field/DateFieldTest.php
+++ b/tests/Form/Field/DateFieldTest.php
@@ -2,9 +2,11 @@
 
 namespace Kirby\Form\Field;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class DateFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('date');
 
@@ -17,7 +19,7 @@ class DateFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testEmptyDate()
+	public function testEmptyDate(): void
 	{
 		$field = $this->field('date', [
 			'value' => null
@@ -27,7 +29,7 @@ class DateFieldTest extends TestCase
 		$this->assertNull($field->toString());
 	}
 
-	public function testMinMax()
+	public function testMinMax(): void
 	{
 		// empty
 		$field = $this->field('date', [
@@ -136,7 +138,7 @@ class DateFieldTest extends TestCase
 		];
 	}
 
-	public function testSave()
+	public function testSave(): void
 	{
 		// default value
 		$field = $this->field('date', [
@@ -156,7 +158,7 @@ class DateFieldTest extends TestCase
 	/**
 	 * @link https://github.com/getkirby/kirby/issues/3642
 	 */
-	public function testTimeWithDefaultNow()
+	public function testTimeWithDefaultNow(): void
 	{
 		$field = $this->field('date', [
 			'time'    => true,
@@ -167,10 +169,8 @@ class DateFieldTest extends TestCase
 		$this->assertSame($now, $field->default());
 	}
 
-	/**
-	 * @dataProvider valueProvider
-	 */
-	public function testValue($input, $expected, $step = null)
+	#[DataProvider('valueProvider')]
+	public function testValue($input, $expected, $step = null): void
 	{
 		$field = $this->field('date', [
 			'value' => $input,

--- a/tests/Form/Field/EmailFieldTest.php
+++ b/tests/Form/Field/EmailFieldTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Field;
 
 class EmailFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('email');
 
@@ -18,7 +18,7 @@ class EmailFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testEmailValidation()
+	public function testEmailValidation(): void
 	{
 		$field = $this->field('email', [
 			'value' => 'mail@getkirby.com'
@@ -33,7 +33,7 @@ class EmailFieldTest extends TestCase
 		$this->assertFalse($field->isValid());
 	}
 
-	public function testMinLength()
+	public function testMinLength(): void
 	{
 		$field = $this->field('email', [
 			'value' => 'mail@test.com',
@@ -44,7 +44,7 @@ class EmailFieldTest extends TestCase
 		$this->assertArrayHasKey('minlength', $field->errors());
 	}
 
-	public function testMaxLength()
+	public function testMaxLength(): void
 	{
 		$field = $this->field('email', [
 			'value'     => 'mail@test.com',

--- a/tests/Form/Field/EntriesFieldTest.php
+++ b/tests/Form/Field/EntriesFieldTest.php
@@ -3,13 +3,13 @@
 namespace Kirby\Form\Field;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Form\Field\EntriesField
- */
+#[CoversClass(EntriesField::class)]
 class EntriesFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('entries');
 
@@ -20,7 +20,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertSame([], $field->value());
 	}
 
-	public function testProps()
+	public function testProps(): void
 	{
 		$field = $this->field('entries');
 		$props = $field->props();
@@ -62,13 +62,13 @@ class EntriesFieldTest extends TestCase
 		$this->assertSame('1/1', $fieldProps['width']);
 	}
 
-	public function testField()
+	public function testField(): void
 	{
 		$field = $this->field('entries');
 		$this->assertSame(['type' => 'text'], $field->field());
 	}
 
-	public function testFieldString()
+	public function testFieldString(): void
 	{
 		$field = $this->field('entries', [
 			'field' => 'url'
@@ -77,7 +77,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertSame(['type' => 'url'], $field->field());
 	}
 
-	public function testFieldArrayOne()
+	public function testFieldArrayOne(): void
 	{
 		$field = $this->field('entries', [
 			'field' => $props = [
@@ -89,7 +89,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertSame($props, $field->field());
 	}
 
-	public function testFieldArrayTwo()
+	public function testFieldArrayTwo(): void
 	{
 		$field = $this->field('entries', [
 			'field' => $props = [
@@ -102,7 +102,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertSame($props, $field->field());
 	}
 
-	public function testFieldLabel()
+	public function testFieldLabel(): void
 	{
 		$field = $this->field('entries', [
 			'field' => [
@@ -114,7 +114,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertArrayNotHasKey('label', $field->field());
 	}
 
-	public function testFieldCounter()
+	public function testFieldCounter(): void
 	{
 		$field = $this->field('entries', [
 			'field' => [
@@ -126,7 +126,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertArrayNotHasKey('counter', $field->field());
 	}
 
-	public function testDefaultValue()
+	public function testDefaultValue(): void
 	{
 		$field = $this->field('entries', [
 			'default' => $defaults = [
@@ -139,7 +139,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertSame($defaults, $field->default());
 	}
 
-	public function testSortable()
+	public function testSortable(): void
 	{
 		$field = $this->field('entries', [
 			'sortable' => false
@@ -148,7 +148,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertFalse($field->sortable());
 	}
 
-	public function testMax()
+	public function testMax(): void
 	{
 		$field = $this->field('entries', [
 			'max'   => 3,
@@ -159,7 +159,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertTrue($field->isValid());
 	}
 
-	public function testMaxValid()
+	public function testMaxValid(): void
 	{
 		$field = $this->field('entries', [
 			'max'   => 3,
@@ -174,7 +174,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertTrue($field->isValid());
 	}
 
-	public function testMaxInvalid()
+	public function testMaxInvalid(): void
 	{
 		$field = $this->field('entries', [
 			'max'   => 1,
@@ -190,7 +190,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertSame($field->errors()['entries'], 'You must not add more than one entry');
 	}
 
-	public function testMin()
+	public function testMin(): void
 	{
 		$field = $this->field('entries', [
 			'min'   => 3,
@@ -203,7 +203,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertSame($field->errors()['entries'], 'You must add at least 3 entries');
 	}
 
-	public function testMinValid()
+	public function testMinValid(): void
 	{
 		$field = $this->field('entries', [
 			'min'   => 2,
@@ -218,7 +218,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertTrue($field->isValid());
 	}
 
-	public function testMinInvalid()
+	public function testMinInvalid(): void
 	{
 		$field = $this->field('entries', [
 			'min'   => 3,
@@ -233,7 +233,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertSame($field->errors()['entries'], 'You must add at least 3 entries');
 	}
 
-	public function testRequiredValid()
+	public function testRequiredValid(): void
 	{
 		$field = $this->field('entries', [
 			'value'    => [
@@ -246,7 +246,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertSame(1, $field->min());
 	}
 
-	public function testRequiredInvalid()
+	public function testRequiredInvalid(): void
 	{
 		$field = $this->field('entries', [
 			'required' => true
@@ -295,10 +295,8 @@ class EntriesFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider supportsProvider
-	 */
-	public function testSupportedFields($type, $expected)
+	#[DataProvider('supportsProvider')]
+	public function testSupportedFields($type, $expected): void
 	{
 		if ($expected === false) {
 			$this->expectException(InvalidArgumentException::class);
@@ -342,10 +340,8 @@ class EntriesFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider validationsProvider
-	 */
-	public function testValidations($type, $value, $expected)
+	#[DataProvider('validationsProvider')]
+	public function testValidations($type, $value, $expected): void
 	{
 		$field = $this->field('entries', [
 			'value'    => [
@@ -365,7 +361,7 @@ class EntriesFieldTest extends TestCase
 		}
 	}
 
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$field = $this->field('entries', [
 			'empty' => $value = 'Custom empty text'
@@ -374,7 +370,7 @@ class EntriesFieldTest extends TestCase
 		$this->assertSame($value, $field->empty());
 	}
 
-	public function testToStoredValue()
+	public function testToStoredValue(): void
 	{
 		$value = [
 			'Text',

--- a/tests/Form/Field/FilesFieldTest.php
+++ b/tests/Form/Field/FilesFieldTest.php
@@ -61,7 +61,7 @@ class FilesFieldTest extends TestCase
 		return $this->app->page('test');
 	}
 
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('files', [
 			'model' => $this->model()
@@ -78,7 +78,7 @@ class FilesFieldTest extends TestCase
 		$this->assertSame('uuid', $field->store());
 	}
 
-	public function testValue()
+	public function testValue(): void
 	{
 		$field = $this->field('files', [
 			'model' => $this->model(),
@@ -100,7 +100,7 @@ class FilesFieldTest extends TestCase
 		$this->assertSame($expected, $ids);
 	}
 
-	public function testMin()
+	public function testMin(): void
 	{
 		$field = $this->field('files', [
 			'model' => $this->model(),
@@ -117,7 +117,7 @@ class FilesFieldTest extends TestCase
 		$this->assertArrayHasKey('min', $field->errors());
 	}
 
-	public function testMax()
+	public function testMax(): void
 	{
 		$field = $this->field('files', [
 			'model' => $this->model(),
@@ -133,7 +133,7 @@ class FilesFieldTest extends TestCase
 		$this->assertArrayHasKey('max', $field->errors());
 	}
 
-	public function testFilesInDraft()
+	public function testFilesInDraft(): void
 	{
 		$field = $this->field('files', [
 			'model' => $this->app->page('test-draft'),
@@ -155,7 +155,7 @@ class FilesFieldTest extends TestCase
 		$this->assertSame($expected, $ids);
 	}
 
-	public function testQueryWithPageParent()
+	public function testQueryWithPageParent(): void
 	{
 		$field = $this->field('files', [
 			'model' => new Page(['slug' => 'test']),
@@ -164,7 +164,7 @@ class FilesFieldTest extends TestCase
 		$this->assertSame('page.files', $field->query());
 	}
 
-	public function testQueryWithSiteParent()
+	public function testQueryWithSiteParent(): void
 	{
 		$field = $this->field('files', [
 			'model' => new Site(),
@@ -173,7 +173,7 @@ class FilesFieldTest extends TestCase
 		$this->assertSame('site.files', $field->query());
 	}
 
-	public function testQueryWithUserParent()
+	public function testQueryWithUserParent(): void
 	{
 		$field = $this->field('files', [
 			'model' => new User(['email' => 'test@getkirby.com']),
@@ -182,7 +182,7 @@ class FilesFieldTest extends TestCase
 		$this->assertSame('user.files', $field->query());
 	}
 
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$field = $this->field('files', [
 			'model' => new Page(['slug' => 'test']),
@@ -192,7 +192,7 @@ class FilesFieldTest extends TestCase
 		$this->assertSame('Test', $field->empty());
 	}
 
-	public function testTranslatedEmpty()
+	public function testTranslatedEmpty(): void
 	{
 		$field = $this->field('files', [
 			'model' => new Page(['slug' => 'test']),
@@ -202,7 +202,7 @@ class FilesFieldTest extends TestCase
 		$this->assertSame('Test', $field->empty());
 	}
 
-	public function testRequiredProps()
+	public function testRequiredProps(): void
 	{
 		$field = $this->field('files', [
 			'model'    => $this->model(),
@@ -213,7 +213,7 @@ class FilesFieldTest extends TestCase
 		$this->assertSame(1, $field->min());
 	}
 
-	public function testRequiredInvalid()
+	public function testRequiredInvalid(): void
 	{
 		$field = $this->field('files', [
 			'model'    => $this->model(),
@@ -223,7 +223,7 @@ class FilesFieldTest extends TestCase
 		$this->assertFalse($field->isValid());
 	}
 
-	public function testRequiredValid()
+	public function testRequiredValid(): void
 	{
 		$field = $this->field('files', [
 			'model'    => $this->model(),
@@ -236,7 +236,7 @@ class FilesFieldTest extends TestCase
 		$this->assertTrue($field->isValid());
 	}
 
-	public function testApi()
+	public function testApi(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -278,7 +278,7 @@ class FilesFieldTest extends TestCase
 		$this->assertSame('c.jpg', $api['data'][2]['id']);
 	}
 
-	public function testParentModel()
+	public function testParentModel(): void
 	{
 		$field = $this->field('files', [
 			'model' => $this->model()
@@ -294,7 +294,7 @@ class FilesFieldTest extends TestCase
 		$this->assertSame($this->app->site(), $field->parentModel());
 	}
 
-	public function testStore()
+	public function testStore(): void
 	{
 		// Default
 		$field = $this->field('files', [

--- a/tests/Form/Field/GapFieldTest.php
+++ b/tests/Form/Field/GapFieldTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Field;
 
 class GapFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('gap');
 

--- a/tests/Form/Field/HeadlineFieldTest.php
+++ b/tests/Form/Field/HeadlineFieldTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Field;
 
 class HeadlineFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('headline');
 

--- a/tests/Form/Field/HiddenFieldTest.php
+++ b/tests/Form/Field/HiddenFieldTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Field;
 
 class HiddenFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('hidden');
 

--- a/tests/Form/Field/InfoFieldTest.php
+++ b/tests/Form/Field/InfoFieldTest.php
@@ -6,7 +6,7 @@ use Kirby\Cms\Page;
 
 class InfoFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('info');
 
@@ -18,7 +18,7 @@ class InfoFieldTest extends TestCase
 		$this->assertFalse($field->save());
 	}
 
-	public function testText()
+	public function testText(): void
 	{
 		// simple text
 		$field = $this->field('info', [

--- a/tests/Form/Field/LayoutFieldTest.php
+++ b/tests/Form/Field/LayoutFieldTest.php
@@ -7,7 +7,7 @@ use Kirby\Cms\Layouts;
 
 class LayoutFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('layout', []);
 
@@ -21,7 +21,7 @@ class LayoutFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testExtends()
+	public function testExtends(): void
 	{
 		$this->app->clone([
 			'blueprints' => [
@@ -71,7 +71,7 @@ class LayoutFieldTest extends TestCase
 		$this->assertArrayHasKey('background-color', $fields);
 	}
 
-	public function testLayouts()
+	public function testLayouts(): void
 	{
 		$field = $this->field('layout', [
 			'layouts' => $layouts = [
@@ -84,7 +84,7 @@ class LayoutFieldTest extends TestCase
 		$this->assertSame($layouts, $field->layouts());
 	}
 
-	public function testProps()
+	public function testProps(): void
 	{
 		$field = $this->field('layout');
 
@@ -119,7 +119,7 @@ class LayoutFieldTest extends TestCase
 		$this->assertSame([['1/1']], $props['layouts']);
 	}
 
-	public function testRoutes()
+	public function testRoutes(): void
 	{
 		$field = $this->field('layout');
 
@@ -129,7 +129,7 @@ class LayoutFieldTest extends TestCase
 		$this->assertCount(7, $routes);
 	}
 
-	public function testToStoredValue()
+	public function testToStoredValue(): void
 	{
 		$value = [
 			[
@@ -185,7 +185,7 @@ class LayoutFieldTest extends TestCase
 		$this->assertSame('', $field->toStoredValue());
 	}
 
-	public function testValidations()
+	public function testValidations(): void
 	{
 		$field = $this->field('layout', [
 			'value' => [
@@ -208,7 +208,7 @@ class LayoutFieldTest extends TestCase
 		$this->assertTrue($field->isValid());
 	}
 
-	public function testValidationsInvalid()
+	public function testValidationsInvalid(): void
 	{
 		$field = $this->field('layout', [
 			'value' => [
@@ -234,7 +234,7 @@ class LayoutFieldTest extends TestCase
 		], $field->errors());
 	}
 
-	public function testValidationsWithInvalidBlockType()
+	public function testValidationsWithInvalidBlockType(): void
 	{
 		$field = $this->field('layout', [
 			'value' => [
@@ -248,7 +248,7 @@ class LayoutFieldTest extends TestCase
 		$this->assertSame([], $field->errors());
 	}
 
-	public function testValidationsSettings()
+	public function testValidationsSettings(): void
 	{
 		$field = $this->field('layout', [
 			'settings' => [
@@ -274,7 +274,7 @@ class LayoutFieldTest extends TestCase
 		$this->assertSame(['layout' => 'There\'s an error in layout 1 settings'], $field->errors());
 	}
 
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$field = $this->field('layout', [
 			'empty' => $value = 'Custom empty text'
@@ -283,7 +283,7 @@ class LayoutFieldTest extends TestCase
 		$this->assertSame($value, $field->empty());
 	}
 
-	public function testDefault()
+	public function testDefault(): void
 	{
 		$field = $this->field('layout', [
 			'default' => [
@@ -317,7 +317,7 @@ class LayoutFieldTest extends TestCase
 		$this->assertSame('Some title', $block['text']);
 	}
 
-	public function testToValues()
+	public function testToValues(): void
 	{
 		$value = [
 			[
@@ -350,7 +350,7 @@ class LayoutFieldTest extends TestCase
 		$this->assertArrayHasKey('id', $form[0]['columns'][0]['blocks'][0]);
 	}
 
-	public function testPaste()
+	public function testPaste(): void
 	{
 		$value = [
 			[
@@ -394,7 +394,7 @@ class LayoutFieldTest extends TestCase
 		$this->assertSame($original[0]['columns'][0]['blocks'][0]['content'], $pasted[0]['columns'][0]['blocks'][0]['content']);
 	}
 
-	public function testRouteCreate()
+	public function testRouteCreate(): void
 	{
 		$this->app = $this->app->clone([
 			'request' => [
@@ -432,7 +432,7 @@ class LayoutFieldTest extends TestCase
 		$this->assertSame([], $response['columns'][1]['blocks']);
 	}
 
-	public function testRoutePaste()
+	public function testRoutePaste(): void
 	{
 		$value = [
 			[

--- a/tests/Form/Field/LineFieldTest.php
+++ b/tests/Form/Field/LineFieldTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Field;
 
 class LineFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('line');
 

--- a/tests/Form/Field/LinkFieldTest.php
+++ b/tests/Form/Field/LinkFieldTest.php
@@ -6,7 +6,7 @@ use Kirby\Exception\InvalidArgumentException;
 
 class LinkFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('link');
 
@@ -30,7 +30,7 @@ class LinkFieldTest extends TestCase
 		], $field->options());
 	}
 
-	public function testOptionsInvalid()
+	public function testOptionsInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid options: foo, bar');

--- a/tests/Form/Field/ListFieldTest.php
+++ b/tests/Form/Field/ListFieldTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Field;
 
 class ListFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('list');
 

--- a/tests/Form/Field/Mixins/FilePickerMixinTest.php
+++ b/tests/Form/Field/Mixins/FilePickerMixinTest.php
@@ -28,7 +28,7 @@ class FilePickerMixinTest extends TestCase
 		App::destroy();
 	}
 
-	public function testPageFiles()
+	public function testPageFiles(): void
 	{
 		Field::$types = [
 			'test' => [
@@ -60,7 +60,7 @@ class FilePickerMixinTest extends TestCase
 		$this->assertSame('c.jpg', $files[2]['id']);
 	}
 
-	public function testFileFiles()
+	public function testFileFiles(): void
 	{
 		Field::$types = [
 			'test' => [
@@ -92,7 +92,7 @@ class FilePickerMixinTest extends TestCase
 		$this->assertSame('test/c.jpg', $files[2]['id']);
 	}
 
-	public function testUserFiles()
+	public function testUserFiles(): void
 	{
 		Field::$types = [
 			'test' => [
@@ -124,7 +124,7 @@ class FilePickerMixinTest extends TestCase
 		$this->assertSame('c.jpg', $files[2]['id']);
 	}
 
-	public function testSiteFiles()
+	public function testSiteFiles(): void
 	{
 		Field::$types = [
 			'test' => [
@@ -155,7 +155,7 @@ class FilePickerMixinTest extends TestCase
 		$this->assertSame('c.jpg', $files[2]['id']);
 	}
 
-	public function testCustomQuery()
+	public function testCustomQuery(): void
 	{
 		Field::$types = [
 			'test' => [
@@ -195,7 +195,7 @@ class FilePickerMixinTest extends TestCase
 		$this->assertSame('c.jpg', $files[2]['id']);
 	}
 
-	public function testMap()
+	public function testMap(): void
 	{
 		Field::$types = [
 			'test' => [

--- a/tests/Form/Field/Mixins/PagePickerMixinTest.php
+++ b/tests/Form/Field/Mixins/PagePickerMixinTest.php
@@ -8,7 +8,7 @@ class PagePickerMixinTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Form.Fields.PagePickerMixin';
 
-	public function testPagesWithoutParent()
+	public function testPagesWithoutParent(): void
 	{
 		$app = $this->app->clone([
 			'fields' => [
@@ -51,7 +51,7 @@ class PagePickerMixinTest extends TestCase
 		$this->assertSame('c', $pages[2]['id']);
 	}
 
-	public function testPagesWithParent()
+	public function testPagesWithParent(): void
 	{
 		$app = $this->app->clone([
 			'fields' => [
@@ -99,7 +99,7 @@ class PagePickerMixinTest extends TestCase
 		$this->assertSame('a/aa', $pages[0]['id']);
 	}
 
-	public function testPageChildren()
+	public function testPageChildren(): void
 	{
 		$app = $this->app->clone([
 			'fields' => [
@@ -151,7 +151,7 @@ class PagePickerMixinTest extends TestCase
 		$this->assertSame('test/c', $pages[2]['id']);
 	}
 
-	public function testPageChildrenWithoutSubpages()
+	public function testPageChildrenWithoutSubpages(): void
 	{
 		$app = $this->app->clone([
 			'fields' => [
@@ -200,7 +200,7 @@ class PagePickerMixinTest extends TestCase
 		$this->assertSame('test/c', $pages[2]['id']);
 	}
 
-	public function testMap()
+	public function testMap(): void
 	{
 		$app = $this->app->clone([
 			'fields' => [

--- a/tests/Form/Field/Mixins/UserPickerMixinTest.php
+++ b/tests/Form/Field/Mixins/UserPickerMixinTest.php
@@ -30,7 +30,7 @@ class UserPickerMixinTest extends TestCase
 		]);
 	}
 
-	public function testUsersWithoutQuery()
+	public function testUsersWithoutQuery(): void
 	{
 		Field::$types = [
 			'test' => [
@@ -57,7 +57,7 @@ class UserPickerMixinTest extends TestCase
 		$this->assertSame('c@getkirby.com', $users[2]['email']);
 	}
 
-	public function testUsersWithQuery()
+	public function testUsersWithQuery(): void
 	{
 		Field::$types = [
 			'test' => [
@@ -85,7 +85,7 @@ class UserPickerMixinTest extends TestCase
 		$this->assertSame('c@getkirby.com', $users[1]['email']);
 	}
 
-	public function testMap()
+	public function testMap(): void
 	{
 		Field::$types = [
 			'test' => [

--- a/tests/Form/Field/MultiselectFieldTest.php
+++ b/tests/Form/Field/MultiselectFieldTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Field;
 
 class MultiselectFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('multiselect');
 
@@ -23,7 +23,7 @@ class MultiselectFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testMin()
+	public function testMin(): void
 	{
 		$field = $this->field('multiselect', [
 			'value'   => 'a',
@@ -35,7 +35,7 @@ class MultiselectFieldTest extends TestCase
 		$this->assertArrayHasKey('min', $field->errors());
 	}
 
-	public function testMax()
+	public function testMax(): void
 	{
 		$field = $this->field('multiselect', [
 			'value'   => 'a, b',
@@ -47,7 +47,7 @@ class MultiselectFieldTest extends TestCase
 		$this->assertArrayHasKey('max', $field->errors());
 	}
 
-	public function testSanitizeOptions()
+	public function testSanitizeOptions(): void
 	{
 		$field = $this->field('multiselect', [
 			'value'   => 'a, b',

--- a/tests/Form/Field/NumberFieldTest.php
+++ b/tests/Form/Field/NumberFieldTest.php
@@ -2,9 +2,11 @@
 
 namespace Kirby\Form\Field;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class NumberFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('number');
 
@@ -36,10 +38,8 @@ class NumberFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider valueProvider
-	 */
-	public function testValue($input, $expected)
+	#[DataProvider('valueProvider')]
+	public function testValue($input, $expected): void
 	{
 		$field = $this->field('number', [
 			'value'   => $input,
@@ -52,7 +52,7 @@ class NumberFieldTest extends TestCase
 		$this->assertSame($expected, $field->step());
 	}
 
-	public function testMin()
+	public function testMin(): void
 	{
 		$field = $this->field('number', [
 			'value' => 1,
@@ -63,7 +63,7 @@ class NumberFieldTest extends TestCase
 		$this->assertArrayHasKey('min', $field->errors());
 	}
 
-	public function testMax()
+	public function testMax(): void
 	{
 		$field = $this->field('number', [
 			'value' => 1,
@@ -74,7 +74,7 @@ class NumberFieldTest extends TestCase
 		$this->assertArrayHasKey('max', $field->errors());
 	}
 
-	public function testLargeValue()
+	public function testLargeValue(): void
 	{
 		$field = $this->field('number', [
 			'value' => 1000

--- a/tests/Form/Field/ObjectFieldTest.php
+++ b/tests/Form/Field/ObjectFieldTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Field;
 
 class ObjectFieldTest extends TestCase
 {
-	public function testData()
+	public function testData(): void
 	{
 		$field = $this->field('object', [
 			'fields' => [
@@ -20,7 +20,7 @@ class ObjectFieldTest extends TestCase
 		$this->assertSame($value, $field->data());
 	}
 
-	public function testDataWhenEmpty()
+	public function testDataWhenEmpty(): void
 	{
 		$field = $this->field('object', [
 			'fields' => [
@@ -33,7 +33,7 @@ class ObjectFieldTest extends TestCase
 		$this->assertSame('', $field->data());
 	}
 
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('object', [
 			'fields' => [
@@ -50,7 +50,7 @@ class ObjectFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testDefaultValue()
+	public function testDefaultValue(): void
 	{
 		$field = $this->field('object', [
 			'fields' => [
@@ -70,7 +70,7 @@ class ObjectFieldTest extends TestCase
 		$this->assertSame($expected, $field->default());
 	}
 
-	public function testErrors()
+	public function testErrors(): void
 	{
 		$field = $this->field('object', [
 			'fields' => [
@@ -94,7 +94,7 @@ class ObjectFieldTest extends TestCase
 		$this->assertSame($expected, $field->errors());
 	}
 
-	public function testErrorsWhenEmpty()
+	public function testErrorsWhenEmpty(): void
 	{
 		$field = $this->field('object', [
 			'fields' => [
@@ -107,13 +107,13 @@ class ObjectFieldTest extends TestCase
 		$this->assertSame([], $field->errors());
 	}
 
-	public function testFieldsMissing()
+	public function testFieldsMissing(): void
 	{
 		$field = $this->field('object', []);
 		$this->assertSame([], $field->fields());
 	}
 
-	public function testTagsField()
+	public function testTagsField(): void
 	{
 		$field = $this->field('object', [
 			'fields' => [

--- a/tests/Form/Field/PagesFieldTest.php
+++ b/tests/Form/Field/PagesFieldTest.php
@@ -43,7 +43,7 @@ class PagesFieldTest extends TestCase
 		return $this->app->page('a');
 	}
 
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('pages', [
 			'model' => $this->model()
@@ -58,7 +58,7 @@ class PagesFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testValue()
+	public function testValue(): void
 	{
 		$field = $this->field('pages', [
 			'model' => $this->model(),
@@ -80,7 +80,7 @@ class PagesFieldTest extends TestCase
 		$this->assertSame($expected, $ids);
 	}
 
-	public function testMin()
+	public function testMin(): void
 	{
 		$field = $this->field('pages', [
 			'model' => $this->model(),
@@ -97,7 +97,7 @@ class PagesFieldTest extends TestCase
 		$this->assertArrayHasKey('min', $field->errors());
 	}
 
-	public function testMax()
+	public function testMax(): void
 	{
 		$field = $this->field('pages', [
 			'model' => $this->model(),
@@ -113,7 +113,7 @@ class PagesFieldTest extends TestCase
 		$this->assertArrayHasKey('max', $field->errors());
 	}
 
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$field = $this->field('pages', [
 			'model' => new Page(['slug' => 'test']),
@@ -123,7 +123,7 @@ class PagesFieldTest extends TestCase
 		$this->assertSame('Test', $field->empty());
 	}
 
-	public function testTranslatedEmpty()
+	public function testTranslatedEmpty(): void
 	{
 		$field = $this->field('pages', [
 			'model' => new Page(['slug' => 'test']),
@@ -133,7 +133,7 @@ class PagesFieldTest extends TestCase
 		$this->assertSame('Test', $field->empty());
 	}
 
-	public function testRequiredProps()
+	public function testRequiredProps(): void
 	{
 		$field = $this->field('pages', [
 			'model'    => new Page(['slug' => 'test']),
@@ -144,7 +144,7 @@ class PagesFieldTest extends TestCase
 		$this->assertSame(1, $field->min());
 	}
 
-	public function testRequiredInvalid()
+	public function testRequiredInvalid(): void
 	{
 		$field = $this->field('pages', [
 			'model'    => new Page(['slug' => 'test']),
@@ -154,7 +154,7 @@ class PagesFieldTest extends TestCase
 		$this->assertFalse($field->isValid());
 	}
 
-	public function testRequiredValid()
+	public function testRequiredValid(): void
 	{
 		$field = $this->field('pages', [
 			'model'    => new Page(['slug' => 'test']),
@@ -167,7 +167,7 @@ class PagesFieldTest extends TestCase
 		$this->assertTrue($field->isValid());
 	}
 
-	public function testApi()
+	public function testApi(): void
 	{
 		$app = new App([
 			'roots' => [

--- a/tests/Form/Field/RadioFieldTest.php
+++ b/tests/Form/Field/RadioFieldTest.php
@@ -2,9 +2,11 @@
 
 namespace Kirby\Form\Field;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class RadioFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('radio');
 
@@ -26,10 +28,8 @@ class RadioFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider valueInputProvider
-	 */
-	public function testValue($input, $expected)
+	#[DataProvider('valueInputProvider')]
+	public function testValue($input, $expected): void
 	{
 		$field = $this->field('radio', [
 			'options' => [

--- a/tests/Form/Field/RangeFieldTest.php
+++ b/tests/Form/Field/RangeFieldTest.php
@@ -6,7 +6,7 @@ use Kirby\Toolkit\I18n;
 
 class RangeFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('range');
 
@@ -21,7 +21,7 @@ class RangeFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testMin()
+	public function testMin(): void
 	{
 		$field = $this->field('range', [
 			'value' => 1,
@@ -32,7 +32,7 @@ class RangeFieldTest extends TestCase
 		$this->assertArrayHasKey('min', $field->errors());
 	}
 
-	public function testMax()
+	public function testMax(): void
 	{
 		$field = $this->field('range', [
 			'value' => 1,
@@ -43,7 +43,7 @@ class RangeFieldTest extends TestCase
 		$this->assertArrayHasKey('max', $field->errors());
 	}
 
-	public function testTooltip()
+	public function testTooltip(): void
 	{
 		$field = $this->field('range', [
 			'tooltip' => [
@@ -58,7 +58,7 @@ class RangeFieldTest extends TestCase
 		$this->assertSame('months', $tooltip['after']);
 	}
 
-	public function testTooltipTranslation()
+	public function testTooltipTranslation(): void
 	{
 		$props = [
 			'tooltip' => [

--- a/tests/Form/Field/SelectFieldTest.php
+++ b/tests/Form/Field/SelectFieldTest.php
@@ -2,9 +2,11 @@
 
 namespace Kirby\Form\Field;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class SelectFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('select');
 
@@ -16,7 +18,7 @@ class SelectFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testOptionsQuery()
+	public function testOptionsQuery(): void
 	{
 		$app = $this->app()->clone([
 			'site' => [
@@ -112,7 +114,7 @@ class SelectFieldTest extends TestCase
 		$this->assertSame($expected, $field->options());
 	}
 
-	public function testOptionsQueryAdditionalData()
+	public function testOptionsQueryAdditionalData(): void
 	{
 		$this->app()->clone([
 			'site' => [
@@ -196,10 +198,8 @@ class SelectFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider valueInputProvider
-	 */
-	public function testValue($input, $expected)
+	#[DataProvider('valueInputProvider')]
+	public function testValue($input, $expected): void
 	{
 		$field = $this->field('select', [
 			'options' => [

--- a/tests/Form/Field/SlugFieldTest.php
+++ b/tests/Form/Field/SlugFieldTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Field;
 
 class SlugFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('slug');
 

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -7,7 +7,7 @@ use Kirby\Cms\Page;
 
 class StructureFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('structure', [
 			'fields' => [
@@ -25,7 +25,7 @@ class StructureFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testTagsFieldInStructure()
+	public function testTagsFieldInStructure(): void
 	{
 		$field = $this->field('structure', [
 			'fields' => [
@@ -52,7 +52,7 @@ class StructureFieldTest extends TestCase
 		$this->assertSame(['a', 'b'], $field->value()[0]['tags']);
 	}
 
-	public function testColumnsFromFields()
+	public function testColumnsFromFields(): void
 	{
 		$field = $this->field('structure', [
 			'fields' => [
@@ -80,7 +80,7 @@ class StructureFieldTest extends TestCase
 		$this->assertSame($expected, $field->columns());
 	}
 
-	public function testColumnsWithCustomMobileSetup()
+	public function testColumnsWithCustomMobileSetup(): void
 	{
 		$field = $this->field('structure', [
 			'columns' => [
@@ -109,7 +109,7 @@ class StructureFieldTest extends TestCase
 		$this->assertSame($expected, $field->columns());
 	}
 
-	public function testColumnsWithI18nLabel()
+	public function testColumnsWithI18nLabel(): void
 	{
 		$field = $this->field('structure', [
 			'columns' => [
@@ -138,7 +138,7 @@ class StructureFieldTest extends TestCase
 		$this->assertSame($expected, $field->columns());
 	}
 
-	public function testLowerCaseColumnsNames()
+	public function testLowerCaseColumnsNames(): void
 	{
 		$field = $this->field('structure', [
 			'columns' => [
@@ -154,7 +154,7 @@ class StructureFieldTest extends TestCase
 		$this->assertSame(['camelcase'], array_keys($field->columns()));
 	}
 
-	public function testMin()
+	public function testMin(): void
 	{
 		$field = $this->field('structure', [
 			'fields' => [
@@ -174,7 +174,7 @@ class StructureFieldTest extends TestCase
 		$this->assertArrayHasKey('min', $field->errors());
 	}
 
-	public function testMax()
+	public function testMax(): void
 	{
 		$field = $this->field('structure', [
 			'fields' => [
@@ -194,7 +194,7 @@ class StructureFieldTest extends TestCase
 		$this->assertArrayHasKey('max', $field->errors());
 	}
 
-	public function testNestedStructures()
+	public function testNestedStructures(): void
 	{
 		$model = new Page([
 			'slug' => 'test'
@@ -283,7 +283,7 @@ class StructureFieldTest extends TestCase
 		$this->assertSame('', $childrenNameField->data());
 	}
 
-	public function testFloatsWithNonUsLocale()
+	public function testFloatsWithNonUsLocale(): void
 	{
 		$field = $this->field('structure', [
 			'fields' => [
@@ -301,7 +301,7 @@ class StructureFieldTest extends TestCase
 		$this->assertIsFloat($field->data()[0]['number']);
 	}
 
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$field = $this->field('structure', [
 			'fields' => [
@@ -315,7 +315,7 @@ class StructureFieldTest extends TestCase
 		$this->assertSame('Test', $field->empty());
 	}
 
-	public function testTranslatedEmpty()
+	public function testTranslatedEmpty(): void
 	{
 		$field = $this->field('structure', [
 			'fields' => [
@@ -329,7 +329,7 @@ class StructureFieldTest extends TestCase
 		$this->assertSame('Test', $field->empty());
 	}
 
-	public function testTranslate()
+	public function testTranslate(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -380,7 +380,7 @@ class StructureFieldTest extends TestCase
 		$this->assertTrue($props['b']['disabled']);
 	}
 
-	public function testDefault()
+	public function testDefault(): void
 	{
 		$field = $this->field('structure', [
 			'fields' => [
@@ -403,7 +403,7 @@ class StructureFieldTest extends TestCase
 		$this->assertSame('B', $field->data(true)[0]['b']);
 	}
 
-	public function testRequiredProps()
+	public function testRequiredProps(): void
 	{
 		$field = $this->field('structure', [
 			'fields' => [
@@ -418,7 +418,7 @@ class StructureFieldTest extends TestCase
 		$this->assertSame(1, $field->min());
 	}
 
-	public function testRequiredInvalid()
+	public function testRequiredInvalid(): void
 	{
 		$field = $this->field('structure', [
 			'fields' => [
@@ -432,7 +432,7 @@ class StructureFieldTest extends TestCase
 		$this->assertFalse($field->isValid());
 	}
 
-	public function testRequiredValid()
+	public function testRequiredValid(): void
 	{
 		$field = $this->field('structure', [
 			'fields' => [
@@ -449,7 +449,7 @@ class StructureFieldTest extends TestCase
 		$this->assertTrue($field->isValid());
 	}
 
-	public function testSubmitWithDisabledFieldAndDefaultValue()
+	public function testSubmitWithDisabledFieldAndDefaultValue(): void
 	{
 		$field = $this->field('structure', [
 			'fields' => [
@@ -477,7 +477,7 @@ class StructureFieldTest extends TestCase
 		$this->assertSame('B', $value[0]['b']);
 	}
 
-	public function testValidationsInvalid()
+	public function testValidationsInvalid(): void
 	{
 		$field = $this->field('structure', [
 			'fields' => [

--- a/tests/Form/Field/TagsFieldTest.php
+++ b/tests/Form/Field/TagsFieldTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Field;
 
 class TagsFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('tags');
 
@@ -22,7 +22,7 @@ class TagsFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testOptionsQuery()
+	public function testOptionsQuery(): void
 	{
 		$app = $this->app()->clone([
 			'site' => [
@@ -117,7 +117,7 @@ class TagsFieldTest extends TestCase
 		$this->assertSame($expected, $field->options());
 	}
 
-	public function testMin()
+	public function testMin(): void
 	{
 		$field = $this->field('tags', [
 			'value'   => 'a',
@@ -131,7 +131,7 @@ class TagsFieldTest extends TestCase
 		$this->assertTrue($field->required());
 	}
 
-	public function testMax()
+	public function testMax(): void
 	{
 		$field = $this->field('tags', [
 			'value'   => 'a, b',
@@ -144,7 +144,7 @@ class TagsFieldTest extends TestCase
 		$this->assertArrayHasKey('max', $field->errors());
 	}
 
-	public function testRequiredProps()
+	public function testRequiredProps(): void
 	{
 		$field = $this->field('tags', [
 			'options'  => ['a', 'b', 'c'],
@@ -155,7 +155,7 @@ class TagsFieldTest extends TestCase
 		$this->assertSame(1, $field->min());
 	}
 
-	public function testRequiredInvalid()
+	public function testRequiredInvalid(): void
 	{
 		$field = $this->field('tags', [
 			'options'  => ['a', 'b', 'c'],
@@ -166,7 +166,7 @@ class TagsFieldTest extends TestCase
 		$this->assertFalse($field->isValid());
 	}
 
-	public function testRequiredValid()
+	public function testRequiredValid(): void
 	{
 		$field = $this->field('tags', [
 			'options'  => ['a', 'b', 'c'],

--- a/tests/Form/Field/TelFieldTest.php
+++ b/tests/Form/Field/TelFieldTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Field;
 
 class TelFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('tel');
 

--- a/tests/Form/Field/TextFieldTest.php
+++ b/tests/Form/Field/TextFieldTest.php
@@ -3,10 +3,11 @@
 namespace Kirby\Form\Field;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class TextFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('text');
 
@@ -35,10 +36,8 @@ class TextFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider converterDataProvider
-	 */
-	public function testConverter($converter, $input, $expected)
+	#[DataProvider('converterDataProvider')]
+	public function testConverter($converter, $input, $expected): void
 	{
 		$field = $this->field('text', [
 			'converter' => $converter,
@@ -50,7 +49,7 @@ class TextFieldTest extends TestCase
 		$this->assertSame($expected, $field->default());
 	}
 
-	public function testInvalidConverter()
+	public function testInvalidConverter(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid converter "does-not-exist"');
@@ -60,7 +59,7 @@ class TextFieldTest extends TestCase
 		]);
 	}
 
-	public function testMinLength()
+	public function testMinLength(): void
 	{
 		$field = $this->field('text', [
 			'value' => 'test',
@@ -71,7 +70,7 @@ class TextFieldTest extends TestCase
 		$this->assertArrayHasKey('minlength', $field->errors());
 	}
 
-	public function testMaxLength()
+	public function testMaxLength(): void
 	{
 		$field = $this->field('text', [
 			'value'     => 'test',

--- a/tests/Form/Field/TextareaFieldTest.php
+++ b/tests/Form/Field/TextareaFieldTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Field;
 
 class TextareaFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('textarea');
 
@@ -22,7 +22,7 @@ class TextareaFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testButtonsDisabled()
+	public function testButtonsDisabled(): void
 	{
 		$field = $this->field('textarea', [
 			'buttons' => false
@@ -31,7 +31,7 @@ class TextareaFieldTest extends TestCase
 		$this->assertFalse($field->buttons());
 	}
 
-	public function testButtonsArray()
+	public function testButtonsArray(): void
 	{
 		$field = $this->field('textarea', [
 			'buttons' => [
@@ -43,7 +43,7 @@ class TextareaFieldTest extends TestCase
 		$this->assertSame(['bold', 'italic'], $field->buttons());
 	}
 
-	public function testDefaultTrimmed()
+	public function testDefaultTrimmed(): void
 	{
 		$field = $this->field('textarea', [
 			'default' => 'test '
@@ -52,7 +52,7 @@ class TextareaFieldTest extends TestCase
 		$this->assertSame('test', $field->default());
 	}
 
-	public function testFiles()
+	public function testFiles(): void
 	{
 		$field = $this->field('textarea', [
 			'value' => 'test',
@@ -64,7 +64,7 @@ class TextareaFieldTest extends TestCase
 		$this->assertSame(['query' => 'page.images'], $field->files());
 	}
 
-	public function testFilesQuery()
+	public function testFilesQuery(): void
 	{
 		$field = $this->field('textarea', [
 			'value' => 'test',
@@ -74,7 +74,7 @@ class TextareaFieldTest extends TestCase
 		$this->assertSame(['query' => 'page.images'], $field->files());
 	}
 
-	public function testFilesWithInvalidInput()
+	public function testFilesWithInvalidInput(): void
 	{
 		$field = $this->field('textarea', [
 			'files' => 1
@@ -83,7 +83,7 @@ class TextareaFieldTest extends TestCase
 		$this->assertSame([], $field->files());
 	}
 
-	public function testMaxLength()
+	public function testMaxLength(): void
 	{
 		$field = $this->field('textarea', [
 			'value'     => 'test',
@@ -94,7 +94,7 @@ class TextareaFieldTest extends TestCase
 		$this->assertArrayHasKey('maxlength', $field->errors());
 	}
 
-	public function testMinLength()
+	public function testMinLength(): void
 	{
 		$field = $this->field('textarea', [
 			'value' => 'test',
@@ -105,7 +105,7 @@ class TextareaFieldTest extends TestCase
 		$this->assertArrayHasKey('minlength', $field->errors());
 	}
 
-	public function testUploads()
+	public function testUploads(): void
 	{
 		$field = $this->field('textarea', [
 			'value' => 'test',
@@ -117,7 +117,7 @@ class TextareaFieldTest extends TestCase
 		$this->assertSame(['template' => 'test', 'accept' => '*'], $field->uploads());
 	}
 
-	public function testUploadsDisabled()
+	public function testUploadsDisabled(): void
 	{
 		$field = $this->field('textarea', [
 			'value' => 'test',
@@ -127,7 +127,7 @@ class TextareaFieldTest extends TestCase
 		$this->assertFalse($field->uploads());
 	}
 
-	public function testUploadsParent()
+	public function testUploadsParent(): void
 	{
 		$field = $this->field('textarea', [
 			'value' => 'test',
@@ -139,7 +139,7 @@ class TextareaFieldTest extends TestCase
 		$this->assertSame(['parent' => 'page.parent', 'accept' => '*'], $field->uploads());
 	}
 
-	public function testUploadsTemplate()
+	public function testUploadsTemplate(): void
 	{
 		$field = $this->field('textarea', [
 			'value' => 'test',
@@ -149,7 +149,7 @@ class TextareaFieldTest extends TestCase
 		$this->assertSame(['template' => 'test', 'accept' => '*'], $field->uploads());
 	}
 
-	public function testUploadsWithInvalidInput()
+	public function testUploadsWithInvalidInput(): void
 	{
 		$field = $this->field('textarea', [
 			'value' => 'test',
@@ -159,7 +159,7 @@ class TextareaFieldTest extends TestCase
 		$this->assertSame(['accept' => '*'], $field->uploads());
 	}
 
-	public function testValueTrimmed()
+	public function testValueTrimmed(): void
 	{
 		$field = $this->field('textarea', [
 			'value' => 'test '

--- a/tests/Form/Field/TimeFieldTest.php
+++ b/tests/Form/Field/TimeFieldTest.php
@@ -2,9 +2,11 @@
 
 namespace Kirby\Form\Field;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class TimeFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('time');
 
@@ -19,7 +21,7 @@ class TimeFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testDisplayFor12HourNotation()
+	public function testDisplayFor12HourNotation(): void
 	{
 		$field = $this->field('time', [
 			'notation' => 12
@@ -28,7 +30,7 @@ class TimeFieldTest extends TestCase
 		$this->assertSame('hh:mm a', $field->display());
 	}
 
-	public function testDisplayWithCustomSetup()
+	public function testDisplayWithCustomSetup(): void
 	{
 		$field = $this->field('time', [
 			'display' => 'HH:mm:ss'
@@ -37,7 +39,7 @@ class TimeFieldTest extends TestCase
 		$this->assertSame('HH:mm:ss', $field->display());
 	}
 
-	public function testMinMax()
+	public function testMinMax(): void
 	{
 		// no value
 		$field = $this->field('time', [
@@ -160,10 +162,8 @@ class TimeFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider valueProvider
-	 */
-	public function testValue($input, $expected, $step = 1)
+	#[DataProvider('valueProvider')]
+	public function testValue($input, $expected, $step = 1): void
 	{
 		$field = $this->field('time', [
 			'default' => $input,

--- a/tests/Form/Field/ToggleFieldTest.php
+++ b/tests/Form/Field/ToggleFieldTest.php
@@ -6,7 +6,7 @@ use Kirby\Toolkit\I18n;
 
 class ToggleFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('toggle');
 
@@ -16,7 +16,7 @@ class ToggleFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testText()
+	public function testText(): void
 	{
 		$field = $this->field('toggle', [
 			'text' => 'Yay {{ page.slug }}'
@@ -25,7 +25,7 @@ class ToggleFieldTest extends TestCase
 		$this->assertSame('Yay test', $field->text());
 	}
 
-	public function testTextWithTranslation()
+	public function testTextWithTranslation(): void
 	{
 		$props = [
 			'text' => [
@@ -45,7 +45,7 @@ class ToggleFieldTest extends TestCase
 		$this->assertSame('Ja test', $field->text());
 	}
 
-	public function testBooleanDefaultValue()
+	public function testBooleanDefaultValue(): void
 	{
 		// true
 		$field = $this->field('toggle', [
@@ -62,7 +62,7 @@ class ToggleFieldTest extends TestCase
 		$this->assertTrue($field->default() === false);
 	}
 
-	public function testTextToggle()
+	public function testTextToggle(): void
 	{
 		$field = $this->field('toggle', [
 			'text' => [
@@ -74,7 +74,7 @@ class ToggleFieldTest extends TestCase
 		$this->assertSame(['Yes test', 'No test'], $field->text());
 	}
 
-	public function testTextToggleWithTranslation()
+	public function testTextToggleWithTranslation(): void
 	{
 		$props = [
 			'text' => [

--- a/tests/Form/Field/TogglesFieldTest.php
+++ b/tests/Form/Field/TogglesFieldTest.php
@@ -2,9 +2,11 @@
 
 namespace Kirby\Form\Field;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class TogglesFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('toggles');
 
@@ -18,7 +20,7 @@ class TogglesFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testGrow()
+	public function testGrow(): void
 	{
 		$field = $this->field('toggles', [
 			'grow' => false
@@ -33,7 +35,7 @@ class TogglesFieldTest extends TestCase
 		$this->assertTrue($field->grow());
 	}
 
-	public function testLabels()
+	public function testLabels(): void
 	{
 		$field = $this->field('toggles', [
 			'labels' => false
@@ -48,7 +50,7 @@ class TogglesFieldTest extends TestCase
 		$this->assertTrue($field->labels());
 	}
 
-	public function testReset()
+	public function testReset(): void
 	{
 		$field = $this->field('toggles', [
 			'reset' => false
@@ -73,10 +75,8 @@ class TogglesFieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider valueInputProvider
-	 */
-	public function testValue($input, $expected)
+	#[DataProvider('valueInputProvider')]
+	public function testValue($input, $expected): void
 	{
 		$field = $this->field('toggles', [
 			'options' => [

--- a/tests/Form/Field/UrlFieldTest.php
+++ b/tests/Form/Field/UrlFieldTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Field;
 
 class UrlFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('url');
 
@@ -18,7 +18,7 @@ class UrlFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testUrlValidation()
+	public function testUrlValidation(): void
 	{
 		$field = $this->field('url', [
 			'value' => 'https://getkirby.com'
@@ -33,7 +33,7 @@ class UrlFieldTest extends TestCase
 		$this->assertFalse($field->isValid());
 	}
 
-	public function testMinLength()
+	public function testMinLength(): void
 	{
 		$field = $this->field('url', [
 			'value' => 'https://test.com',
@@ -44,7 +44,7 @@ class UrlFieldTest extends TestCase
 		$this->assertArrayHasKey('minlength', $field->errors());
 	}
 
-	public function testMaxLength()
+	public function testMaxLength(): void
 	{
 		$field = $this->field('url', [
 			'value'     => 'https://test.com',

--- a/tests/Form/Field/UsersFieldTest.php
+++ b/tests/Form/Field/UsersFieldTest.php
@@ -32,7 +32,7 @@ class UsersFieldTest extends TestCase
 		]);
 	}
 
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('users', [
 			'model' => new Page(['slug' => 'test'])
@@ -47,7 +47,7 @@ class UsersFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testDefaultUser()
+	public function testDefaultUser(): void
 	{
 		$this->app->impersonate('raphael@getkirby.com');
 
@@ -58,7 +58,7 @@ class UsersFieldTest extends TestCase
 		$this->assertSame([], $field->default());
 	}
 
-	public function testCurrentDefaultUser()
+	public function testCurrentDefaultUser(): void
 	{
 		$this->app->impersonate('raphael@getkirby.com');
 
@@ -70,7 +70,7 @@ class UsersFieldTest extends TestCase
 		$this->assertSame('raphael@getkirby.com', $field->default()[0]['email']);
 	}
 
-	public function testMultipleDefaultUsers()
+	public function testMultipleDefaultUsers(): void
 	{
 		$this->app->impersonate('raphael@getkirby.com');
 
@@ -86,7 +86,7 @@ class UsersFieldTest extends TestCase
 		$this->assertSame('donatello@getkirby.com', $field->default()[1]['email']);
 	}
 
-	public function testDefaultUserDisabled()
+	public function testDefaultUserDisabled(): void
 	{
 		$this->app->impersonate('raphael@getkirby.com');
 
@@ -98,7 +98,7 @@ class UsersFieldTest extends TestCase
 		$this->assertSame([], $field->default());
 	}
 
-	public function testValue()
+	public function testValue(): void
 	{
 		$field = $this->field('users', [
 			'model' => new Page(['slug' => 'test']),
@@ -120,7 +120,7 @@ class UsersFieldTest extends TestCase
 		$this->assertSame($expected, $ids);
 	}
 
-	public function testMin()
+	public function testMin(): void
 	{
 		$field = $this->field('users', [
 			'model' => new Page(['slug' => 'test']),
@@ -137,7 +137,7 @@ class UsersFieldTest extends TestCase
 		$this->assertArrayHasKey('min', $field->errors());
 	}
 
-	public function testMax()
+	public function testMax(): void
 	{
 		$field = $this->field('users', [
 			'model' => new Page(['slug' => 'test']),
@@ -153,7 +153,7 @@ class UsersFieldTest extends TestCase
 		$this->assertArrayHasKey('max', $field->errors());
 	}
 
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$field = $this->field('users', [
 			'model' => new Page(['slug' => 'test']),
@@ -163,7 +163,7 @@ class UsersFieldTest extends TestCase
 		$this->assertSame('Test', $field->empty());
 	}
 
-	public function testTranslatedEmpty()
+	public function testTranslatedEmpty(): void
 	{
 		$field = $this->field('users', [
 			'model' => new Page(['slug' => 'test']),
@@ -173,7 +173,7 @@ class UsersFieldTest extends TestCase
 		$this->assertSame('Test', $field->empty());
 	}
 
-	public function testRequiredProps()
+	public function testRequiredProps(): void
 	{
 		$field = $this->field('users', [
 			'model'    => new Page(['slug' => 'test']),
@@ -184,7 +184,7 @@ class UsersFieldTest extends TestCase
 		$this->assertSame(1, $field->min());
 	}
 
-	public function testRequiredInvalid()
+	public function testRequiredInvalid(): void
 	{
 		$field = $this->field('users', [
 			'model'    => new Page(['slug' => 'test']),
@@ -194,7 +194,7 @@ class UsersFieldTest extends TestCase
 		$this->assertFalse($field->isValid());
 	}
 
-	public function testRequiredValid()
+	public function testRequiredValid(): void
 	{
 		$field = $this->field('tags', [
 			'model'    => new Page(['slug' => 'test']),
@@ -207,7 +207,7 @@ class UsersFieldTest extends TestCase
 		$this->assertTrue($field->isValid());
 	}
 
-	public function testApi()
+	public function testApi(): void
 	{
 		$app = $this->app->clone([
 			'options' => ['api.allowImpersonation' => true],

--- a/tests/Form/Field/WriterFieldTest.php
+++ b/tests/Form/Field/WriterFieldTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Field;
 
 class WriterFieldTest extends TestCase
 {
-	public function testDefaultProps()
+	public function testDefaultProps(): void
 	{
 		$field = $this->field('writer');
 
@@ -17,7 +17,7 @@ class WriterFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testValueSanitized()
+	public function testValueSanitized(): void
 	{
 		$field = $this->field('writer', [
 			'value' => 'This is a <strong>test</strong><script>alert("Hacked")</script> with <em>formatting</em> and a <a href="/@/page/abcde">UUID link</a>'
@@ -26,7 +26,7 @@ class WriterFieldTest extends TestCase
 		$this->assertSame('This is a <strong>test</strong> with <em>formatting</em> and a <a href="/@/page/abcde">UUID link</a>', $field->value());
 	}
 
-	public function testValueTrimmed()
+	public function testValueTrimmed(): void
 	{
 		$field = $this->field('writer', [
 			'value' => 'test '

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -6,6 +6,7 @@ use Exception;
 use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class TestField extends FieldClass
 {
@@ -42,15 +43,10 @@ class ValidatedField extends FieldClass
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Form\FieldClass
- */
+#[CoversClass(FieldClass::class)]
 class FieldClassTest extends TestCase
 {
-	/**
-	 * @covers ::__call
-	 */
-	public function test__call()
+	public function test__call(): void
 	{
 		$field = new TestField([
 			'foo' => 'bar'
@@ -59,10 +55,7 @@ class FieldClassTest extends TestCase
 		$this->assertSame('bar', $field->foo());
 	}
 
-	/**
-	 * @covers ::after
-	 */
-	public function testAfter()
+	public function testAfter(): void
 	{
 		$field = new TestField();
 		$this->assertNull($field->after());
@@ -74,19 +67,13 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test', $field->after());
 	}
 
-	/**
-	 * @covers ::api
-	 */
-	public function testApi()
+	public function testApi(): void
 	{
 		$field = new TestField();
 		$this->assertSame([], $field->api());
 	}
 
-	/**
-	 * @covers ::autofocus
-	 */
-	public function testAutofocus()
+	public function testAutofocus(): void
 	{
 		$field = new TestField();
 		$this->assertFalse($field->autofocus());
@@ -95,10 +82,7 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->autofocus());
 	}
 
-	/**
-	 * @covers ::before
-	 */
-	public function testBefore()
+	public function testBefore(): void
 	{
 		$field = new TestField();
 		$this->assertNull($field->before());
@@ -110,10 +94,7 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test', $field->before());
 	}
 
-	/**
-	 * @covers ::data
-	 */
-	public function testData()
+	public function testData(): void
 	{
 		$field = new TestField();
 		$this->assertNull($field->data());
@@ -131,10 +112,7 @@ class FieldClassTest extends TestCase
 		$this->assertSame('test', $field->data());
 	}
 
-	/**
-	 * @covers ::default
-	 */
-	public function testDefault()
+	public function testDefault(): void
 	{
 		$field = new TestField();
 		$this->assertNull($field->default());
@@ -157,20 +135,13 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test title', $field->default());
 	}
 
-	/**
-	 * @covers ::dialogs
-	 */
-	public function testDialogs()
+	public function testDialogs(): void
 	{
 		$field = new TestField();
 		$this->assertSame([], $field->dialogs());
 	}
 
-	/**
-	 * @covers ::disabled
-	 * @covers ::isDisabled
-	 */
-	public function testDisabled()
+	public function testDisabled(): void
 	{
 		$field = new TestField();
 		$this->assertFalse($field->disabled());
@@ -181,20 +152,13 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->isDisabled());
 	}
 
-	/**
-	 * @covers ::drawers
-	 */
-	public function testDrawers()
+	public function testDrawers(): void
 	{
 		$field = new TestField();
 		$this->assertSame([], $field->drawers());
 	}
 
-	/**
-	 * @covers ::errors
-	 * @covers ::validations
-	 */
-	public function testErrors()
+	public function testErrors(): void
 	{
 		$field = new TestField();
 		$this->assertSame([], $field->errors());
@@ -212,10 +176,7 @@ class FieldClassTest extends TestCase
 		$this->assertSame(['custom' => 'Please enter an a'], $field->errors());
 	}
 
-	/**
-	 * @covers ::fill
-	 */
-	public function testFill()
+	public function testFill(): void
 	{
 		$field = new TestField();
 		$this->assertNull($field->value());
@@ -223,11 +184,7 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test value', $field->value());
 	}
 
-	/**
-	 * @covers ::isEmpty
-	 * @covers ::isEmptyValue
-	 */
-	public function testIsEmpty()
+	public function testIsEmpty(): void
 	{
 		$field = new TestField();
 		$this->assertTrue($field->isEmpty());
@@ -236,10 +193,7 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isEmpty());
 	}
 
-	/**
-	 * @covers ::isEmptyValue
-	 */
-	public function testIsEmptyValue()
+	public function testIsEmptyValue(): void
 	{
 		$field = new TestField();
 
@@ -253,10 +207,7 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isEmptyValue('0'));
 	}
 
-	/**
-	 * @covers ::isHidden
-	 */
-	public function testIsHidden()
+	public function testIsHidden(): void
 	{
 		$field = new TestField();
 		$this->assertFalse($field->isHidden());
@@ -265,7 +216,7 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->isHidden());
 	}
 
-	public function testIsTranslatable()
+	public function testIsTranslatable(): void
 	{
 		$language = Language::ensure('current');
 
@@ -273,7 +224,7 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->isTranslatable($language));
 	}
 
-	public function testIsTranslatableWithNonDefaultLanguage()
+	public function testIsTranslatableWithNonDefaultLanguage(): void
 	{
 		$language = new Language([
 			'code'    => 'de',
@@ -287,11 +238,7 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isTranslatable($language));
 	}
 
-	/**
-	 * @covers ::isInvalid
-	 * @covers ::isValid
-	 */
-	public function testInvalid()
+	public function testInvalid(): void
 	{
 		$field = new TestField();
 		$this->assertFalse($field->isInvalid());
@@ -303,11 +250,7 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isInvalid());
 	}
 
-	/**
-	 * @covers ::isRequired
-	 * @covers ::required
-	 */
-	public function testIsRequired()
+	public function testIsRequired(): void
 	{
 		$field = new TestField();
 		$this->assertFalse($field->isRequired());
@@ -318,7 +261,7 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->required());
 	}
 
-	public function testIsStorable()
+	public function testIsStorable(): void
 	{
 		$language = Language::ensure('current');
 
@@ -329,7 +272,7 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isStorable($language));
 	}
 
-	public function testIsStorableWithDisabledField()
+	public function testIsStorableWithDisabledField(): void
 	{
 		$language = Language::ensure('current');
 
@@ -337,7 +280,7 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->isStorable($language), 'The value of a storable field must not be changed on submit, but can still be stored.');
 	}
 
-	public function testIsStorableWithNonDefaultLanguage()
+	public function testIsStorableWithNonDefaultLanguage(): void
 	{
 		$language = new Language([
 			'code'    => 'de',
@@ -351,7 +294,7 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isStorable($language));
 	}
 
-	public function testIsSubmittable()
+	public function testIsSubmittable(): void
 	{
 		$language = Language::ensure('current');
 
@@ -362,7 +305,7 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isSubmittable($language));
 	}
 
-	public function testIsSubmittableWithDisabledField()
+	public function testIsSubmittableWithDisabledField(): void
 	{
 		$language = Language::ensure('current');
 
@@ -370,7 +313,7 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isSubmittable($language));
 	}
 
-	public function testIsSubmittableWithNonDefaultLanguage()
+	public function testIsSubmittableWithNonDefaultLanguage(): void
 	{
 		$language = new Language([
 			'code'    => 'de',
@@ -384,7 +327,7 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isSubmittable($language));
 	}
 
-	public function testIsSubmittableWithWhenQueryAndMatchingValue()
+	public function testIsSubmittableWithWhenQueryAndMatchingValue(): void
 	{
 		$language = Language::ensure('current');
 
@@ -402,7 +345,7 @@ class FieldClassTest extends TestCase
 		$this->assertTrue($field->isSubmittable($language));
 	}
 
-	public function testIsSubmittableWithWhenQueryAndNonMatchingValue()
+	public function testIsSubmittableWithWhenQueryAndNonMatchingValue(): void
 	{
 		$language = Language::ensure('current');
 
@@ -420,10 +363,7 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->isSubmittable($language));
 	}
 
-	/**
-	 * @covers ::hasValue
-	 */
-	public function testHasValue()
+	public function testHasValue(): void
 	{
 		$field = new TestField();
 		$this->assertTrue($field->hasValue());
@@ -432,10 +372,7 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->hasValue());
 	}
 
-	/**
-	 * @covers ::help
-	 */
-	public function testHelp()
+	public function testHelp(): void
 	{
 		$field = new TestField();
 		$this->assertNull($field->help());
@@ -462,10 +399,7 @@ class FieldClassTest extends TestCase
 		$this->assertSame('<p>A field for Test title</p>', $field->help());
 	}
 
-	/**
-	 * @covers ::icon
-	 */
-	public function testIcon()
+	public function testIcon(): void
 	{
 		$field = new TestField();
 		$this->assertNull($field->icon());
@@ -474,10 +408,7 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test', $field->icon());
 	}
 
-	/**
-	 * @covers ::id
-	 */
-	public function testId()
+	public function testId(): void
 	{
 		$field = new TestField();
 		$this->assertSame('test', $field->id());
@@ -486,19 +417,13 @@ class FieldClassTest extends TestCase
 		$this->assertSame('test-id', $field->id());
 	}
 
-	/**
-	 * @covers ::kirby
-	 */
-	public function testKirby()
+	public function testKirby(): void
 	{
 		$field = new TestField();
 		$this->assertSame(kirby(), $field->kirby());
 	}
 
-	/**
-	 * @covers ::label
-	 */
-	public function testLabel()
+	public function testLabel(): void
 	{
 		$field = new TestField();
 		$this->assertSame('Test', $field->label());
@@ -510,10 +435,7 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test', $field->label());
 	}
 
-	/**
-	 * @covers ::model
-	 */
-	public function testModel()
+	public function testModel(): void
 	{
 		$field = new TestField();
 		$site  = site();
@@ -524,10 +446,7 @@ class FieldClassTest extends TestCase
 		$this->assertIsPage($page, $field->model());
 	}
 
-	/**
-	 * @covers ::name
-	 */
-	public function testName()
+	public function testName(): void
 	{
 		$field = new TestField();
 		$this->assertSame('test', $field->name());
@@ -536,19 +455,13 @@ class FieldClassTest extends TestCase
 		$this->assertSame('test-name', $field->name());
 	}
 
-	/**
-	 * @covers ::name
-	 */
-	public function testNameCase()
+	public function testNameCase(): void
 	{
 		$field = new TestField(['name' => 'myTest']);
 		$this->assertSame('mytest', $field->name());
 	}
 
-	/**
-	 * @covers ::params
-	 */
-	public function testParams()
+	public function testParams(): void
 	{
 		$field = new TestField($params = [
 			'foo'      => 'bar',
@@ -559,10 +472,7 @@ class FieldClassTest extends TestCase
 		$this->assertSame($params, $field->params());
 	}
 
-	/**
-	 * @covers ::placeholder
-	 */
-	public function testPlaceholder()
+	public function testPlaceholder(): void
 	{
 		$field = new TestField();
 		$this->assertNull($field->placeholder());
@@ -589,11 +499,7 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Placeholder for Test title', $field->placeholder());
 	}
 
-	/**
-	 * @covers ::props
-	 * @covers ::toArray
-	 */
-	public function testProps()
+	public function testProps(): void
 	{
 		$field = new TestField($props = [
 			'after'       => 'After value',
@@ -622,28 +528,19 @@ class FieldClassTest extends TestCase
 		$this->assertSame($props, $field->props());
 	}
 
-	/**
-	 * @covers ::routes
-	 */
-	public function testRoutes()
+	public function testRoutes(): void
 	{
 		$field = new TestField();
 		$this->assertSame([], $field->routes());
 	}
 
-	/**
-	 * @covers ::save
-	 */
-	public function testSave()
+	public function testSave(): void
 	{
 		$field = new TestField();
 		$this->assertTrue($field->save());
 	}
 
-	/**
-	 * @covers ::siblings
-	 */
-	public function testSiblings()
+	public function testSiblings(): void
 	{
 		$field = new TestField();
 		$this->assertInstanceOf(Fields::class, $field->siblings());
@@ -662,9 +559,6 @@ class FieldClassTest extends TestCase
 		$this->assertSame('b', $field->siblings()->last()->name());
 	}
 
-	/**
-	 * @covers ::submit
-	 */
 	public function testSubmit(): void
 	{
 		$field = new TestField();
@@ -673,10 +567,7 @@ class FieldClassTest extends TestCase
 		$this->assertSame('Test value', $field->value());
 	}
 
-	/**
-	 * @covers ::toStoredValue
-	 */
-	public function testToStoredValue()
+	public function testToStoredValue(): void
 	{
 		$field = new TestField();
 		$field->fill('test');
@@ -684,10 +575,7 @@ class FieldClassTest extends TestCase
 		$this->assertSame('test', $field->toStoredValue());
 	}
 
-	/**
-	 * @covers ::translate
-	 */
-	public function testTranslate()
+	public function testTranslate(): void
 	{
 		$field = new TestField();
 		$this->assertTrue($field->translate());
@@ -696,19 +584,13 @@ class FieldClassTest extends TestCase
 		$this->assertFalse($field->translate());
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testType()
+	public function testType(): void
 	{
 		$field = new TestField();
 		$this->assertSame('test', $field->type());
 	}
 
-	/**
-	 * @covers ::value
-	 */
-	public function testValue()
+	public function testValue(): void
 	{
 		$field = new TestField();
 		$this->assertNull($field->value());
@@ -726,10 +608,7 @@ class FieldClassTest extends TestCase
 		$this->assertNull($field->value());
 	}
 
-	/**
-	 * @covers ::when
-	 */
-	public function testWhen()
+	public function testWhen(): void
 	{
 		$field = new TestField();
 		$this->assertNull($field->when());
@@ -738,10 +617,7 @@ class FieldClassTest extends TestCase
 		$this->assertSame(['a' => 'test'], $field->when());
 	}
 
-	/**
-	 * @covers ::width
-	 */
-	public function testWidth()
+	public function testWidth(): void
 	{
 		$field = new TestField();
 		$this->assertSame('1/1', $field->width());

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -6,10 +6,10 @@ use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Form\Field
- */
+#[CoversClass(Field::class)]
 class FieldTest extends TestCase
 {
 	protected array $originalMixins;
@@ -35,9 +35,6 @@ class FieldTest extends TestCase
 		Field::$mixins = $this->originalMixins;
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstructInvalidType(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -49,7 +46,7 @@ class FieldTest extends TestCase
 		]);
 	}
 
-	public function testAfter()
+	public function testAfter(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -88,11 +85,7 @@ class FieldTest extends TestCase
 		$this->assertSame('blog', $field->after);
 	}
 
-	/**
-	 * @covers ::api
-	 * @covers ::routes
-	 */
-	public function testApi()
+	public function testApi(): void
 	{
 		// no defined as default
 		Field::$types = [
@@ -130,7 +123,7 @@ class FieldTest extends TestCase
 		$this->assertSame($routes, $field->api());
 	}
 
-	public function testAutofocus()
+	public function testAutofocus(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -156,7 +149,7 @@ class FieldTest extends TestCase
 		$this->assertTrue($field->autofocus);
 	}
 
-	public function testBefore()
+	public function testBefore(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -195,7 +188,7 @@ class FieldTest extends TestCase
 		$this->assertSame('blog', $field->before);
 	}
 
-	public function testDefault()
+	public function testDefault(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -243,10 +236,7 @@ class FieldTest extends TestCase
 		$this->assertSame('blog', $field->data(true));
 	}
 
-	/**
-	 * @covers ::dialogs
-	 */
-	public function testDialogs()
+	public function testDialogs(): void
 	{
 		// no defined as default
 		Field::$types = [
@@ -286,10 +276,7 @@ class FieldTest extends TestCase
 		$this->assertSame($routes, $field->dialogs());
 	}
 
-	/**
-	 * @covers ::drawers
-	 */
-	public function testDrawers()
+	public function testDrawers(): void
 	{
 		// no defined as default
 		Field::$types = [
@@ -328,10 +315,7 @@ class FieldTest extends TestCase
 		$this->assertSame($routes, $field->drawers());
 	}
 
-	/**
-	 * @covers ::errors
-	 */
-	public function testErrors()
+	public function testErrors(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -359,10 +343,7 @@ class FieldTest extends TestCase
 		$this->assertSame($expected, $field->errors());
 	}
 
-	/**
-	 * @covers ::fill
-	 */
-	public function testFill()
+	public function testFill(): void
 	{
 		Field::$types = [
 			'test' => [
@@ -388,7 +369,7 @@ class FieldTest extends TestCase
 		$this->assertSame('test2 computed', $field->computedValue());
 	}
 
-	public function testFillWithRestoredState()
+	public function testFillWithRestoredState(): void
 	{
 		Field::$types = [
 			'test' => $definition = [
@@ -419,7 +400,7 @@ class FieldTest extends TestCase
 		$this->assertEquals(Field::setup('test'), $field->optionsDebugger());
 	}
 
-	public function testHelp()
+	public function testHelp(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -449,7 +430,7 @@ class FieldTest extends TestCase
 		$this->assertSame('<p>en</p>', $field->help);
 	}
 
-	public function testIcon()
+	public function testIcon(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -502,10 +483,7 @@ class FieldTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::isDisabled
-	 */
-	public function testDisabled()
+	public function testDisabled(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -533,12 +511,8 @@ class FieldTest extends TestCase
 		$this->assertTrue($field->isDisabled());
 	}
 
-	/**
-	 * @covers ::isEmpty
-	 * @covers ::isEmptyValue
-	 * @dataProvider emptyValuesProvider
-	 */
-	public function testIsEmpty($value, $expected)
+	#[DataProvider('emptyValuesProvider')]
+	public function testIsEmpty($value, $expected): void
 	{
 		Field::$types = [
 			'test' => []
@@ -555,10 +529,7 @@ class FieldTest extends TestCase
 		$this->assertSame($expected, $field->isEmptyValue($value));
 	}
 
-	/**
-	 * @covers ::isEmptyValue
-	 */
-	public function testIsEmptyValueFromOption()
+	public function testIsEmptyValueFromOption(): void
 	{
 		Field::$types = [
 			'test' => [
@@ -578,10 +549,7 @@ class FieldTest extends TestCase
 		$this->assertTrue($field->isEmptyValue('empty'));
 	}
 
-	/**
-	 * @covers ::isHidden
-	 */
-	public function testIsHidden()
+	public function testIsHidden(): void
 	{
 		// default
 		Field::$types = [
@@ -610,11 +578,7 @@ class FieldTest extends TestCase
 		$this->assertTrue($field->isHidden());
 	}
 
-	/**
-	 * @covers ::isInvalid
-	 * @covers ::isValid
-	 */
-	public function testIsInvalidOrValid()
+	public function testIsInvalidOrValid(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -640,10 +604,7 @@ class FieldTest extends TestCase
 		$this->assertTrue($field->isInvalid());
 	}
 
-	/**
-	 * @covers ::isRequired
-	 */
-	public function testIsRequired()
+	public function testIsRequired(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -665,11 +626,7 @@ class FieldTest extends TestCase
 		$this->assertTrue($field->isRequired());
 	}
 
-	/**
-	 * @covers ::hasValue
-	 * @covers ::save
-	 */
-	public function testHasValue()
+	public function testHasValue(): void
 	{
 		Field::$types = [
 			'store-me' => [
@@ -697,10 +654,7 @@ class FieldTest extends TestCase
 		$this->assertFalse($b->save());
 	}
 
-	/**
-	 * @covers ::kirby
-	 */
-	public function testKirby()
+	public function testKirby(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -713,7 +667,7 @@ class FieldTest extends TestCase
 		$this->assertSame($model->kirby(), $field->kirby());
 	}
 
-	public function testLabel()
+	public function testLabel(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -752,7 +706,7 @@ class FieldTest extends TestCase
 		$this->assertSame('blog', $field->label);
 	}
 
-	public function testMixinMin()
+	public function testMixinMin(): void
 	{
 		Field::$mixins['min'] = include kirby()->root('kirby') . '/config/fields/mixins/min.php';
 
@@ -795,10 +749,7 @@ class FieldTest extends TestCase
 		$this->assertSame(5, $field->min());
 	}
 
-	/**
-	 * @covers ::model
-	 */
-	public function testModel()
+	public function testModel(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -811,7 +762,7 @@ class FieldTest extends TestCase
 		$this->assertSame($model, $field->model());
 	}
 
-	public function testName()
+	public function testName(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -833,7 +784,7 @@ class FieldTest extends TestCase
 		$this->assertSame('mytest', $field->name());
 	}
 
-	public function testNameCase()
+	public function testNameCase(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -847,11 +798,7 @@ class FieldTest extends TestCase
 		$this->assertSame('mytest', $field->name());
 	}
 
-	/**
-	 * @covers ::needsValue
-	 * @covers ::errors
-	 */
-	public function testNeedsValue()
+	public function testNeedsValue(): void
 	{
 		$page = new Page(['slug' => 'test']);
 
@@ -954,7 +901,7 @@ class FieldTest extends TestCase
 		$this->assertSame($expected, $field->errors());
 	}
 
-	public function testPlaceholder()
+	public function testPlaceholder(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -993,12 +940,7 @@ class FieldTest extends TestCase
 		$this->assertSame('blog', $field->placeholder);
 	}
 
-	/**
-	 * @covers ::next
-	 * @covers ::prev
-	 * @covers ::siblingsCollection
-	 */
-	public function testPrevNext()
+	public function testPrevNext(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -1023,11 +965,7 @@ class FieldTest extends TestCase
 		$this->assertSame('a', $siblings->last()->prev()->name());
 	}
 
-	/**
-	 * @covers ::siblings
-	 * @covers ::formFields
-	 */
-	public function testSiblings()
+	public function testSiblings(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -1071,9 +1009,6 @@ class FieldTest extends TestCase
 		$this->assertSame('b', $field->formFields()->last()->name());
 	}
 
-	/**
-	 * @covers ::submit
-	 */
 	public function testSubmit(): void
 	{
 		Field::$types = [
@@ -1091,10 +1026,7 @@ class FieldTest extends TestCase
 		$this->assertSame('test2', $field->value());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
-	public function testToArray()
+	public function testToArray(): void
 	{
 		Field::$types = [
 			'test' => [
@@ -1119,11 +1051,7 @@ class FieldTest extends TestCase
 		$this->assertArrayNotHasKey('model', $array);
 	}
 
-	/**
-	 * @covers ::toFormValue
-	 * @covers ::value
-	 */
-	public function testToFormValue()
+	public function testToFormValue(): void
 	{
 		Field::$types['test'] = [];
 
@@ -1151,11 +1079,7 @@ class FieldTest extends TestCase
 		$this->assertNull($field->value());
 	}
 
-	/**
-	 * @covers ::toStoredValue
-	 * @covers ::data
-	 */
-	public function testToStoredValue()
+	public function testToStoredValue(): void
 	{
 		Field::$types = [
 			'test' => [
@@ -1177,11 +1101,7 @@ class FieldTest extends TestCase
 		$this->assertSame('a, b, c', $field->data());
 	}
 
-	/**
-	 * @covers ::toStoredValue
-	 * @covers ::data
-	 */
-	public function testToStoredValueWhenUnsaveable()
+	public function testToStoredValueWhenUnsaveable(): void
 	{
 		Field::$types = [
 			'test' => [
@@ -1200,11 +1120,7 @@ class FieldTest extends TestCase
 		$this->assertNull($field->data());
 	}
 
-	/**
-	 * @covers ::validations
-	 * @covers ::errors
-	 */
-	public function testValidate()
+	public function testValidate(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -1254,11 +1170,7 @@ class FieldTest extends TestCase
 		$this->assertSame($expected, $field->errors());
 	}
 
-	/**
-	 * @covers ::validations
-	 * @covers ::isValid
-	 */
-	public function testValidateByAttr()
+	public function testValidateByAttr(): void
 	{
 		Field::$types = [
 			'test' => []
@@ -1313,12 +1225,7 @@ class FieldTest extends TestCase
 		$this->assertFalse($field->isValid());
 	}
 
-	/**
-	 * @covers ::validations
-	 * @covers ::errors
-	 * @covers ::isValid
-	 */
-	public function testValidateWithCustomValidator()
+	public function testValidateWithCustomValidator(): void
 	{
 		Field::$types = [
 			'test' => [
@@ -1343,7 +1250,7 @@ class FieldTest extends TestCase
 		$this->assertSame(['test' => 'Invalid value: abc'], $field->errors());
 	}
 
-	public function testWidth()
+	public function testWidth(): void
 	{
 		Field::$types = [
 			'test' => []

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -31,7 +31,7 @@ class FieldsTest extends TestCase
 		$this->model = new Page(['slug' => 'test']);
 	}
 
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$fields = new Fields(
 			fields: [
@@ -51,7 +51,7 @@ class FieldsTest extends TestCase
 		$this->assertSame($this->model, $fields->last()->model());
 	}
 
-	public function testConstructWithoutModel()
+	public function testConstructWithoutModel(): void
 	{
 		$fields = new Fields(
 			fields: [
@@ -68,7 +68,7 @@ class FieldsTest extends TestCase
 		$this->assertSame($this->app->site(), $fields->last()->model());
 	}
 
-	public function testDefaults()
+	public function testDefaults(): void
 	{
 		$fields = new Fields([
 			'a' => [
@@ -84,7 +84,7 @@ class FieldsTest extends TestCase
 		$this->assertSame(['a' => 'a', 'b' => 'b'], $fields->defaults());
 	}
 
-	public function testErrors()
+	public function testErrors(): void
 	{
 		$fields = new Fields([
 			'a' => [
@@ -129,7 +129,7 @@ class FieldsTest extends TestCase
 		], $fields->errors());
 	}
 
-	public function testErrorsWithoutErrors()
+	public function testErrorsWithoutErrors(): void
 	{
 		$fields = new Fields([
 			'a' => [
@@ -143,7 +143,7 @@ class FieldsTest extends TestCase
 		$this->assertSame([], $fields->errors());
 	}
 
-	public function testField()
+	public function testField(): void
 	{
 		$fields = new Fields([
 			'test' => [
@@ -154,7 +154,7 @@ class FieldsTest extends TestCase
 		$this->assertSame('test', $fields->field('test')->name());
 	}
 
-	public function testFieldWithMissingField()
+	public function testFieldWithMissingField(): void
 	{
 		$fields = new Fields([
 			'test' => [
@@ -169,7 +169,7 @@ class FieldsTest extends TestCase
 	}
 
 
-	public function testFill()
+	public function testFill(): void
 	{
 		$fields = new Fields([
 			'a' => [
@@ -270,7 +270,7 @@ class FieldsTest extends TestCase
 		], $fields->toFormValues(), 'Unknown fields are included');
 	}
 
-	public function testFind()
+	public function testFind(): void
 	{
 		Field::$types['test'] = [
 			'methods' => [
@@ -298,7 +298,7 @@ class FieldsTest extends TestCase
 		$this->assertNull($fields->find('mother+missing-child'));
 	}
 
-	public function testFindWhenFieldHasNoForm()
+	public function testFindWhenFieldHasNoForm(): void
 	{
 		$fields = new Fields([
 			'mother' => [
@@ -776,7 +776,7 @@ class FieldsTest extends TestCase
 		], $fields->toStoredValues(), 'Unknown fields are included');
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$fields = new Fields([
 			'a' => [
@@ -790,7 +790,7 @@ class FieldsTest extends TestCase
 		$this->assertSame(['a' => 'a', 'b' => 'b'], $fields->toArray(fn ($field) => $field->name()));
 	}
 
-	public function testToFormValues()
+	public function testToFormValues(): void
 	{
 		$fields = new Fields([
 			'a' => [
@@ -917,7 +917,7 @@ class FieldsTest extends TestCase
 		$this->assertTrue($props['b']['translate']);
 	}
 
-	public function testToStoredValues()
+	public function testToStoredValues(): void
 	{
 		Field::$types['test'] = [
 			'save' => function ($value) {

--- a/tests/Form/FormTest.php
+++ b/tests/Form/FormTest.php
@@ -38,7 +38,7 @@ class FormTest extends TestCase
 		$this->tearDownTmp();
 	}
 
-	public function testContent()
+	public function testContent(): void
 	{
 		$form = new Form([
 			'fields' => [],
@@ -51,7 +51,7 @@ class FormTest extends TestCase
 		$this->assertSame($values, $form->content());
 	}
 
-	public function testContentAndDataFromUnsaveableFields()
+	public function testContentAndDataFromUnsaveableFields(): void
 	{
 		$form = new Form([
 			'fields' => [
@@ -71,7 +71,7 @@ class FormTest extends TestCase
 		$this->assertArrayHasKey('info', $form->data());
 	}
 
-	public function testDataWithoutFields()
+	public function testDataWithoutFields(): void
 	{
 		$form = new Form([
 			'fields' => [],
@@ -84,7 +84,7 @@ class FormTest extends TestCase
 		$this->assertSame($values, $form->data());
 	}
 
-	public function testDataFromUnsaveableFields()
+	public function testDataFromUnsaveableFields(): void
 	{
 		$form = new Form([
 			'fields' => [
@@ -101,7 +101,7 @@ class FormTest extends TestCase
 		$this->assertNull($form->data()['info']);
 	}
 
-	public function testDataFromNestedFields()
+	public function testDataFromNestedFields(): void
 	{
 		$form = new Form([
 			'fields' => [
@@ -127,7 +127,7 @@ class FormTest extends TestCase
 		$this->assertSame('a, b', $form->data()['structure'][0]['tags']);
 	}
 
-	public function testDataWithCorrectFieldOrder()
+	public function testDataWithCorrectFieldOrder(): void
 	{
 		$form = new Form([
 			'fields' => [
@@ -153,7 +153,7 @@ class FormTest extends TestCase
 		$this->assertTrue(['a' => 'A', 'b' => 'B modified', 'c' => 'C'] === $form->values());
 	}
 
-	public function testDataWithStrictMode()
+	public function testDataWithStrictMode(): void
 	{
 		$form = new Form([
 			'fields' => [
@@ -179,7 +179,7 @@ class FormTest extends TestCase
 		$this->assertTrue(['a' => 'A', 'b' => 'B'] === $form->values());
 	}
 
-	public function testDataWithUntranslatedFields()
+	public function testDataWithUntranslatedFields(): void
 	{
 		$this->setUpMultiLanguage();
 
@@ -230,7 +230,7 @@ class FormTest extends TestCase
 		$this->assertSame($expected, $form->values());
 	}
 
-	public function testDefaults()
+	public function testDefaults(): void
 	{
 		$form = new Form([
 			'fields' => [
@@ -244,7 +244,7 @@ class FormTest extends TestCase
 		$this->assertSame(['test' => 'Test Value'], $form->defaults());
 	}
 
-	public function testErrors()
+	public function testErrors(): void
 	{
 		$form = new Form([
 			'fields' => [
@@ -288,7 +288,7 @@ class FormTest extends TestCase
 		$this->assertSame($expected, $form->errors());
 	}
 
-	public function testFieldException()
+	public function testFieldException(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Field "test": The field type "does-not-exist" does not exist');
@@ -303,7 +303,7 @@ class FormTest extends TestCase
 		]);
 	}
 
-	public function testFill()
+	public function testFill(): void
 	{
 		$form = new Form([
 			'fields' => [
@@ -321,7 +321,7 @@ class FormTest extends TestCase
 		$this->assertSame(['test' => 'Test Value'], $response->toFormValues());
 	}
 
-	public function testForFileWithoutBlueprint()
+	public function testForFileWithoutBlueprint(): void
 	{
 		$file = new File([
 			'filename' => 'test.jpg',
@@ -336,7 +336,7 @@ class FormTest extends TestCase
 		$this->assertSame(['a' => 'A', 'b' => 'B'], $form->data());
 	}
 
-	public function testForPage()
+	public function testForPage(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -371,7 +371,7 @@ class FormTest extends TestCase
 		$this->assertSame('', $values['date']);
 	}
 
-	public function testForPageWithClosureValues()
+	public function testForPageWithClosureValues(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -393,7 +393,7 @@ class FormTest extends TestCase
 		$this->assertSame('B', $values['b']);
 	}
 
-	public function testLanguage()
+	public function testLanguage(): void
 	{
 		$form = new Form([
 			'fields' => [
@@ -406,7 +406,7 @@ class FormTest extends TestCase
 		$this->assertInstanceOf(Language::class, $form->language());
 	}
 
-	public function testPassthrough()
+	public function testPassthrough(): void
 	{
 		$form = new Form([]);
 
@@ -419,7 +419,7 @@ class FormTest extends TestCase
 		$this->assertSame(['test' => 'Test Value'], $response->toFormValues());
 	}
 
-	public function testReset()
+	public function testReset(): void
 	{
 		$form = new Form([
 			'fields' => [
@@ -443,7 +443,7 @@ class FormTest extends TestCase
 		$this->assertSame(['test' => ''], $form->toFormValues());
 	}
 
-	public function testStrings()
+	public function testStrings(): void
 	{
 		$form = new Form([
 			'fields' => [],
@@ -464,7 +464,7 @@ class FormTest extends TestCase
 		], $form->strings());
 	}
 
-	public function testSubmit()
+	public function testSubmit(): void
 	{
 		$form = new Form([
 			'fields' => [
@@ -482,7 +482,7 @@ class FormTest extends TestCase
 		$this->assertSame(['test' => 'Test Value'], $response->toFormValues());
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$form = new Form([
 			'fields' => [
@@ -509,7 +509,7 @@ class FormTest extends TestCase
 		$this->assertFalse($form->toArray()['invalid']);
 	}
 
-	public function testToFormValues()
+	public function testToFormValues(): void
 	{
 		$form = new Form([
 			'fields' => [
@@ -529,7 +529,7 @@ class FormTest extends TestCase
 		$this->assertSame($values, $form->toFormValues());
 	}
 
-	public function testToProps()
+	public function testToProps(): void
 	{
 		$form = new Form([
 			'fields' => [
@@ -543,7 +543,7 @@ class FormTest extends TestCase
 		$this->assertSame($form->fields()->toProps(), $form->toProps());
 	}
 
-	public function testToStoredValues()
+	public function testToStoredValues(): void
 	{
 		Field::$types['test'] = [
 			'save' => function ($value) {
@@ -574,7 +574,7 @@ class FormTest extends TestCase
 		$this->assertSame($expected, $form->toStoredValues());
 	}
 
-	public function testValuesWithoutFields()
+	public function testValuesWithoutFields(): void
 	{
 		$form = new Form([
 			'fields' => [],

--- a/tests/Form/ValidationsTest.php
+++ b/tests/Form/ValidationsTest.php
@@ -31,14 +31,14 @@ class ValidationsTest extends TestCase
 		Field::$types = [];
 	}
 
-	public function testBooleanValid()
+	public function testBooleanValid(): void
 	{
 		$page  = new Page(['slug' => 'test']);
 		$field = new Field('test', ['model' => $page]);
 		$this->assertTrue(Validations::boolean($field, true));
 	}
 
-	public function testBooleanInvalid()
+	public function testBooleanInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Please confirm or deny');
@@ -48,14 +48,14 @@ class ValidationsTest extends TestCase
 		Validations::boolean($field, 'nope');
 	}
 
-	public function testDateValid()
+	public function testDateValid(): void
 	{
 		$page  = new Page(['slug' => 'test']);
 		$field = new Field('test', ['model' => $page]);
 		$this->assertTrue(Validations::date($field, '2012-12-12'));
 	}
 
-	public function testDateInvalid()
+	public function testDateInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Please enter a valid date');
@@ -65,14 +65,14 @@ class ValidationsTest extends TestCase
 		Validations::date($field, 'somewhen');
 	}
 
-	public function testEmailValid()
+	public function testEmailValid(): void
 	{
 		$page  = new Page(['slug' => 'test']);
 		$field = new Field('test', ['model' => $page]);
 		$this->assertTrue(Validations::email($field, 'test@getkirby.com'));
 	}
 
-	public function testEmailInvalid()
+	public function testEmailInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Please enter a valid email address');
@@ -82,7 +82,7 @@ class ValidationsTest extends TestCase
 		Validations::email($field, 'test[at]getkirby.com');
 	}
 
-	public function testMaxValid()
+	public function testMaxValid(): void
 	{
 		$page  = new Page(['slug' => 'test']);
 		$field = new Field('test', [
@@ -93,7 +93,7 @@ class ValidationsTest extends TestCase
 		$this->assertTrue(Validations::max($field, 4));
 	}
 
-	public function testMaxInvalid()
+	public function testMaxInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Please enter a value equal to or lower than 5');
@@ -107,7 +107,7 @@ class ValidationsTest extends TestCase
 		Validations::max($field, 6);
 	}
 
-	public function testMaxLengthValid()
+	public function testMaxLengthValid(): void
 	{
 		$page  = new Page(['slug' => 'test']);
 		$field = new Field('test', [
@@ -118,7 +118,7 @@ class ValidationsTest extends TestCase
 		$this->assertTrue(Validations::maxlength($field, 'test'));
 	}
 
-	public function testMaxLengthInvalid()
+	public function testMaxLengthInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Please enter a shorter value. (max. 5 characters)');
@@ -132,7 +132,7 @@ class ValidationsTest extends TestCase
 		Validations::maxlength($field, 'testest');
 	}
 
-	public function testMinValid()
+	public function testMinValid(): void
 	{
 		$page  = new Page(['slug' => 'test']);
 		$field = new Field('test', [
@@ -143,7 +143,7 @@ class ValidationsTest extends TestCase
 		$this->assertTrue(Validations::min($field, 6));
 	}
 
-	public function testMinInvalid()
+	public function testMinInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Please enter a value equal to or greater than 5');
@@ -157,7 +157,7 @@ class ValidationsTest extends TestCase
 		Validations::min($field, 4);
 	}
 
-	public function testMinLengthValid()
+	public function testMinLengthValid(): void
 	{
 		$page  = new Page(['slug' => 'test']);
 		$field = new Field('test', [
@@ -168,7 +168,7 @@ class ValidationsTest extends TestCase
 		$this->assertTrue(Validations::minlength($field, 'testest'));
 	}
 
-	public function testMinLengthInvalid()
+	public function testMinLengthInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Please enter a longer value. (min. 5 characters)');
@@ -182,7 +182,7 @@ class ValidationsTest extends TestCase
 		Validations::minlength($field, 'test');
 	}
 
-	public function testPatternValid()
+	public function testPatternValid(): void
 	{
 		$page  = new Page(['slug' => 'test']);
 		$field = new Field('test', [
@@ -196,7 +196,7 @@ class ValidationsTest extends TestCase
 		$this->assertTrue(Validations::pattern($field, '#34b3cd'));
 	}
 
-	public function testPatternInvalid()
+	public function testPatternInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The value does not match the expected pattern');
@@ -210,7 +210,7 @@ class ValidationsTest extends TestCase
 		Validations::pattern($field, '#MMM');
 	}
 
-	public function testPatternInvalidMatchButMore()
+	public function testPatternInvalidMatchButMore(): void
 	{
 		$page  = new Page(['slug' => 'test']);
 		$field = new Field('test', [
@@ -227,7 +227,7 @@ class ValidationsTest extends TestCase
 		Validations::pattern($field, '12345');
 	}
 
-	public function testRequiredValid()
+	public function testRequiredValid(): void
 	{
 		$page  = new Page(['slug' => 'test']);
 		$field = new Field('test', [
@@ -238,7 +238,7 @@ class ValidationsTest extends TestCase
 		$this->assertTrue(Validations::required($field, 'something'));
 	}
 
-	public function testRequiredInvalid()
+	public function testRequiredInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Please enter something');
@@ -252,7 +252,7 @@ class ValidationsTest extends TestCase
 		Validations::required($field, '');
 	}
 
-	public function testOptionValid()
+	public function testOptionValid(): void
 	{
 		$page  = new Page(['slug' => 'test']);
 		$field = new Field('test', [
@@ -266,7 +266,7 @@ class ValidationsTest extends TestCase
 		$this->assertTrue(Validations::option($field, 'a'));
 	}
 
-	public function testOptionInvalid()
+	public function testOptionInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Please select a valid option');
@@ -283,7 +283,7 @@ class ValidationsTest extends TestCase
 		Validations::option($field, 'c');
 	}
 
-	public function testOptionsValid()
+	public function testOptionsValid(): void
 	{
 		$page  = new Page(['slug' => 'test']);
 		$field = new Field('test', [
@@ -297,7 +297,7 @@ class ValidationsTest extends TestCase
 		$this->assertTrue(Validations::options($field, ['a', 'b']));
 	}
 
-	public function testOptionsInvalid()
+	public function testOptionsInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Please select a valid option');
@@ -314,14 +314,14 @@ class ValidationsTest extends TestCase
 		Validations::options($field, ['a', 'c']);
 	}
 
-	public function testTimeValid()
+	public function testTimeValid(): void
 	{
 		$page  = new Page(['slug' => 'test']);
 		$field = new Field('test', ['model' => $page]);
 		$this->assertTrue(Validations::time($field, '10:12'));
 	}
 
-	public function testTimeInvalid()
+	public function testTimeInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Please enter a valid time');


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Form',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
