### PR TITLE
test: Use PHPUnit attributes for `Kirby\Cms`

### DIFF
--- a/tests/Cms/Api/ApiTest.php
+++ b/tests/Cms/Api/ApiTest.php
@@ -78,7 +78,7 @@ class ApiTest extends TestCase
 		setlocale(LC_ALL, $this->locale);
 	}
 
-	public function testCallLocaleSingleLang1()
+	public function testCallLocaleSingleLang1(): void
 	{
 		setlocale(LC_ALL, 'C');
 		$this->assertSame('C', setlocale(LC_ALL, 0));
@@ -87,7 +87,7 @@ class ApiTest extends TestCase
 		$this->assertSame('de_DE.UTF-8', setlocale(LC_ALL, 0));
 	}
 
-	public function testCallLocaleSingleLang2()
+	public function testCallLocaleSingleLang2(): void
 	{
 		setlocale(LC_ALL, 'C');
 		$this->assertSame('C', setlocale(LC_ALL, 0));
@@ -100,7 +100,7 @@ class ApiTest extends TestCase
 		$_GET = [];
 	}
 
-	public function testCallLocaleMultiLang1()
+	public function testCallLocaleMultiLang1(): void
 	{
 		setlocale(LC_ALL, 'C');
 		$this->assertSame('C', setlocale(LC_ALL, 0));
@@ -128,7 +128,7 @@ class ApiTest extends TestCase
 		$this->assertSame('en_US.UTF-8', setlocale(LC_ALL, 0));
 	}
 
-	public function testCallLocaleMultiLang2()
+	public function testCallLocaleMultiLang2(): void
 	{
 		setlocale(LC_ALL, 'C');
 		$this->assertSame('C', setlocale(LC_ALL, 0));
@@ -160,7 +160,7 @@ class ApiTest extends TestCase
 		$_GET = [];
 	}
 
-	public function testCallTranslation()
+	public function testCallTranslation(): void
 	{
 		// with logged in user with language
 		$app = $this->app->clone([
@@ -272,7 +272,7 @@ class ApiTest extends TestCase
 		$this->assertSame('en', I18n::$locale);
 	}
 
-	public function testLanguage()
+	public function testLanguage(): void
 	{
 		$api = $this->api->clone([
 			'requestData' => [
@@ -285,7 +285,7 @@ class ApiTest extends TestCase
 		$this->assertSame('de', $api->language());
 	}
 
-	public function testFile()
+	public function testFile(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -328,7 +328,7 @@ class ApiTest extends TestCase
 		$this->assertSame('test.jpg', $api->file('users/test@getkirby.com', 'test.jpg')->filename());
 	}
 
-	public function testFileNotFound()
+	public function testFileNotFound(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('The file "nope.jpg" cannot be found');
@@ -336,7 +336,7 @@ class ApiTest extends TestCase
 		$this->api->file('site', 'nope.jpg');
 	}
 
-	public function testFileNotReadable()
+	public function testFileNotReadable(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('The file "protected.jpg" cannot be found');
@@ -357,7 +357,7 @@ class ApiTest extends TestCase
 		$this->api->file('site', 'protected.jpg');
 	}
 
-	public function testPage()
+	public function testPage(): void
 	{
 		$a  = $this->app->page('a');
 		$aa = $this->app->page('a/aa');
@@ -370,12 +370,12 @@ class ApiTest extends TestCase
 		$this->api->page('does-not-exist');
 	}
 
-	public function testPages()
+	public function testPages(): void
 	{
 		$this->assertSame(['a/aa', 'a/ab'], $this->api->pages('a')->keys());
 	}
 
-	public function testPagesNotAccessible()
+	public function testPagesNotAccessible(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [
@@ -407,7 +407,7 @@ class ApiTest extends TestCase
 		$this->assertSame(['a', 'c'], $app->api()->pages()->keys());
 	}
 
-	public function testUser()
+	public function testUser(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -431,12 +431,12 @@ class ApiTest extends TestCase
 		$this->api->user('nope@getkirby.com');
 	}
 
-	public function testUsers()
+	public function testUsers(): void
 	{
 		$this->assertSame($this->app->users(), $this->api->users());
 	}
 
-	public function testFileGetRoute()
+	public function testFileGetRoute(): void
 	{
 		// regular
 		$result = $this->api->call('pages/a/files/a-regular-file.jpg', 'GET');
@@ -451,7 +451,7 @@ class ApiTest extends TestCase
 		$this->assertSame('a filename with spaces.jpg', $result['data']['filename']);
 	}
 
-	public function testAuthenticationWithoutCsrf()
+	public function testAuthenticationWithoutCsrf(): void
 	{
 		$auth = $this->createMock(Auth::class);
 		$auth->method('type')->willReturn('session');
@@ -472,7 +472,7 @@ class ApiTest extends TestCase
 		$function->call($api);
 	}
 
-	public function testAuthenticationWithoutUser()
+	public function testAuthenticationWithoutUser(): void
 	{
 		$auth = $this->createMock(Auth::class);
 		$auth->method('user')->willReturn(null);
@@ -492,7 +492,7 @@ class ApiTest extends TestCase
 		$function->call($api);
 	}
 
-	public function testParent()
+	public function testParent(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -537,7 +537,7 @@ class ApiTest extends TestCase
 		$this->assertNull($api->parent('pages/does-not-exist'));
 	}
 
-	public function testFieldApi()
+	public function testFieldApi(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -580,7 +580,7 @@ class ApiTest extends TestCase
 		$this->assertSame('b.jpg', $response['data'][1]['filename']);
 	}
 
-	public function testFieldApiInvalidField()
+	public function testFieldApiInvalidField(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -597,7 +597,7 @@ class ApiTest extends TestCase
 		$app->api()->fieldApi($page, 'nonexists');
 	}
 
-	public function testFieldApiEmptyField()
+	public function testFieldApiEmptyField(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -614,7 +614,7 @@ class ApiTest extends TestCase
 		$app->api()->fieldApi($page, '');
 	}
 
-	public function testRenderExceptionWithDebugging()
+	public function testRenderExceptionWithDebugging(): void
 	{
 		// simulate the document root to test relative file paths
 		$app = $this->app->clone([
@@ -655,7 +655,7 @@ class ApiTest extends TestCase
 		$this->assertSame(json_encode($expected), $result->body());
 	}
 
-	public function testSectionApi()
+	public function testSectionApi(): void
 	{
 		$app = $this->app->clone([
 			'sections' => [
@@ -698,7 +698,7 @@ class ApiTest extends TestCase
 		$this->assertSame('Test', $response['message']);
 	}
 
-	public function testSectionApiWithInvalidSection()
+	public function testSectionApiWithInvalidSection(): void
 	{
 		$app = $this->app->clone([
 			'site' => [

--- a/tests/Cms/Api/collections/ChildrenApiCollectionTest.php
+++ b/tests/Cms/Api/collections/ChildrenApiCollectionTest.php
@@ -8,7 +8,7 @@ class ChildrenApiCollectionTest extends ApiCollectionTestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.ChildrenApiCollection';
 
-	public function testCollection()
+	public function testCollection(): void
 	{
 		$site = new Site([
 			'children' => [

--- a/tests/Cms/Api/collections/FilesApiCollectionTest.php
+++ b/tests/Cms/Api/collections/FilesApiCollectionTest.php
@@ -8,7 +8,7 @@ class FilesApiCollectionTest extends ApiCollectionTestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.FilesApiCollection';
 
-	public function testCollection()
+	public function testCollection(): void
 	{
 		$page = new Page([
 			'slug' => 'test'

--- a/tests/Cms/Api/collections/LanguagesApiCollectionTest.php
+++ b/tests/Cms/Api/collections/LanguagesApiCollectionTest.php
@@ -30,7 +30,7 @@ class LanguagesApiCollectionTest extends ApiCollectionTestCase
 		Dir::make(static::TMP);
 	}
 
-	public function testCollection()
+	public function testCollection(): void
 	{
 		$collection = $this->api->collection('languages', $this->app->languages());
 		$result     = $collection->toArray();

--- a/tests/Cms/Api/collections/PagesApiCollectionTest.php
+++ b/tests/Cms/Api/collections/PagesApiCollectionTest.php
@@ -8,7 +8,7 @@ class PagesApiCollectionTest extends ApiCollectionTestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.PagesApiCollection';
 
-	public function testCollection()
+	public function testCollection(): void
 	{
 		$collection = $this->api->collection('pages', new Pages([
 			new Page(['slug' => 'a']),

--- a/tests/Cms/Api/collections/RolesApiCollectionTest.php
+++ b/tests/Cms/Api/collections/RolesApiCollectionTest.php
@@ -29,7 +29,7 @@ class RolesApiCollectionTest extends ApiCollectionTestCase
 		Dir::make(static::TMP);
 	}
 
-	public function testCollection()
+	public function testCollection(): void
 	{
 		$collection = $this->api->collection('roles', $this->app->roles());
 		$result     = $collection->toArray();

--- a/tests/Cms/Api/collections/TranslationsApiCollectionTest.php
+++ b/tests/Cms/Api/collections/TranslationsApiCollectionTest.php
@@ -6,7 +6,7 @@ use Kirby\Cms\Api\ApiCollectionTestCase;
 
 class TranslationsApiCollectionTest extends ApiCollectionTestCase
 {
-	public function testCollection()
+	public function testCollection(): void
 	{
 		$collection = $this->api->collection('translations', $this->app->translations()->filter('id', 'en'));
 		$result     = $collection->toArray();

--- a/tests/Cms/Api/collections/UsersApiCollectionTest.php
+++ b/tests/Cms/Api/collections/UsersApiCollectionTest.php
@@ -25,7 +25,7 @@ class UsersApiCollectionTest extends ApiCollectionTestCase
 		Dir::make(static::TMP);
 	}
 
-	public function testDefaultCollection()
+	public function testDefaultCollection(): void
 	{
 		$collection = $this->api->collection('users');
 		$result     = $collection->toArray();
@@ -35,7 +35,7 @@ class UsersApiCollectionTest extends ApiCollectionTestCase
 		$this->assertSame('b@getkirby.com', $result[1]['email']);
 	}
 
-	public function testPassedCollection()
+	public function testPassedCollection(): void
 	{
 		$collection = $this->api->collection('users', $this->app->users()->offset(1));
 		$result     = $collection->toArray();

--- a/tests/Cms/Api/models/FileApiModelTest.php
+++ b/tests/Cms/Api/models/FileApiModelTest.php
@@ -8,7 +8,7 @@ class FileApiModelTest extends ApiModelTestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.FileApiModel';
 
-	public function testNextWithTemplate()
+	public function testNextWithTemplate(): void
 	{
 		$page = new Page([
 			'slug'  => 'test',
@@ -22,7 +22,7 @@ class FileApiModelTest extends ApiModelTestCase
 		$this->assertSame('b.jpg', $next['filename']);
 	}
 
-	public function testPrevWithTemplate()
+	public function testPrevWithTemplate(): void
 	{
 		$page = new Page([
 			'slug'  => 'test',

--- a/tests/Cms/Api/models/FileBlueprintApiModelTest.php
+++ b/tests/Cms/Api/models/FileBlueprintApiModelTest.php
@@ -19,7 +19,7 @@ class FileBlueprintApiModelTest extends ApiModelTestCase
 		$this->file = new File(['filename' => 'test.jpg', 'parent' => $page]);
 	}
 
-	public function testName()
+	public function testName(): void
 	{
 		$blueprint = new FileBlueprint([
 			'name'  => 'test',
@@ -29,7 +29,7 @@ class FileBlueprintApiModelTest extends ApiModelTestCase
 		$this->assertAttr($blueprint, 'name', 'test');
 	}
 
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$blueprint = new FileBlueprint([
 			'name'  => 'test',
@@ -45,7 +45,7 @@ class FileBlueprintApiModelTest extends ApiModelTestCase
 		$this->assertArrayHasKey('update', $options);
 	}
 
-	public function testTabs()
+	public function testTabs(): void
 	{
 		$blueprint = new FileBlueprint([
 			'name'  => 'test',
@@ -55,7 +55,7 @@ class FileBlueprintApiModelTest extends ApiModelTestCase
 		$this->assertAttr($blueprint, 'tabs', []);
 	}
 
-	public function testTitle()
+	public function testTitle(): void
 	{
 		$blueprint = new FileBlueprint([
 			'name'  => 'test',

--- a/tests/Cms/Api/models/FileVersionApiModelTest.php
+++ b/tests/Cms/Api/models/FileVersionApiModelTest.php
@@ -35,7 +35,7 @@ class FileVersionApiModelTest extends ApiModelTestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testExists()
+	public function testExists(): void
 	{
 		$version = new FileVersion([
 			'original' => $this->file,
@@ -45,7 +45,7 @@ class FileVersionApiModelTest extends ApiModelTestCase
 		$this->assertAttr($version, 'exists', false);
 	}
 
-	public function testType()
+	public function testType(): void
 	{
 		$version = new FileVersion([
 			'original' => $this->file,
@@ -55,7 +55,7 @@ class FileVersionApiModelTest extends ApiModelTestCase
 		$this->assertAttr($version, 'type', 'image');
 	}
 
-	public function testUrl()
+	public function testUrl(): void
 	{
 		$version = new FileVersion([
 			'original' => $this->file,

--- a/tests/Cms/Api/models/PageApiModelTest.php
+++ b/tests/Cms/Api/models/PageApiModelTest.php
@@ -8,7 +8,7 @@ class PageApiModelTest extends ApiModelTestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.PageApiModel';
 
-	public function testChildren()
+	public function testChildren(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -24,7 +24,7 @@ class PageApiModelTest extends ApiModelTestCase
 		$this->assertSame('test/b', $model['children'][1]['id']);
 	}
 
-	public function testContent()
+	public function testContent(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -37,7 +37,7 @@ class PageApiModelTest extends ApiModelTestCase
 		$this->assertAttr($page, 'content', $content);
 	}
 
-	public function testDrafts()
+	public function testDrafts(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -53,7 +53,7 @@ class PageApiModelTest extends ApiModelTestCase
 		$this->assertSame('test/b', $model['drafts'][1]['id']);
 	}
 
-	public function testFiles()
+	public function testFiles(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -69,7 +69,7 @@ class PageApiModelTest extends ApiModelTestCase
 		$this->assertSame('b.jpg', $model['files'][1]['filename']);
 	}
 
-	public function testHasDrafts()
+	public function testHasDrafts(): void
 	{
 		$page = new Page([
 			'slug' => 'test'
@@ -88,7 +88,7 @@ class PageApiModelTest extends ApiModelTestCase
 		$this->assertAttr($page, 'hasDrafts', true);
 	}
 
-	public function testHasChildren()
+	public function testHasChildren(): void
 	{
 		$page = new Page([
 			'slug' => 'test'
@@ -107,7 +107,7 @@ class PageApiModelTest extends ApiModelTestCase
 		$this->assertAttr($page, 'hasChildren', true);
 	}
 
-	public function testId()
+	public function testId(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -116,7 +116,7 @@ class PageApiModelTest extends ApiModelTestCase
 		$this->assertAttr($page, 'id', 'test');
 	}
 
-	public function testIsSortable()
+	public function testIsSortable(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -125,7 +125,7 @@ class PageApiModelTest extends ApiModelTestCase
 		$this->assertAttr($page, 'isSortable', $page->isSortable());
 	}
 
-	public function testNum()
+	public function testNum(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -135,7 +135,7 @@ class PageApiModelTest extends ApiModelTestCase
 		$this->assertAttr($page, 'num', 2);
 	}
 
-	public function testSlug()
+	public function testSlug(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -144,7 +144,7 @@ class PageApiModelTest extends ApiModelTestCase
 		$this->assertAttr($page, 'slug', 'test');
 	}
 
-	public function testStatus()
+	public function testStatus(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -153,7 +153,7 @@ class PageApiModelTest extends ApiModelTestCase
 		$this->assertAttr($page, 'status', 'unlisted');
 	}
 
-	public function testTemplate()
+	public function testTemplate(): void
 	{
 		$page = new Page([
 			'slug'     => 'test',
@@ -163,7 +163,7 @@ class PageApiModelTest extends ApiModelTestCase
 		$this->assertAttr($page, 'template', 'test');
 	}
 
-	public function testTitle()
+	public function testTitle(): void
 	{
 		$page = new Page([
 			'slug'    => 'test',
@@ -175,7 +175,7 @@ class PageApiModelTest extends ApiModelTestCase
 		$this->assertAttr($page, 'title', 'Test');
 	}
 
-	public function testUrl()
+	public function testUrl(): void
 	{
 		$page = new Page([
 			'slug' => 'test',

--- a/tests/Cms/Api/models/PageBlueprintApiModelTest.php
+++ b/tests/Cms/Api/models/PageBlueprintApiModelTest.php
@@ -12,7 +12,7 @@ class PageBlueprintApiModelTest extends ApiModelTestCase
 		$this->page = new Page(['slug' => 'test']);
 	}
 
-	public function testName()
+	public function testName(): void
 	{
 		$blueprint = new PageBlueprint([
 			'name'  => 'test',
@@ -22,7 +22,7 @@ class PageBlueprintApiModelTest extends ApiModelTestCase
 		$this->assertAttr($blueprint, 'name', 'test');
 	}
 
-	public function testNum()
+	public function testNum(): void
 	{
 		$blueprint = new PageBlueprint([
 			'name'  => 'test',
@@ -33,7 +33,7 @@ class PageBlueprintApiModelTest extends ApiModelTestCase
 		$this->assertAttr($blueprint, 'num', '{{ page.year }}');
 	}
 
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$blueprint = new PageBlueprint([
 			'name'  => 'test',
@@ -57,7 +57,7 @@ class PageBlueprintApiModelTest extends ApiModelTestCase
 		$this->assertArrayHasKey('update', $options);
 	}
 
-	public function testPreview()
+	public function testPreview(): void
 	{
 		$blueprint = new PageBlueprint([
 			'name'    => 'test',
@@ -70,7 +70,7 @@ class PageBlueprintApiModelTest extends ApiModelTestCase
 		$this->assertAttr($blueprint, 'preview', 'test');
 	}
 
-	public function testStatus()
+	public function testStatus(): void
 	{
 		$blueprint = new PageBlueprint([
 			'name'    => 'test',
@@ -86,7 +86,7 @@ class PageBlueprintApiModelTest extends ApiModelTestCase
 		$this->assertAttr($blueprint, 'status', $status);
 	}
 
-	public function testTabs()
+	public function testTabs(): void
 	{
 		$blueprint = new PageBlueprint([
 			'name'  => 'test',
@@ -96,7 +96,7 @@ class PageBlueprintApiModelTest extends ApiModelTestCase
 		$this->assertAttr($blueprint, 'tabs', []);
 	}
 
-	public function testTitle()
+	public function testTitle(): void
 	{
 		$blueprint = new PageBlueprint([
 			'name'  => 'test',

--- a/tests/Cms/Api/models/SiteApiModelTest.php
+++ b/tests/Cms/Api/models/SiteApiModelTest.php
@@ -8,7 +8,7 @@ class SiteApiModelTest extends ApiModelTestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.SiteApiModel';
 
-	public function testBlueprint()
+	public function testBlueprint(): void
 	{
 		$this->app = $this->app->clone([
 			'blueprints' => [
@@ -24,7 +24,7 @@ class SiteApiModelTest extends ApiModelTestCase
 		$this->assertSame('Test', $blueprint['title']);
 	}
 
-	public function testChildren()
+	public function testChildren(): void
 	{
 		$site = new Site([
 			'children' => [
@@ -39,7 +39,7 @@ class SiteApiModelTest extends ApiModelTestCase
 		$this->assertSame('b', $children[1]['id']);
 	}
 
-	public function testContent()
+	public function testContent(): void
 	{
 		$site = new Site([
 			'content' => $content = [
@@ -51,7 +51,7 @@ class SiteApiModelTest extends ApiModelTestCase
 		$this->assertAttr($site, 'content', $content);
 	}
 
-	public function testDrafts()
+	public function testDrafts(): void
 	{
 		$site = new Site([
 			'drafts' => [
@@ -66,7 +66,7 @@ class SiteApiModelTest extends ApiModelTestCase
 		$this->assertSame('b', $drafts[1]['id']);
 	}
 
-	public function testFiles()
+	public function testFiles(): void
 	{
 		$site = new Site([
 			'files' => [
@@ -81,7 +81,7 @@ class SiteApiModelTest extends ApiModelTestCase
 		$this->assertSame('b.jpg', $files[1]['filename']);
 	}
 
-	public function testTitle()
+	public function testTitle(): void
 	{
 		$site = new Site([
 			'content' => [
@@ -92,7 +92,7 @@ class SiteApiModelTest extends ApiModelTestCase
 		$this->assertAttr($site, 'title', 'Test');
 	}
 
-	public function testUrl()
+	public function testUrl(): void
 	{
 		$site = new Site([
 			'url' => 'https://getkirby.com'

--- a/tests/Cms/Api/models/UserApiModelTest.php
+++ b/tests/Cms/Api/models/UserApiModelTest.php
@@ -16,7 +16,7 @@ class UserApiModelTest extends ApiModelTestCase
 		$this->user = new User(['email' => 'test@getkirby.com']);
 	}
 
-	public function testFiles()
+	public function testFiles(): void
 	{
 		$user = new User([
 			'email' => 'test@getkirby.com',
@@ -32,7 +32,7 @@ class UserApiModelTest extends ApiModelTestCase
 		$this->assertSame('b.jpg', $model['files'][1]['filename']);
 	}
 
-	public function testImage()
+	public function testImage(): void
 	{
 		$image = $this->attr($this->user, 'panelImage');
 		$expected = [

--- a/tests/Cms/Api/models/UserBlueprintApiModelTest.php
+++ b/tests/Cms/Api/models/UserBlueprintApiModelTest.php
@@ -14,7 +14,7 @@ class UserBlueprintApiModelTest extends ApiModelTestCase
 		$this->user = new User(['email' => 'test@getkirby.com']);
 	}
 
-	public function testName()
+	public function testName(): void
 	{
 		$blueprint = new UserBlueprint([
 			'name'  => 'test',
@@ -24,7 +24,7 @@ class UserBlueprintApiModelTest extends ApiModelTestCase
 		$this->assertAttr($blueprint, 'name', 'test');
 	}
 
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$blueprint = new UserBlueprint([
 			'name'  => 'test',
@@ -43,7 +43,7 @@ class UserBlueprintApiModelTest extends ApiModelTestCase
 		$this->assertArrayHasKey('update', $options);
 	}
 
-	public function testTabs()
+	public function testTabs(): void
 	{
 		$blueprint = new UserBlueprint([
 			'name'  => 'test',
@@ -53,7 +53,7 @@ class UserBlueprintApiModelTest extends ApiModelTestCase
 		$this->assertAttr($blueprint, 'tabs', []);
 	}
 
-	public function testTitle()
+	public function testTitle(): void
 	{
 		$blueprint = new UserBlueprint([
 			'name'  => 'test',

--- a/tests/Cms/Api/routes/AccountRoutesTest.php
+++ b/tests/Cms/Api/routes/AccountRoutesTest.php
@@ -57,7 +57,7 @@ class AccountRoutesTest extends TestCase
 		App::destroy();
 	}
 
-	public function testAvatar()
+	public function testAvatar(): void
 	{
 		// create an avatar for the user
 		$this->app->user()->createFile([
@@ -71,7 +71,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertSame('profile.jpg', $response['data']['filename']);
 	}
 
-	public function testAvatarDelete()
+	public function testAvatarDelete(): void
 	{
 		// create an avatar for the user
 		$this->app->user()->createFile([
@@ -85,7 +85,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertTrue($response);
 	}
 
-	public function testBlueprint()
+	public function testBlueprint(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [
@@ -105,7 +105,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertSame('admin', $response['data']['name']);
 	}
 
-	public function testBlueprints()
+	public function testBlueprints(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [
@@ -139,7 +139,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertSame('Bar', $response[1]['title']);
 	}
 
-	public function testChangeEmail()
+	public function testChangeEmail(): void
 	{
 		$response = $this->app->api()->call('account/email', 'PATCH', [
 			'body' => [
@@ -151,7 +151,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertSame('admin@getkirby.de', $response['data']['email']);
 	}
 
-	public function testChangeLanguage()
+	public function testChangeLanguage(): void
 	{
 		$response = $this->app->api()->call('account/language', 'PATCH', [
 			'body' => [
@@ -163,7 +163,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertSame('de', $response['data']['language']);
 	}
 
-	public function testChangeName()
+	public function testChangeName(): void
 	{
 		$response = $this->app->api()->call('account/name', 'PATCH', [
 			'body' => [
@@ -175,7 +175,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertSame('Test user', $response['data']['name']);
 	}
 
-	public function testChangePassword()
+	public function testChangePassword(): void
 	{
 		$response = $this->app->api()->call('account/password', 'PATCH', [
 			'body' => [
@@ -188,7 +188,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertTrue($this->app->user()->validatePassword('super-secure-new-password'));
 	}
 
-	public function testChangePasswordMissingCurrentPassword()
+	public function testChangePasswordMissingCurrentPassword(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Please enter a valid password. Passwords must be at least 8 characters long.');
@@ -200,7 +200,7 @@ class AccountRoutesTest extends TestCase
 		]);
 	}
 
-	public function testChangePasswordWrongCurrentPassword()
+	public function testChangePasswordWrongCurrentPassword(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Wrong password');
@@ -213,7 +213,7 @@ class AccountRoutesTest extends TestCase
 		]);
 	}
 
-	public function testChangePasswordReset()
+	public function testChangePasswordReset(): void
 	{
 		$this->app->session()->set('kirby.resetPassword', true);
 
@@ -228,7 +228,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertNull($this->app->session()->get('kirby.resetPassword'));
 	}
 
-	public function testChangeRole()
+	public function testChangeRole(): void
 	{
 		$response = $this->app->api()->call('account/role', 'PATCH', [
 			'body' => [
@@ -240,13 +240,13 @@ class AccountRoutesTest extends TestCase
 		$this->assertSame('editor', $response['data']['role']['name']);
 	}
 
-	public function testDelete()
+	public function testDelete(): void
 	{
 		$response = $this->app->api()->call('account', 'DELETE');
 		$this->assertTrue($response);
 	}
 
-	public function testFields()
+	public function testFields(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [
@@ -285,7 +285,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertSame('Test nested route', $response);
 	}
 
-	public function testFile()
+	public function testFile(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -308,7 +308,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertSame('a.jpg', $response['data']['filename']);
 	}
 
-	public function testFiles()
+	public function testFiles(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -340,7 +340,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertSame('c.jpg', $response['data'][2]['filename']);
 	}
 
-	public function testFilesSorted()
+	public function testFilesSorted(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -373,7 +373,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertSame('a.jpg', $response['data'][1]['filename']);
 	}
 
-	public function testGet()
+	public function testGet(): void
 	{
 		$app = $this->app;
 
@@ -382,7 +382,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertSame('test@getkirby.com', $response['data']['email']);
 	}
 
-	public function testRoles()
+	public function testRoles(): void
 	{
 		$response = $this->app->api()->call('account/roles');
 
@@ -393,7 +393,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertSame('editor', $response['data'][1]['name']);
 	}
 
-	public function testSections()
+	public function testSections(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [
@@ -428,7 +428,7 @@ class AccountRoutesTest extends TestCase
 		$this->assertSame($expected, $response);
 	}
 
-	public function testUpdate()
+	public function testUpdate(): void
 	{
 		$response = $this->app->api()->call('account', 'PATCH', [
 			'body' => [

--- a/tests/Cms/Api/routes/AuthRoutesTest.php
+++ b/tests/Cms/Api/routes/AuthRoutesTest.php
@@ -28,7 +28,7 @@ class AuthRoutesTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testGet()
+	public function testGet(): void
 	{
 		$this->app->impersonate('kirby');
 
@@ -37,7 +37,7 @@ class AuthRoutesTest extends TestCase
 		$this->assertSame('kirby@getkirby.com', $response['data']['email']);
 	}
 
-	public function testLoginWithoutCSRF()
+	public function testLoginWithoutCSRF(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid CSRF token');

--- a/tests/Cms/Api/routes/LanguagesRoutesTest.php
+++ b/tests/Cms/Api/routes/LanguagesRoutesTest.php
@@ -35,7 +35,7 @@ class LanguagesRoutesTest extends TestCase
 		$this->app->impersonate('kirby');
 	}
 
-	public function testList()
+	public function testList(): void
 	{
 		$app = $this->app;
 
@@ -45,7 +45,7 @@ class LanguagesRoutesTest extends TestCase
 		$this->assertSame('de', $response['data'][1]['code']);
 	}
 
-	public function testListDisabled()
+	public function testListDisabled(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -59,7 +59,7 @@ class LanguagesRoutesTest extends TestCase
 		$response = $app->api()->call('languages');
 	}
 
-	public function testCreateDisabled()
+	public function testCreateDisabled(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -73,7 +73,7 @@ class LanguagesRoutesTest extends TestCase
 		$response = $app->api()->call('languages', 'POST');
 	}
 
-	public function testGet()
+	public function testGet(): void
 	{
 		$app = $this->app;
 
@@ -82,7 +82,7 @@ class LanguagesRoutesTest extends TestCase
 		$this->assertSame('de', $response['data']['code']);
 	}
 
-	public function testGetDisabled()
+	public function testGetDisabled(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -96,7 +96,7 @@ class LanguagesRoutesTest extends TestCase
 		$response = $app->api()->call('languages/de');
 	}
 
-	public function testUpdateDisabled()
+	public function testUpdateDisabled(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -110,7 +110,7 @@ class LanguagesRoutesTest extends TestCase
 		$response = $app->api()->call('languages/de', 'PATCH');
 	}
 
-	public function testDeleteDisabled()
+	public function testDeleteDisabled(): void
 	{
 		$app = $this->app->clone([
 			'options' => [

--- a/tests/Cms/Api/routes/PagesRoutesTest.php
+++ b/tests/Cms/Api/routes/PagesRoutesTest.php
@@ -27,7 +27,7 @@ class PagesRoutesTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testGet()
+	public function testGet(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -55,7 +55,7 @@ class PagesRoutesTest extends TestCase
 		$this->assertSame('a/b', $response['data']['id']);
 	}
 
-	public function testChildren()
+	public function testChildren(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -83,7 +83,7 @@ class PagesRoutesTest extends TestCase
 		$this->assertSame('parent/child-b', $response['data'][1]['id']);
 	}
 
-	public function testChildrenWithStatusFilter()
+	public function testChildrenWithStatusFilter(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -156,7 +156,7 @@ class PagesRoutesTest extends TestCase
 		$this->assertSame('parent/draft-a', $response['data'][0]['id']);
 	}
 
-	public function testFiles()
+	public function testFiles(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -189,7 +189,7 @@ class PagesRoutesTest extends TestCase
 		$this->assertSame('c.jpg', $response['data'][2]['filename']);
 	}
 
-	public function testFilesOfAPageWithTheSlugFiles()
+	public function testFilesOfAPageWithTheSlugFiles(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -222,7 +222,7 @@ class PagesRoutesTest extends TestCase
 		$this->assertSame('c.jpg', $response['data'][2]['filename']);
 	}
 
-	public function testFilesSorted()
+	public function testFilesSorted(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -256,7 +256,7 @@ class PagesRoutesTest extends TestCase
 		$this->assertSame('a.jpg', $response['data'][1]['filename']);
 	}
 
-	public function testFile()
+	public function testFile(): void
 	{
 		$app = $this->app->clone([
 			'site' => [

--- a/tests/Cms/Api/routes/RolesRoutesTest.php
+++ b/tests/Cms/Api/routes/RolesRoutesTest.php
@@ -30,7 +30,7 @@ class RolesRoutesTest extends TestCase
 		$this->app->impersonate('kirby');
 	}
 
-	public function testList()
+	public function testList(): void
 	{
 		$app = $this->app;
 
@@ -40,7 +40,7 @@ class RolesRoutesTest extends TestCase
 		$this->assertSame('editor', $response['data'][1]['name']);
 	}
 
-	public function testGet()
+	public function testGet(): void
 	{
 		$app = $this->app;
 

--- a/tests/Cms/Api/routes/SiteRoutesTest.php
+++ b/tests/Cms/Api/routes/SiteRoutesTest.php
@@ -35,14 +35,14 @@ class SiteRoutesTest extends TestCase
 		App::destroy();
 	}
 
-	public function testGet()
+	public function testGet(): void
 	{
 		$response = $this->app->api()->call('site', 'GET');
 
 		$this->assertSame('Test Site', $response['data']['title']);
 	}
 
-	public function testChildren()
+	public function testChildren(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -66,7 +66,7 @@ class SiteRoutesTest extends TestCase
 		$this->assertSame('b', $response['data'][1]['id']);
 	}
 
-	public function testChildrenWithStatusFilter()
+	public function testChildrenWithStatusFilter(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -133,7 +133,7 @@ class SiteRoutesTest extends TestCase
 		$this->assertSame('draft-a', $response['data'][0]['id']);
 	}
 
-	public function testFiles()
+	public function testFiles(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -161,7 +161,7 @@ class SiteRoutesTest extends TestCase
 		$this->assertSame('c.jpg', $response['data'][2]['filename']);
 	}
 
-	public function testFilesSorted()
+	public function testFilesSorted(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -190,7 +190,7 @@ class SiteRoutesTest extends TestCase
 		$this->assertSame('a.jpg', $response['data'][1]['filename']);
 	}
 
-	public function testFile()
+	public function testFile(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -209,7 +209,7 @@ class SiteRoutesTest extends TestCase
 		$this->assertSame('a.jpg', $response['data']['filename']);
 	}
 
-	public function testFind()
+	public function testFind(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -260,7 +260,7 @@ class SiteRoutesTest extends TestCase
 	}
 
 
-	public function testSearchWithGetRequest()
+	public function testSearchWithGetRequest(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -295,7 +295,7 @@ class SiteRoutesTest extends TestCase
 		$this->assertSame('parent/child', $response['data'][0]['id']);
 	}
 
-	public function testSearchWithPostRequest()
+	public function testSearchWithPostRequest(): void
 	{
 		$app = $this->app->clone([
 			'site' => [

--- a/tests/Cms/Api/routes/SystemRoutesTest.php
+++ b/tests/Cms/Api/routes/SystemRoutesTest.php
@@ -17,14 +17,14 @@ class SystemRoutesTest extends TestCase
 		]);
 	}
 
-	public function testGetWithoutUser()
+	public function testGetWithoutUser(): void
 	{
 		$response = $this->app->api()->call('system', 'GET');
 
 		$this->assertArrayNotHasKey('user', $response['data']);
 	}
 
-	public function testGetWithUser()
+	public function testGetWithUser(): void
 	{
 		$this->app->impersonate('kirby');
 

--- a/tests/Cms/Api/routes/TranslationsRoutesTest.php
+++ b/tests/Cms/Api/routes/TranslationsRoutesTest.php
@@ -17,7 +17,7 @@ class TranslationsRoutesTest extends TestCase
 		$this->app->impersonate('kirby');
 	}
 
-	public function testList()
+	public function testList(): void
 	{
 		$app      = $this->app;
 		$response = $app->api()->call('translations');
@@ -26,7 +26,7 @@ class TranslationsRoutesTest extends TestCase
 		$this->assertCount(count($files), $response['data']);
 	}
 
-	public function testGet()
+	public function testGet(): void
 	{
 		$app = $this->app;
 

--- a/tests/Cms/Api/routes/UsersRoutesTest.php
+++ b/tests/Cms/Api/routes/UsersRoutesTest.php
@@ -59,7 +59,7 @@ class UsersRoutesTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testAvatar()
+	public function testAvatar(): void
 	{
 		// create an avatar for the user
 		$this->app->user('admin@getkirby.com')->createFile([
@@ -73,7 +73,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('profile.jpg', $response['data']['filename']);
 	}
 
-	public function testAvatarDelete()
+	public function testAvatarDelete(): void
 	{
 		// create an avatar for the user
 		$this->app->user('admin@getkirby.com')->createFile([
@@ -87,7 +87,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertTrue($response);
 	}
 
-	public function testBlueprint()
+	public function testBlueprint(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [
@@ -107,7 +107,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('admin', $response['data']['name']);
 	}
 
-	public function testBlueprints()
+	public function testBlueprints(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [
@@ -141,7 +141,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('Bar', $response[1]['title']);
 	}
 
-	public function testCreate()
+	public function testCreate(): void
 	{
 		$app = $this->app;
 
@@ -158,7 +158,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('test@getkirby.com', $response['data']['username']);
 	}
 
-	public function testChangeEmail()
+	public function testChangeEmail(): void
 	{
 		$response = $this->app->api()->call('users/admin@getkirby.com/email', 'PATCH', [
 			'body' => [
@@ -170,7 +170,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('admin@getkirby.de', $response['data']['email']);
 	}
 
-	public function testChangeLanguage()
+	public function testChangeLanguage(): void
 	{
 		$response = $this->app->api()->call('users/admin@getkirby.com/language', 'PATCH', [
 			'body' => [
@@ -182,7 +182,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('de', $response['data']['language']);
 	}
 
-	public function testChangeName()
+	public function testChangeName(): void
 	{
 		$response = $this->app->api()->call('users/admin@getkirby.com/name', 'PATCH', [
 			'body' => [
@@ -194,7 +194,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('Test user', $response['data']['name']);
 	}
 
-	public function testChangePassword()
+	public function testChangePassword(): void
 	{
 		$this->app->impersonate('admin@getkirby.com');
 
@@ -209,7 +209,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertTrue($this->app->user('editor@getkirby.com')->validatePassword('super-secure-new-password'));
 	}
 
-	public function testChangePasswordMissingCurrentPassword()
+	public function testChangePasswordMissingCurrentPassword(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Please enter a valid password. Passwords must be at least 8 characters long.');
@@ -223,7 +223,7 @@ class UsersRoutesTest extends TestCase
 		]);
 	}
 
-	public function testChangePasswordWrongCurrentPassword()
+	public function testChangePasswordWrongCurrentPassword(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Wrong password');
@@ -238,7 +238,7 @@ class UsersRoutesTest extends TestCase
 		]);
 	}
 
-	public function testChangePasswordReset()
+	public function testChangePasswordReset(): void
 	{
 		// the password reset mode of the acting user must not take effect when
 		// changing the password of a different user
@@ -256,7 +256,7 @@ class UsersRoutesTest extends TestCase
 		]);
 	}
 
-	public function testChangeRole()
+	public function testChangeRole(): void
 	{
 		$response = $this->app->api()->call('users/editor@getkirby.com/role', 'PATCH', [
 			'body' => [
@@ -268,13 +268,13 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('editor', $response['data']['role']['name']);
 	}
 
-	public function testDelete()
+	public function testDelete(): void
 	{
 		$response = $this->app->api()->call('users/admin@getkirby.com', 'DELETE');
 		$this->assertTrue($response);
 	}
 
-	public function testFields()
+	public function testFields(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [
@@ -313,7 +313,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('Test nested route', $response);
 	}
 
-	public function testFile()
+	public function testFile(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -335,7 +335,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('a.jpg', $response['data']['filename']);
 	}
 
-	public function testFiles()
+	public function testFiles(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -366,7 +366,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('c.jpg', $response['data'][2]['filename']);
 	}
 
-	public function testFilesSorted()
+	public function testFilesSorted(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -398,7 +398,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('a.jpg', $response['data'][1]['filename']);
 	}
 
-	public function testGet()
+	public function testGet(): void
 	{
 		$app = $this->app;
 
@@ -407,7 +407,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('admin@getkirby.com', $response['data']['email']);
 	}
 
-	public function testRoles()
+	public function testRoles(): void
 	{
 		$this->app->impersonate('kirby');
 
@@ -420,7 +420,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('editor', $response['data'][1]['name']);
 	}
 
-	public function testSearchName()
+	public function testSearchName(): void
 	{
 		$app = $this->app;
 
@@ -434,7 +434,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('admin@getkirby.com', $response['data'][0]['email']);
 	}
 
-	public function testSearchWithGetRequest()
+	public function testSearchWithGetRequest(): void
 	{
 		$app = $this->app;
 
@@ -448,7 +448,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('editor@getkirby.com', $response['data'][0]['email']);
 	}
 
-	public function testSearchWithPostRequest()
+	public function testSearchWithPostRequest(): void
 	{
 		$app = $this->app;
 
@@ -462,7 +462,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('editor@getkirby.com', $response['data'][0]['email']);
 	}
 
-	public function testSections()
+	public function testSections(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [
@@ -497,7 +497,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame($expected, $response);
 	}
 
-	public function testUpdate()
+	public function testUpdate(): void
 	{
 		$response = $this->app->api()->call('users/admin@getkirby.com', 'PATCH', [
 			'body' => [
@@ -509,7 +509,7 @@ class UsersRoutesTest extends TestCase
 		$this->assertSame('Admin', $response['data']['content']['position']);
 	}
 
-	public function testUsers()
+	public function testUsers(): void
 	{
 		$response = $this->app->api()->call('users');
 

--- a/tests/Cms/App/AppCachesTest.php
+++ b/tests/Cms/App/AppCachesTest.php
@@ -28,12 +28,12 @@ class AppCachesTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testDisabledCache()
+	public function testDisabledCache(): void
 	{
 		$this->assertInstanceOf(NullCache::class, $this->app()->cache('pages'));
 	}
 
-	public function testEnabledCacheWithoutOptions()
+	public function testEnabledCacheWithoutOptions(): void
 	{
 		$kirby = $this->app([
 			'options' => [
@@ -45,7 +45,7 @@ class AppCachesTest extends TestCase
 		$this->assertSame($kirby->root('cache'), $kirby->cache('pages')->options()['root']);
 	}
 
-	public function testInvalidCacheType()
+	public function testInvalidCacheType(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid cache type "not-exists"');
@@ -61,7 +61,7 @@ class AppCachesTest extends TestCase
 		$kirby->cache('pages');
 	}
 
-	public function testEnabledCacheWithOptions()
+	public function testEnabledCacheWithOptions(): void
 	{
 		$kirby = $this->app([
 			'urls' => [
@@ -82,7 +82,7 @@ class AppCachesTest extends TestCase
 		$this->assertFileExists($root . '/getkirby.com_test/pages/home.cache');
 	}
 
-	public function testEnabledCacheWithOptionsAndPortPrefix()
+	public function testEnabledCacheWithOptionsAndPortPrefix(): void
 	{
 		$kirby = $this->app([
 			'urls' => [
@@ -103,7 +103,7 @@ class AppCachesTest extends TestCase
 		$this->assertFileExists($root . '/127.0.0.1_8000/pages/home.cache');
 	}
 
-	public function testPluginDefaultCache()
+	public function testPluginDefaultCache(): void
 	{
 		App::plugin('developer/plugin', [
 			'options' => [
@@ -114,7 +114,7 @@ class AppCachesTest extends TestCase
 		$this->assertInstanceOf(FileCache::class, $this->app()->cache('developer.plugin'));
 	}
 
-	public function testPluginCustomCache()
+	public function testPluginCustomCache(): void
 	{
 		App::plugin('developer/plugin', [
 			'options' => [
@@ -125,7 +125,7 @@ class AppCachesTest extends TestCase
 		$this->assertInstanceOf(FileCache::class, $this->app()->cache('developer.plugin.api'));
 	}
 
-	public function testDefaultCacheTypeClasses()
+	public function testDefaultCacheTypeClasses(): void
 	{
 		$app = new App([
 			'roots' => [

--- a/tests/Cms/App/AppComponentsTest.php
+++ b/tests/Cms/App/AppComponentsTest.php
@@ -40,7 +40,7 @@ class AppComponentsTest extends TestCase
 		]);
 	}
 
-	public function testCssPlugin()
+	public function testCssPlugin(): void
 	{
 		$this->app->clone([
 			'components' => [
@@ -52,7 +52,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, css('something.css'));
 	}
 
-	public function testJsPlugin()
+	public function testJsPlugin(): void
 	{
 		$this->app->clone([
 			'components' => [
@@ -64,7 +64,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, js('something.js'));
 	}
 
-	public function testKirbyTag()
+	public function testKirbyTag(): void
 	{
 		$tag = $this->app->kirbytag('link', 'https://getkirby.com', ['text' => 'Kirby']);
 		$expected = '<a href="https://getkirby.com">Kirby</a>';
@@ -72,7 +72,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, $tag);
 	}
 
-	public function testKirbyTags()
+	public function testKirbyTags(): void
 	{
 		$tag = $this->app->kirbytags('(link: https://getkirby.com text: Kirby)');
 		$expected = '<a href="https://getkirby.com">Kirby</a>';
@@ -80,7 +80,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, $tag);
 	}
 
-	public function testKirbytext()
+	public function testKirbytext(): void
 	{
 		$text     = 'Test';
 		$expected = '<p>Test</p>';
@@ -88,7 +88,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, $this->app->kirbytext($text));
 	}
 
-	public function testKirbytextWithSafeMode()
+	public function testKirbytextWithSafeMode(): void
 	{
 		$text     = '<h1>**Test**</h1>';
 		$expected = '&lt;h1&gt;<strong>Test</strong>&lt;/h1&gt;';
@@ -101,7 +101,7 @@ class AppComponentsTest extends TestCase
 		]));
 	}
 
-	public function testKirbytextInline()
+	public function testKirbytextInline(): void
 	{
 		$text     = 'Test';
 		$expected = 'Test';
@@ -113,7 +113,7 @@ class AppComponentsTest extends TestCase
 		], true));
 	}
 
-	public function testMarkdown()
+	public function testMarkdown(): void
 	{
 		$text     = 'Test';
 		$expected = '<p>Test</p>';
@@ -121,7 +121,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, $this->app->markdown($text));
 	}
 
-	public function testMarkdownInline()
+	public function testMarkdownInline(): void
 	{
 		$text     = 'Test';
 		$expected = 'Test';
@@ -129,7 +129,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, $this->app->markdown($text, ['inline' => true]));
 	}
 
-	public function testMarkdownWithSafeMode()
+	public function testMarkdownWithSafeMode(): void
 	{
 		$text     = '<div>Test</div>';
 		$expected = '<p>&lt;div&gt;Test&lt;/div&gt;</p>';
@@ -137,7 +137,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, $this->app->markdown($text, ['safe' => true]));
 	}
 
-	public function testMarkdownCachedInstance()
+	public function testMarkdownCachedInstance(): void
 	{
 		$text     = '1st line
 2nd line';
@@ -151,7 +151,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, $this->app->component('markdown')($this->app, $text, ['breaks' => false]));
 	}
 
-	public function testMarkdownPlugin()
+	public function testMarkdownPlugin(): void
 	{
 		$this->app = $this->app->clone([
 			'components' => [
@@ -176,7 +176,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, $this->app->markdown($text, ['inline' => true]));
 	}
 
-	public function testSmartypants()
+	public function testSmartypants(): void
 	{
 		$text     = '"Test"';
 		$expected = '&#8220;Test&#8221;';
@@ -184,7 +184,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, $this->app->smartypants($text));
 	}
 
-	public function testSmartypantsDisabled()
+	public function testSmartypantsDisabled(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -198,7 +198,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, $this->app->smartypants($text));
 	}
 
-	public function testSmartypantsOptions()
+	public function testSmartypantsOptions(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -216,7 +216,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, $this->app->smartypants($text));
 	}
 
-	public function testSmartypantsMultiLang()
+	public function testSmartypantsMultiLang(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -254,7 +254,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, $this->app->smartypants($text));
 	}
 
-	public function testSmartypantsDefaultOptionsOnMultiLang()
+	public function testSmartypantsDefaultOptionsOnMultiLang(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -284,7 +284,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, $this->app->smartypants($text));
 	}
 
-	public function testSmartypantsCachedInstance()
+	public function testSmartypantsCachedInstance(): void
 	{
 		$text     = '"Test"';
 		$expected = '&#8220;Test&#8221;';
@@ -295,7 +295,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame($expected, $this->app->component('smartypants')($this->app, $text, ['doublequote.open' => 'Test']));
 	}
 
-	public function testSnippet()
+	public function testSnippet(): void
 	{
 		$app = $this->app->clone([
 			'roots' => [
@@ -348,7 +348,7 @@ class AppComponentsTest extends TestCase
 		$app->snippet('variable', ['message' => 'test'], false);
 	}
 
-	public function testStorage()
+	public function testStorage(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [
@@ -361,7 +361,7 @@ class AppComponentsTest extends TestCase
 		$this->assertInstanceOf(PlainTextStorage::class, $this->app->storage($this->app->page('test')));
 	}
 
-	public function testStorageWithModifiedComponent()
+	public function testStorageWithModifiedComponent(): void
 	{
 		$this->app = $this->app->clone([
 			'components' => [
@@ -379,12 +379,12 @@ class AppComponentsTest extends TestCase
 		$this->assertInstanceOf(MemoryStorage::class, $this->app->storage($this->app->page('test')));
 	}
 
-	public function testTemplate()
+	public function testTemplate(): void
 	{
 		$this->assertInstanceOf(Template::class, $this->app->template('default'));
 	}
 
-	public function testUrlPlugin()
+	public function testUrlPlugin(): void
 	{
 		$this->app->clone([
 			'components' => [
@@ -395,7 +395,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame('test', url('anything'));
 	}
 
-	public function testUrlPluginWithNativeComponent()
+	public function testUrlPluginWithNativeComponent(): void
 	{
 		$this->app->clone([
 			'components' => [
@@ -413,7 +413,7 @@ class AppComponentsTest extends TestCase
 		$this->assertSame('/any/page', url('any/page'));
 	}
 
-	public function testUrlInvalidUuid()
+	public function testUrlInvalidUuid(): void
 	{
 		$this->app->clone([
 			'roots' => [
@@ -427,7 +427,7 @@ class AppComponentsTest extends TestCase
 		url('page://invalid');
 	}
 
-	public function testEmail()
+	public function testEmail(): void
 	{
 		$app = $this->app->clone([
 			'components' => [

--- a/tests/Cms/App/AppErrorsTest.php
+++ b/tests/Cms/App/AppErrorsTest.php
@@ -4,13 +4,12 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\Exception;
 use Kirby\Filesystem\F;
+use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionMethod;
 use Whoops\Handler\CallbackHandler;
 use Whoops\Handler\PlainTextHandler;
 
-/**
- * @coversDefaultClass \Kirby\Cms\AppErrors
- */
+#[CoversClass(AppErrors::class)]
 class AppErrorsTest extends TestCase
 {
 	protected App|null $originalApp;
@@ -48,10 +47,7 @@ class AppErrorsTest extends TestCase
 		App::$enableWhoops = false;
 	}
 
-	/**
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
-	public function testExceptionHook()
+	public function testExceptionHook(): void
 	{
 		$result = null;
 
@@ -80,10 +76,7 @@ class AppErrorsTest extends TestCase
 		$this->assertStringContainsString('Exception: Some error message in', ErrorLog::$log);
 	}
 
-	/**
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
-	public function testExceptionHookDisableLogging()
+	public function testExceptionHookDisableLogging(): void
 	{
 		$result = null;
 
@@ -113,11 +106,7 @@ class AppErrorsTest extends TestCase
 		$this->assertSame('', ErrorLog::$log);
 	}
 
-	/**
-	 * @covers ::handleCliErrors
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
-	public function testHandleCliErrors()
+	public function testHandleCliErrors(): void
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
 		$whoopsMethod->setAccessible(true);
@@ -135,11 +124,7 @@ class AppErrorsTest extends TestCase
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 	}
 
-	/**
-	 * @covers ::handleErrors
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
-	public function testHandleErrors1()
+	public function testHandleErrors1(): void
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
 		$whoopsMethod->setAccessible(true);
@@ -160,11 +145,7 @@ class AppErrorsTest extends TestCase
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 	}
 
-	/**
-	 * @covers ::handleErrors
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
-	public function testHandleErrors2()
+	public function testHandleErrors2(): void
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
 		$whoopsMethod->setAccessible(true);
@@ -188,11 +169,7 @@ class AppErrorsTest extends TestCase
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 	}
 
-	/**
-	 * @covers ::handleErrors
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
-	public function testHandleErrors3()
+	public function testHandleErrors3(): void
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
 		$whoopsMethod->setAccessible(true);
@@ -221,10 +198,7 @@ class AppErrorsTest extends TestCase
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 	}
 
-	/**
-	 * @covers ::handleErrors
-	 */
-	public function testHandleErrorsGlobalSetting()
+	public function testHandleErrorsGlobalSetting(): void
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
 		$whoopsMethod->setAccessible(true);
@@ -254,11 +228,7 @@ class AppErrorsTest extends TestCase
 		$this->assertCount(2, $handlers);
 	}
 
-	/**
-	 * @covers ::handleHtmlErrors
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
-	public function testHandleHtmlErrors()
+	public function testHandleHtmlErrors(): void
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
 		$whoopsMethod->setAccessible(true);
@@ -332,11 +302,7 @@ class AppErrorsTest extends TestCase
 		$this->assertCount(0, $handlers);
 	}
 
-	/**
-	 * @covers ::handleJsonErrors
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
-	public function testHandleJsonErrors()
+	public function testHandleJsonErrors(): void
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
 		$whoopsMethod->setAccessible(true);
@@ -412,12 +378,7 @@ class AppErrorsTest extends TestCase
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 	}
 
-	/**
-	 * @covers ::setWhoopsHandler
-	 * @covers ::unsetWhoopsHandler
-	 * @covers ::getAdditionalWhoopsHandler
-	 */
-	public function testSetUnsetWhoopsHandler()
+	public function testSetUnsetWhoopsHandler(): void
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
 		$whoopsMethod->setAccessible(true);
@@ -450,10 +411,7 @@ class AppErrorsTest extends TestCase
 		$this->assertCount(0, $handlers);
 	}
 
-	/**
-	 * @covers ::whoops
-	 */
-	public function testWhoops()
+	public function testWhoops(): void
 	{
 		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
 		$whoopsMethod->setAccessible(true);
@@ -471,7 +429,7 @@ class AppErrorsTest extends TestCase
 	/**
 	 * Convert output to returned variable
 	 */
-	protected function _getBufferedContent(string|\Whoops\Handler\CallbackHandler $path): false|string
+	protected function _getBufferedContent(string|CallbackHandler $path): false|string
 	{
 		ob_start();
 

--- a/tests/Cms/App/AppIoTest.php
+++ b/tests/Cms/App/AppIoTest.php
@@ -20,7 +20,7 @@ class AppIoTest extends TestCase
 		]);
 	}
 
-	public function testException()
+	public function testException(): void
 	{
 		$response = $this->app()->io(new Exception(
 			fallback: 'Nope',
@@ -31,7 +31,7 @@ class AppIoTest extends TestCase
 		$this->assertSame('Nope', $response->body());
 	}
 
-	public function testExceptionErrorPage()
+	public function testExceptionErrorPage(): void
 	{
 		$app = $this->app()->clone([
 			'site' => [
@@ -50,7 +50,7 @@ class AppIoTest extends TestCase
 		$this->assertSame('Error: Nope', $response->body());
 	}
 
-	public function testExceptionWithInvalidHttpCode()
+	public function testExceptionWithInvalidHttpCode(): void
 	{
 		$response = $this->app()->io(new \Exception('Nope', 8000));
 
@@ -58,7 +58,7 @@ class AppIoTest extends TestCase
 		$this->assertSame('Nope', $response->body());
 	}
 
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$response = $this->app()->io('');
 
@@ -66,7 +66,7 @@ class AppIoTest extends TestCase
 		$this->assertSame('Not found', $response->body());
 	}
 
-	public function testResponder()
+	public function testResponder(): void
 	{
 		$app   = $this->app();
 		$input = $app->response()->code(201)->body('Test');
@@ -77,7 +77,7 @@ class AppIoTest extends TestCase
 		$this->assertSame('Test', $response->body());
 	}
 
-	public function testResponse()
+	public function testResponse(): void
 	{
 		$input = new Response([
 			'code' => 200,
@@ -107,7 +107,7 @@ class AppIoTest extends TestCase
 		], $response->toArray());
 	}
 
-	public function testPage()
+	public function testPage(): void
 	{
 		$input = new Page([
 			'slug'     => 'test',
@@ -120,7 +120,7 @@ class AppIoTest extends TestCase
 		$this->assertSame('Test template', $response->body());
 	}
 
-	public function testPageErrorPageException()
+	public function testPageErrorPageException(): void
 	{
 		$input = new Page([
 			'slug'     => 'test',
@@ -133,7 +133,7 @@ class AppIoTest extends TestCase
 		$this->assertSame('Exception message', $response->body());
 	}
 
-	public function testPageErrorPageExceptionErrorPage()
+	public function testPageErrorPageExceptionErrorPage(): void
 	{
 		$app = $this->app()->clone([
 			'site' => [
@@ -157,7 +157,7 @@ class AppIoTest extends TestCase
 		$this->assertSame('Error: Exception message', $response->body());
 	}
 
-	public function testString()
+	public function testString(): void
 	{
 		$response = $this->app()->io('Test');
 
@@ -165,7 +165,7 @@ class AppIoTest extends TestCase
 		$this->assertSame('Test', $response->body());
 	}
 
-	public function testArray()
+	public function testArray(): void
 	{
 		$response = $this->app()->io($array = ['foo' => 'bar']);
 

--- a/tests/Cms/App/AppLanguagesTest.php
+++ b/tests/Cms/App/AppLanguagesTest.php
@@ -3,10 +3,11 @@
 namespace Kirby\Cms;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class AppLanguagesTest extends TestCase
 {
-	public function testLanguages()
+	public function testLanguages(): void
 	{
 		$app = new App([
 			'languages' => [
@@ -27,7 +28,7 @@ class AppLanguagesTest extends TestCase
 		$this->assertSame('en', $app->languageCode());
 	}
 
-	public function testLanguageCode()
+	public function testLanguageCode(): void
 	{
 		$app = new App([
 			'languages' => [
@@ -64,10 +65,10 @@ class AppLanguagesTest extends TestCase
 	}
 
 	/**
-	 * @dataProvider detectedLanguageProvider
 	 * @backupGlobals enabled
 	 */
-	public function testDetectedLanguage($accept, $expected)
+	#[DataProvider('detectedLanguageProvider')]
+	public function testDetectedLanguage($accept, $expected): void
 	{
 		// set the accepted visitor language
 		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = $accept;

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -12,6 +12,7 @@ use Kirby\Image\Image;
 use Kirby\Plugin\Plugin;
 use Kirby\Toolkit\Collection;
 use Kirby\Toolkit\I18n;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class DummyAuthChallenge extends Challenge
 {
@@ -51,9 +52,7 @@ class DummyFilePreview
 {
 }
 
-/**
- * @coversDefaultClass \Kirby\Cms\AppPlugins
- */
+#[CoversClass(AppPlugins::class)]
 class AppPluginsTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -62,7 +61,7 @@ class AppPluginsTest extends TestCase
 	// used for testPluginLoader()
 	public static bool $calledPluginsLoadedHook = false;
 
-	public function testApi()
+	public function testApi(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -83,7 +82,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame('nice', $kirby->call('api/awesome'));
 	}
 
-	public function testApiRoutePlugins()
+	public function testApiRoutePlugins(): void
 	{
 		App::plugin('test/a', [
 			'api' => [
@@ -134,7 +133,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame('c', $app->api()->call('c'));
 	}
 
-	public function testApiRouteCallbackPlugins()
+	public function testApiRouteCallbackPlugins(): void
 	{
 		App::plugin('test/a', [
 			'api' => [
@@ -185,7 +184,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame('c', $app->api()->call('c'));
 	}
 
-	public function testApiRouteCallbackPluginWithOptionAccess()
+	public function testApiRouteCallbackPluginWithOptionAccess(): void
 	{
 		App::plugin('your/plugin', [
 			'options' => [
@@ -214,7 +213,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame('Test', $app->api()->call('test'));
 	}
 
-	public function testAuthChallenge()
+	public function testAuthChallenge(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -257,7 +256,7 @@ class AppPluginsTest extends TestCase
 		$kirby->session()->destroy();
 	}
 
-	public function testBlueprint()
+	public function testBlueprint(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -271,7 +270,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame($file, $kirby->extension('blueprints', 'pages/test'));
 	}
 
-	public function testCacheType()
+	public function testCacheType(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -290,7 +289,7 @@ class AppPluginsTest extends TestCase
 		$this->assertInstanceOf(DummyCache::class, $kirby->cache('pages'));
 	}
 
-	public function testCollection()
+	public function testCollection(): void
 	{
 		$pages = new Pages([
 			$page = new Page(['slug' => 'a', 'num' => 1])
@@ -308,7 +307,7 @@ class AppPluginsTest extends TestCase
 		$this->assertIsPage($page, $kirby->collection('test')->first());
 	}
 
-	public function testCollectionFilters()
+	public function testCollectionFilters(): void
 	{
 		// fetch all previous filters
 		$prevFilters = Collection::$filters;
@@ -332,7 +331,7 @@ class AppPluginsTest extends TestCase
 		Collection::$filters = $prevFilters;
 	}
 
-	public function testCommands()
+	public function testCommands(): void
 	{
 		$pages = new Pages([]);
 		$kirby = new App([
@@ -350,7 +349,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame($command, $kirby->extension('commands', 'test'));
 	}
 
-	public function testController()
+	public function testController(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -364,7 +363,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame(['foo' => 'bar'], $kirby->controller('test'));
 	}
 
-	public function testFieldMethod()
+	public function testFieldMethod(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -382,7 +381,7 @@ class AppPluginsTest extends TestCase
 		Field::$methods = [];
 	}
 
-	public function testField()
+	public function testField(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -405,10 +404,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame('shaw', $field->peter());
 	}
 
-	/**
-	 * @covers ::extendFilePreviews
-	 */
-	public function testFilePreviews()
+	public function testFilePreviews(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -422,7 +418,7 @@ class AppPluginsTest extends TestCase
 		$this->assertCount(5, $app->extensions('filePreviews'));
 	}
 
-	public function testKirbyTag()
+	public function testKirbyTag(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -445,7 +441,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame('test', $kirby->kirbytags('(FOO: bar)'));
 	}
 
-	public function testPageMethod()
+	public function testPageMethod(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -463,7 +459,7 @@ class AppPluginsTest extends TestCase
 		Page::$methods = [];
 	}
 
-	public function testPagesMethod()
+	public function testPagesMethod(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -481,7 +477,7 @@ class AppPluginsTest extends TestCase
 		Pages::$methods = [];
 	}
 
-	public function testPageModel()
+	public function testPageModel(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -500,7 +496,7 @@ class AppPluginsTest extends TestCase
 		$this->assertInstanceOf(DummyPage::class, $page);
 	}
 
-	public function testPageModelFromFolder()
+	public function testPageModelFromFolder(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -517,7 +513,7 @@ class AppPluginsTest extends TestCase
 		$this->assertInstanceOf('TestPage', $page);
 	}
 
-	public function testPermission()
+	public function testPermission(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -539,7 +535,7 @@ class AppPluginsTest extends TestCase
 		Permissions::$extendedActions = [];
 	}
 
-	public function testPermissionPlugin()
+	public function testPermissionPlugin(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -564,7 +560,7 @@ class AppPluginsTest extends TestCase
 		Permissions::$extendedActions = [];
 	}
 
-	public function testOption()
+	public function testOption(): void
 	{
 		// simple
 		$kirby = new App([
@@ -579,7 +575,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame('testValue', $kirby->option('testOption'));
 	}
 
-	public function testExtensionsFromFolders()
+	public function testExtensionsFromFolders(): void
 	{
 		Page::$models = [];
 		Dir::copy(static::FIXTURES . '/AppPluginsTest', static::TMP);
@@ -600,7 +596,7 @@ class AppPluginsTest extends TestCase
 		$this->assertEquals($expected, Page::$models); // cannot use strict assertion (filesystem sorting)
 	}
 
-	public function testExtensionsFromOptions()
+	public function testExtensionsFromOptions(): void
 	{
 		$calledRoute = false;
 		$calledHook  = false;
@@ -629,7 +625,7 @@ class AppPluginsTest extends TestCase
 		$this->assertTrue($calledHook);
 	}
 
-	public function testPluginOptions()
+	public function testPluginOptions(): void
 	{
 		App::plugin('test/plugin', [
 			'options' => [
@@ -653,7 +649,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame(['foo' => 'another-bar'], $kirby->option('test.plugin'));
 	}
 
-	public function testPluginOptionsWithNonAssociativeArray()
+	public function testPluginOptionsWithNonAssociativeArray(): void
 	{
 		// non-associative
 		App::plugin('test/plugin', [
@@ -676,7 +672,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame(['three'], $kirby->option('test.plugin.foo'));
 	}
 
-	public function testPluginOptionsWithAssociativeArray()
+	public function testPluginOptionsWithAssociativeArray(): void
 	{
 		// associative
 		App::plugin('test/plugin', [
@@ -704,7 +700,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame(['a' => 'Custom A', 'b' => 'B'], $kirby->option('test.plugin.foo'));
 	}
 
-	public function testRoutes()
+	public function testRoutes(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -721,7 +717,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame('test', $kirby->call('test'));
 	}
 
-	public function testRoutesCallback()
+	public function testRoutesCallback(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -738,7 +734,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame('test', $kirby->call('test'));
 	}
 
-	public function testSnippet()
+	public function testSnippet(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -752,7 +748,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame($file, $kirby->extension('snippets', 'header'));
 	}
 
-	public function testTemplate()
+	public function testTemplate(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -766,7 +762,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame($file, $kirby->extension('templates', 'project'));
 	}
 
-	public function testTranslation()
+	public function testTranslation(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -791,7 +787,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame('Deutscher Test', I18n::translate('test'));
 	}
 
-	public function testTranslationsInPlugin()
+	public function testTranslationsInPlugin(): void
 	{
 		App::plugin('test/test', [
 			'translations' => [
@@ -819,7 +815,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame('Deutscher Test', I18n::translate('test'));
 	}
 
-	public function testUserMethod()
+	public function testUserMethod(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -840,7 +836,7 @@ class AppPluginsTest extends TestCase
 		User::$methods = [];
 	}
 
-	public function testUserModel()
+	public function testUserModel(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -859,7 +855,7 @@ class AppPluginsTest extends TestCase
 		$this->assertInstanceOf(DummyUser::class, $user);
 	}
 
-	public function testUsersMethod()
+	public function testUsersMethod(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -877,7 +873,7 @@ class AppPluginsTest extends TestCase
 		Users::$methods = [];
 	}
 
-	public function testPluginLoader()
+	public function testPluginLoader(): void
 	{
 		$phpUnit  = $this;
 		$executed = 0;
@@ -932,7 +928,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame(1, $executed);
 	}
 
-	public function testPluginLoaderAnonymous()
+	public function testPluginLoaderAnonymous(): void
 	{
 		Dir::copy(static::FIXTURES . '/AppPluginsTest', static::TMP);
 
@@ -951,7 +947,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame($dir . '/test5', $plugin->root());
 	}
 
-	public function testThirdPartyExtensions()
+	public function testThirdPartyExtensions(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -973,7 +969,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame($testBlock, $kirby->extensions('thirdParty')['blocks']['test']);
 	}
 
-	public function testNativeComponents()
+	public function testNativeComponents(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -993,10 +989,7 @@ class AppPluginsTest extends TestCase
 		$this->assertSame('https://getkirby.com/test', $kirby->nativeComponent('url')($kirby, 'test'));
 	}
 
-	/**
-	 * @covers ::extendAreas
-	 */
-	public function testAreas()
+	public function testAreas(): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -1014,10 +1007,7 @@ class AppPluginsTest extends TestCase
 		$this->assertInstanceOf('Closure', $areas['todos'][0]);
 	}
 
-	/**
-	 * @covers ::extendFileTypes
-	 */
-	public function testFileTypes()
+	public function testFileTypes(): void
 	{
 		$kirby = new App([
 			'roots' => [

--- a/tests/Cms/App/AppResolveTest.php
+++ b/tests/Cms/App/AppResolveTest.php
@@ -3,19 +3,15 @@
 namespace Kirby\Cms;
 
 use Kirby\Filesystem\F;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\App
- */
+#[CoversClass(App::class)]
 class AppResolveTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 	public const TMP      = KIRBY_TMP_DIR . '/Cms.AppResolve';
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveHomePage()
+	public function testResolveHomePage(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -36,10 +32,7 @@ class AppResolveTest extends TestCase
 		$this->assertTrue($result->isHomePage());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveMainPage()
+	public function testResolveMainPage(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -60,10 +53,7 @@ class AppResolveTest extends TestCase
 		$this->assertSame('test', $result->id());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveSubPage()
+	public function testResolveSubPage(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -87,10 +77,7 @@ class AppResolveTest extends TestCase
 		$this->assertSame('test/subpage', $result->id());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveDraft()
+	public function testResolveDraft(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -127,10 +114,7 @@ class AppResolveTest extends TestCase
 		$this->assertSame('test/a-draft', $result->id());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolvePageRepresentation()
+	public function testResolvePageRepresentation(): void
 	{
 		F::write($template = static::TMP . '/test.php', 'html');
 		F::write($template = static::TMP . '/test.xml.php', 'xml');
@@ -173,10 +157,7 @@ class AppResolveTest extends TestCase
 		$this->assertSame('png', $result->body());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolvePageHtmlRepresentation()
+	public function testResolvePageHtmlRepresentation(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -198,10 +179,7 @@ class AppResolveTest extends TestCase
 
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveFileDefault()
+	public function testResolveFileDefault(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -228,11 +206,7 @@ class AppResolveTest extends TestCase
 		$this->assertNull($result);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveFile
-	 */
-	public function testResolveSiteFile()
+	public function testResolveSiteFile(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -261,10 +235,7 @@ class AppResolveTest extends TestCase
 		$this->assertSame('test.jpg', $result->id());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolvePageFile()
+	public function testResolvePageFile(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -305,11 +276,7 @@ class AppResolveTest extends TestCase
 		$this->assertSame('test/test.jpg', $result->id());
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveFile
-	 */
-	public function testResolveFileEnabled()
+	public function testResolveFileEnabled(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -346,11 +313,7 @@ class AppResolveTest extends TestCase
 		$this->assertSame('test/test.jpg', $result1->id());
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveFile
-	 */
-	public function testResolveFileDisabled()
+	public function testResolveFileDisabled(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -381,11 +344,7 @@ class AppResolveTest extends TestCase
 		$this->assertNull($result2);
 	}
 
-	/**
-	 * @covers ::resolve
-	 * @covers ::resolveFile
-	 */
-	public function testResolveFileClosure()
+	public function testResolveFileClosure(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -439,10 +398,7 @@ class AppResolveTest extends TestCase
 		$this->assertNull($result2);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveMultilangPageRepresentation()
+	public function testResolveMultilangPageRepresentation(): void
 	{
 		F::write($template = static::TMP . '/test.php', 'html');
 		F::write($template = static::TMP . '/test.xml.php', 'xml');
@@ -524,10 +480,7 @@ class AppResolveTest extends TestCase
 		$this->assertSame('en', $app->language()->code());
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testRepresentationErrorType()
+	public function testRepresentationErrorType(): void
 	{
 		$this->app = new App([
 			'templates' => [

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -10,12 +10,12 @@ use Kirby\Filesystem\F;
 use Kirby\Http\Route;
 use Kirby\Session\Session;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionMethod;
 use Whoops\Handler\PrettyPageHandler;
 
-/**
- * @coversDefaultClass \Kirby\Cms\App
- */
+#[CoversClass(App::class)]
 class AppTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -35,10 +35,7 @@ class AppTest extends TestCase
 		$_SERVER = $this->_SERVER;
 	}
 
-	/**
-	 * @covers ::clone
-	 */
-	public function testClone()
+	public function testClone(): void
 	{
 		$app = new App();
 		$app->data['test'] = 'testtest';
@@ -61,10 +58,7 @@ class AppTest extends TestCase
 		$this->assertSame('testtest', $clone->data['test']);
 	}
 
-	/**
-	 * @covers ::collection
-	 */
-	public function testCollection()
+	public function testCollection(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -86,10 +80,7 @@ class AppTest extends TestCase
 		$this->assertSame('test', $collection->first()->slug());
 	}
 
-	/**
-	 * @covers ::collection
-	 */
-	public function testCollectionWithOptions()
+	public function testCollectionWithOptions(): void
 	{
 		$test = $this;
 		$app  = new App([
@@ -144,10 +135,7 @@ class AppTest extends TestCase
 		$app->collection('overwrites', ['kirby' => 'foo']);
 	}
 
-	/**
-	 * @covers ::contentToken
-	 */
-	public function testContentToken()
+	public function testContentToken(): void
 	{
 		$model = new class () {
 			public function id(): string
@@ -191,10 +179,7 @@ class AppTest extends TestCase
 		$this->assertSame(hash_hmac('sha1', 'test', ' salt'), $app->contentToken(null, 'test'));
 	}
 
-	/**
-	 * @covers ::csrf
-	 */
-	public function testCsrf()
+	public function testCsrf(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -242,7 +227,7 @@ class AppTest extends TestCase
 		$session->destroy();
 	}
 
-	public function testDebugInfo()
+	public function testDebugInfo(): void
 	{
 		$app = new App();
 		$debuginfo = $app->__debugInfo();
@@ -256,7 +241,7 @@ class AppTest extends TestCase
 		$this->assertArrayHasKey('version', $debuginfo);
 	}
 
-	public function testDefaultRoles()
+	public function testDefaultRoles(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -267,7 +252,7 @@ class AppTest extends TestCase
 		$this->assertInstanceOf(Roles::class, $app->roles());
 	}
 
-	public function testEmail()
+	public function testEmail(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -290,10 +275,7 @@ class AppTest extends TestCase
 		$this->assertInstanceOf(PHPMailer::class, $email);
 	}
 
-	/**
-	 * @covers ::environment
-	 */
-	public function testEnvironment()
+	public function testEnvironment(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -307,10 +289,7 @@ class AppTest extends TestCase
 		$this->assertSame($info, $app->environment()->info());
 	}
 
-	/**
-	 * @covers ::environment
-	 */
-	public function testEnvironmentBeforeInitialization()
+	public function testEnvironmentBeforeInitialization(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The environment is not allowed');
@@ -323,10 +302,7 @@ class AppTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::image
-	 */
-	public function testImage()
+	public function testImage(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -365,10 +341,7 @@ class AppTest extends TestCase
 		$this->assertNull($image);
 	}
 
-	/**
-	 * @covers ::models
-	 */
-	public function testModels()
+	public function testModels(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -412,10 +385,7 @@ class AppTest extends TestCase
 		$this->assertSame('test@getkirby.com', $models->current()->email());
 	}
 
-	/**
-	 * @covers ::nonce
-	 */
-	public function testNonce()
+	public function testNonce(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -426,7 +396,7 @@ class AppTest extends TestCase
 		$this->assertIsString($nonce = $app->nonce());
 	}
 
-	public function testOption()
+	public function testOption(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -440,7 +410,7 @@ class AppTest extends TestCase
 		$this->assertSame('bar', $app->option('foo'));
 	}
 
-	public function testOptionWithDotNotation()
+	public function testOptionWithDotNotation(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -456,7 +426,7 @@ class AppTest extends TestCase
 		$this->assertSame('test', $app->option('mother.child'));
 	}
 
-	public function testOptionFromPlugin()
+	public function testOptionFromPlugin(): void
 	{
 		App::plugin('namespace/plugin', [
 			'options' => [
@@ -499,7 +469,7 @@ class AppTest extends TestCase
 		$this->assertSame('B1', $app->option('namespace.plugin.nested')['key']);
 	}
 
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -517,7 +487,7 @@ class AppTest extends TestCase
 		$this->assertSame($options, $app->options());
 	}
 
-	public function testOptionsFromFile()
+	public function testOptionsFromFile(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -540,7 +510,7 @@ class AppTest extends TestCase
 		], $app->options());
 	}
 
-	public function testOptionsFromFileWithEnv1()
+	public function testOptionsFromFileWithEnv1(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -564,7 +534,7 @@ class AppTest extends TestCase
 		], $app->options());
 	}
 
-	public function testOptionsFromFileWithEnv2()
+	public function testOptionsFromFileWithEnv2(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -644,7 +614,7 @@ class AppTest extends TestCase
 		restore_exception_handler();
 	}
 
-	public function testRolesFromFixtures()
+	public function testRolesFromFixtures(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -670,7 +640,7 @@ class AppTest extends TestCase
 	//     $this->assertInstanceOf(\Kirby\Email\Email::class, $email);
 	// }
 
-	public function testRoute()
+	public function testRoute(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -695,7 +665,7 @@ class AppTest extends TestCase
 		$this->assertInstanceOf(Route::class, $route);
 	}
 
-	public function testSession()
+	public function testSession(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -725,7 +695,7 @@ class AppTest extends TestCase
 		$this->assertSame(['Vary' => 'Cookie', 'Cache-Control' => 'custom'], $app->response()->headers());
 	}
 
-	public function testInstance()
+	public function testInstance(): void
 	{
 		$this->assertNull(App::instance(null, true));
 
@@ -742,7 +712,7 @@ class AppTest extends TestCase
 		$this->assertNotSame($instance3, App::instance());
 	}
 
-	public function testFindPageFile()
+	public function testFindPageFile(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -774,7 +744,7 @@ class AppTest extends TestCase
 		$this->assertSame($fileB, $app->file('test-b.jpg', $fileA));
 	}
 
-	public function testFindSiteFile()
+	public function testFindSiteFile(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -818,7 +788,7 @@ class AppTest extends TestCase
 		$this->assertSame($fileC, $app->file('test-c.jpg', $fileC));
 	}
 
-	public function testFindUserFile()
+	public function testFindUserFile(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -846,10 +816,7 @@ class AppTest extends TestCase
 		$this->assertSame($fileB, $app->file('test-b.jpg', $fileA));
 	}
 
-	/**
-	 * @covers ::file
-	 */
-	public function testFindFileByUUID()
+	public function testFindFileByUUID(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -876,7 +843,7 @@ class AppTest extends TestCase
 		$this->assertIsFile($file, $app->file('file://my-file'));
 	}
 
-	public function testBlueprints()
+	public function testBlueprints(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -924,10 +891,8 @@ class AppTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider urlProvider
-	 */
-	public function testUrl($url, $expected)
+	#[DataProvider('urlProvider')]
+	public function testUrl($url, $expected): void
 	{
 		$app = new App([
 			'roots' => [
@@ -945,7 +910,7 @@ class AppTest extends TestCase
 		$_SERVER['SERVER_ADDR'] = null;
 	}
 
-	public function testUrlFromEnvWithDetection()
+	public function testUrlFromEnvWithDetection(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -963,7 +928,7 @@ class AppTest extends TestCase
 		$this->assertSame('https://trykirby.com/panel', $app->url('panel'));
 	}
 
-	public function testUrlFromEnvWithOverride()
+	public function testUrlFromEnvWithOverride(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -981,12 +946,12 @@ class AppTest extends TestCase
 		$this->assertSame('https://getkirby.com/docs/panel', $app->url('panel'));
 	}
 
-	public function testVersionHash()
+	public function testVersionHash(): void
 	{
 		$this->assertSame(md5(App::version()), App::versionHash());
 	}
 
-	public function testSlugsOption()
+	public function testSlugsOption(): void
 	{
 		// string option
 		$app = new App([
@@ -1023,11 +988,7 @@ class AppTest extends TestCase
 		$this->assertSame('ss', Str::$language['ß']);
 	}
 
-	/**
-	 * @covers ::controller
-	 * @covers ::controllerLookup
-	 */
-	public function testController()
+	public function testController(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -1047,11 +1008,7 @@ class AppTest extends TestCase
 		], $app->controller('test'));
 	}
 
-	/**
-	 * @covers ::controller
-	 * @covers ::controllerLookup
-	 */
-	public function testControllerCallback()
+	public function testControllerCallback(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -1074,11 +1031,7 @@ class AppTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::controller
-	 * @covers ::controllerLookup
-	 */
-	public function testControllerRepresentation()
+	public function testControllerRepresentation(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -1098,11 +1051,7 @@ class AppTest extends TestCase
 		], $app->controller('another', contentType: 'json'));
 	}
 
-	/**
-	 * @covers ::controller
-	 * @covers ::controllerLookup
-	 */
-	public function testControllerHtmlForMissingRepresentation()
+	public function testControllerHtmlForMissingRepresentation(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -1122,11 +1071,7 @@ class AppTest extends TestCase
 		], $app->controller('test', contentType: 'json'));
 	}
 
-	/**
-	 * @covers ::controller
-	 * @covers ::controllerLookup
-	 */
-	public function testControllerMissing()
+	public function testControllerMissing(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -1146,11 +1091,7 @@ class AppTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::controller
-	 * @covers ::controllerLookup
-	 */
-	public function testControllerMissingRepresentation()
+	public function testControllerMissingRepresentation(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -1170,10 +1111,7 @@ class AppTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::path
-	 */
-	public function testPath()
+	public function testPath(): void
 	{
 		$app = new App();
 		$this->assertSame('', $app->path());
@@ -1210,10 +1148,7 @@ class AppTest extends TestCase
 		$this->assertSame('foo/bar', $app->path());
 	}
 
-	/**
-	 * @covers ::page
-	 */
-	public function testPageWithUUID()
+	public function testPageWithUUID(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -1233,10 +1168,7 @@ class AppTest extends TestCase
 		$this->assertIsPage($page, $app->page('page://my-page'));
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRender()
+	public function testRender(): void
 	{
 		$app = new App([
 			'roots' => [

--- a/tests/Cms/App/AppTranslationsTest.php
+++ b/tests/Cms/App/AppTranslationsTest.php
@@ -77,7 +77,7 @@ class AppTranslationsTest extends TestCase
 		return $this->app;
 	}
 
-	public function testTranslations()
+	public function testTranslations(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -100,7 +100,7 @@ class AppTranslationsTest extends TestCase
 		$this->assertCount($i, $translations);
 	}
 
-	public function testTranslationFromCurrentLanguage()
+	public function testTranslationFromCurrentLanguage(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -155,7 +155,7 @@ class AppTranslationsTest extends TestCase
 		$this->assertSame('Hallo', t('hello'));
 	}
 
-	public function testTranslationFallback()
+	public function testTranslationFallback(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -200,7 +200,7 @@ class AppTranslationsTest extends TestCase
 		$this->assertSame('English', t('translation.name'));
 	}
 
-	public function testSetCurrentTranslation()
+	public function testSetCurrentTranslation(): void
 	{
 		$app = $this->app();
 
@@ -213,7 +213,7 @@ class AppTranslationsTest extends TestCase
 		$this->assertSame('Reset', t('reset'));
 	}
 
-	public function testTranslationInTemplate()
+	public function testTranslationInTemplate(): void
 	{
 		// create a dummy template
 		F::write(static::TMP . '/test.php', '<?= t("button") ?>');
@@ -259,7 +259,7 @@ class AppTranslationsTest extends TestCase
 		$this->assertSame('Button', $result->body());
 	}
 
-	public function testExceptionWithoutLanguage()
+	public function testExceptionWithoutLanguage(): void
 	{
 		I18n::$load = null;
 		I18n::$translations = [];
@@ -273,7 +273,7 @@ class AppTranslationsTest extends TestCase
 		$this->assertSame($fallbackError, $exception->getMessage());
 	}
 
-	public function testExceptionWithDefaultLanguage()
+	public function testExceptionWithDefaultLanguage(): void
 	{
 		$this->app();
 
@@ -281,7 +281,7 @@ class AppTranslationsTest extends TestCase
 		$this->assertSame('This is a test error', $exception->getMessage());
 	}
 
-	public function testExceptionWithTranslation()
+	public function testExceptionWithTranslation(): void
 	{
 		$app = $this->app();
 		$app->setCurrentTranslation('de');
@@ -290,7 +290,7 @@ class AppTranslationsTest extends TestCase
 		$this->assertSame('Das ist ein Testfehler', $exception->getMessage());
 	}
 
-	public function testExceptionPinned()
+	public function testExceptionPinned(): void
 	{
 		$app = $this->app();
 
@@ -304,7 +304,7 @@ class AppTranslationsTest extends TestCase
 		$this->assertSame('This would be the fallback error', $exception->getMessage());
 	}
 
-	public function testExceptionInvalidKey()
+	public function testExceptionInvalidKey(): void
 	{
 		$app = $this->app();
 
@@ -317,7 +317,7 @@ class AppTranslationsTest extends TestCase
 		$this->assertSame('This would be the fallback error', $exception->getMessage());
 	}
 
-	public function testLanguageTranslationWithSlugs()
+	public function testLanguageTranslationWithSlugs(): void
 	{
 		// create a dummy template
 		F::write(static::TMP . '/test.php', '<?= t("button") ?>');
@@ -388,7 +388,7 @@ class AppTranslationsTest extends TestCase
 		$this->assertSame('kompaniya', Str::slug('Компания'));
 	}
 
-	public function testLocaleString()
+	public function testLocaleString(): void
 	{
 		$this->assertSame('C', setlocale(LC_ALL, '0'));
 
@@ -405,7 +405,7 @@ class AppTranslationsTest extends TestCase
 		$this->assertSame('de_DE.' . $this->localeSuffix, setlocale(LC_CTYPE, '0'));
 	}
 
-	public function testLocaleArray()
+	public function testLocaleArray(): void
 	{
 		$this->assertSame('C', setlocale(LC_ALL, '0'));
 
@@ -428,7 +428,7 @@ class AppTranslationsTest extends TestCase
 		$this->assertSame('de_AT.' . $this->localeSuffix, setlocale(LC_COLLATE, '0'));
 	}
 
-	public function testPanelLanguage()
+	public function testPanelLanguage(): void
 	{
 		// single-language setup
 		$app = new App([

--- a/tests/Cms/App/AppTriggerTest.php
+++ b/tests/Cms/App/AppTriggerTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(App::class)]
 class AppTriggerTest extends TestCase
 {
-	public function testTriggerEvent()
+	public function testTriggerEvent(): void
 	{
 		$self = $this;
 
@@ -23,7 +23,7 @@ class AppTriggerTest extends TestCase
 		$this->app->trigger('test', ['value' => 10]);
 	}
 
-	public function testTriggerWithMultipleParameters()
+	public function testTriggerWithMultipleParameters(): void
 	{
 		$self = $this;
 
@@ -41,7 +41,7 @@ class AppTriggerTest extends TestCase
 		$this->app->trigger('test', ['a' => 5, 'b' => 6, 'c' => 4]);
 	}
 
-	public function testTriggerWithNestedTriggerCall()
+	public function testTriggerWithNestedTriggerCall(): void
 	{
 		$calls = 0;
 
@@ -62,7 +62,7 @@ class AppTriggerTest extends TestCase
 		$this->assertSame(2, $calls);
 	}
 
-	public function testTriggerWithNestedRecursiveTriggerCall()
+	public function testTriggerWithNestedRecursiveTriggerCall(): void
 	{
 		$calls = 0;
 
@@ -83,7 +83,7 @@ class AppTriggerTest extends TestCase
 		$this->assertSame(1, $calls);
 	}
 
-	public function testTriggerWithSingleParameter()
+	public function testTriggerWithSingleParameter(): void
 	{
 		$self = $this;
 
@@ -99,7 +99,7 @@ class AppTriggerTest extends TestCase
 		$this->app->trigger('test', ['value' => 5]);
 	}
 
-	public function testTriggerWithWildcard()
+	public function testTriggerWithWildcard(): void
 	{
 		$self = $this;
 		$calls = 0;
@@ -135,7 +135,7 @@ class AppTriggerTest extends TestCase
 		$this->assertSame(4, $calls);
 	}
 
-	public function testTriggerWithoutArguments()
+	public function testTriggerWithoutArguments(): void
 	{
 		$self = $this;
 
@@ -150,7 +150,7 @@ class AppTriggerTest extends TestCase
 		$this->app->trigger('test');
 	}
 
-	public function testTriggerWithoutHandler()
+	public function testTriggerWithoutHandler(): void
 	{
 		$this->assertNull($this->app->trigger('does-not-exist', ['value' => 10]));
 	}

--- a/tests/Cms/App/AppUsersTest.php
+++ b/tests/Cms/App/AppUsersTest.php
@@ -22,7 +22,7 @@ class AppUsersTest extends TestCase
 		]);
 	}
 
-	public function testImpersonate()
+	public function testImpersonate(): void
 	{
 		$self = $this;
 
@@ -104,13 +104,13 @@ class AppUsersTest extends TestCase
 		$this->assertTrue($caught);
 	}
 
-	public function testImpersonateErrorMissingUser()
+	public function testImpersonateErrorMissingUser(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->app->impersonate('homer@simpsons.com');
 	}
 
-	public function testRolesSet()
+	public function testRolesSet(): void
 	{
 		$app = new App([
 			'roles' => [
@@ -125,7 +125,7 @@ class AppUsersTest extends TestCase
 		$this->assertSame('editor', $app->roles()->last()->name());
 	}
 
-	public function testRolesLoad()
+	public function testRolesLoad(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -137,7 +137,7 @@ class AppUsersTest extends TestCase
 		$this->assertSame('editor', $app->roles()->last()->name());
 	}
 
-	public function testRoleManual()
+	public function testRoleManual(): void
 	{
 		$app = new App([
 			'roles' => [
@@ -152,7 +152,7 @@ class AppUsersTest extends TestCase
 		$this->assertNull($app->role('something'));
 	}
 
-	public function testRoleFromUser()
+	public function testRoleFromUser(): void
 	{
 		$app = new App([
 			'roles' => [
@@ -175,7 +175,7 @@ class AppUsersTest extends TestCase
 		$this->assertSame('editor', $app->role(null, false)->name());
 	}
 
-	public function testRoleFromImpersonatedUser()
+	public function testRoleFromImpersonatedUser(): void
 	{
 		$app = new App([
 			'roles' => [
@@ -198,7 +198,7 @@ class AppUsersTest extends TestCase
 		$this->assertNull($app->role(null, false));
 	}
 
-	public function testUsersLoad()
+	public function testUsersLoad(): void
 	{
 		$app = $this->app->clone([
 			'roots' => [
@@ -210,7 +210,7 @@ class AppUsersTest extends TestCase
 		$this->assertSame('user@getkirby.com', $app->users()->first()->email());
 	}
 
-	public function testUsersSet()
+	public function testUsersSet(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -244,7 +244,7 @@ class AppUsersTest extends TestCase
 		]);
 	}
 
-	public function testUserFromBasicAuth()
+	public function testUserFromBasicAuth(): void
 	{
 		$app  = $this->basicAuthApp();
 		$auth = new BasicAuth(base64_encode('test@getkirby.com:correct-horse-battery-staple'));
@@ -254,7 +254,7 @@ class AppUsersTest extends TestCase
 		$this->assertSame('test@getkirby.com', $user->email());
 	}
 
-	public function testUserFromBasicAuthDisabled()
+	public function testUserFromBasicAuthDisabled(): void
 	{
 		$this->expectException(PermissionException::class);
 		$this->expectExceptionMessage('Basic authentication is not activated');
@@ -271,7 +271,7 @@ class AppUsersTest extends TestCase
 		$user = $app->auth()->currentUserFromBasicAuth($auth);
 	}
 
-	public function testUserFromBasicAuthOverHttp()
+	public function testUserFromBasicAuthOverHttp(): void
 	{
 		$this->expectException(PermissionException::class);
 		$this->expectExceptionMessage('Basic authentication is only allowed over HTTPS');
@@ -286,7 +286,7 @@ class AppUsersTest extends TestCase
 		$user = $app->auth()->currentUserFromBasicAuth($auth);
 	}
 
-	public function testUserFromBasicAuthWithInvalidHeader()
+	public function testUserFromBasicAuthWithInvalidHeader(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid authorization header');

--- a/tests/Cms/App/fixtures/AppIoTest/templates/errorpage-exception.php
+++ b/tests/Cms/App/fixtures/AppIoTest/templates/errorpage-exception.php
@@ -1,6 +1,8 @@
 <?php
 
-throw new Kirby\Exception\ErrorPageException(
+use Kirby\Exception\ErrorPageException;
+
+throw new ErrorPageException(
 	fallback: 'Exception message',
 	httpCode: 403
 );

--- a/tests/Cms/Auth/AuthChallengeTest.php
+++ b/tests/Cms/Auth/AuthChallengeTest.php
@@ -10,11 +10,10 @@ use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Throwable;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth
- */
+#[CoversClass(Auth::class)]
 class AuthChallengeTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.AuthChallenge';
@@ -80,13 +79,7 @@ class AuthChallengeTest extends TestCase
 		$this->failedEmail = null;
 	}
 
-	/**
-	 * @covers ::checkRateLimit
-	 * @covers ::createChallenge
-	 * @covers ::fail
-	 * @covers ::status
-	 */
-	public function testCreateChallenge()
+	public function testCreateChallenge(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -186,11 +179,7 @@ class AuthChallengeTest extends TestCase
 		$this->assertSame('marge@simpsons.com', $this->failedEmail);
 	}
 
-	/**
-	 * @covers ::createChallenge
-	 * @covers ::fail
-	 */
-	public function testCreateChallengeDebugError()
+	public function testCreateChallengeDebugError(): void
 	{
 		$auth = $this->app->auth();
 
@@ -199,11 +188,7 @@ class AuthChallengeTest extends TestCase
 		$auth->createChallenge('error@getkirby.com');
 	}
 
-	/**
-	 * @covers ::createChallenge
-	 * @covers ::fail
-	 */
-	public function testCreateChallengeDebugNotFound()
+	public function testCreateChallengeDebugNotFound(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('The user "invalid@example.com" cannot be found');
@@ -211,12 +196,7 @@ class AuthChallengeTest extends TestCase
 		$this->auth->createChallenge('invalid@example.com');
 	}
 
-	/**
-	 * @covers ::checkRateLimit
-	 * @covers ::createChallenge
-	 * @covers ::fail
-	 */
-	public function testCreateChallengeDebugRateLimit()
+	public function testCreateChallengeDebugRateLimit(): void
 	{
 		$auth = $this->app->auth();
 
@@ -229,12 +209,7 @@ class AuthChallengeTest extends TestCase
 		$auth->createChallenge('marge@simpsons.com');
 	}
 
-	/**
-	 * @covers ::createChallenge
-	 * @covers ::fail
-	 * @covers ::status
-	 */
-	public function testCreateChallengeCustomTimeout()
+	public function testCreateChallengeCustomTimeout(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -271,11 +246,7 @@ class AuthChallengeTest extends TestCase
 		$this->assertSame(MockTime::$time + 10, $session->get('kirby.challenge.timeout'));
 	}
 
-	/**
-	 * @covers ::createChallenge
-	 * @covers ::status
-	 */
-	public function testCreateChallengeLong()
+	public function testCreateChallengeLong(): void
 	{
 		$session = $this->app->session();
 
@@ -291,11 +262,7 @@ class AuthChallengeTest extends TestCase
 		$this->assertFalse($session->timeout());
 	}
 
-	/**
-	 * @covers ::createChallenge
-	 * @covers ::status
-	 */
-	public function testCreateChallengeWithPunycodeEmail()
+	public function testCreateChallengeWithPunycodeEmail(): void
 	{
 		$session = $this->app->session();
 
@@ -310,10 +277,7 @@ class AuthChallengeTest extends TestCase
 		$this->assertSame('test@exämple.com', $session->get('kirby.challenge.email'));
 	}
 
-	/**
-	 * @covers ::enabledChallenges
-	 */
-	public function testEnabledChallenges()
+	public function testEnabledChallenges(): void
 	{
 		// default
 		$app = $this->app->clone([
@@ -346,11 +310,7 @@ class AuthChallengeTest extends TestCase
 		$this->assertSame(['totp', 'sms'], $app->auth()->enabledChallenges());
 	}
 
-	/**
-	 * @covers ::login2fa
-	 * @covers ::status
-	 */
-	public function testLogin2fa()
+	public function testLogin2fa(): void
 	{
 		$session = $this->app->session();
 
@@ -372,11 +332,7 @@ class AuthChallengeTest extends TestCase
 		$this->assertNull($this->failedEmail);
 	}
 
-	/**
-	 * @covers ::login2fa
-	 * @covers ::status
-	 */
-	public function testLogin2faLong()
+	public function testLogin2faLong(): void
 	{
 		$session = $this->app->session();
 
@@ -398,11 +354,7 @@ class AuthChallengeTest extends TestCase
 		$this->assertNull($this->failedEmail);
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::login2fa
-	 */
-	public function testLogin2faInvalidUser()
+	public function testLogin2faInvalidUser(): void
 	{
 		$session = $this->app->session();
 
@@ -411,11 +363,7 @@ class AuthChallengeTest extends TestCase
 		$this->auth->login2fa('invalid@example.com', 'springfield123');
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::login2fa
-	 */
-	public function testLogin2faInvalidPassword()
+	public function testLogin2faInvalidPassword(): void
 	{
 		$session = $this->app->session();
 
@@ -424,10 +372,7 @@ class AuthChallengeTest extends TestCase
 		$this->auth->login2fa('marge@simpsons.com', 'springfield456');
 	}
 
-	/**
-	 * @covers ::verifyChallenge
-	 */
-	public function testVerifyChallenge()
+	public function testVerifyChallenge(): void
 	{
 		$session = $this->app->session();
 
@@ -444,10 +389,7 @@ class AuthChallengeTest extends TestCase
 		$this->assertSame(['kirby.userId' => 'marge'], $session->data()->get());
 	}
 
-	/**
-	 * @covers ::verifyChallenge
-	 */
-	public function testVerifyChallengePasswordReset()
+	public function testVerifyChallengePasswordReset(): void
 	{
 		$session = $this->app->session();
 
@@ -467,11 +409,7 @@ class AuthChallengeTest extends TestCase
 		], $session->data()->get());
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
-	public function testVerifyChallengeNoChallenge1()
+	public function testVerifyChallengeNoChallenge1(): void
 	{
 		try {
 			$this->auth->verifyChallenge('123456');
@@ -490,11 +428,7 @@ class AuthChallengeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
-	public function testVerifyChallengeNoChallenge2()
+	public function testVerifyChallengeNoChallenge2(): void
 	{
 		try {
 			$this->app->session()->set('kirby.challenge.email', 'marge@simpsons.com');
@@ -514,11 +448,7 @@ class AuthChallengeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
-	public function testVerifyChallengeNoChallengeNoDebug1()
+	public function testVerifyChallengeNoChallengeNoDebug1(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -546,11 +476,7 @@ class AuthChallengeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
-	public function testVerifyChallengeNoChallengeNoDebug2()
+	public function testVerifyChallengeNoChallengeNoDebug2(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -573,11 +499,7 @@ class AuthChallengeTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
-	public function testVerifyChallengeInvalidEmail()
+	public function testVerifyChallengeInvalidEmail(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('The user "invalid@example.com" cannot be found');
@@ -588,12 +510,7 @@ class AuthChallengeTest extends TestCase
 		$this->auth->verifyChallenge('123456');
 	}
 
-	/**
-	 * @covers ::checkRateLimit
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
-	public function testVerifyChallengeRateLimited()
+	public function testVerifyChallengeRateLimited(): void
 	{
 		$this->expectException(PermissionException::class);
 		$this->expectExceptionMessage('Rate limit exceeded');
@@ -611,11 +528,7 @@ class AuthChallengeTest extends TestCase
 		$this->auth->verifyChallenge('123456');
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
-	public function testVerifyChallengeTimeLimited()
+	public function testVerifyChallengeTimeLimited(): void
 	{
 		$session = $this->app->session();
 
@@ -649,11 +562,7 @@ class AuthChallengeTest extends TestCase
 		$this->assertNull($session->get('kirby.challenge.timeout'));
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
-	public function testVerifyChallengeTimeLimitedNoDebug()
+	public function testVerifyChallengeTimeLimitedNoDebug(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -688,11 +597,7 @@ class AuthChallengeTest extends TestCase
 		$this->assertNull($session->get('kirby.challenge.timeout'));
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
-	public function testVerifyChallengeInvalidCode()
+	public function testVerifyChallengeInvalidCode(): void
 	{
 		$this->expectException(PermissionException::class);
 		$this->expectExceptionMessage('Invalid code');
@@ -708,11 +613,7 @@ class AuthChallengeTest extends TestCase
 		$this->auth->verifyChallenge('654321');
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::verifyChallenge
-	 */
-	public function testVerifyChallengeInvalidChallenge()
+	public function testVerifyChallengeInvalidChallenge(): void
 	{
 		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('Invalid authentication challenge: test');

--- a/tests/Cms/Auth/AuthCsrfTest.php
+++ b/tests/Cms/Auth/AuthCsrfTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Cms;
 
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth
- */
+#[CoversClass(Auth::class)]
 class AuthCsrfTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.AuthCsrf';
@@ -31,10 +30,7 @@ class AuthCsrfTest extends TestCase
 		$_GET = [];
 	}
 
-	/**
-	 * @covers ::csrf
-	 */
-	public function testCsrfFromSession1()
+	public function testCsrfFromSession1(): void
 	{
 		$this->app->session()->set('kirby.csrf', 'session-csrf');
 
@@ -42,10 +38,7 @@ class AuthCsrfTest extends TestCase
 		$this->assertFalse($this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrf
-	 */
-	public function testCsrfFromSession2()
+	public function testCsrfFromSession2(): void
 	{
 		$this->app->session()->set('kirby.csrf', 'session-csrf');
 
@@ -53,10 +46,7 @@ class AuthCsrfTest extends TestCase
 		$this->assertFalse($this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrf
-	 */
-	public function testCsrfFromSession3()
+	public function testCsrfFromSession3(): void
 	{
 		$this->app->session()->set('kirby.csrf', 'session-csrf');
 
@@ -64,10 +54,7 @@ class AuthCsrfTest extends TestCase
 		$this->assertSame('session-csrf', $this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrf
-	 */
-	public function testCsrfFromSession4()
+	public function testCsrfFromSession4(): void
 	{
 		$this->app->session()->set('kirby.csrf', 'session-csrf');
 
@@ -75,10 +62,7 @@ class AuthCsrfTest extends TestCase
 		$this->assertFalse($this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrf
-	 */
-	public function testCsrfFromOption1()
+	public function testCsrfFromOption1(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -93,10 +77,7 @@ class AuthCsrfTest extends TestCase
 		$this->assertFalse($this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrf
-	 */
-	public function testCsrfFromOption2()
+	public function testCsrfFromOption2(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -111,11 +92,7 @@ class AuthCsrfTest extends TestCase
 		$this->assertSame('option-csrf', $this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrf
-	 * @covers ::csrfFromSession
-	 */
-	public function testCsrfFromOption3()
+	public function testCsrfFromOption3(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -130,11 +107,7 @@ class AuthCsrfTest extends TestCase
 		$this->assertFalse($this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrf
-	 * @covers ::csrfFromSession
-	 */
-	public function testCsrfFromOption4()
+	public function testCsrfFromOption4(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -149,10 +122,7 @@ class AuthCsrfTest extends TestCase
 		$this->assertFalse($this->auth->csrf());
 	}
 
-	/**
-	 * @covers ::csrfFromSession
-	 */
-	public function testCsrfFromSessionPanelDevOption()
+	public function testCsrfFromSessionPanelDevOption(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [

--- a/tests/Cms/Auth/AuthProtectionTest.php
+++ b/tests/Cms/Auth/AuthProtectionTest.php
@@ -6,10 +6,9 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth
- */
+#[CoversClass(Auth::class)]
 class AuthProtectionTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -62,18 +61,12 @@ class AuthProtectionTest extends TestCase
 		$this->failedEmail = null;
 	}
 
-	/**
-	 * @covers ::logfile
-	 */
-	public function testLogfile()
+	public function testLogfile(): void
 	{
 		$this->assertSame(static::TMP . '/site/accounts/.logins', $this->auth->logfile());
 	}
 
-	/**
-	 * @covers ::log
-	 */
-	public function testLog()
+	public function testLog(): void
 	{
 		copy(static::FIXTURES . '/logins.cleanup.json', static::TMP . '/site/accounts/.logins');
 
@@ -106,20 +99,14 @@ class AuthProtectionTest extends TestCase
 		$this->assertFileDoesNotExist(static::TMP . '/site/accounts/.logins');
 	}
 
-	/**
-	 * @covers ::ipHash
-	 */
-	public function testIpHash()
+	public function testIpHash(): void
 	{
 		$this->app->visitor()->ip('10.1.123.234');
 
 		$this->assertSame('87084f11690867b977a611dd2c943a918c3197f4c02b25ab59', $this->auth->ipHash());
 	}
 
-	/**
-	 * @covers ::isBlocked
-	 */
-	public function testIsBlocked()
+	public function testIsBlocked(): void
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 
@@ -134,10 +121,7 @@ class AuthProtectionTest extends TestCase
 		$this->assertTrue($this->auth->isBlocked('lisa@simpsons.com'));
 	}
 
-	/**
-	 * @covers ::track
-	 */
-	public function testTrack()
+	public function testTrack(): void
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 
@@ -192,10 +176,7 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame(json_encode($data), file_get_contents(static::TMP . '/site/accounts/.logins'));
 	}
 
-	/**
-	 * @covers ::validatePassword
-	 */
-	public function testValidatePasswordValid()
+	public function testValidatePasswordValid(): void
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 
@@ -207,11 +188,7 @@ class AuthProtectionTest extends TestCase
 		$this->assertNull($this->failedEmail);
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::validatePassword
-	 */
-	public function testValidatePasswordInvalid1()
+	public function testValidatePasswordInvalid1(): void
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 
@@ -230,11 +207,7 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame('lisa@simpsons.com', $this->failedEmail);
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::validatePassword
-	 */
-	public function testValidatePasswordInvalid2()
+	public function testValidatePasswordInvalid2(): void
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 
@@ -254,11 +227,7 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame('marge@simpsons.com', $this->failedEmail);
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::validatePassword
-	 */
-	public function testValidatePasswordBlocked()
+	public function testValidatePasswordBlocked(): void
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 
@@ -276,11 +245,7 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame('homer@simpsons.com', $this->failedEmail);
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::validatePassword
-	 */
-	public function testValidatePasswordDebugInvalid1()
+	public function testValidatePasswordDebugInvalid1(): void
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 		$this->app = $this->app->clone([
@@ -307,11 +272,7 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame('lisa@simpsons.com', $this->failedEmail);
 	}
 
-	/**
-	 * @covers ::fail
-	 * @covers ::validatePassword
-	 */
-	public function testValidatePasswordDebugInvalid2()
+	public function testValidatePasswordDebugInvalid2(): void
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 		$this->app = $this->app->clone([
@@ -339,12 +300,7 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame('marge@simpsons.com', $this->failedEmail);
 	}
 
-	/**
-	 * @covers ::checkRateLimit
-	 * @covers ::fail
-	 * @covers ::validatePassword
-	 */
-	public function testValidatePasswordDebugBlocked()
+	public function testValidatePasswordDebugBlocked(): void
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 		$this->app = $this->app->clone([
@@ -370,10 +326,7 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame('homer@simpsons.com', $this->failedEmail);
 	}
 
-	/**
-	 * @covers ::validatePassword
-	 */
-	public function testValidatePasswordWithUnicodeEmail()
+	public function testValidatePasswordWithUnicodeEmail(): void
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 
@@ -384,10 +337,7 @@ class AuthProtectionTest extends TestCase
 		$this->assertSame('test@exämple.com', $user->email());
 	}
 
-	/**
-	 * @covers ::validatePassword
-	 */
-	public function testValidatePasswordWithPunycodeEmail()
+	public function testValidatePasswordWithPunycodeEmail(): void
 	{
 		copy(static::FIXTURES . '/logins.json', static::TMP . '/site/accounts/.logins');
 

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -7,11 +7,10 @@ use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Session\AutoSession;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Throwable;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth
- */
+#[CoversClass(Auth::class)]
 class AuthTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Auth';
@@ -65,13 +64,7 @@ class AuthTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::currentUserFromImpersonation
-	 * @covers ::impersonate
-	 * @covers ::status
-	 * @covers ::user
-	 */
-	public function testImpersonate()
+	public function testImpersonate(): void
 	{
 		$this->assertNull($this->auth->user());
 
@@ -147,10 +140,7 @@ class AuthTest extends TestCase
 		$this->assertNull($this->auth->user(null, false));
 	}
 
-	/**
-	 * @covers ::impersonate
-	 */
-	public function testImpersonateInvalidUser()
+	public function testImpersonateInvalidUser(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('The user "lisa@simpsons.com" cannot be found');
@@ -158,10 +148,7 @@ class AuthTest extends TestCase
 		$this->auth->impersonate('lisa@simpsons.com');
 	}
 
-	/**
-	 * @covers ::login
-	 */
-	public function testLogin()
+	public function testLogin(): void
 	{
 		// set the status cache
 		$this->auth->status();
@@ -177,10 +164,7 @@ class AuthTest extends TestCase
 		$this->assertSame('marge@simpsons.com', $this->auth->status()->email());
 	}
 
-	/**
-	 * @covers ::login
-	 */
-	public function testLoginLong()
+	public function testLoginLong(): void
 	{
 		// set the status cache
 		$this->auth->status();
@@ -196,10 +180,7 @@ class AuthTest extends TestCase
 		$this->assertSame('marge@simpsons.com', $this->auth->status()->email());
 	}
 
-	/**
-	 * @covers ::login
-	 */
-	public function testLoginInvalidUser()
+	public function testLoginInvalidUser(): void
 	{
 		$this->expectException(PermissionException::class);
 		$this->expectExceptionMessage('Invalid login');
@@ -207,10 +188,7 @@ class AuthTest extends TestCase
 		$this->auth->login('lisa@simpsons.com', 'springfield123');
 	}
 
-	/**
-	 * @covers ::login
-	 */
-	public function testLoginInvalidPassword()
+	public function testLoginInvalidPassword(): void
 	{
 		$this->expectException(PermissionException::class);
 		$this->expectExceptionMessage('Invalid login');
@@ -218,10 +196,7 @@ class AuthTest extends TestCase
 		$this->auth->login('marge@simpsons.com', 'springfield456');
 	}
 
-	/**
-	 * @covers ::login
-	 */
-	public function testLoginKirby()
+	public function testLoginKirby(): void
 	{
 		$this->expectException(PermissionException::class);
 		$this->expectExceptionMessage(
@@ -232,10 +207,7 @@ class AuthTest extends TestCase
 		$this->auth->login('kirby@getkirby.com', 'somewhere-in-japan');
 	}
 
-	/**
-	 * @covers ::logout
-	 */
-	public function testLogoutActive()
+	public function testLogoutActive(): void
 	{
 		$session = $this->app->session();
 
@@ -256,10 +228,7 @@ class AuthTest extends TestCase
 		], $this->auth->status()->toArray());
 	}
 
-	/**
-	 * @covers ::logout
-	 */
-	public function testLogoutPending()
+	public function testLogoutPending(): void
 	{
 		$session = $this->app->session();
 
@@ -281,10 +250,7 @@ class AuthTest extends TestCase
 		], $this->auth->status()->toArray());
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeBasic1()
+	public function testTypeBasic1(): void
 	{
 		$app = $this->app->clone([
 			'server' => [
@@ -302,10 +268,7 @@ class AuthTest extends TestCase
 		$this->assertTrue($app->response()->usesAuth());
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeBasic2()
+	public function testTypeBasic2(): void
 	{
 		// non-existing basic auth should
 		// fall back to impersonation
@@ -317,10 +280,7 @@ class AuthTest extends TestCase
 		$this->assertTrue($this->app->response()->usesAuth());
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeBasic3()
+	public function testTypeBasic3(): void
 	{
 		// non-existing basic auth without
 		// impersonation should fall back to session
@@ -330,10 +290,7 @@ class AuthTest extends TestCase
 		$this->assertTrue($this->app->response()->usesAuth());
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeBasic4()
+	public function testTypeBasic4(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -353,10 +310,7 @@ class AuthTest extends TestCase
 		$this->assertFalse($app->response()->usesAuth());
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeImpersonate()
+	public function testTypeImpersonate(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -371,10 +325,7 @@ class AuthTest extends TestCase
 		$this->assertSame('impersonate', $app->auth()->type());
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeSession()
+	public function testTypeSession(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -387,11 +338,7 @@ class AuthTest extends TestCase
 		$this->assertSame('session', $app->auth()->type());
 	}
 
-	/**
-	 * @covers ::status
-	 * @covers ::user
-	 */
-	public function testUserSession()
+	public function testUserSession(): void
 	{
 		$session = $this->app->session();
 		$session->set('kirby.userId', 'marge');
@@ -421,11 +368,7 @@ class AuthTest extends TestCase
 		], $this->auth->status()->toArray());
 	}
 
-	/**
-	 * @covers ::status
-	 * @covers ::user
-	 */
-	public function testUserSessionManualSession()
+	public function testUserSessionManualSession(): void
 	{
 		$session = (new AutoSession($this->app->root('sessions')))->createManually();
 		$session->set('kirby.userId', 'homer');
@@ -441,10 +384,7 @@ class AuthTest extends TestCase
 		], $this->auth->status()->toArray());
 	}
 
-	/**
-	 * @covers ::currentUserFromSession
-	 */
-	public function testUserSessionOldTimestamp()
+	public function testUserSessionOldTimestamp(): void
 	{
 		$session = $this->app->session();
 		$session->set('kirby.userId', 'homer');
@@ -462,10 +402,7 @@ class AuthTest extends TestCase
 		$this->assertSame([], $session->data()->get());
 	}
 
-	/**
-	 * @covers ::currentUserFromSession
-	 */
-	public function testUserSessionNoTimestamp()
+	public function testUserSessionNoTimestamp(): void
 	{
 		$session = $this->app->session();
 		$session->set('kirby.userId', 'homer');
@@ -482,11 +419,7 @@ class AuthTest extends TestCase
 		$this->assertSame([], $session->data()->get());
 	}
 
-	/**
-	 * @covers ::status
-	 * @covers ::user
-	 */
-	public function testUserBasicAuth()
+	public function testUserBasicAuth(): void
 	{
 		$this->app->clone([
 			'server' => [
@@ -505,10 +438,7 @@ class AuthTest extends TestCase
 		], $this->auth->status()->toArray());
 	}
 
-	/**
-	 * @covers ::user
-	 */
-	public function testUserBasicAuthInvalid1()
+	public function testUserBasicAuthInvalid1(): void
 	{
 		$this->expectException(PermissionException::class);
 		$this->expectExceptionMessage('Invalid login');
@@ -522,10 +452,7 @@ class AuthTest extends TestCase
 		$this->auth->user();
 	}
 
-	/**
-	 * @covers ::user
-	 */
-	public function testUserBasicAuthInvalid2()
+	public function testUserBasicAuthInvalid2(): void
 	{
 		$this->expectException(PermissionException::class);
 		$this->expectExceptionMessage('Invalid login');

--- a/tests/Cms/Auth/Challenge/ChallengeTest.php
+++ b/tests/Cms/Auth/Challenge/ChallengeTest.php
@@ -7,6 +7,7 @@ use Kirby\Cms\TestCase;
 use Kirby\Cms\User;
 use Kirby\Filesystem\Dir;
 use Kirby\Session\Session;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class MockChallenge extends Challenge
 {
@@ -19,9 +20,7 @@ class MockChallenge extends Challenge
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth\Challenge
- */
+#[CoversClass(Challenge::class)]
 class ChallengeTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Auth.Challenge';
@@ -50,10 +49,7 @@ class ChallengeTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::verify
-	 */
-	public function testVerify()
+	public function testVerify(): void
 	{
 		$user = $this->app->user('homer@simpsons.com');
 

--- a/tests/Cms/Auth/Challenge/EmailChallengeTest.php
+++ b/tests/Cms/Auth/Challenge/EmailChallengeTest.php
@@ -6,10 +6,9 @@ use Kirby\Cms\App;
 use Kirby\Cms\TestCase;
 use Kirby\Email\Email;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth\EmailChallenge
- */
+#[CoversClass(EmailChallenge::class)]
 class EmailChallengeTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/../fixtures';
@@ -57,19 +56,13 @@ class EmailChallengeTest extends TestCase
 		unset($_SERVER['SERVER_NAME']);
 	}
 
-	/**
-	 * @covers ::isAvailable
-	 */
-	public function testIsAvailable()
+	public function testIsAvailable(): void
 	{
 		$user = $this->app->user('homer@simpsons.com');
 		$this->assertTrue(EmailChallenge::isAvailable($user, 'login'));
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateLogin()
+	public function testCreateLogin(): void
 	{
 		$user = $this->app->user('homer@simpsons.com');
 		$options = ['mode' => 'login', 'timeout' => 7.3 * 60];
@@ -95,10 +88,7 @@ class EmailChallengeTest extends TestCase
 		$this->assertNotSame($code1, $code2);
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreatePathUrl()
+	public function testCreatePathUrl(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -126,10 +116,7 @@ class EmailChallengeTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreate2FA()
+	public function testCreate2FA(): void
 	{
 		$user = $this->app->user('homer@simpsons.com');
 		$options = ['mode' => '2fa', 'timeout' => 7.3 * 60];
@@ -155,10 +142,7 @@ class EmailChallengeTest extends TestCase
 		$this->assertNotSame($code1, $code2);
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateReset()
+	public function testCreateReset(): void
 	{
 		$user = $this->app->user('marge@simpsons.com');
 		$options = ['mode' => 'password-reset', 'timeout' => 7.3 * 60];
@@ -184,10 +168,7 @@ class EmailChallengeTest extends TestCase
 		$this->assertNotSame($code1, $code2);
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateResetUserLanguage()
+	public function testCreateResetUserLanguage(): void
 	{
 		$user = $this->app->user('bart@simpsons.com');
 		$options = ['mode' => 'password-reset', 'timeout' => 7.3 * 60];
@@ -213,10 +194,7 @@ class EmailChallengeTest extends TestCase
 		$this->assertNotSame($code1, $code2);
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateCustom()
+	public function testCreateCustom(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -247,10 +225,7 @@ class EmailChallengeTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateCustomHtml()
+	public function testCreateCustomHtml(): void
 	{
 		$this->app = $this->app->clone([
 			'templates' => [

--- a/tests/Cms/Auth/Challenge/TotpChallengeTest.php
+++ b/tests/Cms/Auth/Challenge/TotpChallengeTest.php
@@ -6,10 +6,9 @@ use Kirby\Cms\App;
 use Kirby\Cms\TestCase;
 use Kirby\Filesystem\Dir;
 use Kirby\Toolkit\Totp;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth\TotpChallenge
- */
+#[CoversClass(TotpChallenge::class)]
 class TotpChallengeTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Auth.TotpChallenge';
@@ -36,10 +35,7 @@ class TotpChallengeTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::isAvailable
-	 */
-	public function testIsAvailable()
+	public function testIsAvailable(): void
 	{
 		$user = $this->app->user('homer@simpsons.com');
 		$this->assertFalse(TotpChallenge::isAvailable($user, 'login'));
@@ -47,19 +43,13 @@ class TotpChallengeTest extends TestCase
 		$this->assertTrue(TotpChallenge::isAvailable($user, 'login'));
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreate()
+	public function testCreate(): void
 	{
 		$user = $this->app->user('homer@simpsons.com');
 		$this->assertNull(TotpChallenge::create($user, []));
 	}
 
-	/**
-	 * @covers ::verify
-	 */
-	public function testVerify()
+	public function testVerify(): void
 	{
 		$user = $this->app->user('homer@simpsons.com');
 		$totp = new Totp();

--- a/tests/Cms/Auth/StatusTest.php
+++ b/tests/Cms/Auth/StatusTest.php
@@ -5,11 +5,9 @@ namespace Kirby\Cms\Auth;
 use Kirby\Cms\App;
 use Kirby\Cms\TestCase;
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Auth\Status
- * @covers ::__construct
- */
+#[CoversClass(Status::class)]
 class StatusTest extends TestCase
 {
 	public function setUp(): void
@@ -27,10 +25,7 @@ class StatusTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::__toString
-	 */
-	public function testToString()
+	public function testToString(): void
 	{
 		$status = new Status([
 			'kirby'  => $this->app,
@@ -40,10 +35,7 @@ class StatusTest extends TestCase
 		$this->assertSame('active', (string)$status);
 	}
 
-	/**
-	 * @covers ::challenge
-	 */
-	public function testChallenge()
+	public function testChallenge(): void
 	{
 		// no challenge when not in pending status
 		$status = new Status([
@@ -82,10 +74,7 @@ class StatusTest extends TestCase
 		$this->assertNull($status->challenge(false));
 	}
 
-	/**
-	 * @covers ::email
-	 */
-	public function testEmail()
+	public function testEmail(): void
 	{
 		$status = new Status([
 			'kirby'  => $this->app,
@@ -101,10 +90,7 @@ class StatusTest extends TestCase
 		$this->assertSame('homer@simpsons.com', $status->email());
 	}
 
-	/**
-	 * @covers ::mode
-	 */
-	public function testMode()
+	public function testMode(): void
 	{
 		$status = new Status([
 			'kirby'  => $this->app,
@@ -120,10 +106,7 @@ class StatusTest extends TestCase
 		$this->assertSame('password-reset', $status->mode());
 	}
 
-	/**
-	 * @covers ::status
-	 */
-	public function testStatus()
+	public function testStatus(): void
 	{
 		$status = new Status([
 			'kirby'  => $this->app,
@@ -157,10 +140,7 @@ class StatusTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$status = new Status([
 			'kirby'             => $this->app,
@@ -179,10 +159,7 @@ class StatusTest extends TestCase
 		], $status->toArray());
 	}
 
-	/**
-	 * @covers ::user
-	 */
-	public function testUser()
+	public function testUser(): void
 	{
 		// only return active users
 		$status = new Status([

--- a/tests/Cms/Blocks/BlockMethodsTest.php
+++ b/tests/Cms/Blocks/BlockMethodsTest.php
@@ -18,7 +18,7 @@ class BlockMethodsTest extends TestCase
 		]);
 	}
 
-	public function testBlockMethod()
+	public function testBlockMethod(): void
 	{
 		$block = new Block(['type' => 'test']);
 		$this->assertSame('block method', $block->test());

--- a/tests/Cms/Blocks/BlockModelsTest.php
+++ b/tests/Cms/Blocks/BlockModelsTest.php
@@ -37,7 +37,7 @@ class BlockModelsTest extends TestCase
 		];
 	}
 
-	public function testBlockModel()
+	public function testBlockModel(): void
 	{
 		$block = Block::factory(['type' => 'heading']);
 
@@ -46,7 +46,7 @@ class BlockModelsTest extends TestCase
 		$this->assertSame($block->id(), $block->test());
 	}
 
-	public function testBlockModelFromConfig()
+	public function testBlockModelFromConfig(): void
 	{
 		new App([
 			'roots' => [
@@ -64,7 +64,7 @@ class BlockModelsTest extends TestCase
 		$this->assertSame($block->id(), $block->test());
 	}
 
-	public function testMissingBlockModel()
+	public function testMissingBlockModel(): void
 	{
 		$block = Block::factory(['type' => 'image']);
 
@@ -73,7 +73,7 @@ class BlockModelsTest extends TestCase
 		$this->assertFalse(method_exists($block, 'test'));
 	}
 
-	public function testDefaultBlockModel()
+	public function testDefaultBlockModel(): void
 	{
 		new App([
 			'roots' => [

--- a/tests/Cms/Blocks/BlockTest.php
+++ b/tests/Cms/Blocks/BlockTest.php
@@ -23,7 +23,7 @@ class BlockTest extends TestCase
 		$this->page = new Page(['slug' => 'test']);
 	}
 
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$block = new Block(['type' => 'test']);
 
@@ -33,7 +33,7 @@ class BlockTest extends TestCase
 		$this->assertSame('test', $block->type());
 	}
 
-	public function testConstructWithoutType()
+	public function testConstructWithoutType(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The block type is missing');
@@ -41,7 +41,7 @@ class BlockTest extends TestCase
 		$block = new Block([]);
 	}
 
-	public function testContent()
+	public function testContent(): void
 	{
 		$block = new Block([
 			'type'    => 'heading',
@@ -65,7 +65,7 @@ class BlockTest extends TestCase
 	/**
 	 * @todo block.converter remove eventually
 	 */
-	public function testContentWhenNotArrayConvertedAsEditorBlock()
+	public function testContentWhenNotArrayConvertedAsEditorBlock(): void
 	{
 		$block = new Block([
 			'type'    => 'heading',
@@ -75,7 +75,7 @@ class BlockTest extends TestCase
 		$this->assertSame($content, $block->content()->toArray()['text']);
 	}
 
-	public function testController()
+	public function testController(): void
 	{
 		$block = new Block([
 			'type' => 'heading',
@@ -92,7 +92,7 @@ class BlockTest extends TestCase
 		$this->assertNull($block->controller()['next']);
 	}
 
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$block = Block::factory([
 			'type' => 'heading'
@@ -101,7 +101,7 @@ class BlockTest extends TestCase
 		$this->assertInstanceOf(Block::class, $block);
 	}
 
-	public function testIsEmpty()
+	public function testIsEmpty(): void
 	{
 		$block = new Block([
 			'type' => 'heading'
@@ -121,7 +121,7 @@ class BlockTest extends TestCase
 		$this->assertTrue($block->isNotEmpty());
 	}
 
-	public function testIsHidden()
+	public function testIsHidden(): void
 	{
 		$block = new Block([
 			'type' => 'heading',
@@ -131,7 +131,7 @@ class BlockTest extends TestCase
 		$this->assertTrue($block->isHidden());
 	}
 
-	public function testParent()
+	public function testParent(): void
 	{
 		$block = new Block([
 			'parent' => $page = new Page(['slug' => 'test']),
@@ -141,7 +141,7 @@ class BlockTest extends TestCase
 		$this->assertIsPage($page, $block->content()->parent());
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$block = new Block([
 			'type' => 'heading',
@@ -159,7 +159,7 @@ class BlockTest extends TestCase
 		], $block->toArray());
 	}
 
-	public function testToField()
+	public function testToField(): void
 	{
 		$block = new Block([
 			'content' => [
@@ -176,7 +176,7 @@ class BlockTest extends TestCase
 		$this->assertSame($expected, $block->toField()->value());
 	}
 
-	public function testToHtml()
+	public function testToHtml(): void
 	{
 		$block = new Block([
 			'content' => [
@@ -192,7 +192,7 @@ class BlockTest extends TestCase
 		$this->assertSame($expected, (string)$block);
 	}
 
-	public function testToHtmlInvalid()
+	public function testToHtmlInvalid(): void
 	{
 		new App([
 			'roots' => [
@@ -211,7 +211,7 @@ class BlockTest extends TestCase
 		$this->assertSame('', $block->toHtml());
 	}
 
-	public function testToHtmlInvalidWithDebugMode()
+	public function testToHtmlInvalidWithDebugMode(): void
 	{
 		new App([
 			'roots' => [
@@ -234,7 +234,7 @@ class BlockTest extends TestCase
 		$this->assertSame($expected, $block->toHtml());
 	}
 
-	public function testToHtmlWithCustomSnippets()
+	public function testToHtmlWithCustomSnippets(): void
 	{
 		$this->app = new App([
 			'roots' => [
@@ -257,7 +257,7 @@ class BlockTest extends TestCase
 		$this->assertSame($expected, (string)$block);
 	}
 
-	public function testExcerpt()
+	public function testExcerpt(): void
 	{
 		$block = new Block([
 			'content' => [
@@ -322,7 +322,7 @@ class BlockTest extends TestCase
 		]);
 	}
 
-	public function testHiddenSiblings()
+	public function testHiddenSiblings(): void
 	{
 		$blocks = $this->samplePrevNextBlocks();
 		$block = $blocks->first();
@@ -331,7 +331,7 @@ class BlockTest extends TestCase
 		$this->assertNull($block->prev());
 	}
 
-	public function testVisibleSiblings()
+	public function testVisibleSiblings(): void
 	{
 		$blocks = $this->samplePrevNextBlocks();
 		$block = $blocks->last();
@@ -340,7 +340,7 @@ class BlockTest extends TestCase
 		$this->assertNull($block->next());
 	}
 
-	public function testPrevNextVisible()
+	public function testPrevNextVisible(): void
 	{
 		$blocks = $this->samplePrevNextBlocks();
 		$block = $blocks->nth(4);
@@ -351,7 +351,7 @@ class BlockTest extends TestCase
 		$this->assertSame('markdown', $block->next()->type());
 	}
 
-	public function testPrevNextHidden()
+	public function testPrevNextHidden(): void
 	{
 		$blocks = $this->samplePrevNextBlocks();
 		$block = $blocks->nth(5);
@@ -362,7 +362,7 @@ class BlockTest extends TestCase
 		$this->assertSame('quote', $block->next()->type());
 	}
 
-	public function testImageBlock()
+	public function testImageBlock(): void
 	{
 		$this->app = new App([
 			'roots' => [

--- a/tests/Cms/Blocks/BlocksMethodsTest.php
+++ b/tests/Cms/Blocks/BlocksMethodsTest.php
@@ -18,7 +18,7 @@ class BlocksMethodsTest extends TestCase
 		]);
 	}
 
-	public function testBlocksMethod()
+	public function testBlocksMethod(): void
 	{
 		$input = [
 			['type' => 'heading']

--- a/tests/Cms/Blocks/BlocksTest.php
+++ b/tests/Cms/Blocks/BlocksTest.php
@@ -22,7 +22,7 @@ class BlocksTest extends TestCase
 		$this->page = new Page(['slug' => 'test']);
 	}
 
-	public function testFactoryFromLayouts()
+	public function testFactoryFromLayouts(): void
 	{
 		$layouts = [
 			[
@@ -59,7 +59,7 @@ class BlocksTest extends TestCase
 	/**
 	 * @todo block.converter remove eventually
 	 */
-	public function testFactoryFromBuilderWithColumns()
+	public function testFactoryFromBuilderWithColumns(): void
 	{
 		$builder = [
 			[
@@ -79,7 +79,7 @@ class BlocksTest extends TestCase
 		$this->assertSame('text', $blocks->last()->type());
 	}
 
-	public function testHasType()
+	public function testHasType(): void
 	{
 		$input = [
 			[
@@ -93,7 +93,7 @@ class BlocksTest extends TestCase
 		$this->assertFalse($blocks->hasType('code'));
 	}
 
-	public function testParseJson()
+	public function testParseJson(): void
 	{
 		$input = [
 			[
@@ -105,7 +105,7 @@ class BlocksTest extends TestCase
 		$this->assertSame($input, $result);
 	}
 
-	public function testParseHtml()
+	public function testParseHtml(): void
 	{
 		$input = '<h1>Test</h1>';
 		$expected = [
@@ -122,7 +122,7 @@ class BlocksTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	public function testParseEmpty()
+	public function testParseEmpty(): void
 	{
 		$result = Blocks::parse(null);
 		$this->assertSame([], $result);
@@ -131,7 +131,7 @@ class BlocksTest extends TestCase
 		$this->assertSame([], $result);
 	}
 
-	public function testParseString()
+	public function testParseString(): void
 	{
 		$expected = [
 			[
@@ -146,7 +146,7 @@ class BlocksTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	public function testParsePageObject()
+	public function testParsePageObject(): void
 	{
 		$expected = [
 			[
@@ -161,7 +161,7 @@ class BlocksTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	public function testToHtml()
+	public function testToHtml(): void
 	{
 		$blocks = Blocks::factory([
 			[
@@ -183,7 +183,7 @@ class BlocksTest extends TestCase
 		$this->assertSame($expected, $blocks->toHtml());
 	}
 
-	public function testToHtmlWithCustomSnippets()
+	public function testToHtmlWithCustomSnippets(): void
 	{
 		$this->app = new App([
 			'roots' => [
@@ -212,7 +212,7 @@ class BlocksTest extends TestCase
 		$this->assertSame($expected, $blocks->toHtml());
 	}
 
-	public function testExcerpt()
+	public function testExcerpt(): void
 	{
 		$blocks = Blocks::factory([
 			[
@@ -240,7 +240,7 @@ class BlocksTest extends TestCase
 	/**
 	 * @todo block.converter remove eventually
 	 */
-	public function testParseYaml()
+	public function testParseYaml(): void
 	{
 		$input = [
 			[

--- a/tests/Cms/Blueprints/BlueprintExtendAndUnsetTest.php
+++ b/tests/Cms/Blueprints/BlueprintExtendAndUnsetTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Exception;
 use Kirby\TestCase;
 
 class BlueprintExtendAndUnsetTest extends TestCase
@@ -67,7 +68,7 @@ class BlueprintExtendAndUnsetTest extends TestCase
 		]);
 	}
 
-	public function testExtendAndUnsetTab()
+	public function testExtendAndUnsetTab(): void
 	{
 		$blueprint = new Blueprint([
 			'title'  => 'extended',
@@ -84,7 +85,7 @@ class BlueprintExtendAndUnsetTest extends TestCase
 		$this->assertIsNotArray($blueprint->tab('seo'));
 	}
 
-	public function testExtendAndUnsetSection()
+	public function testExtendAndUnsetSection(): void
 	{
 		$blueprint = new Blueprint([
 			'title'  => 'extended',
@@ -101,7 +102,7 @@ class BlueprintExtendAndUnsetTest extends TestCase
 
 		try {
 			$sections = $blueprint->tab('content')['columns'][0]['sections'];
-		} catch (\Exception $e) {
+		} catch (Exception $e) {
 			$this->assertNull($e->getMessage(), 'Failed to getg sections.');
 		}
 
@@ -112,7 +113,7 @@ class BlueprintExtendAndUnsetTest extends TestCase
 		$this->assertArrayNotHasKey('files', $sections);
 	}
 
-	public function testExtendAndUnsetFields()
+	public function testExtendAndUnsetFields(): void
 	{
 		$blueprint = new Blueprint([
 			'title'  => 'extended',
@@ -129,7 +130,7 @@ class BlueprintExtendAndUnsetTest extends TestCase
 
 		try {
 			$fields = $blueprint->tab('seo')['columns'][0]['sections']['seo-fields']['fields'];
-		} catch (\Exception $e) {
+		} catch (Exception $e) {
 			$this->assertNull($e->getMessage(), 'Failed to get fields.');
 		}
 
@@ -140,7 +141,7 @@ class BlueprintExtendAndUnsetTest extends TestCase
 		$this->assertArrayNotHasKey('seoDescription', $fields);
 	}
 
-	public function testExtendAndUnsetColumns()
+	public function testExtendAndUnsetColumns(): void
 	{
 		$blueprint = new Blueprint([
 			'title'   => 'extended',

--- a/tests/Cms/Blueprints/BlueprintFieldTest.php
+++ b/tests/Cms/Blueprints/BlueprintFieldTest.php
@@ -23,7 +23,7 @@ class BlueprintFieldTest extends TestCase
 		]);
 	}
 
-	public function testFieldPropsDefaults()
+	public function testFieldPropsDefaults(): void
 	{
 		$props = Blueprint::fieldProps([
 			'name' => 'test',
@@ -36,7 +36,7 @@ class BlueprintFieldTest extends TestCase
 		$this->assertSame('1/1', $props['width']);
 	}
 
-	public function testFieldTypeFromName()
+	public function testFieldTypeFromName(): void
 	{
 		$props = Blueprint::fieldProps([
 			'name' => 'text',
@@ -47,7 +47,7 @@ class BlueprintFieldTest extends TestCase
 		$this->assertSame('Text', $props['label']);
 	}
 
-	public function testMissingFieldName()
+	public function testMissingFieldName(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The field name is missing');
@@ -55,7 +55,7 @@ class BlueprintFieldTest extends TestCase
 		$props = Blueprint::fieldProps([]);
 	}
 
-	public function testInvalidFieldType()
+	public function testInvalidFieldType(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid field type ("test")');
@@ -66,7 +66,7 @@ class BlueprintFieldTest extends TestCase
 		]);
 	}
 
-	public function testFieldError()
+	public function testFieldError(): void
 	{
 		$props = Blueprint::fieldError('test', 'something went wrong');
 		$expected = [
@@ -80,7 +80,7 @@ class BlueprintFieldTest extends TestCase
 		$this->assertSame($expected, $props);
 	}
 
-	public function testExtendField()
+	public function testExtendField(): void
 	{
 		$props = Blueprint::fieldProps([
 			'name'    => 'test',
@@ -97,7 +97,7 @@ class BlueprintFieldTest extends TestCase
 		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 
-	public function testExtendFieldFromString()
+	public function testExtendFieldFromString(): void
 	{
 		$props = Blueprint::fieldProps('fields/test');
 
@@ -106,7 +106,7 @@ class BlueprintFieldTest extends TestCase
 		$this->assertSame('text', $props['type']);
 	}
 
-	public function testExtendFieldWithNonAssociativeOptions()
+	public function testExtendFieldWithNonAssociativeOptions(): void
 	{
 		$this->app = $this->app->clone([
 			'blueprints' => [
@@ -143,7 +143,7 @@ class BlueprintFieldTest extends TestCase
 		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 
-	public function testNestedFields()
+	public function testNestedFields(): void
 	{
 		$props = Blueprint::fieldProps([
 			'name'   => 'test',
@@ -161,7 +161,7 @@ class BlueprintFieldTest extends TestCase
 		$this->assertSame('1/1', $props['fields']['headline']['width']);
 	}
 
-	public function testFieldGroup()
+	public function testFieldGroup(): void
 	{
 		$props = Blueprint::fieldProps([
 			'name'   => 'test',
@@ -189,7 +189,7 @@ class BlueprintFieldTest extends TestCase
 		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 
-	public function testFieldGroupWhen()
+	public function testFieldGroupWhen(): void
 	{
 		$props = Blueprint::fieldProps([
 			'name'   => 'test',
@@ -223,7 +223,7 @@ class BlueprintFieldTest extends TestCase
 		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 
-	public function testFieldGroupWhenMerge()
+	public function testFieldGroupWhenMerge(): void
 	{
 		$props = Blueprint::fieldProps([
 			'name'   => 'test',

--- a/tests/Cms/Blueprints/BlueprintFieldsTest.php
+++ b/tests/Cms/Blueprints/BlueprintFieldsTest.php
@@ -21,13 +21,13 @@ class BlueprintFieldsTest extends TestCase
 		]);
 	}
 
-	public function testEmptyFields()
+	public function testEmptyFields(): void
 	{
 		$fields = Blueprint::fieldsProps(false);
 		$this->assertSame([], $fields);
 	}
 
-	public function testNameOnlyField()
+	public function testNameOnlyField(): void
 	{
 		$fields = Blueprint::fieldsProps([
 			'text' => true
@@ -45,7 +45,7 @@ class BlueprintFieldsTest extends TestCase
 		$this->assertEquals($expected, $fields); // cannot use strict assertion (array order)
 	}
 
-	public function testFieldFromString()
+	public function testFieldFromString(): void
 	{
 		$fields = Blueprint::fieldsProps([
 			'hello' => 'fields/test'
@@ -63,7 +63,7 @@ class BlueprintFieldsTest extends TestCase
 		$this->assertEquals($expected, $fields); // cannot use strict assertion (array order)
 	}
 
-	public function testFieldGroup()
+	public function testFieldGroup(): void
 	{
 		$fields = Blueprint::fieldsProps([
 			'header' => [
@@ -106,7 +106,7 @@ class BlueprintFieldsTest extends TestCase
 		$this->assertEquals($expected, $fields); // cannot use strict assertion (array order)
 	}
 
-	public function testMultipleFieldGroups()
+	public function testMultipleFieldGroups(): void
 	{
 		$fields = Blueprint::fieldsProps([
 			'header' => [
@@ -163,7 +163,7 @@ class BlueprintFieldsTest extends TestCase
 		$this->assertEquals($expected, $fields); // cannot use strict assertion (array order)
 	}
 
-	public function testFieldError()
+	public function testFieldError(): void
 	{
 		$props = Blueprint::fieldsProps([
 			'test' => [

--- a/tests/Cms/Blueprints/BlueprintPresetsTest.php
+++ b/tests/Cms/Blueprints/BlueprintPresetsTest.php
@@ -21,7 +21,7 @@ class BlueprintPresetsTest extends TestCase
 	/**
 	 * Page
 	 */
-	public function testPagePresetDefault()
+	public function testPagePresetDefault(): void
 	{
 		$preset = $this->load('page');
 
@@ -56,7 +56,7 @@ class BlueprintPresetsTest extends TestCase
 		$this->assertSame($expected, $props);
 	}
 
-	public function testPagePresetNoFiles()
+	public function testPagePresetNoFiles(): void
 	{
 		$preset = $this->load('page');
 
@@ -88,7 +88,7 @@ class BlueprintPresetsTest extends TestCase
 		$this->assertSame($expected, $props);
 	}
 
-	public function testPagePresetNoPages()
+	public function testPagePresetNoPages(): void
 	{
 		$preset = $this->load('page');
 
@@ -119,7 +119,7 @@ class BlueprintPresetsTest extends TestCase
 		$this->assertSame($expected, $props);
 	}
 
-	public function testPagePresetNoSidebar()
+	public function testPagePresetNoSidebar(): void
 	{
 		$preset = $this->load('page');
 
@@ -136,7 +136,7 @@ class BlueprintPresetsTest extends TestCase
 		$this->assertSame($expected, $props);
 	}
 
-	public function testPagePresetCustomSidebar()
+	public function testPagePresetCustomSidebar(): void
 	{
 		$preset = $this->load('page');
 
@@ -174,7 +174,7 @@ class BlueprintPresetsTest extends TestCase
 	/**
 	 * Pages
 	 */
-	public function testPagesPresetDefault()
+	public function testPagesPresetDefault(): void
 	{
 		$preset = $this->load('pages');
 
@@ -201,7 +201,7 @@ class BlueprintPresetsTest extends TestCase
 		$this->assertSame($expected, $props);
 	}
 
-	public function testPagesPresetWithUnlisted()
+	public function testPagesPresetWithUnlisted(): void
 	{
 		$preset = $this->load('pages');
 
@@ -239,7 +239,7 @@ class BlueprintPresetsTest extends TestCase
 	/**
 	 * Files
 	 */
-	public function testFilesPresetDefault()
+	public function testFilesPresetDefault(): void
 	{
 		$preset = $this->load('files');
 
@@ -262,7 +262,7 @@ class BlueprintPresetsTest extends TestCase
 		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 
-	public function testFilesPresetWithLabel()
+	public function testFilesPresetWithLabel(): void
 	{
 		$preset = $this->load('files');
 
@@ -287,7 +287,7 @@ class BlueprintPresetsTest extends TestCase
 		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 
-	public function testFilesPresetWithLayout()
+	public function testFilesPresetWithLayout(): void
 	{
 		$preset = $this->load('files');
 
@@ -312,7 +312,7 @@ class BlueprintPresetsTest extends TestCase
 		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 
-	public function testFilesPresetWithTemplate()
+	public function testFilesPresetWithTemplate(): void
 	{
 		$preset = $this->load('files');
 
@@ -337,7 +337,7 @@ class BlueprintPresetsTest extends TestCase
 		$this->assertEquals($expected, $props); // cannot use strict assertion (array order)
 	}
 
-	public function testFilesPresetWithImage()
+	public function testFilesPresetWithImage(): void
 	{
 		$preset = $this->load('files');
 

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -2,15 +2,16 @@
 
 namespace Kirby\Cms;
 
+use Exception;
 use Kirby\Data\Data;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 use Kirby\Toolkit\I18n;
+use PHPUnit\Framework\Attributes\CoversClass;
+use stdClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Blueprint
- */
+#[CoversClass(Blueprint::class)]
 class BlueprintTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Blueprint';
@@ -35,10 +36,7 @@ class BlueprintTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructWithoutModel()
+	public function testConstructWithoutModel(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('A blueprint model is required');
@@ -46,18 +44,15 @@ class BlueprintTest extends TestCase
 		new Blueprint([]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructInvalidModel()
+	public function testConstructInvalidModel(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid blueprint model');
 
-		new Blueprint(['model' => new \stdClass()]);
+		new Blueprint(['model' => new stdClass()]);
 	}
 
-	public function testConvertColumnsToTabs()
+	public function testConvertColumnsToTabs(): void
 	{
 		$columns = [
 			[
@@ -112,10 +107,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame($expected['main'], $blueprint->tab());
 	}
 
-	/**
-	 * @covers ::acceptedFileTemplates
-	 */
-	public function testAcceptedFileTemplatesDefault()
+	public function testAcceptedFileTemplatesDefault(): void
 	{
 		$blueprint = new Blueprint([
 			'model' => $this->model,
@@ -130,10 +122,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame(['default'], $blueprint->acceptedFileTemplates());
 	}
 
-	/**
-	 * @covers ::acceptedFileTemplates
-	 */
-	public function testAcceptedFileTemplatesFromFields()
+	public function testAcceptedFileTemplatesFromFields(): void
 	{
 		$this->app = new App([
 			'roots' => [
@@ -217,10 +206,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame(['a', 'b', 'c', 'd', 'e'], $blueprint->acceptedFileTemplates());
 	}
 
-	/**
-	 * @covers ::acceptedFileTemplates
-	 */
-	public function testAcceptedFileTemplatesFromFieldsAndSections()
+	public function testAcceptedFileTemplatesFromFieldsAndSections(): void
 	{
 		$this->app = new App([
 			'roots' => [
@@ -270,10 +256,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame(['a', 'b', 'c'], $blueprint->acceptedFileTemplates());
 	}
 
-	/**
-	 * @covers ::acceptedFileTemplates
-	 */
-	public function testAcceptedFileTemplatesFromSection()
+	public function testAcceptedFileTemplatesFromSection(): void
 	{
 		$this->app = new App([
 			'roots' => [
@@ -300,10 +283,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame(['a'], $blueprint->acceptedFileTemplates('a'));
 	}
 
-	/**
-	 * @covers ::acceptedFileTemplates
-	 */
-	public function testAcceptedFileTemplatesFromSections()
+	public function testAcceptedFileTemplatesFromSections(): void
 	{
 		$this->app = new App([
 			'roots' => [
@@ -337,10 +317,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame(['a', 'b'], $blueprint->acceptedFileTemplates());
 	}
 
-	/**
-	 * @covers ::buttons
-	 */
-	public function testButtons()
+	public function testButtons(): void
 	{
 		$blueprint = new Blueprint([
 			'model' => $this->model,
@@ -351,10 +328,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame(['foo', 'bar'], $blueprint->buttons());
 	}
 
-	/**
-	 * @covers ::buttons
-	 */
-	public function testButtonsDisabled()
+	public function testButtonsDisabled(): void
 	{
 		$blueprint = new Blueprint([
 			'model' => $this->model,
@@ -365,10 +339,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame(false, $blueprint->buttons());
 	}
 
-	/**
-	 * @covers ::__debugInfo
-	 */
-	public function testDebugInfo()
+	public function testDebugInfo(): void
 	{
 		$blueprint = new Blueprint([
 			'model' => $this->model,
@@ -384,7 +355,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame($expected, $blueprint->__debugInfo());
 	}
 
-	public function testSectionsToColumns()
+	public function testSectionsToColumns(): void
 	{
 		$sections = [
 			'pages' => [
@@ -420,7 +391,7 @@ class BlueprintTest extends TestCase
 		$this->assertEquals($expected, $blueprint->toArray()['tabs']); // cannot use strict assertion (array order)
 	}
 
-	public function testFieldsToSections()
+	public function testFieldsToSections(): void
 	{
 		$fields = [
 			'headline' => [
@@ -460,10 +431,7 @@ class BlueprintTest extends TestCase
 		$this->assertEquals($expected, $blueprint->toArray()['tabs']); // cannot use strict assertion (array order)
 	}
 
-	/**
-	 * @covers ::title
-	 */
-	public function testTitle()
+	public function testTitle(): void
 	{
 		$blueprint = new Blueprint([
 			'title' => 'Test',
@@ -473,10 +441,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame('Test', $blueprint->title());
 	}
 
-	/**
-	 * @covers ::title
-	 */
-	public function testTitleTranslated()
+	public function testTitleTranslated(): void
 	{
 		$blueprint = new Blueprint([
 			'title' => ['en' => 'Test'],
@@ -486,10 +451,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame('Test', $blueprint->title());
 	}
 
-	/**
-	 * @covers ::title
-	 */
-	public function testTitleTranslatedFallback()
+	public function testTitleTranslatedFallback(): void
 	{
 		I18n::$locale       = 'de';
 		I18n::$translations = ['en' => ['my.i18n.string' => 'success']];
@@ -502,7 +464,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame('success', $blueprint->title());
 	}
 
-	public function testTitleTranslatedFallbackForRoles()
+	public function testTitleTranslatedFallbackForRoles(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -536,10 +498,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame('My custom role', $role);
 	}
 
-	/**
-	 * @covers ::title
-	 */
-	public function testTitleFromName()
+	public function testTitleFromName(): void
 	{
 		$blueprint = new Blueprint([
 			'model' => $this->model
@@ -555,10 +514,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame('Test', $blueprint->title());
 	}
 
-	/**
-	 * @covers ::extend
-	 */
-	public function testExtend()
+	public function testExtend(): void
 	{
 		new App([
 			'blueprints' => [
@@ -576,10 +532,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame('Extension Test', $blueprint->title());
 	}
 
-	/**
-	 * @covers ::extend
-	 */
-	public function testExtendWithInvalidSnippet()
+	public function testExtendWithInvalidSnippet(): void
 	{
 		$blueprint = new Blueprint([
 			'extends' => 'notFound',
@@ -589,10 +542,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame('Default', $blueprint->title());
 	}
 
-	/**
-	 * @covers ::extend
-	 */
-	public function testExtendMultiple()
+	public function testExtendMultiple(): void
 	{
 		new App([
 			'blueprints' => [
@@ -632,11 +582,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame('1/3', $field['width']);
 	}
 
-	/**
-	 * @covers ::factory
-	 * @covers ::find
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		Blueprint::$loaded = [];
 
@@ -652,11 +598,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame('pages/test', $blueprint->name());
 	}
 
-	/**
-	 * @covers ::factory
-	 * @covers ::find
-	 */
-	public function testFactoryWithCallbackArray()
+	public function testFactoryWithCallbackArray(): void
 	{
 		Blueprint::$loaded = [];
 
@@ -672,11 +614,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame('pages/test', $blueprint->name());
 	}
 
-	/**
-	 * @covers ::factory
-	 * @covers ::find
-	 */
-	public function testFactoryWithCallbackString()
+	public function testFactoryWithCallbackString(): void
 	{
 		Blueprint::$loaded = [];
 
@@ -698,20 +636,13 @@ class BlueprintTest extends TestCase
 		$this->assertSame('pages/test', $blueprint->name());
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactoryForMissingBlueprint()
+	public function testFactoryForMissingBlueprint(): void
 	{
 		$blueprint = Blueprint::factory('notFound', null, new Page(['slug' => 'test']));
 		$this->assertNull($blueprint);
 	}
 
-	/**
-	 * @covers ::fields
-	 * @covers ::field
-	 */
-	public function testFields()
+	public function testFields(): void
 	{
 		$blueprint = new Blueprint([
 			'model' => $this->model,
@@ -729,10 +660,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame($fields['test'], $blueprint->field('test'));
 	}
 
-	/**
-	 * @covers ::fields
-	 */
-	public function testNestedFields()
+	public function testNestedFields(): void
 	{
 		$blueprint = new Blueprint([
 			'model' => $this->model,
@@ -753,7 +681,7 @@ class BlueprintTest extends TestCase
 		$this->assertArrayNotHasKey('child-field', $blueprint->fields());
 	}
 
-	public function testInvalidSectionType()
+	public function testInvalidSectionType(): void
 	{
 		$blueprint = new Blueprint([
 			'model' => $this->model,
@@ -773,7 +701,7 @@ class BlueprintTest extends TestCase
 
 		try {
 			$sections = $blueprint->tab('main')['columns'][0]['sections'];
-		} catch (\Exception $e) {
+		} catch (Exception $e) {
 			$this->assertNull($e->getMessage(), 'Failed to get sections.');
 		}
 
@@ -784,10 +712,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame('Invalid section type for section "main"', $sections['main']['label']);
 	}
 
-	/**
-	 * @covers ::isDefault
-	 */
-	public function testIsDefault()
+	public function testIsDefault(): void
 	{
 		$blueprint = new Blueprint([
 			'model' => $this->model,
@@ -797,7 +722,7 @@ class BlueprintTest extends TestCase
 		$this->assertTrue($blueprint->isDefault());
 	}
 
-	public function testSectionTypeFromName()
+	public function testSectionTypeFromName(): void
 	{
 		// with options
 		$blueprint = new Blueprint([
@@ -821,10 +746,7 @@ class BlueprintTest extends TestCase
 		$this->assertSame('info', $blueprint->sections()['info']->type());
 	}
 
-	/**
-	 * @covers ::preset
-	 */
-	public function testPreset()
+	public function testPreset(): void
 	{
 		$blueprint = new Blueprint([
 			'model'  => $this->model,

--- a/tests/Cms/Blueprints/FileBlueprintTest.php
+++ b/tests/Cms/Blueprints/FileBlueprintTest.php
@@ -60,7 +60,7 @@ class FileBlueprintTest extends TestCase
 	}
 
 	#[DataProvider('acceptAttributeProvider')]
-	public function testAcceptAttribute($accept, $expected, $notExpected)
+	public function testAcceptAttribute($accept, $expected, $notExpected): void
 	{
 		Blueprint::$loaded['files/acceptAttribute'] = [
 			'accept' => $accept
@@ -83,7 +83,7 @@ class FileBlueprintTest extends TestCase
 		}
 	}
 
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$page = new Page([
 			'slug' => 'test'
@@ -109,7 +109,7 @@ class FileBlueprintTest extends TestCase
 		$this->assertSame($expected, $blueprint->options());
 	}
 
-	public function testTemplateFromContent()
+	public function testTemplateFromContent(): void
 	{
 		$page = new Page([
 			'slug' => 'test'
@@ -126,7 +126,7 @@ class FileBlueprintTest extends TestCase
 		$this->assertSame('gallery', $file->template());
 	}
 
-	public function testCustomTemplate()
+	public function testCustomTemplate(): void
 	{
 		$page = new Page([
 			'slug' => 'test'
@@ -141,7 +141,7 @@ class FileBlueprintTest extends TestCase
 		$this->assertSame('gallery', $file->template());
 	}
 
-	public function testDefaultBlueprint()
+	public function testDefaultBlueprint(): void
 	{
 		$page = new Page([
 			'slug' => 'test'
@@ -158,7 +158,7 @@ class FileBlueprintTest extends TestCase
 		$this->assertInstanceOf(FileBlueprint::class, $blueprint);
 	}
 
-	public function testCustomBlueprint()
+	public function testCustomBlueprint(): void
 	{
 		new App([
 			'blueprints' => [
@@ -185,7 +185,7 @@ class FileBlueprintTest extends TestCase
 		$this->assertSame('Gallery', $blueprint->title());
 	}
 
-	public function testAccept()
+	public function testAccept(): void
 	{
 		$page = new Page([
 			'slug' => 'test'
@@ -344,7 +344,7 @@ class FileBlueprintTest extends TestCase
 		], $blueprint->accept());
 	}
 
-	public function testAcceptMime()
+	public function testAcceptMime(): void
 	{
 		$page = new Page([
 			'slug' => 'test'
@@ -419,7 +419,7 @@ class FileBlueprintTest extends TestCase
 		$this->assertSame('image/jpeg, application/pdf', $blueprint->acceptMime());
 	}
 
-	public function testExtendAccept()
+	public function testExtendAccept(): void
 	{
 		new App([
 			'roots' => [

--- a/tests/Cms/Blueprints/PageBlueprintTest.php
+++ b/tests/Cms/Blueprints/PageBlueprintTest.php
@@ -13,7 +13,7 @@ class PageBlueprintTest extends TestCase
 		Blueprint::$loaded = [];
 	}
 
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$blueprint = new PageBlueprint([
 			'model' => new Page(['slug' => 'test'])
@@ -41,7 +41,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertEquals($expected, $blueprint->options()); // cannot use strict assertion (array order)
 	}
 
-	public function testExtendedOptionsFromString()
+	public function testExtendedOptionsFromString(): void
 	{
 		new App([
 			'blueprints' => [
@@ -79,7 +79,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertEquals($expected, $blueprint->options()); // cannot use strict assertion (array order)
 	}
 
-	public function testExtendedOptions()
+	public function testExtendedOptions(): void
 	{
 		new App([
 			'blueprints' => [
@@ -135,7 +135,7 @@ class PageBlueprintTest extends TestCase
 	}
 
 	#[DataProvider('numProvider')]
-	public function testNum($input, $expected)
+	public function testNum($input, $expected): void
 	{
 		$blueprint = new PageBlueprint([
 			'model' => new Page(['slug' => 'test']),
@@ -145,7 +145,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame($expected, $blueprint->num());
 	}
 
-	public function testStatus()
+	public function testStatus(): void
 	{
 		$blueprint = new PageBlueprint([
 			'model'  => new Page(['slug' => 'test']),
@@ -174,7 +174,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame($expected, $blueprint->status());
 	}
 
-	public function testStatusWithCustomText()
+	public function testStatusWithCustomText(): void
 	{
 		$expected = [
 			'draft' => [
@@ -199,7 +199,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame($expected, $blueprint->status());
 	}
 
-	public function testStatusTranslations()
+	public function testStatusTranslations(): void
 	{
 		new App([
 			'roots' => [
@@ -245,7 +245,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame($expected, $blueprint->status());
 	}
 
-	public function testInvalidStatus()
+	public function testInvalidStatus(): void
 	{
 		$input = [
 			'draft'    => 'Draft',
@@ -272,7 +272,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame($expected, $blueprint->status());
 	}
 
-	public function testExtendStatus()
+	public function testExtendStatus(): void
 	{
 		new App([
 			'blueprints' => [
@@ -325,7 +325,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame($expected, $blueprint->status());
 	}
 
-	public function testExtendStatusFromString()
+	public function testExtendStatusFromString(): void
 	{
 		new App([
 			'blueprints' => [
@@ -354,7 +354,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame($expected, $blueprint->status());
 	}
 
-	public function testExtendNum()
+	public function testExtendNum(): void
 	{
 		new App([
 			'blueprints' => [
@@ -375,7 +375,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame('date', $blueprint->num());
 	}
 
-	public function testTitleI18n()
+	public function testTitleI18n(): void
 	{
 		$app = new App([
 			'site' => [
@@ -420,7 +420,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame('Simple Page', $page->blueprint()->title());
 	}
 
-	public function testTitleI18nWithFallbackLanguage()
+	public function testTitleI18nWithFallbackLanguage(): void
 	{
 		$app = new App([
 			'site' => [
@@ -457,7 +457,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame('Thanks to fallback', $page->blueprint()->title());
 	}
 
-	public function testTitleI18nArray()
+	public function testTitleI18nArray(): void
 	{
 		$app = new App([
 			'site' => [
@@ -497,7 +497,7 @@ class PageBlueprintTest extends TestCase
 		$this->assertSame('My title', $page->blueprint()->title());
 	}
 
-	public function testTitleI18nArrayFallBack()
+	public function testTitleI18nArrayFallBack(): void
 	{
 		$app = new App([
 			'site' => [

--- a/tests/Cms/Blueprints/SiteBlueprintTest.php
+++ b/tests/Cms/Blueprints/SiteBlueprintTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(SiteBlueprint::class)]
 class SiteBlueprintTest extends TestCase
 {
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$blueprint = new SiteBlueprint([
 			'model' => new Site()

--- a/tests/Cms/Blueprints/UserBlueprintTest.php
+++ b/tests/Cms/Blueprints/UserBlueprintTest.php
@@ -12,7 +12,7 @@ class UserBlueprintTest extends TestCase
 		Blueprint::$loaded = [];
 	}
 
-	public function testTranslatedDescription()
+	public function testTranslatedDescription(): void
 	{
 		$blueprint = new UserBlueprint([
 			'model' => new User(['email' => 'test@getkirby.com']),
@@ -25,7 +25,7 @@ class UserBlueprintTest extends TestCase
 		$this->assertSame('User', $blueprint->description());
 	}
 
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$blueprint = new UserBlueprint([
 			'model' => new User(['email' => 'test@getkirby.com'])
@@ -45,7 +45,7 @@ class UserBlueprintTest extends TestCase
 		$this->assertSame($expected, $blueprint->options());
 	}
 
-	public function testTitleI18n()
+	public function testTitleI18n(): void
 	{
 		$app = new App([
 			'blueprints' => [
@@ -89,7 +89,7 @@ class UserBlueprintTest extends TestCase
 		$this->assertSame('Editor role', $user->role()->title());
 	}
 
-	public function testTitleI18nWithFallbackLanguage()
+	public function testTitleI18nWithFallbackLanguage(): void
 	{
 		$app = new App([
 			'blueprints' => [
@@ -124,7 +124,7 @@ class UserBlueprintTest extends TestCase
 		$this->assertSame('Editor role', $user->role()->title());
 	}
 
-	public function testTitleI18nArray()
+	public function testTitleI18nArray(): void
 	{
 		$app = new App([
 			'blueprints' => [
@@ -165,7 +165,7 @@ class UserBlueprintTest extends TestCase
 		$this->assertSame('Editor role', $user->role()->title());
 	}
 
-	public function testTitleI18nArrayFallBack()
+	public function testTitleI18nArrayFallBack(): void
 	{
 		$app = new App([
 			'blueprints' => [

--- a/tests/Cms/Collections/CollectionsTest.php
+++ b/tests/Cms/Collections/CollectionsTest.php
@@ -15,7 +15,7 @@ class CollectionsTest extends TestCase
 		]);
 	}
 
-	public function testGetAndCall()
+	public function testGetAndCall(): void
 	{
 		$app        = $this->_app();
 		$collection = new Collection();
@@ -29,7 +29,7 @@ class CollectionsTest extends TestCase
 		$this->assertEquals($collection, $result); // cannot use strict assertion (different object)
 	}
 
-	public function testGetWithData()
+	public function testGetWithData(): void
 	{
 		$app    = $this->_app();
 		$result = $app->collections()->get('string', [
@@ -40,7 +40,7 @@ class CollectionsTest extends TestCase
 		$this->assertSame('ab', $result);
 	}
 
-	public function testGetWithRearrangedData()
+	public function testGetWithRearrangedData(): void
 	{
 		$app    = $this->_app();
 		$result = $app->collections()->get('rearranged', [
@@ -51,7 +51,7 @@ class CollectionsTest extends TestCase
 		$this->assertSame('ab', $result);
 	}
 
-	public function testGetWithDifferentData()
+	public function testGetWithDifferentData(): void
 	{
 		$app = $this->_app();
 
@@ -68,7 +68,7 @@ class CollectionsTest extends TestCase
 		$this->assertSame('cd', $result);
 	}
 
-	public function testGetCloned()
+	public function testGetCloned(): void
 	{
 		$app         = $this->_app();
 		$collections = $app->collections();
@@ -83,7 +83,7 @@ class CollectionsTest extends TestCase
 		$this->assertCount(0, $b);
 	}
 
-	public function testHas()
+	public function testHas(): void
 	{
 		$app = $this->_app();
 		$this->assertTrue($app->collections()->has('test'));
@@ -91,7 +91,7 @@ class CollectionsTest extends TestCase
 		$this->assertTrue($app->collections()->has('test'));
 	}
 
-	public function testLoad()
+	public function testLoad(): void
 	{
 		$app = $this->_app();
 		$result = $app->collections()->load('test');
@@ -101,7 +101,7 @@ class CollectionsTest extends TestCase
 		$this->assertSame('a', $result());
 	}
 
-	public function testLoadNested()
+	public function testLoadNested(): void
 	{
 		$app = $this->_app();
 		$result = $app->collections()->load('nested/test');

--- a/tests/Cms/Collections/PaginationTest.php
+++ b/tests/Cms/Collections/PaginationTest.php
@@ -17,7 +17,7 @@ class PaginationTest extends TestCase
 		]);
 	}
 
-	public function testCustomAppUrl()
+	public function testCustomAppUrl(): void
 	{
 		$this->app->clone([
 			'options' => [
@@ -34,7 +34,7 @@ class PaginationTest extends TestCase
 		$this->assertSame('https://getkirby.com/page:2', $pagination->nextPageUrl());
 	}
 
-	public function testSubfolderUrl()
+	public function testSubfolderUrl(): void
 	{
 		$this->app->clone([
 			'options' => [
@@ -51,7 +51,7 @@ class PaginationTest extends TestCase
 		$this->assertSame('http://localhost/starterkit/page:2', $pagination->nextPageUrl());
 	}
 
-	public function testCurrentPageUrl()
+	public function testCurrentPageUrl(): void
 	{
 		$pagination = $this->pagination([
 			'page' => 2
@@ -60,7 +60,7 @@ class PaginationTest extends TestCase
 		$this->assertSame('https://getkirby.com/page:2', $pagination->pageUrl());
 	}
 
-	public function testCurrentPageUrlWithFirstPage()
+	public function testCurrentPageUrlWithFirstPage(): void
 	{
 		$pagination = $this->pagination([
 			'page' => 1
@@ -69,7 +69,7 @@ class PaginationTest extends TestCase
 		$this->assertSame('https://getkirby.com', $pagination->pageUrl());
 	}
 
-	public function testPageUrl()
+	public function testPageUrl(): void
 	{
 		$pagination = $this->pagination();
 
@@ -80,19 +80,19 @@ class PaginationTest extends TestCase
 		$this->assertNull($pagination->pageUrl(13));
 	}
 
-	public function testFirstPageUrl()
+	public function testFirstPageUrl(): void
 	{
 		$pagination = $this->pagination();
 		$this->assertSame('https://getkirby.com', $pagination->firstPageUrl());
 	}
 
-	public function testLastPageUrl()
+	public function testLastPageUrl(): void
 	{
 		$pagination = $this->pagination();
 		$this->assertSame('https://getkirby.com/page:12', $pagination->lastPageUrl());
 	}
 
-	public function testFirstLastPageUrlNull()
+	public function testFirstLastPageUrlNull(): void
 	{
 		$pagination = new Pagination([
 			'page'  => 1,
@@ -105,7 +105,7 @@ class PaginationTest extends TestCase
 		$this->assertNull($pagination->lastPageUrl());
 	}
 
-	public function testNextPageUrl()
+	public function testNextPageUrl(): void
 	{
 		$pagination = $this->pagination([
 			'page' => 2
@@ -114,13 +114,13 @@ class PaginationTest extends TestCase
 		$this->assertSame('https://getkirby.com/page:3', $pagination->nextPageUrl());
 	}
 
-	public function testNonExistingNextPage()
+	public function testNonExistingNextPage(): void
 	{
 		$pagination = $this->pagination(['page' => 12]);
 		$this->assertNull($pagination->nextPageUrl());
 	}
 
-	public function testPrevPageUrl()
+	public function testPrevPageUrl(): void
 	{
 		$pagination = $this->pagination([
 			'page' => 3
@@ -129,13 +129,13 @@ class PaginationTest extends TestCase
 		$this->assertSame('https://getkirby.com/page:2', $pagination->prevPageUrl());
 	}
 
-	public function testNonExistingPrevPage()
+	public function testNonExistingPrevPage(): void
 	{
 		$pagination = $this->pagination(['page' => 1]);
 		$this->assertNull($pagination->prevPageUrl());
 	}
 
-	public function testPrevPageUrlWithFirstPage()
+	public function testPrevPageUrlWithFirstPage(): void
 	{
 		$pagination = $this->pagination([
 			'page' => 2
@@ -144,7 +144,7 @@ class PaginationTest extends TestCase
 		$this->assertSame('https://getkirby.com', $pagination->prevPageUrl());
 	}
 
-	public function testMethod()
+	public function testMethod(): void
 	{
 		$pagination = $this->pagination([
 			'page' => 2

--- a/tests/Cms/Collections/SearchTest.php
+++ b/tests/Cms/Collections/SearchTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Cms;
 
 class SearchTest extends TestCase
 {
-	public function testCollection()
+	public function testCollection(): void
 	{
 		$collection = Pages::factory([
 			[
@@ -48,7 +48,7 @@ class SearchTest extends TestCase
 	}
 
 
-	public function testIgnoreFieldCase()
+	public function testIgnoreFieldCase(): void
 	{
 		$collection = Pages::factory([
 			[
@@ -83,7 +83,7 @@ class SearchTest extends TestCase
 		$this->assertCount(3, $search);
 	}
 
-	public function testIgnoreCaseI18n()
+	public function testIgnoreCaseI18n(): void
 	{
 		$collection = Pages::factory([
 			[
@@ -157,21 +157,21 @@ class SearchTest extends TestCase
 		]);
 	}
 
-	public function testFiles()
+	public function testFiles(): void
 	{
 		$this->assertCount(5, $this->app()->site()->index()->files());
 		$this->assertInstanceOf(Files::class, $files = Search::files('phone'));
 		$this->assertCount(2, $files);
 	}
 
-	public function testPages()
+	public function testPages(): void
 	{
 		$this->assertCount(3, $this->app()->site()->index());
 		$this->assertInstanceOf(Pages::class, $pages = Search::pages('products'));
 		$this->assertCount(1, $pages);
 	}
 
-	public function testUsers()
+	public function testUsers(): void
 	{
 		$this->assertCount(5, $this->app()->users());
 		$this->assertInstanceOf(Users::class, $users = Search::users('user'));

--- a/tests/Cms/CoreTest.php
+++ b/tests/Cms/CoreTest.php
@@ -2,9 +2,9 @@
 
 namespace Kirby\Cms;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Core
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Core::class)]
 class CoreTest extends TestCase
 {
 	protected Core $core;
@@ -15,20 +15,14 @@ class CoreTest extends TestCase
 		$this->core = new Core($this->app);
 	}
 
-	/**
-	 * @covers ::area
-	 */
-	public function testArea()
+	public function testArea(): void
 	{
 		$area = $this->core->area('site');
 
 		$this->assertSame('Site', $area['label']);
 	}
 
-	/**
-	 * @covers ::areas
-	 */
-	public function testAreas()
+	public function testAreas(): void
 	{
 		$areas = $this->core->areas();
 		$this->assertArrayHasKey('account', $areas);
@@ -39,19 +33,13 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('users', $areas);
 	}
 
-	/**
-	 * @covers ::authChallenges
-	 */
-	public function testAuthChallenges()
+	public function testAuthChallenges(): void
 	{
 		$authChallenges = $this->core->authChallenges();
 		$this->assertArrayHasKey('email', $authChallenges);
 	}
 
-	/**
-	 * @covers ::blueprintPresets
-	 */
-	public function testBlueprintPresets()
+	public function testBlueprintPresets(): void
 	{
 		$blueprintPresets = $this->core->blueprintPresets();
 		$this->assertArrayHasKey('pages', $blueprintPresets);
@@ -59,10 +47,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('files', $blueprintPresets);
 	}
 
-	/**
-	 * @covers ::blueprints
-	 */
-	public function testBlueprints()
+	public function testBlueprints(): void
 	{
 		$blueprints = $this->core->blueprints();
 
@@ -83,10 +68,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('site', $blueprints);
 	}
 
-	/**
-	 * @covers ::caches
-	 */
-	public function testCaches()
+	public function testCaches(): void
 	{
 		$caches = $this->core->caches();
 
@@ -94,10 +76,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('uuid', $caches);
 	}
 
-	/**
-	 * @covers ::cacheTypes
-	 */
-	public function testCacheTypes()
+	public function testCacheTypes(): void
 	{
 		$cacheTypes = $this->core->cacheTypes();
 
@@ -107,10 +86,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('memory', $cacheTypes);
 	}
 
-	/**
-	 * @covers ::components
-	 */
-	public function testComponents()
+	public function testComponents(): void
 	{
 		$components = $this->core->components();
 
@@ -127,10 +103,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('url', $components);
 	}
 
-	/**
-	 * @covers ::fieldMethodAliases
-	 */
-	public function testFieldMethodAliases()
+	public function testFieldMethodAliases(): void
 	{
 		$aliases = $this->core->fieldMethodAliases();
 
@@ -149,10 +122,7 @@ class CoreTest extends TestCase
 		$this->assertSame('xml', $aliases['x']);
 	}
 
-	/**
-	 * @covers ::fieldMethods
-	 */
-	public function testFieldMethods()
+	public function testFieldMethods(): void
 	{
 		$methods = $this->core->fieldMethods();
 
@@ -203,10 +173,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('yaml', $methods);
 	}
 
-	/**
-	 * @covers ::fieldMixins
-	 */
-	public function testFieldMixins()
+	public function testFieldMixins(): void
 	{
 		$mixins = $this->core->fieldMixins();
 
@@ -221,10 +188,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('userpicker', $mixins);
 	}
 
-	/**
-	 * @covers ::fields
-	 */
-	public function testFields()
+	public function testFields(): void
 	{
 		$fields = $this->core->fields();
 
@@ -259,19 +223,13 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('writer', $fields);
 	}
 
-	/**
-	 * @covers ::area
-	 */
-	public function testFilePreviews()
+	public function testFilePreviews(): void
 	{
 		$previews = $this->core->filePreviews();
 		$this->assertCount(4, $previews);
 	}
 
-	/**
-	 * @covers ::load
-	 */
-	public function testLoad()
+	public function testLoad(): void
 	{
 		$loader = $this->core->load();
 
@@ -279,10 +237,7 @@ class CoreTest extends TestCase
 		$this->assertFalse($loader->withPlugins());
 	}
 
-	/**
-	 * @covers ::roots
-	 */
-	public function testRoots()
+	public function testRoots(): void
 	{
 		$roots = $this->core->roots();
 
@@ -314,10 +269,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('roles', $roots);
 	}
 
-	/**
-	 * @covers ::routes
-	 */
-	public function testRoutes()
+	public function testRoutes(): void
 	{
 		$routes = $this->core->routes();
 
@@ -325,10 +277,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('after', $routes);
 	}
 
-	/**
-	 * @covers ::snippets
-	 */
-	public function testSnippets()
+	public function testSnippets(): void
 	{
 		$snippets = $this->core->snippets();
 
@@ -345,10 +294,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('blocks/video', $snippets);
 	}
 
-	/**
-	 * @covers ::kirbyTagAliases
-	 */
-	public function testKirbyTagAliases()
+	public function testKirbyTagAliases(): void
 	{
 		$aliases = $this->core->kirbyTagAliases();
 
@@ -356,10 +302,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('vimeo', $aliases);
 	}
 
-	/**
-	 * @covers ::kirbyTags
-	 */
-	public function testKirbyTags()
+	public function testKirbyTags(): void
 	{
 		$tags = $this->core->kirbyTags();
 
@@ -373,10 +316,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('video', $tags);
 	}
 
-	/**
-	 * @covers ::sectionMixins
-	 */
-	public function testSectionMixins()
+	public function testSectionMixins(): void
 	{
 		$mixins = $this->core->sectionMixins();
 
@@ -390,10 +330,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('parent', $mixins);
 	}
 
-	/**
-	 * @covers ::sections
-	 */
-	public function testSections()
+	public function testSections(): void
 	{
 		$sections = $this->core->sections();
 
@@ -403,10 +340,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('pages', $sections);
 	}
 
-	/**
-	 * @covers ::templates
-	 */
-	public function testTemplates()
+	public function testTemplates(): void
 	{
 		$templates = $this->core->templates();
 
@@ -414,10 +348,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('emails/auth/password-reset', $templates);
 	}
 
-	/**
-	 * @covers ::urls
-	 */
-	public function testUrls()
+	public function testUrls(): void
 	{
 		$urls = $this->core->urls();
 

--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -9,7 +9,7 @@ class EmailTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/emails';
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$props = [
 			'one' => 'eins',
@@ -35,7 +35,7 @@ class EmailTest extends TestCase
 		$this->assertSame($expected, $email->toArray());
 	}
 
-	public function testPresets()
+	public function testPresets(): void
 	{
 		$app = new App([
 			'options' => [
@@ -57,7 +57,7 @@ class EmailTest extends TestCase
 		$this->assertSame([$cc], $email->toArray()['cc']);
 	}
 
-	public function testInvalidPreset()
+	public function testInvalidPreset(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionCode('error.email.preset.notFound');
@@ -65,7 +65,7 @@ class EmailTest extends TestCase
 		$email = new Email('not-a-preset', []);
 	}
 
-	public function testTemplate()
+	public function testTemplate(): void
 	{
 		$app = new App([
 			'templates' => [
@@ -81,7 +81,7 @@ class EmailTest extends TestCase
 		$this->assertSame('Cheers, Alex!', $email->toArray()['body']);
 	}
 
-	public function testTemplateHtml()
+	public function testTemplateHtml(): void
 	{
 		$app = new App([
 			'templates' => [
@@ -94,7 +94,7 @@ class EmailTest extends TestCase
 		], $email->toArray()['body']);
 	}
 
-	public function testTemplateHtmlText()
+	public function testTemplateHtmlText(): void
 	{
 		$app = new App([
 			'templates' => [
@@ -109,7 +109,7 @@ class EmailTest extends TestCase
 		], $email->toArray()['body']);
 	}
 
-	public function testInvalidTemplate()
+	public function testInvalidTemplate(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('The email template "subscription" cannot be found');
@@ -119,7 +119,7 @@ class EmailTest extends TestCase
 		]);
 	}
 
-	public function testTransformSimple()
+	public function testTransformSimple(): void
 	{
 		$email = new Email([
 			'from'     => 'sales@company.com',
@@ -146,7 +146,7 @@ class EmailTest extends TestCase
 		], $email->toArray()['attachments']);
 	}
 
-	public function testTransformComplex()
+	public function testTransformComplex(): void
 	{
 		$app = new App([
 			'site' => new Site(),
@@ -199,7 +199,7 @@ class EmailTest extends TestCase
 		], $email->toArray()['attachments']);
 	}
 
-	public function testTransformCollection()
+	public function testTransformCollection(): void
 	{
 		$to = new Users([
 			new User(['email' => 'ceo@company.com', 'name' => 'Company CEO']),
@@ -218,7 +218,7 @@ class EmailTest extends TestCase
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function testUserData()
+	public function testUserData(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -246,7 +246,7 @@ class EmailTest extends TestCase
 		$this->assertSame('Welcome, Mario!', trim($email->toArray()['body']));
 	}
 
-	public function testBeforeSend()
+	public function testBeforeSend(): void
 	{
 		new App([
 			'options' => [

--- a/tests/Cms/Events/EventTest.php
+++ b/tests/Cms/Events/EventTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(Event::class)]
 class EventTest extends TestCase
 {
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$args = ['arg1' => 'Arg1', 'arg2' => 123];
 
@@ -62,7 +62,7 @@ class EventTest extends TestCase
 		$this->assertSame($args, $event->arguments());
 	}
 
-	public function testArgument()
+	public function testArgument(): void
 	{
 		$event = new Event('page.create:after', ['arg1' => 'Arg1', 'arg2' => 123]);
 
@@ -75,7 +75,7 @@ class EventTest extends TestCase
 		$this->assertNull($event->arg3());
 	}
 
-	public function testCall()
+	public function testCall(): void
 	{
 		$self     = $this;
 		$eventObj = new Event('page.create:after', ['arg1' => 'Arg1', 'arg2' => 123]);
@@ -105,7 +105,7 @@ class EventTest extends TestCase
 		$this->assertSame('another value', $result);
 	}
 
-	public function testNameWildcards()
+	public function testNameWildcards(): void
 	{
 		// event with full name
 		$event = new Event('page.create:after', []);
@@ -174,7 +174,7 @@ class EventTest extends TestCase
 		$this->assertSame([], $event->nameWildcards());
 	}
 
-	public function testExport()
+	public function testExport(): void
 	{
 		$name       = 'page.create:after';
 		$arguments  = ['arg1' => 'Arg1', 'arg2' => 123];
@@ -187,7 +187,7 @@ class EventTest extends TestCase
 		$this->assertSame(compact('name', 'arguments'), $event->__debugInfo());
 	}
 
-	public function testUpdateArgument()
+	public function testUpdateArgument(): void
 	{
 		$event = new Event('page.create:after', ['arg1' => 'Arg1', 'arg2' => 123]);
 
@@ -200,7 +200,7 @@ class EventTest extends TestCase
 		$this->assertSame(456, $event->arg2());
 	}
 
-	public function testUpdateArgumentDoesNotExist()
+	public function testUpdateArgumentDoesNotExist(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The argument arg3 does not exist');
@@ -210,7 +210,7 @@ class EventTest extends TestCase
 		$event->updateArgument('arg3', 'New Arg3');
 	}
 
-	public function testUpdateArgumentWithNullValue()
+	public function testUpdateArgumentWithNullValue(): void
 	{
 		$event = new Event('page.create:after', ['arg1' => 'Arg1', 'arg2' => 123]);
 
@@ -219,7 +219,7 @@ class EventTest extends TestCase
 		$this->assertSame('Arg1', $event->argument('arg1'));
 	}
 
-	public function testUpdateArgumentWithNextModel()
+	public function testUpdateArgumentWithNextModel(): void
 	{
 		$mutablePage = new Page(['slug' => 'test']);
 

--- a/tests/Cms/Facades/RTest.php
+++ b/tests/Cms/Facades/RTest.php
@@ -13,7 +13,7 @@ class RTest extends TestCase
 		]);
 	}
 
-	public function testInstance()
+	public function testInstance(): void
 	{
 		$this->assertSame($this->app->request(), R::instance());
 	}

--- a/tests/Cms/Facades/STest.php
+++ b/tests/Cms/Facades/STest.php
@@ -24,7 +24,7 @@ class STest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testInstance()
+	public function testInstance(): void
 	{
 		$this->assertSame($this->app->session(), S::instance());
 	}

--- a/tests/Cms/Facades/UrlTest.php
+++ b/tests/Cms/Facades/UrlTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Cms;
 
 use Kirby\Filesystem\F;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Url
- */
+#[CoversClass(Url::class)]
 class UrlTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Url';
@@ -23,15 +22,12 @@ class UrlTest extends TestCase
 		]);
 	}
 
-	public function testHome()
+	public function testHome(): void
 	{
 		$this->assertSame('https://getkirby.com', Url::home());
 	}
 
-	/**
-	 * @covers ::slug
-	 */
-	public function testSlug()
+	public function testSlug(): void
 	{
 		// default length
 		$this->assertSame(
@@ -64,7 +60,7 @@ class UrlTest extends TestCase
 		);
 	}
 
-	public function testTo()
+	public function testTo(): void
 	{
 		$this->assertSame('https://getkirby.com', Url::to());
 		$this->assertSame('https://getkirby.com', Url::to(''));
@@ -72,7 +68,7 @@ class UrlTest extends TestCase
 		$this->assertSame('https://getkirby.com/projects', Url::to('projects'));
 	}
 
-	public function testToWithLanguage()
+	public function testToWithLanguage(): void
 	{
 		$this->app->clone([
 			'languages' => [
@@ -113,7 +109,7 @@ class UrlTest extends TestCase
 		$this->assertSame('https://getkirby.com/de/custom', Url::to('c', 'de'));
 	}
 
-	public function testToTemplateAsset()
+	public function testToTemplateAsset(): void
 	{
 		$app = new App([
 			'roots' => [

--- a/tests/Cms/Facades/VTest.php
+++ b/tests/Cms/Facades/VTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Toolkit\V;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class VTest extends TestCase
 {
@@ -53,15 +54,13 @@ class VTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider messageInput
-	 */
-	public function testMessage($validator, $args, $expected)
+	#[DataProvider('messageInput')]
+	public function testMessage($validator, $args, $expected): void
 	{
 		$this->assertSame($expected, V::message($validator, ...$args));
 	}
 
-	public function testMessageInvalidValidator()
+	public function testMessageInvalidValidator(): void
 	{
 		$this->assertNull(V::message('foo'));
 	}

--- a/tests/Cms/Facades/VisitorTest.php
+++ b/tests/Cms/Facades/VisitorTest.php
@@ -13,7 +13,7 @@ class VisitorTest extends TestCase
 		]);
 	}
 
-	public function testInstance()
+	public function testInstance(): void
 	{
 		$this->assertSame($this->app->visitor(), Visitor::instance());
 	}

--- a/tests/Cms/Fieldsets/FieldsetTest.php
+++ b/tests/Cms/Fieldsets/FieldsetTest.php
@@ -5,13 +5,12 @@ namespace Kirby\Cms;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Form\Form;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Fieldset
- */
+#[CoversClass(Fieldset::class)]
 class FieldsetTest extends TestCase
 {
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$fieldset = new Fieldset([
 			'type' => 'test'
@@ -25,17 +24,14 @@ class FieldsetTest extends TestCase
 		$this->assertTrue($fieldset->translate());
 	}
 
-	public function testConstructWithMissingType()
+	public function testConstructWithMissingType(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The fieldset type is missing');
 		$fieldset = new Fieldset();
 	}
 
-	/**
-	 * @covers ::disabled
-	 */
-	public function testDisabled()
+	public function testDisabled(): void
 	{
 		$fieldset = new Fieldset([
 			'type'     => 'test',
@@ -45,10 +41,7 @@ class FieldsetTest extends TestCase
 		$this->assertTrue($fieldset->disabled());
 	}
 
-	/**
-	 * @covers ::editable
-	 */
-	public function testEditable()
+	public function testEditable(): void
 	{
 		$fieldset = new Fieldset([
 			'type'   => 'test',
@@ -62,10 +55,7 @@ class FieldsetTest extends TestCase
 		$this->assertTrue($fieldset->editable());
 	}
 
-	/**
-	 * @covers ::editable
-	 */
-	public function testEditableWhenDisabled()
+	public function testEditableWhenDisabled(): void
 	{
 		$fieldset = new Fieldset([
 			'type'     => 'test',
@@ -80,10 +70,7 @@ class FieldsetTest extends TestCase
 		$this->assertFalse($fieldset->editable());
 	}
 
-	/**
-	 * @covers ::fields
-	 */
-	public function testFields()
+	public function testFields(): void
 	{
 		$fieldset = new Fieldset([
 			'type'   => 'test',
@@ -97,10 +84,7 @@ class FieldsetTest extends TestCase
 		$this->assertSame('text', $fieldset->fields()['text']['type']);
 	}
 
-	/**
-	 * @covers ::fields
-	 */
-	public function testFieldsInTabs()
+	public function testFieldsInTabs(): void
 	{
 		$fieldset = new Fieldset([
 			'type'   => 'test',
@@ -118,10 +102,7 @@ class FieldsetTest extends TestCase
 		$this->assertSame('text', $fieldset->fields()['text']['type']);
 	}
 
-	/**
-	 * @covers ::form
-	 */
-	public function testForm()
+	public function testForm(): void
 	{
 		$fieldset = new Fieldset([
 			'type' => 'test',
@@ -136,10 +117,7 @@ class FieldsetTest extends TestCase
 		$this->assertInstanceOf(Form::class, $form);
 	}
 
-	/**
-	 * @covers ::icon
-	 */
-	public function testIcon()
+	public function testIcon(): void
 	{
 		$fieldset = new Fieldset([
 			'type' => 'test',
@@ -149,10 +127,7 @@ class FieldsetTest extends TestCase
 		$this->assertSame('test', $fieldset->icon());
 	}
 
-	/**
-	 * @covers ::label
-	 */
-	public function testLabel()
+	public function testLabel(): void
 	{
 		$fieldset = new Fieldset([
 			'type'  => 'test',
@@ -162,10 +137,7 @@ class FieldsetTest extends TestCase
 		$this->assertSame('Test', $fieldset->label());
 	}
 
-	/**
-	 * @covers ::label
-	 */
-	public function testLabelWithTranslation()
+	public function testLabelWithTranslation(): void
 	{
 		$fieldset = new Fieldset([
 			'type'  => 'test',
@@ -178,10 +150,7 @@ class FieldsetTest extends TestCase
 		$this->assertSame('English', $fieldset->label());
 	}
 
-	/**
-	 * @covers ::model
-	 */
-	public function testModel()
+	public function testModel(): void
 	{
 		$fieldset = new Fieldset([
 			'type'   => 'test',
@@ -191,10 +160,7 @@ class FieldsetTest extends TestCase
 		$this->assertSame($model, $fieldset->model());
 	}
 
-	/**
-	 * @covers ::name
-	 */
-	public function testName()
+	public function testName(): void
 	{
 		$fieldset = new Fieldset([
 			'type'  => 'test',
@@ -204,10 +170,7 @@ class FieldsetTest extends TestCase
 		$this->assertSame('test', $fieldset->name());
 	}
 
-	/**
-	 * @covers ::name
-	 */
-	public function testNameTranslated()
+	public function testNameTranslated(): void
 	{
 		$fieldset = new Fieldset([
 			'type'  => 'test',
@@ -220,10 +183,7 @@ class FieldsetTest extends TestCase
 		$this->assertSame('English name', $fieldset->name());
 	}
 
-	/**
-	 * @covers ::name
-	 */
-	public function testNameFromTitle()
+	public function testNameFromTitle(): void
 	{
 		$fieldset = new Fieldset([
 			'type'  => 'test',
@@ -233,10 +193,7 @@ class FieldsetTest extends TestCase
 		$this->assertSame('Test Title', $fieldset->name());
 	}
 
-	/**
-	 * @covers ::name
-	 */
-	public function testNameFromTitleTranslated()
+	public function testNameFromTitleTranslated(): void
 	{
 		$fieldset = new Fieldset([
 			'type'  => 'test',
@@ -249,10 +206,7 @@ class FieldsetTest extends TestCase
 		$this->assertSame('English name', $fieldset->name());
 	}
 
-	/**
-	 * @covers ::preview
-	 */
-	public function testPreview()
+	public function testPreview(): void
 	{
 		$fieldset = new Fieldset([
 			'type'    => 'test',
@@ -262,10 +216,7 @@ class FieldsetTest extends TestCase
 		$this->assertSame('test', $fieldset->preview());
 	}
 
-	/**
-	 * @covers ::tabs
-	 */
-	public function testTabs()
+	public function testTabs(): void
 	{
 		$fieldset = new Fieldset([
 			'type' => 'test',
@@ -282,10 +233,7 @@ class FieldsetTest extends TestCase
 		$this->assertCount(2, $fieldset->tabs()['content']['fields']);
 	}
 
-	/**
-	 * @covers ::translate
-	 */
-	public function testTranslate()
+	public function testTranslate(): void
 	{
 		$fieldset = new Fieldset([
 			'type'      => 'test',
@@ -295,10 +243,7 @@ class FieldsetTest extends TestCase
 		$this->assertFalse($fieldset->translate());
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testType()
+	public function testType(): void
 	{
 		$fieldset = new Fieldset([
 			'type' => 'test',
@@ -307,10 +252,7 @@ class FieldsetTest extends TestCase
 		$this->assertSame('test', $fieldset->type());
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$fieldset = new Fieldset([
 			'type' => 'test',
@@ -337,10 +279,7 @@ class FieldsetTest extends TestCase
 		$this->assertSame($expected, $fieldset->toArray());
 	}
 
-	/**
-	 * @covers ::unset
-	 */
-	public function testUnset()
+	public function testUnset(): void
 	{
 		$fieldset = new Fieldset([
 			'type'  => 'test',
@@ -350,10 +289,7 @@ class FieldsetTest extends TestCase
 		$this->assertTrue($fieldset->unset());
 	}
 
-	/**
-	 * @covers ::wysiwyg
-	 */
-	public function testWysiwyg()
+	public function testWysiwyg(): void
 	{
 		$fieldset = new Fieldset([
 			'type'    => 'test',

--- a/tests/Cms/Fieldsets/FieldsetsTest.php
+++ b/tests/Cms/Fieldsets/FieldsetsTest.php
@@ -6,7 +6,7 @@ use Kirby\TestCase;
 
 class FieldsetsTest extends TestCase
 {
-	public function testExtendGroups()
+	public function testExtendGroups(): void
 	{
 		new App([
 			'roots' => [
@@ -38,7 +38,7 @@ class FieldsetsTest extends TestCase
 		$this->assertSame(['heading', 'text'], $fieldsets->groups()['test']['sets']);
 	}
 
-	public function testExtendsTabsOverwrite()
+	public function testExtendsTabsOverwrite(): void
 	{
 		new App([
 			'roots' => [

--- a/tests/Cms/File/FileChangeNameTest.php
+++ b/tests/Cms/File/FileChangeNameTest.php
@@ -85,7 +85,7 @@ class FileChangeNameTest extends ModelTestCase
 		$this->assertFileExists($result->version('latest')->contentFile('de'));
 	}
 
-	public function testChangeNameHooks()
+	public function testChangeNameHooks(): void
 	{
 		$calls = 0;
 		$phpunit = $this;

--- a/tests/Cms/File/FileChangeTemplateTest.php
+++ b/tests/Cms/File/FileChangeTemplateTest.php
@@ -312,7 +312,7 @@ class FileChangeTemplateTest extends ModelTestCase
 		$this->assertNull($modified->content()->get('template')->value());
 	}
 
-	public function testChangeTemplateInvalidAccept()
+	public function testChangeTemplateInvalidAccept(): void
 	{
 		$this->app = $this->app->clone([
 			'blueprints' => [
@@ -364,7 +364,7 @@ class FileChangeTemplateTest extends ModelTestCase
 		$file->changeTemplate('for-default-b');
 	}
 
-	public function testChangeTemplateManipulate()
+	public function testChangeTemplateManipulate(): void
 	{
 		$testImage = static::FIXTURES . '/test.jpg';
 
@@ -423,7 +423,7 @@ class FileChangeTemplateTest extends ModelTestCase
 		$this->assertSame(100, $file->height());
 	}
 
-	public function testChangeTemplateManipulateNonImage()
+	public function testChangeTemplateManipulateNonImage(): void
 	{
 		$this->app = $this->app->clone([
 			'blueprints' => [

--- a/tests/Cms/File/FileCopyTest.php
+++ b/tests/Cms/File/FileCopyTest.php
@@ -10,7 +10,7 @@ class FileCopyTest extends ModelTestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.FileCopy';
 
-	public function testCopyRenewUuid()
+	public function testCopyRenewUuid(): void
 	{
 		// create dumy file
 		F::write($source = static::TMP . '/original.md', '# Foo');

--- a/tests/Cms/File/FileModificationsTest.php
+++ b/tests/Cms/File/FileModificationsTest.php
@@ -6,6 +6,7 @@ use Kirby\Content\Field;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Asset;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(FileModifications::class)]
 class FileModificationsTest extends ModelTestCase
@@ -272,9 +273,7 @@ class FileModificationsTest extends ModelTestCase
 		];
 	}
 
-	/**
-	 * @dataProvider cropOptionsProvider
-	 */
+	#[DataProvider('cropOptionsProvider')]
 	public function testCrop($args, $expected): void
 	{
 		$app = $this->app->clone([

--- a/tests/Cms/File/FilePreviewUrlTest.php
+++ b/tests/Cms/File/FilePreviewUrlTest.php
@@ -9,7 +9,7 @@ class FilePreviewUrlTest extends ModelTestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.FilePreviewUrl';
 
-	public function testPreviewUrlRedirects()
+	public function testPreviewUrlRedirects(): void
 	{
 		$app = $this->app->clone([
 			'users' => [

--- a/tests/Cms/File/FileTest.php
+++ b/tests/Cms/File/FileTest.php
@@ -70,7 +70,7 @@ class FileTest extends ModelTestCase
 		);
 	}
 
-	public function testConstructWithoutFilename()
+	public function testConstructWithoutFilename(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The filename and parent are required');
@@ -78,7 +78,7 @@ class FileTest extends ModelTestCase
 		new File([]);
 	}
 
-	public function testConstructWithoutParent()
+	public function testConstructWithoutParent(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The filename and parent are required');

--- a/tests/Cms/Files/FilesMethodsTest.php
+++ b/tests/Cms/Files/FilesMethodsTest.php
@@ -9,7 +9,7 @@ class FilesMethodsTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.FilesMethodsTest';
 
-	public function testFilesMethod()
+	public function testFilesMethod(): void
 	{
 		$this->app = $this->app->clone([
 			'filesMethods' => [

--- a/tests/Cms/Files/FilesTest.php
+++ b/tests/Cms/Files/FilesTest.php
@@ -6,15 +6,14 @@ use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\F;
 use Kirby\Uuid\Uuids;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Files
- */
+#[CoversClass(Files::class)]
 class FilesTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Files';
 
-	public function testAddFile()
+	public function testAddFile(): void
 	{
 		$parent = new Page(['slug' => 'test']);
 
@@ -34,7 +33,7 @@ class FilesTest extends TestCase
 		$this->assertSame('b.jpg', $result->nth(1)->filename());
 	}
 
-	public function testAddCollection()
+	public function testAddCollection(): void
 	{
 		$parent = new Page(['slug' => 'test']);
 
@@ -55,7 +54,7 @@ class FilesTest extends TestCase
 		$this->assertSame('c.jpg', $c->nth(2)->filename());
 	}
 
-	public function testAddById()
+	public function testAddById(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -88,7 +87,7 @@ class FilesTest extends TestCase
 		$this->assertSame('b/a.jpg', $files->nth(2)->id());
 	}
 
-	public function testAddNull()
+	public function testAddNull(): void
 	{
 		$files = new Files();
 		$this->assertCount(0, $files);
@@ -98,7 +97,7 @@ class FilesTest extends TestCase
 		$this->assertCount(0, $files);
 	}
 
-	public function testAddFalse()
+	public function testAddFalse(): void
 	{
 		$files = new Files();
 		$this->assertCount(0, $files);
@@ -108,7 +107,7 @@ class FilesTest extends TestCase
 		$this->assertCount(0, $files);
 	}
 
-	public function testAddInvalidObject()
+	public function testAddInvalidObject(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('You must pass a Files or File object or an ID of an existing file to the Files collection');
@@ -118,10 +117,7 @@ class FilesTest extends TestCase
 		$files->add($site);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
-	public function testDelete()
+	public function testDelete(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -162,10 +158,7 @@ class FilesTest extends TestCase
 		$this->assertFileDoesNotExist($b);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
-	public function testDeleteWithInvalidIds()
+	public function testDeleteWithInvalidIds(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -211,11 +204,7 @@ class FilesTest extends TestCase
 		$this->assertFileExists($b);
 	}
 
-	/**
-	 * @covers ::findByKey
-	 * @covers ::findByUuid
-	 */
-	public function testFindByUuid()
+	public function testFindByUuid(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -242,11 +231,7 @@ class FilesTest extends TestCase
 		Uuids::cache()->flush();
 	}
 
-	/**
-	 * @covers ::niceSize
-	 * @covers ::size
-	 */
-	public function testSize()
+	public function testSize(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -272,10 +257,7 @@ class FilesTest extends TestCase
 		$this->assertSame('6 B', $files->niceSize());
 	}
 
-	/**
-	 * @covers ::sorted
-	 */
-	public function testSortedByFilename()
+	public function testSortedByFilename(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -295,10 +277,7 @@ class FilesTest extends TestCase
 		$this->assertSame('b.jpg', $files->last()->filename());
 	}
 
-	/**
-	 * @covers ::sorted
-	 */
-	public function testSortedBySort()
+	public function testSortedBySort(): void
 	{
 		$app = new App([
 			'roots' => [

--- a/tests/Cms/FindTest.php
+++ b/tests/Cms/FindTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Cms;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Find
- */
+#[CoversClass(Find::class)]
 class FindTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Find';
@@ -24,9 +23,6 @@ class FindTest extends TestCase
 		Dir::make(static::TMP);
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFileForPage(): void
 	{
 		$app = $this->app->clone([
@@ -55,9 +51,6 @@ class FindTest extends TestCase
 		$this->assertSame('aa.jpg', Find::file('pages/a+aa', 'aa.jpg')->filename());
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFileForSite(): void
 	{
 		$app = $this->app->clone([
@@ -72,9 +65,6 @@ class FindTest extends TestCase
 		$this->assertSame('test.jpg', Find::file('site', 'test.jpg')->filename());
 	}
 
-	/**
-	 * @covers ::file
-	 */
 	public function testFileForUser(): void
 	{
 		$app = $this->app->clone([
@@ -92,10 +82,7 @@ class FindTest extends TestCase
 		$this->assertSame('test.jpg', Find::file('users/test@getkirby.com', 'test.jpg')->filename());
 	}
 
-	/**
-	 * @covers ::file
-	 */
-	public function testFileNotFound()
+	public function testFileNotFound(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('The file "nope.jpg" cannot be found');
@@ -103,10 +90,7 @@ class FindTest extends TestCase
 		Find::file('site', 'nope.jpg');
 	}
 
-	/**
-	 * @covers ::file
-	 */
-	public function testFileNotReadable()
+	public function testFileNotReadable(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -125,10 +109,7 @@ class FindTest extends TestCase
 		Find::file('site', 'protected.jpg');
 	}
 
-	/**
-	 * @covers ::language
-	 */
-	public function testLanguage()
+	public function testLanguage(): void
 	{
 		$app = $this->app->clone([
 			'languages' => [
@@ -150,10 +131,7 @@ class FindTest extends TestCase
 		$this->assertSame('de', Find::language('de')->code());
 	}
 
-	/**
-	 * @covers ::language
-	 */
-	public function testLanguageNotFound()
+	public function testLanguageNotFound(): void
 	{
 		$this->app->impersonate('kirby');
 
@@ -163,10 +141,7 @@ class FindTest extends TestCase
 		Find::language('en');
 	}
 
-	/**
-	 * @covers ::page
-	 */
-	public function testPage()
+	public function testPage(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -199,10 +174,7 @@ class FindTest extends TestCase
 		$this->assertSame($b, Find::page('page://my-uuid'));
 	}
 
-	/**
-	 * @covers ::page
-	 */
-	public function testPageNotReadable()
+	public function testPageNotReadable(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [
@@ -228,10 +200,7 @@ class FindTest extends TestCase
 		Find::page('a');
 	}
 
-	/**
-	 * @covers ::page
-	 */
-	public function testPageNotFound()
+	public function testPageNotFound(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('The page "does-not-exist" cannot be found');
@@ -239,10 +208,7 @@ class FindTest extends TestCase
 		Find::page('does-not-exist');
 	}
 
-	/**
-	 * @covers ::parent
-	 */
-	public function testParent()
+	public function testParent(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -302,40 +268,28 @@ class FindTest extends TestCase
 		$this->assertIsFile(Find::parent('users/test@getkirby.com/files/userfile.jpg'));
 	}
 
-	/**
-	 * @covers ::parent
-	 */
-	public function testParentWithInvalidModelType()
+	public function testParentWithInvalidModelType(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid model type: something');
 		$this->assertNull(Find::parent('something/something'));
 	}
 
-	/**
-	 * @covers ::parent
-	 */
-	public function testParentNotFound()
+	public function testParentNotFound(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('The page "does-not-exist" cannot be found');
 		$this->assertNull(Find::parent('pages/does-not-exist'));
 	}
 
-	/**
-	 * @covers ::parent
-	 */
-	public function testParentUndefined()
+	public function testParentUndefined(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('The user cannot be found');
 		$this->assertNull(Find::parent('users/does-not-exist'));
 	}
 
-	/**
-	 * @covers ::user
-	 */
-	public function testUser()
+	public function testUser(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -350,10 +304,7 @@ class FindTest extends TestCase
 		$this->assertSame('test@getkirby.com', Find::user('test@getkirby.com')->email());
 	}
 
-	/**
-	 * @covers ::user
-	 */
-	public function testUserWithAuthentication()
+	public function testUserWithAuthentication(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -372,10 +323,7 @@ class FindTest extends TestCase
 		$this->assertSame('test@getkirby.com', Find::user()->email());
 	}
 
-	/**
-	 * @covers ::user
-	 */
-	public function testUserWithoutAllowedImpersonation()
+	public function testUserWithoutAllowedImpersonation(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -393,10 +341,7 @@ class FindTest extends TestCase
 		Find::user()->email();
 	}
 
-	/**
-	 * @covers ::user
-	 */
-	public function testUserForAccountArea()
+	public function testUserForAccountArea(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -416,10 +361,7 @@ class FindTest extends TestCase
 		$this->assertSame('test@getkirby.com', Find::user('account')->email());
 	}
 
-	/**
-	 * @covers ::user
-	 */
-	public function testUserNotFound()
+	public function testUserNotFound(): void
 	{
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('The user "nope@getkirby.com" cannot be found');

--- a/tests/Cms/Helpers/HelperFunctionsTest.php
+++ b/tests/Cms/Helpers/HelperFunctionsTest.php
@@ -36,31 +36,31 @@ class HelperFunctionsTest extends HelpersTestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testAttrWithBeforeValue()
+	public function testAttrWithBeforeValue(): void
 	{
 		$attr = attr(['test' => 'test'], ' ');
 		$this->assertSame(' test="test"', $attr);
 	}
 
-	public function testAttrWithAfterValue()
+	public function testAttrWithAfterValue(): void
 	{
 		$attr = attr(['test' => 'test'], null, ' ');
 		$this->assertSame('test="test" ', $attr);
 	}
 
-	public function testAttrWithoutValues()
+	public function testAttrWithoutValues(): void
 	{
 		$attr = attr([]);
 		$this->assertNull($attr);
 	}
 
-	public function testAsset()
+	public function testAsset(): void
 	{
 		$asset = asset('something.jpg');
 		$this->assertInstanceOf(Asset::class, $asset);
 	}
 
-	public function testCollection()
+	public function testCollection(): void
 	{
 		$this->app->clone([
 			'site' => [
@@ -82,7 +82,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame(8, $collection);
 	}
 
-	public function testCsrf()
+	public function testCsrf(): void
 	{
 		$session = $this->app->session();
 
@@ -123,7 +123,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$session->destroy();
 	}
 
-	public function testCss()
+	public function testCss(): void
 	{
 		$result   = css('assets/css/index.css');
 		$expected = '<link href="https://getkirby.com/assets/css/index.css" rel="stylesheet">';
@@ -131,7 +131,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $result);
 	}
 
-	public function testCssWithMediaOption()
+	public function testCssWithMediaOption(): void
 	{
 		$result   = css('assets/css/index.css', 'print');
 		$expected = '<link href="https://getkirby.com/assets/css/index.css" media="print" rel="stylesheet">';
@@ -139,7 +139,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $result);
 	}
 
-	public function testCssWithAttrs()
+	public function testCssWithAttrs(): void
 	{
 		$result   = css('assets/css/index.css', ['integrity' => 'nope']);
 		$expected = '<link href="https://getkirby.com/assets/css/index.css" integrity="nope" rel="stylesheet">';
@@ -147,7 +147,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $result);
 	}
 
-	public function testCssWithValidRelAttr()
+	public function testCssWithValidRelAttr(): void
 	{
 		$result   = css('assets/css/index.css', ['rel' => 'alternate stylesheet', 'title' => 'High contrast']);
 		$expected = '<link href="https://getkirby.com/assets/css/index.css" rel="alternate stylesheet" title="High contrast">';
@@ -155,7 +155,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $result);
 	}
 
-	public function testCssWithInvalidRelAttr()
+	public function testCssWithInvalidRelAttr(): void
 	{
 		$result   = css('assets/css/index.css', ['rel' => 'alternate', 'title' => 'High contrast']);
 		$expected = '<link href="https://getkirby.com/assets/css/index.css" rel="stylesheet" title="High contrast">';
@@ -163,7 +163,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $result);
 	}
 
-	public function testCssWithRelAttrButNoTitle()
+	public function testCssWithRelAttrButNoTitle(): void
 	{
 		$result   = css('assets/css/index.css', ['rel' => 'alternate stylesheet']);
 		$expected = '<link href="https://getkirby.com/assets/css/index.css" rel="stylesheet">';
@@ -171,7 +171,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $result);
 	}
 
-	public function testCssWithArray()
+	public function testCssWithArray(): void
 	{
 		$result = css([
 			'assets/css/a.css',
@@ -184,7 +184,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $result);
 	}
 
-	public function testDeprecated()
+	public function testDeprecated(): void
 	{
 		$this->assertError(
 			E_USER_DEPRECATED,
@@ -193,7 +193,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		);
 	}
 
-	public function testDumpOnCli()
+	public function testDumpOnCli(): void
 	{
 		if (KIRBY_DUMP_OVERRIDDEN === true) {
 			$this->markTestSkipped('The dump() helper was externally overridden.');
@@ -206,7 +206,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		dump('test2', true);
 	}
 
-	public function testDumpOnServer()
+	public function testDumpOnServer(): void
 	{
 		if (KIRBY_DUMP_OVERRIDDEN === true) {
 			$this->markTestSkipped('The dump() helper was externally overridden.');
@@ -223,7 +223,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		dump('test2', true);
 	}
 
-	public function testE()
+	public function testE(): void
 	{
 		$this->expectOutputString('ad');
 
@@ -232,13 +232,13 @@ class HelperFunctionsTest extends HelpersTestCase
 		e(1 === 2, 'e');
 	}
 
-	public function testEscWithInvalidContext()
+	public function testEscWithInvalidContext(): void
 	{
 		$escaped = esc('test', 'does-not-exist');
 		$this->assertSame('test', $escaped);
 	}
 
-	public function testGist()
+	public function testGist(): void
 	{
 		$gist     = gist('https://gist.github.com/bastianallgeier/d61ab782cd5c2cc02b6f6fec54fd1985', 'static.php');
 		$expected = '<script src="https://gist.github.com/bastianallgeier/d61ab782cd5c2cc02b6f6fec54fd1985.js?file=static.php"></script>';
@@ -246,19 +246,19 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($gist, $expected);
 	}
 
-	public function testH()
+	public function testH(): void
 	{
 		$html = h('Guns & Roses');
 		$this->assertSame('Guns &amp; Roses', $html);
 	}
 
-	public function testHtml()
+	public function testHtml(): void
 	{
 		$html = html('Guns & Roses');
 		$this->assertSame('Guns &amp; Roses', $html);
 	}
 
-	public function testImage()
+	public function testImage(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -294,7 +294,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertNull($image);
 	}
 
-	public function testInvalid()
+	public function testInvalid(): void
 	{
 		$data = [
 			'username' => 123,
@@ -334,7 +334,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame([], $result);
 	}
 
-	public function testInvalidSimple()
+	public function testInvalidSimple(): void
 	{
 		$data   = ['homer', null];
 		$rules  = [['alpha'], ['required']];
@@ -342,7 +342,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame(1, $result[1]);
 	}
 
-	public function testInvalidRequired()
+	public function testInvalidRequired(): void
 	{
 		$rules    = ['email' => ['required']];
 		$messages = ['email' => ''];
@@ -372,7 +372,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame([], $result);
 	}
 
-	public function testInvalidOptions()
+	public function testInvalidOptions(): void
 	{
 		$rules = [
 			'username' => ['min' => 6]
@@ -402,7 +402,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame([], $result);
 	}
 
-	public function testInvalidWithMultipleMessages()
+	public function testInvalidWithMultipleMessages(): void
 	{
 		$data     = ['username' => ''];
 		$rules    = ['username' => ['required', 'alpha', 'min' => 4]];
@@ -441,7 +441,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame([], $result);
 	}
 
-	public function testJs()
+	public function testJs(): void
 	{
 		$result   = js('assets/js/index.js');
 		$expected = '<script src="https://getkirby.com/assets/js/index.js"></script>';
@@ -449,7 +449,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $result);
 	}
 
-	public function testJsWithAsyncOption()
+	public function testJsWithAsyncOption(): void
 	{
 		$result   = js('assets/js/index.js', true);
 		$expected = '<script async src="https://getkirby.com/assets/js/index.js"></script>';
@@ -457,7 +457,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $result);
 	}
 
-	public function testJsWithAttrs()
+	public function testJsWithAttrs(): void
 	{
 		$result   = js('assets/js/index.js', ['integrity' => 'nope']);
 		$expected = '<script integrity="nope" src="https://getkirby.com/assets/js/index.js"></script>';
@@ -465,7 +465,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $result);
 	}
 
-	public function testJsWithArray()
+	public function testJsWithArray(): void
 	{
 		$result = js([
 			'assets/js/a.js',
@@ -478,12 +478,12 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $result);
 	}
 
-	public function testKirby()
+	public function testKirby(): void
 	{
 		$this->assertSame($this->app, kirby());
 	}
 
-	public function testKirbyTag()
+	public function testKirbyTag(): void
 	{
 		$tag = kirbytag('link', 'https://getkirby.com', ['text' => 'Kirby']);
 		$expected = '<a href="https://getkirby.com">Kirby</a>';
@@ -491,7 +491,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $tag);
 	}
 
-	public function testKirbyTags()
+	public function testKirbyTags(): void
 	{
 		$tag = kirbytags('(link: https://getkirby.com text: Kirby)');
 		$expected = '<a href="https://getkirby.com">Kirby</a>';
@@ -499,7 +499,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $tag);
 	}
 
-	public function testKirbyText()
+	public function testKirbyText(): void
 	{
 		$text     = 'This is **just** a text.';
 		$expected = '<p>This is <strong>just</strong> a text.</p>';
@@ -508,7 +508,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, kt($text));
 	}
 
-	public function testKirbyTextWithSafeMode()
+	public function testKirbyTextWithSafeMode(): void
 	{
 		$text     = '<h1>Kirby</h1>';
 		$expected = '<p>&lt;h1&gt;Kirby&lt;/h1&gt;</p>';
@@ -517,7 +517,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, kt($text, ['markdown' => ['safe' => true]]));
 	}
 
-	public function testKirbyTextInline()
+	public function testKirbyTextInline(): void
 	{
 		$text     = 'This is **just** a text.';
 		$expected = 'This is <strong>just</strong> a text.';
@@ -526,7 +526,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, kti($text));
 	}
 
-	public function testKirbyTextInlineWithSafeMode()
+	public function testKirbyTextInlineWithSafeMode(): void
 	{
 		$text     = 'This is <b>just</b> a text.';
 		$expected = 'This is &lt;b&gt;just&lt;/b&gt; a text.';
@@ -535,7 +535,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, kti($text, ['markdown' => ['safe' => true]]));
 	}
 
-	public function testLoad()
+	public function testLoad(): void
 	{
 		load([
 			'helperstest\\a' => static::FIXTURES . '/load/a/a.php',
@@ -550,7 +550,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertFalse(class_exists('HelpersTest\\C'));
 	}
 
-	public function testMarkdown()
+	public function testMarkdown(): void
 	{
 		$tag = markdown('# Kirby');
 		$expected = '<h1>Kirby</h1>';
@@ -558,7 +558,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $tag);
 	}
 
-	public function testMarkdownWithSafeMode()
+	public function testMarkdownWithSafeMode(): void
 	{
 		$tag = markdown('<h1>Kirby</h1>', ['safe' => true]);
 		$expected = '<p>&lt;h1&gt;Kirby&lt;/h1&gt;</p>';
@@ -566,7 +566,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $tag);
 	}
 
-	public function testOption()
+	public function testOption(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -578,7 +578,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame('fallback', option('does-not-exist', 'fallback'));
 	}
 
-	public function testPage()
+	public function testPage(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -607,7 +607,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame('test', $page->slug());
 	}
 
-	public function testPages()
+	public function testPages(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -626,7 +626,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertCount(2, $pages);
 	}
 
-	public function testParam()
+	public function testParam(): void
 	{
 		$this->app->clone([
 			'server' => [
@@ -638,7 +638,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame('value-B/B:', param('b/b:'));
 	}
 
-	public function testParams()
+	public function testParams(): void
 	{
 		$this->app->clone([
 			'server' => [
@@ -649,7 +649,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame(['a' => 'value-a', 'b/b:' => 'value-B/B:'], params());
 	}
 
-	public function testQr()
+	public function testQr(): void
 	{
 		$url = 'https://getkirby.com';
 		$qr    = qr($url);
@@ -673,14 +673,14 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($page->url(), $qr->data);
 	}
 
-	public function testR()
+	public function testR(): void
 	{
 		$this->assertSame('a', r(1 === 1, 'a', 'b'));
 		$this->assertSame('b', r(1 === 2, 'a', 'b'));
 		$this->assertNull(r(1 === 2, 'a'));
 	}
 
-	public function testRouter()
+	public function testRouter(): void
 	{
 		$routes = [
 			[
@@ -704,12 +704,12 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame('yes: foo', $result);
 	}
 
-	public function testSite()
+	public function testSite(): void
 	{
 		$this->assertSame($this->app->site(), site());
 	}
 
-	public function testSize()
+	public function testSize(): void
 	{
 		// number
 		$this->assertSame(3, size(3));
@@ -724,7 +724,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame(3, size(new Collection(['a', 'b', 'c'])));
 	}
 
-	public function testSmartypants()
+	public function testSmartypants(): void
 	{
 		$text     = smartypants('"Test"');
 		$expected = '&#8220;Test&#8221;';
@@ -732,7 +732,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $text);
 	}
 
-	public function testSmartypantsWithKirbytext()
+	public function testSmartypantsWithKirbytext(): void
 	{
 		$this->app->clone([
 			'roots' => [
@@ -749,7 +749,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $text);
 	}
 
-	public function testSnippet()
+	public function testSnippet(): void
 	{
 		$this->app->clone([
 			'roots' => [
@@ -762,7 +762,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame('Hello world', $result);
 	}
 
-	public function testSnippetNullArgument()
+	public function testSnippetNullArgument(): void
 	{
 		$this->app->clone([
 			'roots' => [
@@ -775,7 +775,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame('', $result);
 	}
 
-	public function testSnippetNotExists()
+	public function testSnippetNotExists(): void
 	{
 		$this->app->clone([
 			'roots' => [
@@ -788,7 +788,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame('', $result);
 	}
 
-	public function testSnippetAlternatives()
+	public function testSnippetAlternatives(): void
 	{
 		$this->app->clone([
 			'roots' => [
@@ -805,7 +805,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame('Hello world', $result);
 	}
 
-	public function testSnippetObject()
+	public function testSnippetObject(): void
 	{
 		$this->app->clone([
 			'roots' => [
@@ -818,7 +818,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame('Hello another world', $result);
 	}
 
-	public function testSnippetEcho()
+	public function testSnippetEcho(): void
 	{
 		$this->expectOutputString('Hello world');
 
@@ -832,7 +832,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		snippet('snippet', ['message' => 'world']);
 	}
 
-	public function testSnippetWithSlots()
+	public function testSnippetWithSlots(): void
 	{
 		$this->app->clone([
 			'roots' => [
@@ -851,29 +851,29 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame('Test', ob_get_clean());
 	}
 
-	public function testSvg()
+	public function testSvg(): void
 	{
 		$result = svg('test.svg');
 		$this->assertSame('<svg>test</svg>', trim($result));
 	}
 
-	public function testSvgWithAbsolutePath()
+	public function testSvgWithAbsolutePath(): void
 	{
 		$result = svg(static::FIXTURES . '/test.svg');
 		$this->assertSame('<svg>test</svg>', trim($result));
 	}
 
-	public function testSvgWithInvalidFileType()
+	public function testSvgWithInvalidFileType(): void
 	{
 		$this->assertFalse(svg(123));
 	}
 
-	public function testSvgWithMissingFile()
+	public function testSvgWithMissingFile(): void
 	{
 		$this->assertFalse(svg('somefile.svg'));
 	}
 
-	public function testSvgWithFileObject()
+	public function testSvgWithFileObject(): void
 	{
 		$file = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
@@ -886,13 +886,13 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame('test', svg($file));
 	}
 
-	public function testTimestamp()
+	public function testTimestamp(): void
 	{
 		$result = timestamp('2021-12-12 12:12:12');
 		$this->assertSame('2021-12-12 12:12:12', date('Y-m-d H:i:s', $result));
 	}
 
-	public function testTimestampWithStep()
+	public function testTimestampWithStep(): void
 	{
 		$result = timestamp('2021-12-12 12:12:12', [
 			'unit' => 'minute',
@@ -902,13 +902,13 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame('2021-12-12 12:10:00', date('Y-m-d H:i:s', $result));
 	}
 
-	public function testTimestampWithInvalidDate()
+	public function testTimestampWithInvalidDate(): void
 	{
 		$result = timestamp('invalid date');
 		$this->assertNull($result);
 	}
 
-	public function testTc()
+	public function testTc(): void
 	{
 		$this->app->clone([
 			'translations' => [
@@ -925,7 +925,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame('Many cars', tc('car', 4));
 	}
 
-	public function testTcWithPlaceholders()
+	public function testTcWithPlaceholders(): void
 	{
 		$this->app->clone([
 			'translations' => [
@@ -949,7 +949,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame('1234567 Autos', tc('car', 1234567, 'de', false));
 	}
 
-	public function testUrl()
+	public function testUrl(): void
 	{
 		$this->app->clone([
 			'options' => [
@@ -961,7 +961,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($url . '/test', u('test'));
 	}
 
-	public function testUrlWithOptions()
+	public function testUrlWithOptions(): void
 	{
 		$this->app->clone([
 			'options' => [
@@ -980,7 +980,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, u('test', $options));
 	}
 
-	public function testVideo()
+	public function testVideo(): void
 	{
 		$video    = video('https://youtube.com/watch?v=xB3s_f7PzYk');
 		$expected = '<iframe allow="fullscreen" allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk"></iframe>';
@@ -988,7 +988,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $video);
 	}
 
-	public function testYoutubeVideoWithOptions()
+	public function testYoutubeVideoWithOptions(): void
 	{
 		$video = video('https://youtube.com/watch?v=xB3s_f7PzYk', [
 			'youtube' => [
@@ -1001,7 +1001,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $video);
 	}
 
-	public function testVimeoVideoWithOptions()
+	public function testVimeoVideoWithOptions(): void
 	{
 		$video = video('https://vimeo.com/335292911', [
 			'vimeo' => [
@@ -1014,7 +1014,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $video);
 	}
 
-	public function testVimeo()
+	public function testVimeo(): void
 	{
 		$video    = vimeo('https://vimeo.com/335292911');
 		$expected = '<iframe allow="fullscreen" allowfullscreen src="https://player.vimeo.com/video/335292911"></iframe>';
@@ -1022,7 +1022,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $video);
 	}
 
-	public function testVimeoWithOptions()
+	public function testVimeoWithOptions(): void
 	{
 		$video    = vimeo('https://vimeo.com/335292911', ['controls' => 0]);
 		$expected = '<iframe allow="fullscreen" allowfullscreen src="https://player.vimeo.com/video/335292911?controls=0"></iframe>';
@@ -1030,7 +1030,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $video);
 	}
 
-	public function testWidont()
+	public function testWidont(): void
 	{
 		$result   = widont('This is a headline');
 		$expected = 'This is a&nbsp;headline';
@@ -1038,7 +1038,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $result);
 	}
 
-	public function testYoutube()
+	public function testYoutube(): void
 	{
 		$video    = youtube('https://youtube.com/watch?v=xB3s_f7PzYk');
 		$expected = '<iframe allow="fullscreen" allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk"></iframe>';
@@ -1046,7 +1046,7 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($expected, $video);
 	}
 
-	public function testYoutubeWithOptions()
+	public function testYoutubeWithOptions(): void
 	{
 		$video    = youtube('https://youtube.com/watch?v=xB3s_f7PzYk', ['controls' => 0]);
 		$expected = '<iframe allow="fullscreen" allowfullscreen src="https://youtube.com/embed/xB3s_f7PzYk?controls=0"></iframe>';

--- a/tests/Cms/Html/HtmlTest.php
+++ b/tests/Cms/Html/HtmlTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Cms;
 
 use Kirby\Filesystem\Dir;
 use Kirby\Plugin\Plugin;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Html
- */
+#[CoversClass(Html::class)]
 class HtmlTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -27,10 +26,7 @@ class HtmlTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::css
-	 */
-	public function testCss()
+	public function testCss(): void
 	{
 		$result   = Html::css('assets/css/index.css');
 		$expected = '<link href="https://getkirby.com/assets/css/index.css" rel="stylesheet">';
@@ -38,10 +34,7 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::css
-	 */
-	public function testCssWithMediaOption()
+	public function testCssWithMediaOption(): void
 	{
 		$result   = Html::css('assets/css/index.css', 'print');
 		$expected = '<link href="https://getkirby.com/assets/css/index.css" media="print" rel="stylesheet">';
@@ -49,10 +42,7 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::css
-	 */
-	public function testCssWithAttrs()
+	public function testCssWithAttrs(): void
 	{
 		$result   = Html::css('assets/css/index.css', ['integrity' => 'nope']);
 		$expected = '<link href="https://getkirby.com/assets/css/index.css" integrity="nope" rel="stylesheet">';
@@ -60,10 +50,7 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::css
-	 */
-	public function testCssWithValidRelAttr()
+	public function testCssWithValidRelAttr(): void
 	{
 		$result   = Html::css('assets/css/index.css', ['rel' => 'alternate stylesheet', 'title' => 'High contrast']);
 		$expected = '<link href="https://getkirby.com/assets/css/index.css" rel="alternate stylesheet" title="High contrast">';
@@ -71,10 +58,7 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::css
-	 */
-	public function testCssWithInvalidRelAttr()
+	public function testCssWithInvalidRelAttr(): void
 	{
 		$result   = Html::css('assets/css/index.css', ['rel' => 'alternate', 'title' => 'High contrast']);
 		$expected = '<link href="https://getkirby.com/assets/css/index.css" rel="stylesheet" title="High contrast">';
@@ -82,10 +66,7 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::css
-	 */
-	public function testCssWithRelAttrButNoTitle()
+	public function testCssWithRelAttrButNoTitle(): void
 	{
 		$result   = Html::css('assets/css/index.css', ['rel' => 'alternate stylesheet']);
 		$expected = '<link href="https://getkirby.com/assets/css/index.css" rel="stylesheet">';
@@ -93,10 +74,7 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::css
-	 */
-	public function testCssWithArray()
+	public function testCssWithArray(): void
 	{
 		$result = Html::css([
 			'assets/css/a.css',
@@ -109,10 +87,7 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::css
-	 */
-	public function testCssWithPluginAssets()
+	public function testCssWithPluginAssets(): void
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
 			'root' => $root = static::TMP . '/plugin'
@@ -125,10 +100,7 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::js
-	 */
-	public function testJs()
+	public function testJs(): void
 	{
 		$result   = Html::js('assets/js/index.js');
 		$expected = '<script src="https://getkirby.com/assets/js/index.js"></script>';
@@ -136,10 +108,7 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::js
-	 */
-	public function testJsWithAsyncOption()
+	public function testJsWithAsyncOption(): void
 	{
 		$result   = Html::js('assets/js/index.js', true);
 		$expected = '<script async src="https://getkirby.com/assets/js/index.js"></script>';
@@ -147,10 +116,7 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::js
-	 */
-	public function testJsWithAttrs()
+	public function testJsWithAttrs(): void
 	{
 		$result   = Html::js('assets/js/index.js', ['integrity' => 'nope']);
 		$expected = '<script integrity="nope" src="https://getkirby.com/assets/js/index.js"></script>';
@@ -158,10 +124,7 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::js
-	 */
-	public function testJsWithArray()
+	public function testJsWithArray(): void
 	{
 		$result = Html::js([
 			'assets/js/a.js',
@@ -174,10 +137,7 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::js
-	 */
-	public function testJsWithPluginAssets()
+	public function testJsWithPluginAssets(): void
 	{
 		$plugin = new Plugin('getkirby/test-plugin', [
 			'root' => $root = static::TMP . '/plugin'
@@ -190,44 +150,29 @@ class HtmlTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::svg
-	 */
-	public function testSvg()
+	public function testSvg(): void
 	{
 		$result = Html::svg('test.svg');
 		$this->assertSame('<svg>test</svg>', trim($result));
 	}
 
-	/**
-	 * @covers ::svg
-	 */
-	public function testSvgWithAbsolutePath()
+	public function testSvgWithAbsolutePath(): void
 	{
 		$result = Html::svg(static::TMP . '/test.svg');
 		$this->assertSame('<svg>test</svg>', trim($result));
 	}
 
-	/**
-	 * @covers ::svg
-	 */
-	public function testSvgWithInvalidFileType()
+	public function testSvgWithInvalidFileType(): void
 	{
 		$this->assertFalse(Html::svg(123));
 	}
 
-	/**
-	 * @covers ::svg
-	 */
-	public function testSvgWithMissingFile()
+	public function testSvgWithMissingFile(): void
 	{
 		$this->assertFalse(Html::svg('somefile.svg'));
 	}
 
-	/**
-	 * @covers ::svg
-	 */
-	public function testSvgWithFileObject()
+	public function testSvgWithFileObject(): void
 	{
 		$file = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()

--- a/tests/Cms/Ingredients/IngredientsTest.php
+++ b/tests/Cms/Ingredients/IngredientsTest.php
@@ -16,19 +16,19 @@ class IngredientsTest extends TestCase
 		]);
 	}
 
-	public function testGet()
+	public function testGet(): void
 	{
 		$this->assertSame('A', $this->ingredients->a);
 		$this->assertSame('B', $this->ingredients->b);
 	}
 
-	public function testCall()
+	public function testCall(): void
 	{
 		$this->assertSame('A', $this->ingredients->a());
 		$this->assertSame('B', $this->ingredients->b());
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$expected = [
 			'a' => 'A',

--- a/tests/Cms/Ingredients/RootsTest.php
+++ b/tests/Cms/Ingredients/RootsTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Cms;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class RootsTest extends TestCase
 {
 	protected string|null $indexRoot;
@@ -55,10 +57,8 @@ class RootsTest extends TestCase
 		return static::rootProvider(realpath(__DIR__ . '/../../../../'));
 	}
 
-	/**
-	 * @dataProvider defaultRootProvider
-	 */
-	public function testDefaultRoot($root, $method)
+	#[DataProvider('defaultRootProvider')]
+	public function testDefaultRoot($root, $method): void
 	{
 		// fake the default behavior for this test
 		Core::$indexRoot = null;
@@ -73,10 +73,8 @@ class RootsTest extends TestCase
 		return static::rootProvider('/var/www/getkirby.com');
 	}
 
-	/**
-	 * @dataProvider customIndexRootProvider
-	 */
-	public function testCustomIndexRoot($root, $method)
+	#[DataProvider('customIndexRootProvider')]
+	public function testCustomIndexRoot($root, $method): void
 	{
 		$app = new App([
 			'roots' => [
@@ -103,10 +101,8 @@ class RootsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider customRootProvider
-	 */
-	public function testCustomRoot($root, $method)
+	#[DataProvider('customRootProvider')]
+	public function testCustomRoot($root, $method): void
 	{
 		// public directory setup
 		$base   = '/var/www/getkirby.com';

--- a/tests/Cms/Ingredients/UrlsTest.php
+++ b/tests/Cms/Ingredients/UrlsTest.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Cms;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class UrlsTest extends TestCase
 {
 	public static function defaultUrlProvider(): array
@@ -13,10 +15,8 @@ class UrlsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider defaultUrlProvider
-	 */
-	public function testDefaulUrl($url, $method)
+	#[DataProvider('defaultUrlProvider')]
+	public function testDefaulUrl($url, $method): void
 	{
 		$app  = new App([
 			'roots' => [
@@ -37,10 +37,8 @@ class UrlsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider customBaseUrlProvider
-	 */
-	public function testWithCustomBaseUrl($url, $method)
+	#[DataProvider('customBaseUrlProvider')]
+	public function testWithCustomBaseUrl($url, $method): void
 	{
 		$app = new App([
 			'roots' => [
@@ -63,10 +61,8 @@ class UrlsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider customUrlProvider
-	 */
-	public function testWithCustomUrl($url, $method)
+	#[DataProvider('customUrlProvider')]
+	public function testWithCustomUrl($url, $method): void
 	{
 		$app = new App([
 			'roots' => [
@@ -82,7 +78,7 @@ class UrlsTest extends TestCase
 		$this->assertSame($url, $urls->$method());
 	}
 
-	public function testCurrent()
+	public function testCurrent(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -93,7 +89,7 @@ class UrlsTest extends TestCase
 		$this->assertSame('/', $app->url('current'));
 	}
 
-	public function testCurrentInSubfolderSetup()
+	public function testCurrentInSubfolderSetup(): void
 	{
 		$app = $this->app->clone([
 			'cli' => false,
@@ -119,7 +115,7 @@ class UrlsTest extends TestCase
 		$this->assertSame('http://localhost/starterkit/sub/folder', $app->url('current'));
 	}
 
-	public function testCurrentWithCustomIndex()
+	public function testCurrentWithCustomIndex(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -133,7 +129,7 @@ class UrlsTest extends TestCase
 		$this->assertSame('http://getkirby.com', $app->url('current'));
 	}
 
-	public function testCurrentWithCustomPath()
+	public function testCurrentWithCustomPath(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -145,7 +141,7 @@ class UrlsTest extends TestCase
 		$this->assertSame('/test/path', $app->url('current'));
 	}
 
-	public function testCurrentWithCustomPathAndCustomIndex()
+	public function testCurrentWithCustomPathAndCustomIndex(): void
 	{
 		$app = new App([
 			'roots' => [

--- a/tests/Cms/Items/ItemTest.php
+++ b/tests/Cms/Items/ItemTest.php
@@ -22,7 +22,7 @@ class ItemTest extends TestCase
 		$this->field = new Field($this->page, 'test', 'abcde');
 	}
 
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$item = new Item();
 
@@ -32,7 +32,7 @@ class ItemTest extends TestCase
 		$this->assertInstanceOf(Items::class, $item->siblings());
 	}
 
-	public function testField()
+	public function testField(): void
 	{
 		$item = new Item([
 			'parent' => $this->page,
@@ -42,7 +42,7 @@ class ItemTest extends TestCase
 		$this->assertSame($this->field, $item->field());
 	}
 
-	public function testIs()
+	public function testIs(): void
 	{
 		$a = new Item(['name' => 'a']);
 		$b = new Item(['name' => 'b']);
@@ -51,7 +51,7 @@ class ItemTest extends TestCase
 		$this->assertFalse($a->is($b));
 	}
 
-	public function testParent()
+	public function testParent(): void
 	{
 		$item = new Item([
 			'parent' => $this->page,
@@ -60,7 +60,7 @@ class ItemTest extends TestCase
 		$this->assertSame($this->page, $item->parent());
 	}
 
-	public function testSiblings()
+	public function testSiblings(): void
 	{
 		$items = Items::factory([
 			['type' => 'a'],
@@ -75,7 +75,7 @@ class ItemTest extends TestCase
 		$this->assertSame($items, $item->siblings());
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$item = new Item();
 		$this->assertSame([

--- a/tests/Cms/Items/ItemsTest.php
+++ b/tests/Cms/Items/ItemsTest.php
@@ -22,7 +22,7 @@ class ItemsTest extends TestCase
 		$this->field = new Field($this->page, 'test', 'abcde');
 	}
 
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$items = new Items();
 
@@ -37,7 +37,7 @@ class ItemsTest extends TestCase
 		$this->assertSame($b->id(), $items->last()->id());
 	}
 
-	public function testFactoryFromArray()
+	public function testFactoryFromArray(): void
 	{
 		$items = Items::factory(
 			[
@@ -62,7 +62,7 @@ class ItemsTest extends TestCase
 		$this->assertSame($this->field, $items->first()->field());
 	}
 
-	public function testField()
+	public function testField(): void
 	{
 		$items = new Items([]);
 
@@ -76,7 +76,7 @@ class ItemsTest extends TestCase
 		$this->assertSame($this->field, $items->field());
 	}
 
-	public function testParent()
+	public function testParent(): void
 	{
 		$items = new Items([]);
 
@@ -89,7 +89,7 @@ class ItemsTest extends TestCase
 		$this->assertSame($this->page, $items->parent());
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$items = new Items();
 

--- a/tests/Cms/KirbyTextTest.php
+++ b/tests/Cms/KirbyTextTest.php
@@ -6,7 +6,7 @@ use Kirby\TestCase;
 
 class KirbyTextTest extends TestCase
 {
-	public function testBeforeHook()
+	public function testBeforeHook(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -22,7 +22,7 @@ class KirbyTextTest extends TestCase
 		$this->assertSame('<p>test</p>', $app->kirbytext('Test'));
 	}
 
-	public function testAfterHook()
+	public function testAfterHook(): void
 	{
 		$app = new App([
 			'roots' => [

--- a/tests/Cms/Languages/LanguageConversionTest.php
+++ b/tests/Cms/Languages/LanguageConversionTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Cms;
 
 use Kirby\Data\Data;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Language
- */
+#[CoversClass(Language::class)]
 class LanguageConversionTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.LanguageConversion';

--- a/tests/Cms/Languages/LanguagePermissionsTest.php
+++ b/tests/Cms/Languages/LanguagePermissionsTest.php
@@ -3,10 +3,11 @@
 namespace Kirby\Cms;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Cms\LanguagePermissions
- */
+#[CoversClass(LanguagePermissions::class)]
+#[CoversClass(ModelPermissions::class)]
 class LanguagePermissionsTest extends TestCase
 {
 	public static function actionProvider(): array
@@ -18,11 +19,8 @@ class LanguagePermissionsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithAdmin($action)
+	#[DataProvider('actionProvider')]
+	public function testWithAdmin($action): void
 	{
 		$kirby = new App([
 			'roots' => [
@@ -42,11 +40,8 @@ class LanguagePermissionsTest extends TestCase
 		$this->assertTrue($perms->can($action));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithNobody($action)
+	#[DataProvider('actionProvider')]
+	public function testWithNobody($action): void
 	{
 		new App([
 			'roots' => [
@@ -64,11 +59,8 @@ class LanguagePermissionsTest extends TestCase
 		$this->assertFalse($perms->can($action));
 	}
 
-	/**
-	 * @covers \Kirby\Cms\ModelPermissions::can
-	 * @dataProvider actionProvider
-	 */
-	public function testWithNoAdmin($action)
+	#[DataProvider('actionProvider')]
+	public function testWithNoAdmin($action): void
 	{
 		$app = new App([
 			'languages' => [
@@ -112,10 +104,7 @@ class LanguagePermissionsTest extends TestCase
 		$this->assertFalse($perms->can($action));
 	}
 
-	/**
-	 * @covers ::canDelete
-	 */
-	public function testCanDeleteWhenNotDeletable()
+	public function testCanDeleteWhenNotDeletable(): void
 	{
 		$app = new App([
 			'languages' => [

--- a/tests/Cms/Languages/LanguageRouterTest.php
+++ b/tests/Cms/Languages/LanguageRouterTest.php
@@ -32,7 +32,7 @@ class LanguageRouterTest extends TestCase
 		App::destroy();
 	}
 
-	public function testRouteForSingleLanguage()
+	public function testRouteForSingleLanguage(): void
 	{
 		$app = $this->app->clone([
 			'routes' => [
@@ -58,7 +58,7 @@ class LanguageRouterTest extends TestCase
 		$this->assertSame('en', $router->call('anything'));
 	}
 
-	public function testRouteWithoutLanguageScope()
+	public function testRouteWithoutLanguageScope(): void
 	{
 		$app = $this->app->clone([
 			'routes' => [
@@ -74,7 +74,7 @@ class LanguageRouterTest extends TestCase
 		$this->assertCount(1, $language->router()->routes());
 	}
 
-	public function testRouteForMultipleLanguages()
+	public function testRouteForMultipleLanguages(): void
 	{
 		$app = $this->app->clone([
 			'routes' => [
@@ -95,7 +95,7 @@ class LanguageRouterTest extends TestCase
 		$this->assertSame('slug', $router->call('slug'));
 	}
 
-	public function testRouteWildcard()
+	public function testRouteWildcard(): void
 	{
 		$app = $this->app->clone([
 			'routes' => [
@@ -116,7 +116,7 @@ class LanguageRouterTest extends TestCase
 		$this->assertSame('slug', $router->call('slug'));
 	}
 
-	public function testRouteWithPageScope()
+	public function testRouteWithPageScope(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -140,7 +140,7 @@ class LanguageRouterTest extends TestCase
 		$this->assertSame('slug', $router->call('notes/slug'));
 	}
 
-	public function testRouteWithPageScopeAndMultiplePatterns()
+	public function testRouteWithPageScopeAndMultiplePatterns(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -168,7 +168,7 @@ class LanguageRouterTest extends TestCase
 		$this->assertSame('slug', $router->call('notes/b/slug'));
 	}
 
-	public function testRouteWithPageScopeAndInvalidPage()
+	public function testRouteWithPageScopeAndInvalidPage(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -193,7 +193,7 @@ class LanguageRouterTest extends TestCase
 		$router   = $language->router()->call('notes/a/slug');
 	}
 
-	public function testUUIDRoute()
+	public function testUUIDRoute(): void
 	{
 		$app = $this->app->clone([
 			'site' => [

--- a/tests/Cms/Languages/LanguageRoutesTest.php
+++ b/tests/Cms/Languages/LanguageRoutesTest.php
@@ -32,7 +32,7 @@ class LanguageRoutesTest extends TestCase
 		]);
 	}
 
-	public function testFallback()
+	public function testFallback(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -52,7 +52,7 @@ class LanguageRoutesTest extends TestCase
 		$this->assertSame($app->language()->code(), 'de');
 	}
 
-	public function testNotNextWhenFalsyReturn()
+	public function testNotNextWhenFalsyReturn(): void
 	{
 		$a = $b = $c = $d = $e = 0;
 

--- a/tests/Cms/Languages/LanguageRulesTest.php
+++ b/tests/Cms/Languages/LanguageRulesTest.php
@@ -7,10 +7,9 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\PermissionException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\LanguageRules
- */
+#[CoversClass(LanguageRules::class)]
 class LanguageRulesTest extends TestCase
 {
 	public function setUp(): void
@@ -36,10 +35,7 @@ class LanguageRulesTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreate()
+	public function testCreate(): void
 	{
 		$this->app->impersonate('admin@getkirby.com');
 
@@ -53,10 +49,7 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::create($language);
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateWithInvalidCode()
+	public function testCreateWithInvalidCode(): void
 	{
 		$language = new Language([
 			'code' => 'l',
@@ -68,10 +61,7 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::create($language);
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateWithInvalidName()
+	public function testCreateWithInvalidName(): void
 	{
 		$language = new Language([
 			'code' => 'de',
@@ -84,10 +74,7 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::create($language);
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateWhenExists()
+	public function testCreateWhenExists(): void
 	{
 		$language = $this->createMock(Language::class);
 		$language->method('code')->willReturn('de');
@@ -100,10 +87,7 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::create($language);
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateWithoutCurrentUser()
+	public function testCreateWithoutCurrentUser(): void
 	{
 		$language = new Language([
 			'code' => 'de',
@@ -116,10 +100,7 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::create($language);
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateWithoutPermissions()
+	public function testCreateWithoutPermissions(): void
 	{
 		$this->app->impersonate('test@getkirby.com');
 
@@ -134,10 +115,7 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::create($language);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
-	public function testDelete()
+	public function testDelete(): void
 	{
 		$this->app->impersonate('admin@getkirby.com');
 
@@ -151,10 +129,7 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::delete($language);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
-	public function testDeleteWhenNotDeletable()
+	public function testDeleteWhenNotDeletable(): void
 	{
 		$language = $this->createMock(Language::class);
 		$language->method('isDeletable')->willReturn(false);
@@ -165,10 +140,7 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::delete($language);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
-	public function testDeleteWithoutCurrentUser()
+	public function testDeleteWithoutCurrentUser(): void
 	{
 		$language = new Language([
 			'code' => 'de',
@@ -181,10 +153,7 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::delete($language);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
-	public function testDeleteWithoutPermissions()
+	public function testDeleteWithoutPermissions(): void
 	{
 		$this->app->impersonate('test@getkirby.com');
 
@@ -199,10 +168,7 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::delete($language);
 	}
 
-	/**
-	 * @covers ::update
-	 */
-	public function testUpdate()
+	public function testUpdate(): void
 	{
 		$this->app->impersonate('admin@getkirby.com');
 
@@ -216,10 +182,7 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::update($language);
 	}
 
-	/**
-	 * @covers ::update
-	 */
-	public function testUpdateWithoutCode()
+	public function testUpdateWithoutCode(): void
 	{
 		$language = $this->createMock(Language::class);
 		$language->method('code')->willReturn('');
@@ -231,10 +194,7 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::update($language);
 	}
 
-	/**
-	 * @covers ::update
-	 */
-	public function testUpdateWithoutName()
+	public function testUpdateWithoutName(): void
 	{
 		$language = $this->createMock(Language::class);
 		$language->method('code')->willReturn('de');
@@ -246,10 +206,7 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::update($language);
 	}
 
-	/**
-	 * @covers ::update
-	 */
-	public function testUpdateWithoutCurrentUser()
+	public function testUpdateWithoutCurrentUser(): void
 	{
 		$language = new Language([
 			'code' => 'de',
@@ -262,10 +219,7 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::update($language);
 	}
 
-	/**
-	 * @covers ::update
-	 */
-	public function testUpdateWithoutPermissions()
+	public function testUpdateWithoutPermissions(): void
 	{
 		$this->app->impersonate('test@getkirby.com');
 
@@ -280,10 +234,7 @@ class LanguageRulesTest extends TestCase
 		LanguageRules::update($language);
 	}
 
-	/**
-	 * @covers ::update
-	 */
-	public function testUpdateDemoteDefault()
+	public function testUpdateDemoteDefault(): void
 	{
 		$this->app = $this->app->clone([
 			'languages' => [

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -9,10 +9,10 @@ use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Language
- */
+#[CoversClass(Language::class)]
 class LanguageTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Language';
@@ -33,10 +33,7 @@ class LanguageTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstructNoCode()
+	public function testConstructNoCode(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The property "code" is required');
@@ -58,11 +55,8 @@ class LanguageTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::baseUrl
-	 * @dataProvider baseUrlProvider
-	 */
-	public function testBaseUrl($kirbyUrl, $url, $expected)
+	#[DataProvider('baseUrlProvider')]
+	public function testBaseUrl($kirbyUrl, $url, $expected): void
 	{
 		new App([
 			'roots' => [
@@ -82,10 +76,7 @@ class LanguageTest extends TestCase
 		$this->assertSame($expected, $language->baseUrl());
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreate()
+	public function testCreate(): void
 	{
 		$this->app->impersonate('kirby');
 
@@ -100,10 +91,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('/en', $language->url());
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateNoPermissions()
+	public function testCreateNoPermissions(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [
@@ -130,10 +118,7 @@ class LanguageTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateWithoutLoggedUser()
+	public function testCreateWithoutLoggedUser(): void
 	{
 		$this->expectException(PermissionException::class);
 		$this->expectExceptionMessage('You are not allowed to create a language');
@@ -143,10 +128,7 @@ class LanguageTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::create
-	 */
-	public function testCreateHooks()
+	public function testCreateHooks(): void
 	{
 		$calls = 0;
 		$phpunit = $this;
@@ -177,21 +159,14 @@ class LanguageTest extends TestCase
 		$this->assertSame(2, $calls);
 	}
 
-	/**
-	 * @covers ::code
-	 * @covers ::id
-	 */
-	public function testCodeAndId()
+	public function testCodeAndId(): void
 	{
 		$language = new Language(['code' => 'en']);
 		$this->assertSame('en', $language->code());
 		$this->assertSame('en', $language->id());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
-	public function testDelete()
+	public function testDelete(): void
 	{
 		$this->app->impersonate('kirby');
 
@@ -199,10 +174,7 @@ class LanguageTest extends TestCase
 		$this->assertTrue($language->delete());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
-	public function testDeleteNoPermissions()
+	public function testDeleteNoPermissions(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [
@@ -229,10 +201,7 @@ class LanguageTest extends TestCase
 		$language->delete();
 	}
 
-	/**
-	 * @covers ::delete
-	 */
-	public function testDeleteWithoutLoggedUser()
+	public function testDeleteWithoutLoggedUser(): void
 	{
 		$this->app->impersonate('kirby');
 		$language = Language::create(['code' => 'en']);
@@ -245,10 +214,7 @@ class LanguageTest extends TestCase
 		$language->delete();
 	}
 
-	/**
-	 * @covers ::delete
-	 */
-	public function testDeleteHooks()
+	public function testDeleteHooks(): void
 	{
 		$calls = 0;
 		$phpunit = $this;
@@ -285,10 +251,7 @@ class LanguageTest extends TestCase
 		$this->assertSame(2, $calls);
 	}
 
-	/**
-	 * @covers ::direction
-	 */
-	public function testDirection()
+	public function testDirection(): void
 	{
 		//default
 		$language = new Language([
@@ -318,7 +281,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('ltr', $language->direction());
 	}
 
-	public function testEnsureInMultiLanguageMode()
+	public function testEnsureInMultiLanguageMode(): void
 	{
 		$app = new App([
 			'languages' => [
@@ -358,7 +321,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('en', $language->code());
 	}
 
-	public function testEnsureInSingleLanguageMode()
+	public function testEnsureInSingleLanguageMode(): void
 	{
 		new App([
 			'roots' => [
@@ -371,10 +334,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('en', $language->code());
 	}
 
-	/**
-	 * @covers ::exists
-	 */
-	public function testExists()
+	public function testExists(): void
 	{
 		new App([
 			'roots' => [
@@ -393,10 +353,7 @@ class LanguageTest extends TestCase
 		$this->assertTrue($language->exists());
 	}
 
-	/**
-	 * @covers ::is
-	 */
-	public function testIs()
+	public function testIs(): void
 	{
 		$app = new App([
 			'languages' => [
@@ -426,10 +383,7 @@ class LanguageTest extends TestCase
 		$this->assertFalse($en->is($de));
 	}
 
-	/**
-	 * @covers ::isDefault
-	 */
-	public function testIsDefault()
+	public function testIsDefault(): void
 	{
 		// default
 		$language = new Language([
@@ -459,10 +413,7 @@ class LanguageTest extends TestCase
 		$this->assertFalse($language->isDefault());
 	}
 
-	/**
-	 * @covers ::isSingle
-	 */
-	public function testIsSingle()
+	public function testIsSingle(): void
 	{
 		// default
 		$language = new Language([
@@ -480,10 +431,7 @@ class LanguageTest extends TestCase
 		$this->assertTrue($language->isSingle());
 	}
 
-	/**
-	 * @covers ::locale
-	 */
-	public function testLocale()
+	public function testLocale(): void
 	{
 		$language = new Language([
 			'code' => 'en',
@@ -494,10 +442,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('en_US', $language->locale(LC_ALL));
 	}
 
-	/**
-	 * @covers ::locale
-	 */
-	public function testLocaleArray1()
+	public function testLocaleArray1(): void
 	{
 		$language = new Language([
 			'code' => 'en',
@@ -516,10 +461,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('en_US', $language->locale(LC_MONETARY));
 	}
 
-	/**
-	 * @covers ::locale
-	 */
-	public function testLocaleArray2()
+	public function testLocaleArray2(): void
 	{
 		$language = new Language([
 			'code' => 'en',
@@ -536,10 +478,7 @@ class LanguageTest extends TestCase
 		$this->assertNull($language->locale(LC_MONETARY));
 	}
 
-	/**
-	 * @covers ::locale
-	 */
-	public function testLocaleArray3()
+	public function testLocaleArray3(): void
 	{
 		$language = new Language([
 			'code' => 'en',
@@ -558,10 +497,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('en_US', $language->locale(LC_MONETARY));
 	}
 
-	/**
-	 * @covers ::locale
-	 */
-	public function testLocaleInvalid()
+	public function testLocaleInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 
@@ -571,10 +507,7 @@ class LanguageTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::locale
-	 */
-	public function testLocaleDefault()
+	public function testLocaleDefault(): void
 	{
 		$language = new Language([
 			'code' => 'en',
@@ -583,10 +516,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('en', $language->locale(LC_ALL));
 	}
 
-	/**
-	 * @covers ::name
-	 */
-	public function testName()
+	public function testName(): void
 	{
 		$language = new Language([
 			'code' => 'en',
@@ -617,11 +547,8 @@ class LanguageTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::path
-	 * @dataProvider pathProvider
-	 */
-	public function testPath($input, $expected)
+	#[DataProvider('pathProvider')]
+	public function testPath($input, $expected): void
 	{
 		$language = new Language([
 			'code' => 'en',
@@ -647,11 +574,8 @@ class LanguageTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::pattern
-	 * @dataProvider patternProvider
-	 */
-	public function testPattern($input, $expected)
+	#[DataProvider('patternProvider')]
+	public function testPattern($input, $expected): void
 	{
 		$language = new Language([
 			'code' => 'en',
@@ -661,10 +585,7 @@ class LanguageTest extends TestCase
 		$this->assertSame($expected, $language->pattern());
 	}
 
-	/**
-	 * @covers ::root
-	 */
-	public function testRoot()
+	public function testRoot(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -679,10 +600,7 @@ class LanguageTest extends TestCase
 		$this->assertSame(static::TMP . '/site/languages/de.php', $language->root());
 	}
 
-	/**
-	 * @covers ::router
-	 */
-	public function testRouter()
+	public function testRouter(): void
 	{
 		$language = new Language([
 			'code' => 'de'
@@ -691,10 +609,7 @@ class LanguageTest extends TestCase
 		$this->assertInstanceOf(LanguageRouter::class, $language->router());
 	}
 
-	/**
-	 * @covers ::save
-	 */
-	public function testSave()
+	public function testSave(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -765,10 +680,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('test', $data['custom']);
 	}
 
-	/**
-	 * @covers ::single
-	 */
-	public function testSingle()
+	public function testSingle(): void
 	{
 		$language = Language::single();
 
@@ -776,11 +688,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('en', $language->name());
 	}
 
-	/**
-	 * @covers ::toArray
-	 * @covers ::__debugInfo
-	 */
-	public function testToArrayAndDebuginfo()
+	public function testToArrayAndDebuginfo(): void
 	{
 		$language = new Language([
 			'code'   => 'de',
@@ -802,10 +710,7 @@ class LanguageTest extends TestCase
 		$this->assertSame($expected, $language->__debugInfo());
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrlWithRelativeValue()
+	public function testUrlWithRelativeValue(): void
 	{
 		$language = new Language([
 			'code' => 'en',
@@ -815,10 +720,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('/super', $language->url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrlWithAbsoluteValue()
+	public function testUrlWithAbsoluteValue(): void
 	{
 		$language = new Language([
 			'code' => 'en',
@@ -828,10 +730,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('https://en.getkirby.com', $language->url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrlWithDash()
+	public function testUrlWithDash(): void
 	{
 		$language = new Language([
 			'code' => 'en',
@@ -841,10 +740,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('/', $language->url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrlDefault()
+	public function testUrlDefault(): void
 	{
 		$language = new Language([
 			'code' => 'en',
@@ -853,10 +749,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('/en', $language->url());
 	}
 
-	/**
-	 * @covers ::update
-	 */
-	public function testUpdate()
+	public function testUpdate(): void
 	{
 		Dir::make(static::TMP . '/content');
 
@@ -871,10 +764,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('English', $language->name());
 	}
 
-	/**
-	 * @covers ::update
-	 */
-	public function testUpdateDefault()
+	public function testUpdateDefault(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -922,10 +812,7 @@ class LanguageTest extends TestCase
 		$app->language('de')->update(['default' => false]);
 	}
 
-	/**
-	 * @covers ::update
-	 */
-	public function testUpdateHooks()
+	public function testUpdateHooks(): void
 	{
 		$calls = 0;
 		$phpunit = $this;
@@ -968,10 +855,7 @@ class LanguageTest extends TestCase
 		$this->assertSame(2, $calls);
 	}
 
-	/**
-	 * @covers ::update
-	 */
-	public function testUpdateNoPermissions()
+	public function testUpdateNoPermissions(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [
@@ -999,10 +883,7 @@ class LanguageTest extends TestCase
 		$language->update(['name' => 'English']);
 	}
 
-	/**
-	 * @covers ::update
-	 */
-	public function testUpdateWithoutLoggedUser()
+	public function testUpdateWithoutLoggedUser(): void
 	{
 		$this->app->impersonate('kirby');
 		$language = Language::create(['code' => 'en']);
@@ -1015,10 +896,7 @@ class LanguageTest extends TestCase
 		$language->update(['name' => 'English']);
 	}
 
-	/**
-	 * @covers ::variable
-	 */
-	public function testVariable()
+	public function testVariable(): void
 	{
 		$language = new Language([
 			'code' => 'en',
@@ -1029,10 +907,7 @@ class LanguageTest extends TestCase
 		$this->assertSame('test', $variable->key());
 	}
 
-	/**
-	 * @covers ::variable
-	 */
-	public function testVariableDecode()
+	public function testVariableDecode(): void
 	{
 		$language = new Language([
 			'code' => 'en',

--- a/tests/Cms/Languages/LanguagesTest.php
+++ b/tests/Cms/Languages/LanguagesTest.php
@@ -44,7 +44,7 @@ class LanguagesTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testCodes()
+	public function testCodes(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -78,7 +78,7 @@ class LanguagesTest extends TestCase
 		$this->assertSame(['default'], $app->languages()->codes());
 	}
 
-	public function testEnsureInMultiLanguageMode()
+	public function testEnsureInMultiLanguageMode(): void
 	{
 		$languages = Languages::ensure();
 
@@ -87,7 +87,7 @@ class LanguagesTest extends TestCase
 		$this->assertSame('de', $languages->last()->code());
 	}
 
-	public function testEnsureInSingleLanguageMode()
+	public function testEnsureInSingleLanguageMode(): void
 	{
 		new App([
 			'roots' => [
@@ -101,14 +101,14 @@ class LanguagesTest extends TestCase
 		$this->assertSame('en', $languages->first()->code());
 	}
 
-	public function testLoad()
+	public function testLoad(): void
 	{
 		$this->assertCount(2, $this->languages);
 		$this->assertSame(['en', 'de'], $this->languages->codes());
 		$this->assertSame('en', $this->languages->default()->code());
 	}
 
-	public function testLoadFromFiles()
+	public function testLoadFromFiles(): void
 	{
 		$this->app->clone([
 			'roots' => [
@@ -134,12 +134,12 @@ class LanguagesTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	public function testDefault()
+	public function testDefault(): void
 	{
 		$this->assertSame('en', $this->languages->default()->code());
 	}
 
-	public function testMultipleDefault()
+	public function testMultipleDefault(): void
 	{
 		$this->expectException(DuplicateException::class);
 
@@ -163,7 +163,7 @@ class LanguagesTest extends TestCase
 		]);
 	}
 
-	public function testCreate()
+	public function testCreate(): void
 	{
 		$this->app->impersonate('kirby');
 

--- a/tests/Cms/Layouts/LayoutColumnMethodsTest.php
+++ b/tests/Cms/Layouts/LayoutColumnMethodsTest.php
@@ -18,7 +18,7 @@ class LayoutColumnMethodsTest extends TestCase
 		]);
 	}
 
-	public function testLayoutColumnMethod()
+	public function testLayoutColumnMethod(): void
 	{
 		$column = new LayoutColumn();
 		$this->assertSame('layout column method', $column->test());

--- a/tests/Cms/Layouts/LayoutColumnTest.php
+++ b/tests/Cms/Layouts/LayoutColumnTest.php
@@ -6,7 +6,7 @@ use Kirby\TestCase;
 
 class LayoutColumnTest extends TestCase
 {
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$column = new LayoutColumn();
 		$this->assertInstanceOf(Blocks::class, $column->blocks());
@@ -14,7 +14,7 @@ class LayoutColumnTest extends TestCase
 		$this->assertSame(12, $column->span());
 	}
 
-	public function testBlocks()
+	public function testBlocks(): void
 	{
 		$column = new LayoutColumn([
 			'blocks' => [
@@ -27,7 +27,7 @@ class LayoutColumnTest extends TestCase
 		$this->assertSame('text', $column->blocks()->last()->type());
 	}
 
-	public function testHiddenBlocks()
+	public function testHiddenBlocks(): void
 	{
 		$column = new LayoutColumn([
 			'blocks' => [
@@ -42,7 +42,7 @@ class LayoutColumnTest extends TestCase
 		$this->assertCount(2, $column->blocks(true));
 	}
 
-	public function testSpan()
+	public function testSpan(): void
 	{
 		$column = new LayoutColumn([
 			'width' => '1/2'
@@ -52,7 +52,7 @@ class LayoutColumnTest extends TestCase
 		$this->assertSame(3, $column->span(6));
 	}
 
-	public function testWidth()
+	public function testWidth(): void
 	{
 		$column = new LayoutColumn([
 			'width' => '1/2'
@@ -61,7 +61,7 @@ class LayoutColumnTest extends TestCase
 		$this->assertSame('1/2', $column->width());
 	}
 
-	public function testIsEmpty()
+	public function testIsEmpty(): void
 	{
 		$column = new LayoutColumn([
 			'blocks' => []
@@ -71,7 +71,7 @@ class LayoutColumnTest extends TestCase
 		$this->assertFalse($column->isNotEmpty());
 	}
 
-	public function testIsNotEmpty()
+	public function testIsNotEmpty(): void
 	{
 		$column = new LayoutColumn([
 			'blocks' => [

--- a/tests/Cms/Layouts/LayoutMethodsTest.php
+++ b/tests/Cms/Layouts/LayoutMethodsTest.php
@@ -18,7 +18,7 @@ class LayoutMethodsTest extends TestCase
 		]);
 	}
 
-	public function testLayoutMethod()
+	public function testLayoutMethod(): void
 	{
 		$layout = new Layout();
 		$this->assertSame('layout method', $layout->test());

--- a/tests/Cms/Layouts/LayoutTest.php
+++ b/tests/Cms/Layouts/LayoutTest.php
@@ -6,13 +6,13 @@ use Kirby\TestCase;
 
 class LayoutTest extends TestCase
 {
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		$layout = new Layout();
 		$this->assertInstanceOf(LayoutColumns::class, $layout->columns());
 	}
 
-	public function testIsEmpty()
+	public function testIsEmpty(): void
 	{
 		$layout = new Layout([
 			'columns' => []
@@ -22,7 +22,7 @@ class LayoutTest extends TestCase
 		$this->assertFalse($layout->isNotEmpty());
 	}
 
-	public function testIsNotEmpty()
+	public function testIsNotEmpty(): void
 	{
 		$layout = new Layout([
 			'columns' => [
@@ -45,7 +45,7 @@ class LayoutTest extends TestCase
 		$this->assertTrue($layout->isNotEmpty());
 	}
 
-	public function testIsEmptyWithHidden()
+	public function testIsEmptyWithHidden(): void
 	{
 		$layout = new Layout([
 			'columns' => [

--- a/tests/Cms/Layouts/LayoutsMethodsTest.php
+++ b/tests/Cms/Layouts/LayoutsMethodsTest.php
@@ -18,7 +18,7 @@ class LayoutsMethodsTest extends TestCase
 		]);
 	}
 
-	public function testLayoutsMethod()
+	public function testLayoutsMethod(): void
 	{
 		$layouts = Layouts::factory();
 		$this->assertSame('layouts method', $layouts->test());

--- a/tests/Cms/Layouts/LayoutsTest.php
+++ b/tests/Cms/Layouts/LayoutsTest.php
@@ -6,7 +6,7 @@ use Kirby\TestCase;
 
 class LayoutsTest extends TestCase
 {
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$layouts = Layouts::factory([
 			[
@@ -25,7 +25,7 @@ class LayoutsTest extends TestCase
 		$this->assertSame('1/2', $layouts->first()->columns()->first()->width());
 	}
 
-	public function testFactoryIsWrappingBlocks()
+	public function testFactoryIsWrappingBlocks(): void
 	{
 		$layouts = Layouts::factory([
 			[
@@ -51,7 +51,7 @@ class LayoutsTest extends TestCase
 		$this->assertSame('Text', $blocks->last()->text()->value());
 	}
 
-	public function testHasBlockType()
+	public function testHasBlockType(): void
 	{
 		$layouts = Layouts::factory([
 			[
@@ -68,7 +68,7 @@ class LayoutsTest extends TestCase
 		$this->assertFalse($layouts->hasBlockType('code'));
 	}
 
-	public function testParse()
+	public function testParse(): void
 	{
 		$data = [
 			[
@@ -86,7 +86,7 @@ class LayoutsTest extends TestCase
 		$this->assertSame($data, $result);
 	}
 
-	public function testParseArray()
+	public function testParseArray(): void
 	{
 		$data = [
 			[
@@ -103,7 +103,7 @@ class LayoutsTest extends TestCase
 		$this->assertSame($data, $result);
 	}
 
-	public function testParseEmpty()
+	public function testParseEmpty(): void
 	{
 		$result = Layouts::parse(null);
 		$this->assertSame([], $result);
@@ -121,7 +121,7 @@ class LayoutsTest extends TestCase
 		$this->assertSame([], $result);
 	}
 
-	public function testToBlocks()
+	public function testToBlocks(): void
 	{
 		$data = [
 			[
@@ -140,7 +140,7 @@ class LayoutsTest extends TestCase
 		$this->assertInstanceOf(Blocks::class, $blocks);
 	}
 
-	public function testHiddenBlocks()
+	public function testHiddenBlocks(): void
 	{
 		$data = [
 			[

--- a/tests/Cms/Loader/LoaderTest.php
+++ b/tests/Cms/Loader/LoaderTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Cms;
 
 use Closure;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Loader
- */
+#[CoversClass(Loader::class)]
 class LoaderTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
@@ -19,21 +18,14 @@ class LoaderTest extends TestCase
 		$this->loader = new Loader($this->app);
 	}
 
-	/**
-	 * @covers ::area
-	 */
-	public function testArea()
+	public function testArea(): void
 	{
 		$area = $this->loader->area('site');
 
 		$this->assertSame('Site', $area['label']);
 	}
 
-	/**
-	 * @covers ::area
-	 * @covers ::areas
-	 */
-	public function testAreaPlugin()
+	public function testAreaPlugin(): void
 	{
 		$this->app = $this->app->clone([
 			'areas' => [
@@ -48,11 +40,7 @@ class LoaderTest extends TestCase
 		$this->assertSame('Todos', $area['label']);
 	}
 
-	/**
-	 * @covers ::area
-	 * @covers ::areas
-	 */
-	public function testAreaCorePlugin()
+	public function testAreaCorePlugin(): void
 	{
 		$this->app = $this->app->clone([
 			'areas' => [
@@ -67,10 +55,7 @@ class LoaderTest extends TestCase
 		$this->assertSame('Seite', $area['label']);
 	}
 
-	/**
-	 * @covers ::areas
-	 */
-	public function testAreaDropdownPlugin()
+	public function testAreaDropdownPlugin(): void
 	{
 		$this->app = $this->app->clone([
 			'areas' => [
@@ -89,10 +74,7 @@ class LoaderTest extends TestCase
 		$this->assertSame('foo', $dropdown['options']());
 	}
 
-	/**
-	 * @covers ::areas
-	 */
-	public function testAreas()
+	public function testAreas(): void
 	{
 		$areas = $this->loader->areas();
 
@@ -104,30 +86,21 @@ class LoaderTest extends TestCase
 		$this->assertSame('Users', $areas['users']['label']);
 	}
 
-	/**
-	 * @covers ::component
-	 */
-	public function testComponent()
+	public function testComponent(): void
 	{
 		$component = $this->loader->component('url');
 
 		$this->assertInstanceOf('Closure', $component);
 	}
 
-	/**
-	 * @covers ::components
-	 */
-	public function testComponents()
+	public function testComponents(): void
 	{
 		$components = $this->loader->components();
 
 		$this->assertArrayHasKey('url', $components);
 	}
 
-	/**
-	 * @covers ::extension
-	 */
-	public function testExtension()
+	public function testExtension(): void
 	{
 		$extension = $this->loader->extension('tags', 'video');
 
@@ -135,10 +108,7 @@ class LoaderTest extends TestCase
 		$this->assertInstanceOf('Closure', $extension['html']);
 	}
 
-	/**
-	 * @covers ::extensions
-	 */
-	public function testExtensions()
+	public function testExtensions(): void
 	{
 		$extensions = $this->loader->extensions('tags');
 
@@ -146,10 +116,7 @@ class LoaderTest extends TestCase
 		$this->assertArrayHasKey('video', $extensions);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveArray()
+	public function testResolveArray(): void
 	{
 		$resolved = $this->loader->resolve([
 			'test' => 'Test'
@@ -158,10 +125,7 @@ class LoaderTest extends TestCase
 		$this->assertSame('Test', $resolved['test']);
 	}
 
-	/**
-	 * @covers ::resolveArea
-	 */
-	public function testResolveArea()
+	public function testResolveArea(): void
 	{
 		$resolved = $this->loader->resolveArea([
 			'dropdowns' => [
@@ -176,10 +140,7 @@ class LoaderTest extends TestCase
 		);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveClosure()
+	public function testResolveClosure(): void
 	{
 		$resolved = $this->loader->resolve(fn () => [
 			'test' => 'Test'
@@ -188,30 +149,21 @@ class LoaderTest extends TestCase
 		$this->assertSame('Test', $resolved['test']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolvePHPFile()
+	public function testResolvePHPFile(): void
 	{
 		$resolved = $this->loader->resolve(static::FIXTURES . '/resolve.php');
 
 		$this->assertSame('Test', $resolved['test']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
-	public function testResolveYamlFile()
+	public function testResolveYamlFile(): void
 	{
 		$resolved = $this->loader->resolve(static::FIXTURES . '/resolve.yml');
 
 		$this->assertSame('Test', $resolved['test']);
 	}
 
-	/**
-	 * @covers ::resolveAll
-	 */
-	public function testResolveAll()
+	public function testResolveAll(): void
 	{
 		$resolved = $this->loader->resolveAll([
 			'test' => static::FIXTURES . '/resolve.php'
@@ -220,10 +172,7 @@ class LoaderTest extends TestCase
 		$this->assertSame('Test', $resolved['test']['test']);
 	}
 
-	/**
-	 * @covers ::section
-	 */
-	public function testSection()
+	public function testSection(): void
 	{
 		$section = $this->loader->section('pages');
 
@@ -232,10 +181,7 @@ class LoaderTest extends TestCase
 		$this->assertArrayHasKey('methods', $section);
 	}
 
-	/**
-	 * @covers ::sections
-	 */
-	public function testSections()
+	public function testSections(): void
 	{
 		$sections = $this->loader->sections();
 
@@ -243,10 +189,7 @@ class LoaderTest extends TestCase
 		$this->assertArrayHasKey('info', $sections);
 	}
 
-	/**
-	 * @covers ::withPlugins
-	 */
-	public function testWithPlugins()
+	public function testWithPlugins(): void
 	{
 		$loader = new Loader($this->app);
 		$this->assertTrue($loader->withPlugins());

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -2,6 +2,9 @@
 
 namespace Kirby\Cms;
 
+use Exception;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 
@@ -10,7 +13,7 @@ class MediaTest extends TestCase
 	public const FIXTURES = __DIR__ . '/fixtures';
 	public const TMP      = KIRBY_TMP_DIR . '/Cms.Media';
 
-	public function testLinkSiteFile()
+	public function testLinkSiteFile(): void
 	{
 		F::write(static::TMP . '/content/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
 
@@ -22,7 +25,7 @@ class MediaTest extends TestCase
 		$this->assertSame('image/svg+xml', $result->type());
 	}
 
-	public function testLinkPageFile()
+	public function testLinkPageFile(): void
 	{
 		F::write(static::TMP . '/content/projects/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
 
@@ -34,7 +37,7 @@ class MediaTest extends TestCase
 		$this->assertSame('image/svg+xml', $result->type());
 	}
 
-	public function testLinkWithInvalidHash()
+	public function testLinkWithInvalidHash(): void
 	{
 		F::write(static::TMP . '/content/projects/test.svg', '<svg xmlns="http://www.w3.org/2000/svg"/>');
 
@@ -52,17 +55,17 @@ class MediaTest extends TestCase
 		$this->assertFalse($result);
 	}
 
-	public function testLinkWithoutModel()
+	public function testLinkWithoutModel(): void
 	{
 		$this->assertFalse(Media::link(null, 'hash', 'filename.jpg'));
 	}
 
-	public function testLinkNonExistingFile()
+	public function testLinkNonExistingFile(): void
 	{
 		$this->assertFalse(Media::link($this->app->site(), 'hash', 'filename.jpg'));
 	}
 
-	public function testPublish()
+	public function testPublish(): void
 	{
 		$site = new Site();
 
@@ -94,7 +97,7 @@ class MediaTest extends TestCase
 		$this->assertDirectoryDoesNotExist($versionB1);
 	}
 
-	public function testUnpublish()
+	public function testUnpublish(): void
 	{
 		$page = new Page([
 			'slug' => 'test'
@@ -129,7 +132,7 @@ class MediaTest extends TestCase
 		$this->assertDirectoryDoesNotExist($versionB2);
 	}
 
-	public function testUnpublishAndIgnore()
+	public function testUnpublishAndIgnore(): void
 	{
 		$page = new Page([
 			'slug' => 'test'
@@ -164,7 +167,7 @@ class MediaTest extends TestCase
 		$this->assertDirectoryDoesNotExist($versionB2);
 	}
 
-	public function testUnpublishNonExistingDirectory()
+	public function testUnpublishNonExistingDirectory(): void
 	{
 		$directory = static::TMP . '/does-not-exist';
 
@@ -181,7 +184,7 @@ class MediaTest extends TestCase
 		$this->assertTrue(Media::unpublish($directory, $file));
 	}
 
-	public function testThumb()
+	public function testThumb(): void
 	{
 		Dir::make(static::TMP . '/content');
 
@@ -211,7 +214,7 @@ class MediaTest extends TestCase
 		$this->assertSame(64, $thumbInfo[1]);
 	}
 
-	public function testThumbWithoutJobsFile()
+	public function testThumbWithoutJobsFile(): void
 	{
 		Dir::make(static::TMP . '/content');
 
@@ -221,7 +224,7 @@ class MediaTest extends TestCase
 		// get file object
 		$file = $this->app->file('test.jpg');
 
-		$this->expectException(\Kirby\Exception\NotFoundException::class);
+		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('The thumbnail configuration could not be found');
 
 		// invalid with no job file
@@ -229,7 +232,7 @@ class MediaTest extends TestCase
 		$this->assertFalse($thumb);
 	}
 
-	public function testThumbWithIncompleteJobFile()
+	public function testThumbWithIncompleteJobFile(): void
 	{
 		Dir::make(static::TMP . '/content');
 
@@ -242,14 +245,14 @@ class MediaTest extends TestCase
 		// create an empty job file
 		F::write($file->mediaDir() . '/.jobs/' . $file->filename() . '.json', '{}');
 
-		$this->expectException(\Kirby\Exception\InvalidArgumentException::class);
+		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Incomplete thumbnail configuration');
 
 		$thumb = Media::thumb($file, $file->mediaHash(), $file->filename());
 		$this->assertFalse($thumb);
 	}
 
-	public function testThumbWhenGenerationFails()
+	public function testThumbWhenGenerationFails(): void
 	{
 		Dir::make(static::TMP . '/content');
 
@@ -267,13 +270,13 @@ class MediaTest extends TestCase
 		$jobString = '{"width":64,"height":64,"quality":null,"crop":"center","filename":"test.jpg"}';
 		F::write($file->mediaDir() . '/.jobs/' . $file->filename() . '.json', $jobString);
 
-		$this->expectException(\Exception::class);
+		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('File not found');
 
 		Media::thumb($site, $file->mediaHash(), $file->filename());
 	}
 
-	public function testThumbStringModel()
+	public function testThumbStringModel(): void
 	{
 		Dir::make(static::TMP . '/content');
 

--- a/tests/Cms/Model/ModelCommitTest.php
+++ b/tests/Cms/Model/ModelCommitTest.php
@@ -44,7 +44,7 @@ class ModelCommitTest extends TestCase
 		];
 	}
 
-	public function testAfter()
+	public function testAfter(): void
 	{
 		$phpunit = $this;
 		$calls   = 0;
@@ -78,7 +78,7 @@ class ModelCommitTest extends TestCase
 		$this->assertSame(1, $calls);
 	}
 
-	public function testAfterFlushesCache()
+	public function testAfterFlushesCache(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -107,7 +107,7 @@ class ModelCommitTest extends TestCase
 		$this->assertSame(null, $this->app->cache('pages')->get('test'));
 	}
 
-	public function testAfterHookArgumentsForPageCreate()
+	public function testAfterHookArgumentsForPageCreate(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -127,7 +127,7 @@ class ModelCommitTest extends TestCase
 		], $args);
 	}
 
-	public function testAfterHookArgumentsForPageDuplicate()
+	public function testAfterHookArgumentsForPageDuplicate(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -152,7 +152,7 @@ class ModelCommitTest extends TestCase
 		], $args);
 	}
 
-	public function testAfterHookArgumentsForPageDelete()
+	public function testAfterHookArgumentsForPageDelete(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -173,7 +173,7 @@ class ModelCommitTest extends TestCase
 		], $args);
 	}
 
-	public function testAfterHookArgumentsForPageUpdate()
+	public function testAfterHookArgumentsForPageUpdate(): void
 	{
 		$oldPage = new Page([
 			'slug' => 'test',
@@ -198,7 +198,7 @@ class ModelCommitTest extends TestCase
 		], $args);
 	}
 
-	public function testAfterHookArgumentsForFileCreate()
+	public function testAfterHookArgumentsForFileCreate(): void
 	{
 		$file = new File([
 			'parent'   => $this->app->site(),
@@ -219,7 +219,7 @@ class ModelCommitTest extends TestCase
 		], $args);
 	}
 
-	public function testAfterHookArgumentsForFileDelete()
+	public function testAfterHookArgumentsForFileDelete(): void
 	{
 		$file = new File([
 			'parent'   => $this->app->site(),
@@ -241,7 +241,7 @@ class ModelCommitTest extends TestCase
 		], $args);
 	}
 
-	public function testAfterHookArgumentsForFileUpdate()
+	public function testAfterHookArgumentsForFileUpdate(): void
 	{
 		$oldFile = new File([
 			'parent'   => $this->app->site(),
@@ -268,7 +268,7 @@ class ModelCommitTest extends TestCase
 		], $args);
 	}
 
-	public function testAfterHookArgumentsForSiteActions()
+	public function testAfterHookArgumentsForSiteActions(): void
 	{
 		$oldSite = new Site([
 			'name' => 'Test'
@@ -293,7 +293,7 @@ class ModelCommitTest extends TestCase
 		], $args);
 	}
 
-	public function testAfterHookArgumentsForUserCreate()
+	public function testAfterHookArgumentsForUserCreate(): void
 	{
 		$user = new User([
 			'email' => 'test@test.com'
@@ -313,7 +313,7 @@ class ModelCommitTest extends TestCase
 		], $args);
 	}
 
-	public function testAfterHookArgumentsForUserDelete()
+	public function testAfterHookArgumentsForUserDelete(): void
 	{
 		$user = new User([
 			'email' => 'test@test.com'
@@ -334,7 +334,7 @@ class ModelCommitTest extends TestCase
 		], $args);
 	}
 
-	public function testAfterHookArgumentsForUserUpdate()
+	public function testAfterHookArgumentsForUserUpdate(): void
 	{
 		$oldUser = new User([
 			'email' => 'test@test.com'
@@ -359,7 +359,7 @@ class ModelCommitTest extends TestCase
 		], $args);
 	}
 
-	public function testBefore()
+	public function testBefore(): void
 	{
 		$phpunit = $this;
 		$calls   = 0;
@@ -393,7 +393,7 @@ class ModelCommitTest extends TestCase
 		$this->assertSame(1, $calls);
 	}
 
-	public function testHook()
+	public function testHook(): void
 	{
 		$phpunit = $this;
 		$calls   = 0;
@@ -440,7 +440,7 @@ class ModelCommitTest extends TestCase
 		$this->assertSame(1, $calls);
 	}
 
-	public function testHookWithModifiedModel()
+	public function testHookWithModifiedModel(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [
@@ -485,7 +485,7 @@ class ModelCommitTest extends TestCase
 		$this->assertSame('Modified', $this->app->page('test')->title()->value(), 'The app state should be updated as well');
 	}
 
-	public function testHookWithModifiedModelLegacyMethod()
+	public function testHookWithModifiedModelLegacyMethod(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [
@@ -534,7 +534,7 @@ class ModelCommitTest extends TestCase
 		$this->assertSame('Modified', $this->app->page('test')->title()->value(), 'The app state should be updated as well');
 	}
 
-	public function testHookWithMultipleHandlers()
+	public function testHookWithMultipleHandlers(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [
@@ -592,7 +592,7 @@ class ModelCommitTest extends TestCase
 		$this->assertSame('Modified Subtitle', $this->app->page('test')->subtitle()->value());
 	}
 
-	public function testHookWithMultipleHandlersAndLegacyMethod()
+	public function testHookWithMultipleHandlersAndLegacyMethod(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [

--- a/tests/Cms/Model/ModelStateTest.php
+++ b/tests/Cms/Model/ModelStateTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(ModelState::class)]
 class ModelStateTest extends TestCase
 {
-	public function testUpdateFile()
+	public function testUpdateFile(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [
@@ -41,7 +41,7 @@ class ModelStateTest extends TestCase
 		$this->assertSame($next, $parent->file('test.jpg'));
 	}
 
-	public function testUpdateFileWithDuplicateAsMethod()
+	public function testUpdateFileWithDuplicateAsMethod(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [
@@ -75,7 +75,7 @@ class ModelStateTest extends TestCase
 		$this->assertSame($current, $parent->file('test.jpg'));
 	}
 
-	public function testUpdatePage()
+	public function testUpdatePage(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [
@@ -107,7 +107,7 @@ class ModelStateTest extends TestCase
 		$this->assertSame($next, $this->app->page('test'));
 	}
 
-	public function testUpdatePageWithDuplicateAsMethod()
+	public function testUpdatePageWithDuplicateAsMethod(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [
@@ -139,7 +139,7 @@ class ModelStateTest extends TestCase
 		$this->assertSame($current, $this->app->page('test'));
 	}
 
-	public function testUpdateSite()
+	public function testUpdateSite(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [
@@ -164,7 +164,7 @@ class ModelStateTest extends TestCase
 		$this->assertSame($this->app->site(), $next);
 	}
 
-	public function testUpdateSiteWithDuplicateAsMethod()
+	public function testUpdateSiteWithDuplicateAsMethod(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [
@@ -190,7 +190,7 @@ class ModelStateTest extends TestCase
 		$this->assertSame($current, $this->app->site());
 	}
 
-	public function testUpdateUser()
+	public function testUpdateUser(): void
 	{
 		$this->app = $this->app->clone([
 			'users' => [
@@ -215,7 +215,7 @@ class ModelStateTest extends TestCase
 		$this->assertSame($this->app->user('admin'), $next);
 	}
 
-	public function testUpdateUserWithDuplicateAsMethod()
+	public function testUpdateUserWithDuplicateAsMethod(): void
 	{
 		$this->app = $this->app->clone([
 			'users' => [

--- a/tests/Cms/Model/ModelWithContentTest.php
+++ b/tests/Cms/Model/ModelWithContentTest.php
@@ -136,7 +136,7 @@ class ModelWithContentTest extends TestCase
 		];
 	}
 
-	public function testContentForInvalidTranslation()
+	public function testContentForInvalidTranslation(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -169,7 +169,7 @@ class ModelWithContentTest extends TestCase
 		$app->page('foo')->content('fr');
 	}
 
-	public function testContentUpdate()
+	public function testContentUpdate(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -194,7 +194,7 @@ class ModelWithContentTest extends TestCase
 		$this->assertSame('Test', $page->content()->get('title')->value());
 	}
 
-	public function testContentUpdateWithMultipleLanguages()
+	public function testContentUpdateWithMultipleLanguages(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -231,7 +231,7 @@ class ModelWithContentTest extends TestCase
 		$this->assertSame('Test', $page->content()->get('title')->value());
 	}
 
-	public function testContentWithChanges()
+	public function testContentWithChanges(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -270,7 +270,7 @@ class ModelWithContentTest extends TestCase
 	}
 
 	#[DataProvider('modelsProvider')]
-	public function testBlueprints(ModelWithContent $model)
+	public function testBlueprints(ModelWithContent $model): void
 	{
 		$model = new BlueprintsModelWithContent($model);
 
@@ -334,7 +334,7 @@ class ModelWithContentTest extends TestCase
 		$this->assertFalse($model->isValid());
 	}
 
-	public function testKirby()
+	public function testKirby(): void
 	{
 		$kirby = new App();
 		$model = new Page([
@@ -344,7 +344,7 @@ class ModelWithContentTest extends TestCase
 		$this->assertSame($kirby, $model->kirby());
 	}
 
-	public function testLock()
+	public function testLock(): void
 	{
 		$page = new Page(['slug' => 'foo']);
 		$lock = $page->lock();
@@ -356,7 +356,7 @@ class ModelWithContentTest extends TestCase
 	}
 
 	#[DataProvider('modelsProvider')]
-	public function testPurge(ModelWithContent $model)
+	public function testPurge(ModelWithContent $model): void
 	{
 		$model = new BlueprintsModelWithContent($model);
 
@@ -391,7 +391,7 @@ class ModelWithContentTest extends TestCase
 		$this->assertNull($model->blueprintsCache());
 	}
 
-	public function testSite()
+	public function testSite(): void
 	{
 		$site  = new Site();
 		$model = new Page([
@@ -401,14 +401,14 @@ class ModelWithContentTest extends TestCase
 		$this->assertIsSite($site, $model->site());
 	}
 
-	public function testToSafeString()
+	public function testToSafeString(): void
 	{
 		$model = new Page(['slug' => 'foo', 'content' => ['title' => 'value &']]);
 		$this->assertSame('Hello value &amp; foo', $model->toSafeString('Hello {{ model.title }} {{ model.slug }}'));
 		$this->assertSame('Hello value & foo', $model->toSafeString('Hello {< model.title >} {{ model.slug }}'));
 	}
 
-	public function testToSafeStringWithData()
+	public function testToSafeStringWithData(): void
 	{
 		$model = new Site();
 		$this->assertSame(
@@ -431,7 +431,7 @@ class ModelWithContentTest extends TestCase
 		);
 	}
 
-	public function testToSafeStringWithFallback()
+	public function testToSafeStringWithFallback(): void
 	{
 		$model = new Site();
 		$this->assertSame('Hello ', $model->toSafeString('Hello {{ invalid }}', []));
@@ -444,7 +444,7 @@ class ModelWithContentTest extends TestCase
 		$this->assertSame('Hello foo/{{ invalid }}', $model->toSafeString('Hello {{ model.slug }}/{{ invalid }}', [], null));
 	}
 
-	public function testToString()
+	public function testToString(): void
 	{
 		$model = new Site();
 		$this->assertSame('Hello home', $model->toString('Hello {{ model.homePageId }}'));
@@ -453,7 +453,7 @@ class ModelWithContentTest extends TestCase
 		$this->assertSame('Hello foo/home', $model->toString('Hello {{ model.slug }}/{{ site.homePageId }}'));
 	}
 
-	public function testToStringWithData()
+	public function testToStringWithData(): void
 	{
 		$model = new Site();
 		$this->assertSame('Hello home in value', $model->toString('Hello {{ model.homePageId }} in {{ key }}', ['key' => 'value']));
@@ -465,7 +465,7 @@ class ModelWithContentTest extends TestCase
 		);
 	}
 
-	public function testToStringWithFallback()
+	public function testToStringWithFallback(): void
 	{
 		$model = new Site();
 		$this->assertSame('Hello ', $model->toString('Hello {{ invalid }}', []));
@@ -478,7 +478,7 @@ class ModelWithContentTest extends TestCase
 		$this->assertSame('Hello foo/{{ invalid }}', $model->toString('Hello {{ model.slug }}/{{ invalid }}', [], null));
 	}
 
-	public function testToStringWithoutValue()
+	public function testToStringWithoutValue(): void
 	{
 		$model = new Site();
 		$this->assertSame('', $model->toString());
@@ -487,7 +487,7 @@ class ModelWithContentTest extends TestCase
 		$this->assertSame('foo', $model->toString());
 	}
 
-	public function testTranslation()
+	public function testTranslation(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -543,7 +543,7 @@ class ModelWithContentTest extends TestCase
 		$this->assertSame('Deutscher Titel', $current->content()['title']);
 	}
 
-	public function testTranslationWithInvalidLanguauge()
+	public function testTranslationWithInvalidLanguauge(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -570,13 +570,13 @@ class ModelWithContentTest extends TestCase
 			]
 		]);
 
-		$this->expectException(\Kirby\Exception\NotFoundException::class);
+		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Invalid language: fr');
 
 		$fr = $app->page('foo')->translation('fr');
 	}
 
-	public function testUuid()
+	public function testUuid(): void
 	{
 		$model = new Site();
 		$this->assertInstanceOf(SiteUuid::class, $model->uuid());
@@ -585,7 +585,7 @@ class ModelWithContentTest extends TestCase
 		$this->assertInstanceOf(PageUuid::class, $model->uuid());
 	}
 
-	public function testVersion()
+	public function testVersion(): void
 	{
 		$model = new Site();
 		$this->assertInstanceOf(Version::class, $model->version('latest'));
@@ -598,7 +598,7 @@ class ModelWithContentTest extends TestCase
 		$this->assertSame('latest', $model->version(VersionId::latest())->id()->value());
 	}
 
-	public function testVersionFallback()
+	public function testVersionFallback(): void
 	{
 		$model = new Page(['slug' => 'foo']);
 		$this->assertInstanceOf(Version::class, $model->version());

--- a/tests/Cms/Nests/NestCollectionTest.php
+++ b/tests/Cms/Nests/NestCollectionTest.php
@@ -6,7 +6,7 @@ use Kirby\TestCase;
 
 class NestCollectionTest extends TestCase
 {
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$collection = new NestCollection([
 			new NestObject([

--- a/tests/Cms/Nests/NestObjectTest.php
+++ b/tests/Cms/Nests/NestObjectTest.php
@@ -7,7 +7,7 @@ use Kirby\TestCase;
 
 class NestObjectTest extends TestCase
 {
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$o = new NestObject($expected = [
 			'a' => 'A',
@@ -17,7 +17,7 @@ class NestObjectTest extends TestCase
 		$this->assertSame($expected, $o->toArray());
 	}
 
-	public function testToArrayWithFields()
+	public function testToArrayWithFields(): void
 	{
 		$o = new NestObject([
 			'a' => new Field(null, 'a', 'A'),
@@ -32,7 +32,7 @@ class NestObjectTest extends TestCase
 		$this->assertSame($expected, $o->toArray());
 	}
 
-	public function testToArrayWithNestedObjects()
+	public function testToArrayWithNestedObjects(): void
 	{
 		$o = new NestObject([
 			'user' => new NestObject([

--- a/tests/Cms/Nests/NestTest.php
+++ b/tests/Cms/Nests/NestTest.php
@@ -6,7 +6,7 @@ use Kirby\TestCase;
 
 class NestTest extends TestCase
 {
-	public function testCreateScalar()
+	public function testCreateScalar(): void
 	{
 		$n = Nest::create($expected = 'a');
 
@@ -14,14 +14,14 @@ class NestTest extends TestCase
 		$this->assertEquals($expected, $n); // cannot use strict assertion (string conversion)
 	}
 
-	public function testCreateEmptyCollection()
+	public function testCreateEmptyCollection(): void
 	{
 		$n = Nest::create([]);
 		$this->assertInstanceOf(NestCollection::class, $n);
 		$this->assertCount(0, $n);
 	}
 
-	public function testCreateObject()
+	public function testCreateObject(): void
 	{
 		$n = Nest::create($expected = [
 			'a' => 'A',
@@ -33,7 +33,7 @@ class NestTest extends TestCase
 		$this->assertSame($expected, $n->toArray());
 	}
 
-	public function testCreateCollection()
+	public function testCreateCollection(): void
 	{
 		$n = Nest::create($expected = ['A', 2, false]);
 

--- a/tests/Cms/Page/PageChangeTitleTest.php
+++ b/tests/Cms/Page/PageChangeTitleTest.php
@@ -28,7 +28,7 @@ class PageChangeTitleTest extends ModelTestCase
 		$this->assertSame($modified, $childrenAndDrafts->find('test'));
 	}
 
-	public function testChangeTitleWhenChangesExist()
+	public function testChangeTitleWhenChangesExist(): void
 	{
 		$page = Page::create([
 			'slug' => 'test',

--- a/tests/Cms/Page/PageUpdateTest.php
+++ b/tests/Cms/Page/PageUpdateTest.php
@@ -15,7 +15,7 @@ class PageUpdateTest extends ModelTestCase
 		Page $original,
 		Pages $drafts,
 		Pages $childrenAndDrafts
-	) {
+	): void {
 		$this->assertSame('Test', $modified->headline()->value());
 
 		// assert that the page status didn't change with the update

--- a/tests/Cms/Page/PageUrlAndUriTest.php
+++ b/tests/Cms/Page/PageUrlAndUriTest.php
@@ -51,7 +51,7 @@ class PageUrlAndUriTest extends ModelTestCase
 		$this->assertSame('home', $page->uri());
 	}
 
-	public function testHomeChildUrlAndUriInMultiLanguageMode()
+	public function testHomeChildUrlAndUriInMultiLanguageMode(): void
 	{
 		$this->setUpMultiLanguage();
 

--- a/tests/Cms/Pages/PagesMethodsTest.php
+++ b/tests/Cms/Pages/PagesMethodsTest.php
@@ -20,7 +20,7 @@ class PagesMethodsTest extends TestCase
 		]);
 	}
 
-	public function testPagesMethod()
+	public function testPagesMethod(): void
 	{
 		$pages = $this->app->site()->children();
 		$this->assertSame('pages method', $pages->test());

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Cms;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Pages
- */
+#[CoversClass(Pages::class)]
 class PagesTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Pages';
@@ -22,7 +21,7 @@ class PagesTest extends TestCase
 		]);
 	}
 
-	public function testAddPage()
+	public function testAddPage(): void
 	{
 		$pages = Pages::factory([
 			['slug' => 'a']
@@ -39,7 +38,7 @@ class PagesTest extends TestCase
 		$this->assertSame('b', $result->nth(1)->slug());
 	}
 
-	public function testAddCollection()
+	public function testAddCollection(): void
 	{
 		$a = Pages::factory([
 			['slug' => 'a']
@@ -58,7 +57,7 @@ class PagesTest extends TestCase
 		$this->assertSame('c', $c->nth(2)->slug());
 	}
 
-	public function testAddById()
+	public function testAddById(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -87,7 +86,7 @@ class PagesTest extends TestCase
 		$this->assertSame('a/aa', $pages->nth(2)->id());
 	}
 
-	public function testAddNull()
+	public function testAddNull(): void
 	{
 		$pages = new Pages();
 		$this->assertCount(0, $pages);
@@ -97,7 +96,7 @@ class PagesTest extends TestCase
 		$this->assertCount(0, $pages);
 	}
 
-	public function testAddFalse()
+	public function testAddFalse(): void
 	{
 		$pages = new Pages();
 		$this->assertCount(0, $pages);
@@ -107,7 +106,7 @@ class PagesTest extends TestCase
 		$this->assertCount(0, $pages);
 	}
 
-	public function testAddInvalidObject()
+	public function testAddInvalidObject(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('You must pass a Pages or Page object or an ID of an existing page to the Pages collection');
@@ -117,7 +116,7 @@ class PagesTest extends TestCase
 		$pages->add($site);
 	}
 
-	public function testAudio()
+	public function testAudio(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -138,7 +137,7 @@ class PagesTest extends TestCase
 		$this->assertSame(['a.mp3', 'b.mp3'], $pages->audio()->pluck('filename'));
 	}
 
-	public function testCode()
+	public function testCode(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -159,14 +158,14 @@ class PagesTest extends TestCase
 		$this->assertSame(['a.js', 'b.js'], $pages->code()->pluck('filename'));
 	}
 
-	public function testConstructWithCollection()
+	public function testConstructWithCollection(): void
 	{
 		$pages = new Pages($this->pages()->not('a'));
 
 		$this->assertCount(2, $pages);
 	}
 
-	public function testChildren()
+	public function testChildren(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -195,10 +194,7 @@ class PagesTest extends TestCase
 		$this->assertSame($expected, $pages->children()->keys());
 	}
 
-	/**
-	 * @covers ::delete
-	 */
-	public function testDelete()
+	public function testDelete(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -239,10 +235,7 @@ class PagesTest extends TestCase
 		$this->assertDirectoryDoesNotExist($b);
 	}
 
-	/**
-	 * @covers ::delete
-	 */
-	public function testDeleteWithInvalidIds()
+	public function testDeleteWithInvalidIds(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -288,7 +281,7 @@ class PagesTest extends TestCase
 		$this->assertDirectoryExists($b);
 	}
 
-	public function testDocuments()
+	public function testDocuments(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -309,7 +302,7 @@ class PagesTest extends TestCase
 		$this->assertSame(['a.pdf', 'b.pdf'], $pages->documents()->pluck('filename'));
 	}
 
-	public function testDrafts()
+	public function testDrafts(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -338,7 +331,7 @@ class PagesTest extends TestCase
 		$this->assertSame($expected, $pages->drafts()->keys());
 	}
 
-	public function testFiles()
+	public function testFiles(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -358,20 +351,20 @@ class PagesTest extends TestCase
 		$this->assertSame(['a.jpg', 'b.pdf'], $pages->files()->pluck('filename'));
 	}
 
-	public function testFind()
+	public function testFind(): void
 	{
 		$this->assertIsPage('a', $this->pages()->find('a'));
 		$this->assertIsPage('b', $this->pages()->find('b'));
 		$this->assertIsPage('c', $this->pages()->find('c'));
 	}
 
-	public function testFindWithExtension()
+	public function testFindWithExtension(): void
 	{
 		$this->assertIsPage('a', $this->pages()->find('a.xml'));
 		$this->assertIsPage('b', $this->pages()->find('b.json'));
 	}
 
-	public function testFindByUuid()
+	public function testFindByUuid(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -400,7 +393,7 @@ class PagesTest extends TestCase
 		$this->assertIsPage('c/d', $app->page('page://test-d'));
 	}
 
-	public function testFindChildren()
+	public function testFindChildren(): void
 	{
 		$site = new Site([
 			'children' => [
@@ -453,7 +446,7 @@ class PagesTest extends TestCase
 		$this->assertNull($pages->find(null));
 	}
 
-	public function testFindChildrenTranslated()
+	public function testFindChildrenTranslated(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -612,7 +605,7 @@ class PagesTest extends TestCase
 		$this->assertNull($pages->find('kind'));
 	}
 
-	public function testFindChildrenWithSwappedSlugsTranslated()
+	public function testFindChildrenWithSwappedSlugsTranslated(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -728,7 +721,7 @@ class PagesTest extends TestCase
 		$this->assertIsPage('zzz/yyy', $pages->find('zzz/yyy'));
 	}
 
-	public function testFindMultiple()
+	public function testFindMultiple(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -747,7 +740,7 @@ class PagesTest extends TestCase
 		$this->assertTrue($collection->has($page));
 	}
 
-	public function testImages()
+	public function testImages(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -768,7 +761,7 @@ class PagesTest extends TestCase
 		$this->assertSame(['a.jpg', 'b.png'], $pages->images()->pluck('filename'));
 	}
 
-	public function testIndex()
+	public function testIndex(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -807,7 +800,7 @@ class PagesTest extends TestCase
 		$this->assertSame($expected, $pages->index()->keys());
 	}
 
-	public function testIndexWithDrafts()
+	public function testIndexWithDrafts(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -854,7 +847,7 @@ class PagesTest extends TestCase
 		$this->assertSame($expected, $pages->index(true)->keys());
 	}
 
-	public function testIndexCacheMode()
+	public function testIndexCacheMode(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -923,7 +916,7 @@ class PagesTest extends TestCase
 		$this->assertSame($expectedIndexWithDrafts, $pages->index(true)->keys());
 	}
 
-	public function testNotTemplate()
+	public function testNotTemplate(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -951,7 +944,7 @@ class PagesTest extends TestCase
 		$this->assertSame([], $pages->notTemplate(['a', 'b', 'c'])->pluck('slug'));
 	}
 
-	public function testNums()
+	public function testNums(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -967,22 +960,22 @@ class PagesTest extends TestCase
 		$this->assertSame([1, 2], $pages->nums());
 	}
 
-	public function testListed()
+	public function testListed(): void
 	{
 		$this->assertCount(2, $this->pages()->listed());
 	}
 
-	public function testUnlisted()
+	public function testUnlisted(): void
 	{
 		$this->assertCount(1, $this->pages()->unlisted());
 	}
 
-	public function testPublished()
+	public function testPublished(): void
 	{
 		$this->assertCount(3, $this->pages()->published());
 	}
 
-	public function testSearch()
+	public function testSearch(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -1015,7 +1008,7 @@ class PagesTest extends TestCase
 		$this->assertCount(0, $result);
 	}
 
-	public function testSearchWords()
+	public function testSearchWords(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -1057,7 +1050,7 @@ class PagesTest extends TestCase
 		$this->assertCount(4, $result);
 	}
 
-	public function testCustomMethods()
+	public function testCustomMethods(): void
 	{
 		Pages::$methods = [
 			'test' => function () {
@@ -1085,7 +1078,7 @@ class PagesTest extends TestCase
 		Pages::$methods = [];
 	}
 
-	public function testTemplate()
+	public function testTemplate(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -1107,7 +1100,7 @@ class PagesTest extends TestCase
 		$this->assertSame(['a', 'b', 'c'], $pages->template(['a', 'b'])->pluck('slug'));
 	}
 
-	public function testVideos()
+	public function testVideos(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -1128,7 +1121,7 @@ class PagesTest extends TestCase
 		$this->assertSame(['a.mov', 'b.mp4'], $pages->videos()->pluck('filename'));
 	}
 
-	public function testFactoryIsDraftProp()
+	public function testFactoryIsDraftProp(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -1147,7 +1140,7 @@ class PagesTest extends TestCase
 		$this->assertSame([true, false, false], $pages->pluck('isDraft'));
 	}
 
-	public function testFactoryDraftParameter()
+	public function testFactoryDraftParameter(): void
 	{
 		$pages = Pages::factory([
 			[
@@ -1166,7 +1159,7 @@ class PagesTest extends TestCase
 		$this->assertSame([true, true, true], $pages->pluck('isDraft'));
 	}
 
-	public function testIsReadable()
+	public function testIsReadable(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -1212,7 +1205,7 @@ class PagesTest extends TestCase
 		$this->assertFalse($page->isReadable());
 	}
 
-	public function testIsListable()
+	public function testIsListable(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -1268,7 +1261,7 @@ class PagesTest extends TestCase
 		$this->assertFalse($page->isListable());
 	}
 
-	public function testIsAccessible()
+	public function testIsAccessible(): void
 	{
 		$app = new App([
 			'roots' => [

--- a/tests/Cms/Permissions/PermissionsTest.php
+++ b/tests/Cms/Permissions/PermissionsTest.php
@@ -3,10 +3,10 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Permissions
- */
+#[CoversClass(Permissions::class)]
 class PermissionsTest extends TestCase
 {
 	public function tearDown(): void
@@ -68,12 +68,8 @@ class PermissionsTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::for
-	 * @dataProvider actionsProvider
-	 */
-	public function testActions(string $category, $action)
+	#[DataProvider('actionsProvider')]
+	public function testActions(string $category, $action): void
 	{
 		// default
 		$p = new Permissions();
@@ -110,7 +106,7 @@ class PermissionsTest extends TestCase
 		$this->assertTrue($p->for($category, $action));
 	}
 
-	public function testExtendActions()
+	public function testExtendActions(): void
 	{
 		Permissions::$extendedActions = [
 			'test-category' => [
@@ -137,7 +133,7 @@ class PermissionsTest extends TestCase
 		$this->assertFalse($permissions->for('test-category', 'does-not-exist'));
 	}
 
-	public function testExtendActionsCoreOverride()
+	public function testExtendActionsCoreOverride(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The action pages is already a core action');
@@ -151,10 +147,7 @@ class PermissionsTest extends TestCase
 		new Permissions();
 	}
 
-	/**
-	 * @covers ::for
-	 */
-	public function testForDefault()
+	public function testForDefault(): void
 	{
 		// exists
 		$p = new Permissions();

--- a/tests/Cms/ResponderTest.php
+++ b/tests/Cms/ResponderTest.php
@@ -3,10 +3,9 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Responder
- */
+#[CoversClass(Responder::class)]
 class ResponderTest extends TestCase
 {
 	public function setUp(): void
@@ -23,10 +22,7 @@ class ResponderTest extends TestCase
 		unset($_COOKIE['foo'], $_SERVER['HTTP_AUTHORIZATION']);
 	}
 
-	/**
-	 * @covers ::cache
-	 */
-	public function testCache()
+	public function testCache(): void
 	{
 		$responder = new Responder();
 		$this->assertTrue($responder->cache());
@@ -38,10 +34,7 @@ class ResponderTest extends TestCase
 		$this->assertTrue($responder->cache());
 	}
 
-	/**
-	 * @covers ::cache
-	 */
-	public function testCacheUsesCookies()
+	public function testCacheUsesCookies(): void
 	{
 		$_COOKIE['foo'] = 'bar';
 
@@ -52,10 +45,7 @@ class ResponderTest extends TestCase
 		$this->assertFalse($responder->cache());
 	}
 
-	/**
-	 * @covers ::cache
-	 */
-	public function testCacheUsesAuth()
+	public function testCacheUsesAuth(): void
 	{
 		$this->kirby([
 			'server' => [
@@ -70,10 +60,7 @@ class ResponderTest extends TestCase
 		$this->assertFalse($responder->cache());
 	}
 
-	/**
-	 * @covers ::expires
-	 */
-	public function testExpires()
+	public function testExpires(): void
 	{
 		$responder = new Responder();
 		$this->assertNull($responder->expires());
@@ -118,10 +105,7 @@ class ResponderTest extends TestCase
 		$this->assertSame(1609459200, $responder->expires());
 	}
 
-	/**
-	 * @covers ::expires
-	 */
-	public function testExpiresInvalidString()
+	public function testExpiresInvalidString(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid time string "abcde"');
@@ -130,10 +114,7 @@ class ResponderTest extends TestCase
 		$responder->expires('abcde');
 	}
 
-	/**
-	 * @covers ::fromArray
-	 */
-	public function testFromArray()
+	public function testFromArray(): void
 	{
 		$responder = new Responder();
 		$responder->fromArray([
@@ -160,10 +141,7 @@ class ResponderTest extends TestCase
 		$this->assertSame(['foo'], $responder->usesCookies());
 	}
 
-	/**
-	 * @covers ::header
-	 */
-	public function testHeader()
+	public function testHeader(): void
 	{
 		$responder = new Responder();
 
@@ -205,10 +183,7 @@ class ResponderTest extends TestCase
 		$this->assertSame('private', $responder->header('Cache-Control'));
 	}
 
-	/**
-	 * @covers ::headers
-	 */
-	public function testHeaders()
+	public function testHeaders(): void
 	{
 		$responder = new Responder();
 		$this->assertSame([], $responder->headers());
@@ -220,10 +195,7 @@ class ResponderTest extends TestCase
 		$this->assertSame($headers, $responder->headers());
 	}
 
-	/**
-	 * @covers ::headers
-	 */
-	public function testHeadersCacheBehavior()
+	public function testHeadersCacheBehavior(): void
 	{
 		$responder = new Responder();
 		$this->assertSame([], $responder->headers());
@@ -252,10 +224,7 @@ class ResponderTest extends TestCase
 		$this->assertSame(['Cache-Control' => 'private'], $responder->headers());
 	}
 
-	/**
-	 * @covers ::isPrivate
-	 */
-	public function testIsPrivate()
+	public function testIsPrivate(): void
 	{
 		$responder = new Responder();
 
@@ -287,10 +256,7 @@ class ResponderTest extends TestCase
 		$this->assertFalse($responder->isPrivate(false, []));
 	}
 
-	/**
-	 * @covers ::toArray
-	 */
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$responder = new Responder();
 		$responder->fromArray([
@@ -315,10 +281,7 @@ class ResponderTest extends TestCase
 		], $responder->toArray());
 	}
 
-	/**
-	 * @covers ::usesAuth
-	 */
-	public function testUsesAuth()
+	public function testUsesAuth(): void
 	{
 		$responder = new Responder();
 		$this->assertFalse($responder->usesAuth());
@@ -330,10 +293,7 @@ class ResponderTest extends TestCase
 		$this->assertFalse($responder->usesAuth());
 	}
 
-	/**
-	 * @covers ::usesCookie
-	 */
-	public function testUsesCookie()
+	public function testUsesCookie(): void
 	{
 		$responder = new Responder();
 		$this->assertSame([], $responder->usesCookies());
@@ -349,10 +309,7 @@ class ResponderTest extends TestCase
 		$this->assertSame(['foo', 'bar'], $responder->usesCookies());
 	}
 
-	/**
-	 * @covers ::usesCookies
-	 */
-	public function testUsesCookies()
+	public function testUsesCookies(): void
 	{
 		$responder = new Responder();
 		$this->assertSame([], $responder->usesCookies());

--- a/tests/Cms/ResponseTest.php
+++ b/tests/Cms/ResponseTest.php
@@ -2,9 +2,9 @@
 
 namespace Kirby\Cms;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Response
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Response::class)]
 class ResponseTest extends TestCase
 {
 	public function setUp(): void
@@ -16,10 +16,7 @@ class ResponseTest extends TestCase
 		]);
 	}
 
-	/**
-	 * @covers ::redirect
-	 */
-	public function testRedirect()
+	public function testRedirect(): void
 	{
 		$response = Response::redirect();
 		$this->assertSame('', $response->body());
@@ -27,10 +24,7 @@ class ResponseTest extends TestCase
 		$this->assertEquals(['Location' => 'https://getkirby.test'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
-	/**
-	 * @covers ::redirect
-	 */
-	public function testRedirectWithLocation()
+	public function testRedirectWithLocation(): void
 	{
 		$response = Response::redirect('https://getkirby.com');
 		$this->assertSame('', $response->body());
@@ -38,10 +32,7 @@ class ResponseTest extends TestCase
 		$this->assertEquals(['Location' => 'https://getkirby.com'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
-	/**
-	 * @covers ::redirect
-	 */
-	public function testRedirectWithInternationalLocation()
+	public function testRedirectWithInternationalLocation(): void
 	{
 		$response = Response::redirect('https://täst.de');
 		$this->assertSame('', $response->body());
@@ -49,10 +40,7 @@ class ResponseTest extends TestCase
 		$this->assertEquals(['Location' => 'https://xn--tst-qla.de'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
-	/**
-	 * @covers ::redirect
-	 */
-	public function testRedirectWithResponseCodeAndUri()
+	public function testRedirectWithResponseCodeAndUri(): void
 	{
 		$response = Response::redirect('/uri', 301);
 		$this->assertSame('', $response->body());

--- a/tests/Cms/Roles/RoleTest.php
+++ b/tests/Cms/Roles/RoleTest.php
@@ -17,7 +17,7 @@ class RoleTest extends TestCase
 		]);
 	}
 
-	public function testProps()
+	public function testProps(): void
 	{
 		$role = new Role([
 			'description' => 'Test',
@@ -30,7 +30,7 @@ class RoleTest extends TestCase
 		$this->assertSame('Test', $role->description());
 	}
 
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$app  = $this->app();
 		$role = Role::load(static::FIXTURES . '/blueprints/users/editor.yml');
@@ -40,7 +40,7 @@ class RoleTest extends TestCase
 		$this->assertSame('This should be inherited', $role->description());
 	}
 
-	public function testMissingRole()
+	public function testMissingRole(): void
 	{
 		$this->expectException(Exception::class);
 
@@ -48,7 +48,7 @@ class RoleTest extends TestCase
 		Role::load('does-not-exist');
 	}
 
-	public function testDefaultAdmin()
+	public function testDefaultAdmin(): void
 	{
 		$app  = $this->app();
 		$role = Role::defaultAdmin();
@@ -57,7 +57,7 @@ class RoleTest extends TestCase
 		$this->assertSame('Admin', $role->title());
 	}
 
-	public function testDefaultNobody()
+	public function testDefaultNobody(): void
 	{
 		$app  = $this->app();
 		$role = Role::defaultNobody();
@@ -67,7 +67,7 @@ class RoleTest extends TestCase
 		$this->assertTrue($role->isNobody());
 	}
 
-	public function testTranslateTitle()
+	public function testTranslateTitle(): void
 	{
 		$role = new Role([
 			'name' => 'editor',
@@ -80,7 +80,7 @@ class RoleTest extends TestCase
 		$this->assertSame('Editor', $role->title());
 	}
 
-	public function testTranslateDescription()
+	public function testTranslateDescription(): void
 	{
 		$role = new Role([
 			'name' => 'editor',
@@ -93,7 +93,7 @@ class RoleTest extends TestCase
 		$this->assertSame('Editor', $role->title());
 	}
 
-	public function testToArrayAndDebugInfo()
+	public function testToArrayAndDebugInfo(): void
 	{
 		$role = new Role([
 			'name'        => 'editor',

--- a/tests/Cms/Roles/RolesTest.php
+++ b/tests/Cms/Roles/RolesTest.php
@@ -9,7 +9,7 @@ class RolesTest extends TestCase
 	public const FIXTURES = __DIR__ . '/fixtures';
 	public const TMP      = KIRBY_TMP_DIR . '/Cms.Roles';
 
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$roles = Roles::factory([
 			[
@@ -26,7 +26,7 @@ class RolesTest extends TestCase
 		$this->assertSame('editor', $roles->last()->name());
 	}
 
-	public function testLoad()
+	public function testLoad(): void
 	{
 		$roles = Roles::load(static::FIXTURES . '/blueprints/users');
 
@@ -39,7 +39,7 @@ class RolesTest extends TestCase
 		$this->assertSame('editor', $roles->last()->name());
 	}
 
-	public function testLoadFromPlugins()
+	public function testLoadFromPlugins(): void
 	{
 		$app = new App([
 			'blueprints' => [
@@ -61,7 +61,7 @@ class RolesTest extends TestCase
 		$this->assertSame('editor', $roles->last()->name());
 	}
 
-	public function testLoadFromPluginsCallbackString()
+	public function testLoadFromPluginsCallbackString(): void
 	{
 		new App([
 			'roots' => [
@@ -95,7 +95,7 @@ class RolesTest extends TestCase
 		$this->assertSame('editor', $roles->last()->name());
 	}
 
-	public function testLoadFromPluginsCallbackArray()
+	public function testLoadFromPluginsCallbackArray(): void
 	{
 		new App([
 			'blueprints' => [
@@ -121,7 +121,7 @@ class RolesTest extends TestCase
 		$this->assertSame('editor', $roles->last()->name());
 	}
 
-	public function testCanBeChanged()
+	public function testCanBeChanged(): void
 	{
 		$app = new App([
 			'users' => [
@@ -159,7 +159,7 @@ class RolesTest extends TestCase
 		$this->assertCount(2, $canBeChanged);
 	}
 
-	public function testCanBeCreated()
+	public function testCanBeCreated(): void
 	{
 		$app = new App([
 			'users' => [

--- a/tests/Cms/Routes/RouterTest.php
+++ b/tests/Cms/Routes/RouterTest.php
@@ -6,12 +6,13 @@ use InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\I18n;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RouterTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Router';
 
-	public function testHomeRoute()
+	public function testHomeRoute(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -26,7 +27,7 @@ class RouterTest extends TestCase
 		$this->assertSame('home', $page->id());
 	}
 
-	public function testHomeFolderRoute()
+	public function testHomeFolderRoute(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -41,7 +42,7 @@ class RouterTest extends TestCase
 		$this->assertSame(302, $response->code());
 	}
 
-	public function testHomeCustomFolderRoute()
+	public function testHomeCustomFolderRoute(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -61,7 +62,7 @@ class RouterTest extends TestCase
 		$this->assertSame(302, $response->code());
 	}
 
-	public function testHomeRouteWithoutHomePage()
+	public function testHomeRouteWithoutHomePage(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -75,7 +76,7 @@ class RouterTest extends TestCase
 		$app->call('/');
 	}
 
-	public function testPageRoute()
+	public function testPageRoute(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -92,7 +93,7 @@ class RouterTest extends TestCase
 		$this->assertSame('projects', $page->id());
 	}
 
-	public function testPageRepresentationRoute()
+	public function testPageRepresentationRoute(): void
 	{
 		F::write($template = static::TMP . '/test.php', 'html');
 		F::write($template = static::TMP . '/test.xml.php', 'xml');
@@ -123,7 +124,7 @@ class RouterTest extends TestCase
 		$this->assertSame('xml', $result->body());
 	}
 
-	public function testPageFileRouteDefault()
+	public function testPageFileRouteDefault(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -144,7 +145,7 @@ class RouterTest extends TestCase
 		$this->assertNull($file);
 	}
 
-	public function testPageFileRouteEnabled()
+	public function testPageFileRouteEnabled(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -171,7 +172,7 @@ class RouterTest extends TestCase
 		$this->assertSame('projects/cover.jpg', $file->id());
 	}
 
-	public function testSiteFileRouteDefault()
+	public function testSiteFileRouteDefault(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -187,7 +188,7 @@ class RouterTest extends TestCase
 		$this->assertNull($file);
 	}
 
-	public function testSiteFileRouteEnabled()
+	public function testSiteFileRouteEnabled(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -209,7 +210,7 @@ class RouterTest extends TestCase
 		$this->assertSame('background.jpg', $file->id());
 	}
 
-	public function testNestedPageRoute()
+	public function testNestedPageRoute(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -231,13 +232,13 @@ class RouterTest extends TestCase
 		$this->assertSame('projects/project-a', $page->id());
 	}
 
-	public function testNotFoundRoute()
+	public function testNotFoundRoute(): void
 	{
 		$page = $this->app->call('not-found');
 		$this->assertNull($page);
 	}
 
-	public function testPageMediaRoute()
+	public function testPageMediaRoute(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -260,7 +261,7 @@ class RouterTest extends TestCase
 		$this->assertInstanceOf(Response::class, $response);
 	}
 
-	public function testSiteMediaRoute()
+	public function testSiteMediaRoute(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -278,7 +279,7 @@ class RouterTest extends TestCase
 		$this->assertInstanceOf(Response::class, $response);
 	}
 
-	public function testUserMediaRoute()
+	public function testUserMediaRoute(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -300,7 +301,7 @@ class RouterTest extends TestCase
 		$this->assertInstanceOf(Response::class, $response);
 	}
 
-	public function testDisabledApi()
+	public function testDisabledApi(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -316,7 +317,7 @@ class RouterTest extends TestCase
 		$this->assertSame('api/(:all)', $patterns[0]);
 	}
 
-	public function testDisabledPanel()
+	public function testDisabledPanel(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -351,10 +352,8 @@ class RouterTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider customRouteProvider
-	 */
-	public function testCustomRoute($pattern, $path)
+	#[DataProvider('customRouteProvider')]
+	public function testCustomRoute($pattern, $path): void
 	{
 		$app = $this->app->clone([
 			'routes' => [
@@ -368,7 +367,7 @@ class RouterTest extends TestCase
 		$this->assertSame('test', $app->call($path));
 	}
 
-	public function testBadMethodRoute()
+	public function testBadMethodRoute(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid routing method: WURST');
@@ -377,7 +376,7 @@ class RouterTest extends TestCase
 		$this->app->call('/', 'WURST');
 	}
 
-	public function testMultiLangHomeRoute()
+	public function testMultiLangHomeRoute(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -424,7 +423,7 @@ class RouterTest extends TestCase
 		$this->assertInstanceOf(Responder::class, $result);
 	}
 
-	public function testMultiLangHomeRouteWithoutLanguageCode()
+	public function testMultiLangHomeRouteWithoutLanguageCode(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -475,10 +474,8 @@ class RouterTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider multiDomainProvider
-	 */
-	public function testMultiLangHomeWithDifferentDomains($domain, $language)
+	#[DataProvider('multiDomainProvider')]
+	public function testMultiLangHomeWithDifferentDomains($domain, $language): void
 	{
 		$app = $this->app->clone([
 			'urls' => [
@@ -516,10 +513,8 @@ class RouterTest extends TestCase
 		$this->assertSame($language, I18n::locale());
 	}
 
-	/**
-	 * @dataProvider multiDomainProvider
-	 */
-	public function testMultiLangHomeWithDifferentDomainsAndPath($domain, $language)
+	#[DataProvider('multiDomainProvider')]
+	public function testMultiLangHomeWithDifferentDomainsAndPath($domain, $language): void
 	{
 		$app = $this->app->clone([
 			'urls' => [
@@ -570,10 +565,8 @@ class RouterTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider acceptedLanguageProvider
-	 */
-	public function testMultiLangHomeRouteWithoutLanguageCodeAndLanguageDetection($accept, $redirect)
+	#[DataProvider('acceptedLanguageProvider')]
+	public function testMultiLangHomeRouteWithoutLanguageCodeAndLanguageDetection($accept, $redirect): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -613,7 +606,7 @@ class RouterTest extends TestCase
 		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = $acceptedLanguage;
 	}
 
-	public function testMultiLangHomeRouteWithoutHomePage()
+	public function testMultiLangHomeRouteWithoutHomePage(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -640,7 +633,7 @@ class RouterTest extends TestCase
 		$app->call('/');
 	}
 
-	public function testMultiLangPageRoute()
+	public function testMultiLangPageRoute(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -681,7 +674,7 @@ class RouterTest extends TestCase
 		$this->assertSame('fr', I18n::locale());
 	}
 
-	public function testMultilangPageRepresentationRoute()
+	public function testMultilangPageRepresentationRoute(): void
 	{
 		F::write($template = static::TMP . '/test.php', 'html');
 		F::write($template = static::TMP . '/test.xml.php', 'xml');
@@ -739,7 +732,7 @@ class RouterTest extends TestCase
 		$this->assertSame('en', I18n::locale());
 	}
 
-	public function testMultilangPageRepresentationRouteWithoutLanguageCode()
+	public function testMultilangPageRepresentationRouteWithoutLanguageCode(): void
 	{
 		F::write($template = static::TMP . '/test.php', 'html');
 		F::write($template = static::TMP . '/test.xml.php', 'xml');
@@ -798,7 +791,7 @@ class RouterTest extends TestCase
 		$this->assertSame('en', I18n::locale());
 	}
 
-	public function testCustomMediaFolder()
+	public function testCustomMediaFolder(): void
 	{
 		$app = new App([
 			'roots' => [

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -37,7 +37,7 @@ class FilesSectionTest extends TestCase
 		return $this->app;
 	}
 
-	public function testAccept()
+	public function testAccept(): void
 	{
 		$section = new Section('files', [
 			'name'     => 'test',
@@ -48,7 +48,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('*', $section->accept());
 	}
 
-	public function testBatchDefault()
+	public function testBatchDefault(): void
 	{
 		$section = new Section('files', [
 			'name'  => 'test',
@@ -59,7 +59,7 @@ class FilesSectionTest extends TestCase
 		$this->assertFalse($section->toArray()['options']['batch']);
 	}
 
-	public function testBatchDisabled()
+	public function testBatchDisabled(): void
 	{
 		$section = new Section('files', [
 			'name'  => 'test',
@@ -71,7 +71,7 @@ class FilesSectionTest extends TestCase
 		$this->assertFalse($section->toArray()['options']['batch']);
 	}
 
-	public function testBatchEnabled()
+	public function testBatchEnabled(): void
 	{
 		$section = new Section('files', [
 			'name'  => 'test',
@@ -83,7 +83,7 @@ class FilesSectionTest extends TestCase
 		$this->assertTrue($section->toArray()['options']['batch']);
 	}
 
-	public function testHeadline()
+	public function testHeadline(): void
 	{
 		// single headline
 		$section = new Section('files', [
@@ -107,7 +107,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('Files', $section->headline());
 	}
 
-	public function testMax()
+	public function testMax(): void
 	{
 		$model = new Page([
 			'slug'  => 'test',
@@ -148,7 +148,7 @@ class FilesSectionTest extends TestCase
 		$this->assertTrue($section->upload()['multiple']);
 	}
 
-	public function testParent()
+	public function testParent(): void
 	{
 		$app = new App([
 			'site' => [
@@ -186,7 +186,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('pages/b/files', $section->upload()['api']);
 	}
 
-	public function testParentCollectionFail()
+	public function testParentCollectionFail(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('The parent for the section "files" has to be a page, site or user object');
@@ -211,7 +211,7 @@ class FilesSectionTest extends TestCase
 		$section->parentModel();
 	}
 
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$section = new Section('files', [
 			'name'  => 'test',
@@ -222,7 +222,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('Test', $section->empty());
 	}
 
-	public function testTranslatedEmpty()
+	public function testTranslatedEmpty(): void
 	{
 		$section = new Section('files', [
 			'name'  => 'test',
@@ -233,7 +233,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('Test', $section->empty());
 	}
 
-	public function testDragText()
+	public function testDragText(): void
 	{
 		$model = new Page([
 			'slug'  => 'test',
@@ -259,7 +259,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('(image: file://test-a)', $data[0]['dragText']);
 	}
 
-	public function testDragTextWithDifferentParent()
+	public function testDragTextWithDifferentParent(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -295,7 +295,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('(image: file://test-file-a)', $data[0]['dragText']);
 	}
 
-	public function testHelp()
+	public function testHelp(): void
 	{
 		// single help
 		$section = new Section('files', [
@@ -319,7 +319,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('<p>Information</p>', $section->help());
 	}
 
-	public function testSortBy()
+	public function testSortBy(): void
 	{
 		$this->app->impersonate('kirby');
 
@@ -383,7 +383,7 @@ class FilesSectionTest extends TestCase
 		setlocale(LC_ALL, $locale);
 	}
 
-	public function testSortable()
+	public function testSortable(): void
 	{
 		$section = new Section('files', [
 			'name'  => 'test',
@@ -393,7 +393,7 @@ class FilesSectionTest extends TestCase
 		$this->assertTrue($section->sortable());
 	}
 
-	public function testDisableSortable()
+	public function testDisableSortable(): void
 	{
 		$section = new Section('files', [
 			'name'     => 'test',
@@ -404,7 +404,7 @@ class FilesSectionTest extends TestCase
 		$this->assertFalse($section->sortable());
 	}
 
-	public function testDisableSortableWhenSortBy()
+	public function testDisableSortableWhenSortBy(): void
 	{
 		$section = new Section('files', [
 			'name'   => 'test',
@@ -415,7 +415,7 @@ class FilesSectionTest extends TestCase
 		$this->assertFalse($section->sortable());
 	}
 
-	public function testFlip()
+	public function testFlip(): void
 	{
 		$model = new Page([
 			'slug'  => 'test',
@@ -443,7 +443,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('a.jpg', $section->data()[2]['filename']);
 	}
 
-	public function testTranslatedInfo()
+	public function testTranslatedInfo(): void
 	{
 		$model = new Page([
 			'slug'  => 'test',
@@ -467,7 +467,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('en: test', $section->data()[1]['info']);
 	}
 
-	public function testTranslatedText()
+	public function testTranslatedText(): void
 	{
 		$model = new Page([
 			'slug'  => 'test',
@@ -491,7 +491,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('en: b.jpg', $section->data()[1]['text']);
 	}
 
-	public function testSearchDefault()
+	public function testSearchDefault(): void
 	{
 		$model = new Page([
 			'slug'  => 'test',
@@ -510,7 +510,7 @@ class FilesSectionTest extends TestCase
 		$this->assertCount(3, $section->data());
 	}
 
-	public function testSearchWithNoQuery()
+	public function testSearchWithNoQuery(): void
 	{
 		$model = new Page([
 			'slug'  => 'test',
@@ -530,7 +530,7 @@ class FilesSectionTest extends TestCase
 		$this->assertCount(3, $section->data());
 	}
 
-	public function testSearchWithQuery1()
+	public function testSearchWithQuery1(): void
 	{
 		$app = $this->app->clone([
 			'request' => [
@@ -559,7 +559,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('mount-bike.jpg', $section->data()[1]['filename']);
 	}
 
-	public function testSearchWithQuery2()
+	public function testSearchWithQuery2(): void
 	{
 		$app = $this->app->clone([
 			'request' => [
@@ -588,7 +588,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('mountain.jpg', $section->data()[1]['filename']);
 	}
 
-	public function testSearchWithQuery3()
+	public function testSearchWithQuery3(): void
 	{
 		$app = $this->app->clone([
 			'request' => [
@@ -617,7 +617,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('mountain.jpg', $section->data()[0]['filename']);
 	}
 
-	public function testSearchWithFlip()
+	public function testSearchWithFlip(): void
 	{
 		$app = $this->app->clone([
 			'request' => [
@@ -647,7 +647,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('mount-bike.jpg', $section->data()[1]['filename']);
 	}
 
-	public function testSearchWithSortBy()
+	public function testSearchWithSortBy(): void
 	{
 		$app = $this->app->clone([
 			'request' => [
@@ -677,7 +677,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('mount-bike.jpg', $section->data()[1]['filename']);
 	}
 
-	public function testTableLayout()
+	public function testTableLayout(): void
 	{
 		$model = new Page([
 			'slug'  => 'test',
@@ -704,7 +704,7 @@ class FilesSectionTest extends TestCase
 		], $item['title']);
 	}
 
-	public function testTableLayoutWithCustomColumns()
+	public function testTableLayoutWithCustomColumns(): void
 	{
 		$model = new Page([
 			'slug'  => 'test',
@@ -731,7 +731,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('Alt test', $section->data()[0]['alt']);
 	}
 
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$model = new Page([
 			'slug'  => 'test',
@@ -754,7 +754,7 @@ class FilesSectionTest extends TestCase
 		$this->assertNull($options['link']);
 	}
 
-	public function testSort()
+	public function testSort(): void
 	{
 		$model = new Page([
 			'slug'  => 'test',

--- a/tests/Cms/Sections/InfoSectionTest.php
+++ b/tests/Cms/Sections/InfoSectionTest.php
@@ -17,7 +17,7 @@ class InfoSectionTest extends TestCase
 		]);
 	}
 
-	public function testHeadline()
+	public function testHeadline(): void
 	{
 		// single headline
 		$section = new Section('info', [
@@ -41,7 +41,7 @@ class InfoSectionTest extends TestCase
 		$this->assertSame('Information', $section->headline());
 	}
 
-	public function testText()
+	public function testText(): void
 	{
 		// single language text
 		$section = new Section('info', [
@@ -65,7 +65,7 @@ class InfoSectionTest extends TestCase
 		$this->assertSame('<p>Information</p>', $section->text());
 	}
 
-	public function testTheme()
+	public function testTheme(): void
 	{
 		$section = new Section('info', [
 			'name'  => 'test',
@@ -76,7 +76,7 @@ class InfoSectionTest extends TestCase
 		$this->assertSame('notice', $section->theme());
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$section = new Section('info', [
 			'name'  => 'test',

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -6,6 +6,7 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\Panel\Model;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class PagesSectionTest extends TestCase
 {
@@ -30,7 +31,7 @@ class PagesSectionTest extends TestCase
 		App::destroy();
 	}
 
-	public function testBatchDefault()
+	public function testBatchDefault(): void
 	{
 		$section = new Section('pages', [
 			'name'  => 'test',
@@ -41,7 +42,7 @@ class PagesSectionTest extends TestCase
 		$this->assertFalse($section->toArray()['options']['batch']);
 	}
 
-	public function testBatchDisabled()
+	public function testBatchDisabled(): void
 	{
 		$section = new Section('pages', [
 			'name'  => 'test',
@@ -53,7 +54,7 @@ class PagesSectionTest extends TestCase
 		$this->assertFalse($section->toArray()['options']['batch']);
 	}
 
-	public function testBatchEnabled()
+	public function testBatchEnabled(): void
 	{
 		$section = new Section('pages', [
 			'name'  => 'test',
@@ -65,7 +66,7 @@ class PagesSectionTest extends TestCase
 		$this->assertTrue($section->toArray()['options']['batch']);
 	}
 
-	public function testHeadline()
+	public function testHeadline(): void
 	{
 		// single headline
 		$section = new Section('pages', [
@@ -89,7 +90,7 @@ class PagesSectionTest extends TestCase
 		$this->assertSame('Pages', $section->headline());
 	}
 
-	public function testHeadlineFromLabel()
+	public function testHeadlineFromLabel(): void
 	{
 		// single label
 		$section = new Section('pages', [
@@ -114,7 +115,7 @@ class PagesSectionTest extends TestCase
 	}
 
 
-	public function testParent()
+	public function testParent(): void
 	{
 		$parent = new Page([
 			'slug' => 'test',
@@ -141,7 +142,7 @@ class PagesSectionTest extends TestCase
 		$this->assertSame('test/a', $section->parent()->id());
 	}
 
-	public function testParentWithInvalidOption()
+	public function testParentWithInvalidOption(): void
 	{
 		$parent = new Page([
 			'slug' => 'test',
@@ -174,10 +175,8 @@ class PagesSectionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider statusProvider
-	 */
-	public function testStatus($input, $expected)
+	#[DataProvider('statusProvider')]
+	public function testStatus($input, $expected): void
 	{
 		$section = new Section('pages', [
 			'name'   => 'test',
@@ -188,7 +187,7 @@ class PagesSectionTest extends TestCase
 		$this->assertSame($expected, $section->status());
 	}
 
-	public function testAdd()
+	public function testAdd(): void
 	{
 		$section = new Section('pages', [
 			'name'  => 'test',
@@ -209,10 +208,8 @@ class PagesSectionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider addableStatusProvider
-	 */
-	public function testAddWhenStatusIs($input, $expected)
+	#[DataProvider('addableStatusProvider')]
+	public function testAddWhenStatusIs($input, $expected): void
 	{
 		$section = new Section('pages', [
 			'name'   => 'test',
@@ -241,10 +238,8 @@ class PagesSectionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider addableStatusCreateProvider
-	 */
-	public function testAddWhenStatusCreatedMatchesStatusShown($create, $shown, $expected)
+	#[DataProvider('addableStatusCreateProvider')]
+	public function testAddWhenStatusCreatedMatchesStatusShown($create, $shown, $expected): void
 	{
 		$this->app->clone([
 			'blueprints' => [
@@ -265,7 +260,7 @@ class PagesSectionTest extends TestCase
 		Blueprint::$loaded = [];
 	}
 
-	public function testAddWhenMultipleStatusCreated()
+	public function testAddWhenMultipleStatusCreated(): void
 	{
 		$this->app->clone([
 			'blueprints' => [
@@ -288,7 +283,7 @@ class PagesSectionTest extends TestCase
 		$this->assertFalse($section->add());
 	}
 
-	public function testAddWhenSectionIsFull()
+	public function testAddWhenSectionIsFull(): void
 	{
 		$page = new Page([
 			'slug'     => 'test',
@@ -306,7 +301,7 @@ class PagesSectionTest extends TestCase
 		$this->assertFalse($section->add());
 	}
 
-	public function testSortBy()
+	public function testSortBy(): void
 	{
 		$locale = setlocale(LC_ALL, 0);
 		setlocale(LC_ALL, ['de_DE.ISO8859-1', 'de_DE']);
@@ -372,7 +367,7 @@ class PagesSectionTest extends TestCase
 		setlocale(LC_ALL, $locale);
 	}
 
-	public function testSortByMultiple()
+	public function testSortByMultiple(): void
 	{
 		$page = new Page([
 			'slug'     => 'test',
@@ -409,7 +404,7 @@ class PagesSectionTest extends TestCase
 		$this->assertSame('test/subpage-4', $section->data()[3]['id']);
 	}
 
-	public function testSortable()
+	public function testSortable(): void
 	{
 		$section = new Section('pages', [
 			'name'  => 'test',
@@ -419,7 +414,7 @@ class PagesSectionTest extends TestCase
 		$this->assertTrue($section->sortable());
 	}
 
-	public function testDisableSortable()
+	public function testDisableSortable(): void
 	{
 		$section = new Section('pages', [
 			'name'     => 'test',
@@ -430,7 +425,7 @@ class PagesSectionTest extends TestCase
 		$this->assertFalse($section->sortable());
 	}
 
-	public function testFlip()
+	public function testFlip(): void
 	{
 		$page = new Page([
 			'slug'     => 'test',
@@ -463,10 +458,8 @@ class PagesSectionTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider sortableStatusProvider
-	 */
-	public function testSortableStatus($input, $expected)
+	#[DataProvider('sortableStatusProvider')]
+	public function testSortableStatus($input, $expected): void
 	{
 		$section = new Section('pages', [
 			'name'     => 'test',
@@ -477,7 +470,7 @@ class PagesSectionTest extends TestCase
 		$this->assertSame($expected, $section->sortable());
 	}
 
-	public function testImageString()
+	public function testImageString(): void
 	{
 		$model = new Page([
 			'slug' => 'test',
@@ -515,7 +508,7 @@ class PagesSectionTest extends TestCase
 		$this->assertArrayNotHasKey('src', $data[2]['image']);
 	}
 
-	public function testTemplates()
+	public function testTemplates(): void
 	{
 		// single template
 		$section = new Section('pages', [
@@ -545,7 +538,7 @@ class PagesSectionTest extends TestCase
 		$this->assertSame(['blog'], $section->templates());
 	}
 
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$section = new Section('pages', [
 			'name'  => 'test',
@@ -556,7 +549,7 @@ class PagesSectionTest extends TestCase
 		$this->assertSame('Test', $section->empty());
 	}
 
-	public function testTranslatedEmpty()
+	public function testTranslatedEmpty(): void
 	{
 		$section = new Section('pages', [
 			'name'  => 'test',
@@ -567,7 +560,7 @@ class PagesSectionTest extends TestCase
 		$this->assertSame('Test', $section->empty());
 	}
 
-	public function testHelp()
+	public function testHelp(): void
 	{
 		// single help
 		$section = new Section('pages', [
@@ -591,7 +584,7 @@ class PagesSectionTest extends TestCase
 		$this->assertSame('<p>Information</p>', $section->help());
 	}
 
-	public function testTranslatedInfo()
+	public function testTranslatedInfo(): void
 	{
 		$page = new Page([
 			'slug'     => 'test',
@@ -617,7 +610,7 @@ class PagesSectionTest extends TestCase
 		$this->assertSame('en: subpage-3', $section->data()[2]['info']);
 	}
 
-	public function testTranslatedText()
+	public function testTranslatedText(): void
 	{
 		$page = new Page([
 			'slug'     => 'test',
@@ -643,7 +636,7 @@ class PagesSectionTest extends TestCase
 		$this->assertSame('en: B', $section->data()[2]['text']);
 	}
 
-	public function testUnreadable()
+	public function testUnreadable(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [
@@ -675,7 +668,7 @@ class PagesSectionTest extends TestCase
 		$this->assertCount(2, $section->data());
 	}
 
-	public function testSearchDefault()
+	public function testSearchDefault(): void
 	{
 		$model = new Page([
 			'slug'     => 'test',
@@ -694,7 +687,7 @@ class PagesSectionTest extends TestCase
 		$this->assertCount(3, $section->data());
 	}
 
-	public function testSearchWithNoQuery()
+	public function testSearchWithNoQuery(): void
 	{
 		$model = new Page([
 			'slug'     => 'test',
@@ -714,7 +707,7 @@ class PagesSectionTest extends TestCase
 		$this->assertCount(3, $section->data());
 	}
 
-	public function testSearchWithQuery1()
+	public function testSearchWithQuery1(): void
 	{
 		$_GET['searchterm'] = 'bike';
 
@@ -740,7 +733,7 @@ class PagesSectionTest extends TestCase
 		$_GET = [];
 	}
 
-	public function testSearchWithQuery2()
+	public function testSearchWithQuery2(): void
 	{
 		$_GET['searchterm'] = 'mount';
 
@@ -766,7 +759,7 @@ class PagesSectionTest extends TestCase
 		$_GET = [];
 	}
 
-	public function testSearchWithQuery3()
+	public function testSearchWithQuery3(): void
 	{
 		$_GET['searchterm'] = 'mountain';
 
@@ -792,7 +785,7 @@ class PagesSectionTest extends TestCase
 		$_GET = [];
 	}
 
-	public function testSearchWithFlip()
+	public function testSearchWithFlip(): void
 	{
 		$_GET['searchterm'] = 'bike';
 
@@ -819,7 +812,7 @@ class PagesSectionTest extends TestCase
 		$_GET = [];
 	}
 
-	public function testSearchWithSortBy()
+	public function testSearchWithSortBy(): void
 	{
 		$_GET['searchterm'] = 'bike';
 
@@ -846,7 +839,7 @@ class PagesSectionTest extends TestCase
 		$_GET = [];
 	}
 
-	public function testTableLayout()
+	public function testTableLayout(): void
 	{
 		$model = new Page([
 			'slug' => 'test',
@@ -873,7 +866,7 @@ class PagesSectionTest extends TestCase
 		], $item['title']);
 	}
 
-	public function testTableLayoutWithCustomColumns()
+	public function testTableLayoutWithCustomColumns(): void
 	{
 		$model = new Page([
 			'slug' => 'test',
@@ -902,7 +895,7 @@ class PagesSectionTest extends TestCase
 		$this->assertSame('2012-12-12', $section->data()[0]['date']);
 	}
 
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$model = new Page([
 			'slug' => 'test',
@@ -927,7 +920,7 @@ class PagesSectionTest extends TestCase
 		$this->assertNull($options['link']);
 	}
 
-	public function testQuery()
+	public function testQuery(): void
 	{
 		$section = new Section('pages', [
 			'name'  => 'test',
@@ -953,7 +946,7 @@ class PagesSectionTest extends TestCase
 		$this->assertCount(1, $section->pages());
 	}
 
-	public function testTemplatesIgnore()
+	public function testTemplatesIgnore(): void
 	{
 		$parent = new Page([
 			'slug' => 'test',
@@ -1002,7 +995,7 @@ class PagesSectionTest extends TestCase
 		$this->assertCount(3, $section->pages());
 	}
 
-	public function testBlueprints()
+	public function testBlueprints(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [

--- a/tests/Cms/Sections/SectionTest.php
+++ b/tests/Cms/Sections/SectionTest.php
@@ -27,7 +27,7 @@ class SectionTest extends TestCase
 		Section::$types = $this->sectionTypes;
 	}
 
-	public function testApi()
+	public function testApi(): void
 	{
 		// no defined as default
 		Section::$types = [
@@ -58,7 +58,7 @@ class SectionTest extends TestCase
 		$this->assertSame('Hello World', $section->api());
 	}
 
-	public function testMissingModel()
+	public function testMissingModel(): void
 	{
 		Section::$types['test'] = [];
 
@@ -68,7 +68,7 @@ class SectionTest extends TestCase
 		$section = new Section('test', []);
 	}
 
-	public function testPropsDefaults()
+	public function testPropsDefaults(): void
 	{
 		Section::$types['test'] = [
 			'props' => [
@@ -85,7 +85,7 @@ class SectionTest extends TestCase
 		$this->assertSame(['one', 'two'], $section->buttons());
 	}
 
-	public function testToResponse()
+	public function testToResponse(): void
 	{
 		Section::$types['test'] = [
 			'props' => [

--- a/tests/Cms/Sections/StatsSectionTest.php
+++ b/tests/Cms/Sections/StatsSectionTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\TestCase;
+use stdClass;
 
 class MockPageForStatsSection extends Page
 {
@@ -51,7 +52,7 @@ class StatsSectionTest extends TestCase
 		$this->model = new MockPageForStatsSection(['slug' => 'test']);
 	}
 
-	public function testHeadline()
+	public function testHeadline(): void
 	{
 		// single headline
 		$section = new Section('stats', [
@@ -75,7 +76,7 @@ class StatsSectionTest extends TestCase
 		$this->assertSame('Stats', $section->headline());
 	}
 
-	public function testReports()
+	public function testReports(): void
 	{
 		$section = new Section('stats', [
 			'name'     => 'test',
@@ -86,7 +87,7 @@ class StatsSectionTest extends TestCase
 		$this->assertSame($reports, $section->reports());
 	}
 
-	public function testReportsFromQuery()
+	public function testReportsFromQuery(): void
 	{
 		$section = new Section('stats', [
 			'name'     => 'test',
@@ -97,19 +98,19 @@ class StatsSectionTest extends TestCase
 		$this->assertSame($this->model->reports(), $section->reports());
 	}
 
-	public function testReportsFromInvalidValue()
+	public function testReportsFromInvalidValue(): void
 	{
 		$section = new Section('stats', [
 			'name'     => 'test',
 			'model'    => $this->model,
-			'reports'  => new \stdClass()
+			'reports'  => new stdClass()
 		]);
 
 		$this->assertSame([], $section->reports());
 	}
 
 
-	public function testReportsWithQueries()
+	public function testReportsWithQueries(): void
 	{
 		$section = new Section('stats', [
 			'name'     => 'test',
@@ -122,7 +123,7 @@ class StatsSectionTest extends TestCase
 		$this->assertSame([$this->model->report()], $section->reports());
 	}
 
-	public function testReportsWithInvalidQueries()
+	public function testReportsWithInvalidQueries(): void
 	{
 		$section = new Section('stats', [
 			'name'     => 'test',
@@ -135,7 +136,7 @@ class StatsSectionTest extends TestCase
 		$this->assertSame([], $section->reports());
 	}
 
-	public function testReportsTranslatedInfo()
+	public function testReportsTranslatedInfo(): void
 	{
 		$section = new Section('stats', [
 			'name'     => 'test',

--- a/tests/Cms/Sections/mixins/BatchSectionMixinTest.php
+++ b/tests/Cms/Sections/mixins/BatchSectionMixinTest.php
@@ -65,7 +65,7 @@ class BatchSectionMixinTest extends TestCase
 		App::destroy();
 	}
 
-	public function testBatchDisabled()
+	public function testBatchDisabled(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -74,7 +74,7 @@ class BatchSectionMixinTest extends TestCase
 		$this->assertFalse($section->batch());
 	}
 
-	public function testBatchEnabled()
+	public function testBatchEnabled(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -84,7 +84,7 @@ class BatchSectionMixinTest extends TestCase
 		$this->assertTrue($section->batch());
 	}
 
-	public function testDeleteSelectedWithoutIds()
+	public function testDeleteSelectedWithoutIds(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -94,7 +94,7 @@ class BatchSectionMixinTest extends TestCase
 		$this->assertTrue($section->deleteSelected([]));
 	}
 
-	public function testDeleteSelectedWhenDisabled()
+	public function testDeleteSelectedWhenDisabled(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -107,7 +107,7 @@ class BatchSectionMixinTest extends TestCase
 		$section->deleteSelected(['test/a', 'test/b']);
 	}
 
-	public function testDeleteSelectedWhenExceedingMin()
+	public function testDeleteSelectedWhenExceedingMin(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -123,7 +123,7 @@ class BatchSectionMixinTest extends TestCase
 		]);
 	}
 
-	public function testDeleteSelected()
+	public function testDeleteSelected(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,

--- a/tests/Cms/Sections/mixins/EmptySectionMixinTest.php
+++ b/tests/Cms/Sections/mixins/EmptySectionMixinTest.php
@@ -23,7 +23,7 @@ class EmptySectionMixinTest extends TestCase
 		];
 	}
 
-	public function testDefaultEmpty()
+	public function testDefaultEmpty(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -32,7 +32,7 @@ class EmptySectionMixinTest extends TestCase
 		$this->assertNull($section->empty());
 	}
 
-	public function testEmpty()
+	public function testEmpty(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -42,7 +42,7 @@ class EmptySectionMixinTest extends TestCase
 		$this->assertSame('Test', $section->empty());
 	}
 
-	public function testTranslateEmpty()
+	public function testTranslateEmpty(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,

--- a/tests/Cms/Sections/mixins/LayoutMixinTest.php
+++ b/tests/Cms/Sections/mixins/LayoutMixinTest.php
@@ -27,7 +27,7 @@ class LayoutMixinTest extends TestCase
 		];
 	}
 
-	public function testColumns()
+	public function testColumns(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -36,7 +36,7 @@ class LayoutMixinTest extends TestCase
 		$this->assertSame([], $section->columns());
 	}
 
-	public function testColumnsWithTableLayout()
+	public function testColumnsWithTableLayout(): void
 	{
 		$section = new Section('test', [
 			'model'  => $this->page,
@@ -55,7 +55,7 @@ class LayoutMixinTest extends TestCase
 		$this->assertSame($expected, $section->columns());
 	}
 
-	public function testColumnsWithText()
+	public function testColumnsWithText(): void
 	{
 		$section = new Section('test', [
 			'model'  => $this->page,
@@ -80,7 +80,7 @@ class LayoutMixinTest extends TestCase
 		$this->assertSame($expected, $section->columns());
 	}
 
-	public function testColumnsWithTextAndInfo()
+	public function testColumnsWithTextAndInfo(): void
 	{
 		$section = new Section('test', [
 			'model'  => $this->page,
@@ -110,7 +110,7 @@ class LayoutMixinTest extends TestCase
 		$this->assertSame($expected, $section->columns());
 	}
 
-	public function testColumnsWithFlag()
+	public function testColumnsWithFlag(): void
 	{
 		$section = new Section('pages', [
 			'model'  => $this->page,
@@ -135,7 +135,7 @@ class LayoutMixinTest extends TestCase
 		$this->assertSame($expected, $section->columns());
 	}
 
-	public function testColumnsWithCustomColumns()
+	public function testColumnsWithCustomColumns(): void
 	{
 		$section = new Section('test', [
 			'model'   => $this->page,
@@ -181,7 +181,7 @@ class LayoutMixinTest extends TestCase
 		$this->assertSame($expected, $section->columns());
 	}
 
-	public function testColumnsValues()
+	public function testColumnsValues(): void
 	{
 		$model = new Page([
 			'slug' => 'test',
@@ -232,7 +232,7 @@ class LayoutMixinTest extends TestCase
 	}
 
 
-	public function testLayout()
+	public function testLayout(): void
 	{
 		// default
 		$section = new Section('test', [
@@ -258,7 +258,7 @@ class LayoutMixinTest extends TestCase
 		$this->assertSame('list', $section->layout());
 	}
 
-	public function testSize()
+	public function testSize(): void
 	{
 		// default
 		$section = new Section('test', [

--- a/tests/Cms/Sections/mixins/MaxSectionMixinTest.php
+++ b/tests/Cms/Sections/mixins/MaxSectionMixinTest.php
@@ -26,7 +26,7 @@ class MaxSectionMixinTest extends TestCase
 		];
 	}
 
-	public function testDefaultMax()
+	public function testDefaultMax(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -35,7 +35,7 @@ class MaxSectionMixinTest extends TestCase
 		$this->assertNull($section->max());
 	}
 
-	public function testMax()
+	public function testMax(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -45,7 +45,7 @@ class MaxSectionMixinTest extends TestCase
 		$this->assertSame(1, $section->max());
 	}
 
-	public function testIsNotFull()
+	public function testIsNotFull(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -56,7 +56,7 @@ class MaxSectionMixinTest extends TestCase
 		$this->assertTrue($section->validateMax());
 	}
 
-	public function testIsFull()
+	public function testIsFull(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -67,7 +67,7 @@ class MaxSectionMixinTest extends TestCase
 		$this->assertFalse($section->validateMax());
 	}
 
-	public function testIsExactlyFull()
+	public function testIsExactlyFull(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,

--- a/tests/Cms/Sections/mixins/MinSectionMixinTest.php
+++ b/tests/Cms/Sections/mixins/MinSectionMixinTest.php
@@ -26,7 +26,7 @@ class MinSectionMixinTest extends TestCase
 		];
 	}
 
-	public function testDefaultMin()
+	public function testDefaultMin(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -35,7 +35,7 @@ class MinSectionMixinTest extends TestCase
 		$this->assertNull($section->min());
 	}
 
-	public function testMin()
+	public function testMin(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -45,7 +45,7 @@ class MinSectionMixinTest extends TestCase
 		$this->assertSame(1, $section->min());
 	}
 
-	public function testIsInvalid()
+	public function testIsInvalid(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -55,7 +55,7 @@ class MinSectionMixinTest extends TestCase
 		$this->assertFalse($section->validateMin());
 	}
 
-	public function testIsValid()
+	public function testIsValid(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -65,7 +65,7 @@ class MinSectionMixinTest extends TestCase
 		$this->assertTrue($section->validateMin());
 	}
 
-	public function testIsExactlyValid()
+	public function testIsExactlyValid(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,

--- a/tests/Cms/Sections/mixins/SortMixinTest.php
+++ b/tests/Cms/Sections/mixins/SortMixinTest.php
@@ -33,7 +33,7 @@ class SortMixinTest extends TestCase
 		];
 	}
 
-	public function testFlip()
+	public function testFlip(): void
 	{
 		// default
 		$section = new Section('test', [
@@ -59,7 +59,7 @@ class SortMixinTest extends TestCase
 		$this->assertFalse($section->flip());
 	}
 
-	public function testSortable()
+	public function testSortable(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -68,7 +68,7 @@ class SortMixinTest extends TestCase
 		$this->assertTrue($section->sortable());
 	}
 
-	public function testSortableWhileFlipped()
+	public function testSortableWhileFlipped(): void
 	{
 		$section = new Section('test', [
 			'model' => $this->page,
@@ -78,7 +78,7 @@ class SortMixinTest extends TestCase
 		$this->assertFalse($section->sortable());
 	}
 
-	public function testSortableWhileSearching()
+	public function testSortableWhileSearching(): void
 	{
 		$section = new Section('test', [
 			'model'      => $this->page,
@@ -88,7 +88,7 @@ class SortMixinTest extends TestCase
 		$this->assertFalse($section->sortable());
 	}
 
-	public function testSortableWhileSorted()
+	public function testSortableWhileSorted(): void
 	{
 		$section = new Section('test', [
 			'model'  => $this->page,
@@ -98,7 +98,7 @@ class SortMixinTest extends TestCase
 		$this->assertFalse($section->sortable());
 	}
 
-	public function testSortableWithUnsortableStatus()
+	public function testSortableWithUnsortableStatus(): void
 	{
 		$section = new Section('pages', [
 			'model'  => $this->page,
@@ -108,7 +108,7 @@ class SortMixinTest extends TestCase
 		$this->assertFalse($section->sortable());
 	}
 
-	public function testSortBy()
+	public function testSortBy(): void
 	{
 		// default
 		$section = new Section('test', [

--- a/tests/Cms/Site/SiteChangeTitleTest.php
+++ b/tests/Cms/Site/SiteChangeTitleTest.php
@@ -16,7 +16,7 @@ class SiteChangeTitleTest extends ModelTestCase
 		$this->assertSame('Test', $site->title()->value());
 	}
 
-	public function testChangeTitleWhenChangesExist()
+	public function testChangeTitleWhenChangesExist(): void
 	{
 		$site = new Site();
 

--- a/tests/Cms/Site/SiteTest.php
+++ b/tests/Cms/Site/SiteTest.php
@@ -83,7 +83,7 @@ class SiteTest extends ModelTestCase
 		$this->assertSame('https://getkirby.com', $string);
 	}
 
-	public function testPanel()
+	public function testPanel(): void
 	{
 		$site = new Site();
 		$this->assertInstanceOf(Panel::class, $site->panel());

--- a/tests/Cms/Structures/StructureMethodsTest.php
+++ b/tests/Cms/Structures/StructureMethodsTest.php
@@ -18,7 +18,7 @@ class StructureMethodsTest extends TestCase
 		]);
 	}
 
-	public function testBlocksMethod()
+	public function testBlocksMethod(): void
 	{
 		$blocks = Structure::factory([]);
 		$this->assertSame('structure method', $blocks->test());

--- a/tests/Cms/Structures/StructureObjectMethodsTest.php
+++ b/tests/Cms/Structures/StructureObjectMethodsTest.php
@@ -18,7 +18,7 @@ class StructureObjectMethodsTest extends TestCase
 		]);
 	}
 
-	public function testBlockMethod()
+	public function testBlockMethod(): void
 	{
 		$structure = new StructureObject();
 		$this->assertSame('structure object method', $structure->test());

--- a/tests/Cms/Structures/StructureObjectTest.php
+++ b/tests/Cms/Structures/StructureObjectTest.php
@@ -6,19 +6,19 @@ use TypeError;
 
 class StructureObjectTest extends TestCase
 {
-	public function testId()
+	public function testId(): void
 	{
 		$object = new StructureObject(['id' => 'test']);
 		$this->assertSame('test', $object->id());
 	}
 
-	public function testInvalidId()
+	public function testInvalidId(): void
 	{
 		$this->expectException(TypeError::class);
 		new StructureObject(['id' => []]);
 	}
 
-	public function testContent()
+	public function testContent(): void
 	{
 		$content = ['test' => 'Test'];
 		$object  = new StructureObject([
@@ -29,7 +29,7 @@ class StructureObjectTest extends TestCase
 		$this->assertSame($content, $object->content()->toArray());
 	}
 
-	public function testToDate()
+	public function testToDate(): void
 	{
 		$object = new StructureObject([
 			'id'      => 'test',
@@ -41,7 +41,7 @@ class StructureObjectTest extends TestCase
 		$this->assertSame('12.12.2012', $object->date()->toDate('d.m.Y'));
 	}
 
-	public function testDefaultContent()
+	public function testDefaultContent(): void
 	{
 		$object  = new StructureObject([
 			'id' => 'test',
@@ -50,7 +50,7 @@ class StructureObjectTest extends TestCase
 		$this->assertSame([], $object->content()->toArray());
 	}
 
-	public function testFields()
+	public function testFields(): void
 	{
 		$object = new StructureObject([
 			'id'      => 'test',
@@ -67,7 +67,7 @@ class StructureObjectTest extends TestCase
 		$this->assertSame('Text', $object->text()->value());
 	}
 
-	public function testFieldsParent()
+	public function testFieldsParent(): void
 	{
 		$parent = new Page(['slug' => 'test']);
 		$object = new StructureObject([
@@ -83,7 +83,7 @@ class StructureObjectTest extends TestCase
 		$this->assertSame($parent, $object->text()->parent());
 	}
 
-	public function testParent()
+	public function testParent(): void
 	{
 		$parent = new Page(['slug' => 'test']);
 		$object = new StructureObject([
@@ -94,7 +94,7 @@ class StructureObjectTest extends TestCase
 		$this->assertSame($parent, $object->parent());
 	}
 
-	public function testParentFallback()
+	public function testParentFallback(): void
 	{
 		$object = new StructureObject([
 			'id'     => 'test',
@@ -103,7 +103,7 @@ class StructureObjectTest extends TestCase
 		$this->assertIsSite($object->parent());
 	}
 
-	public function testInvalidParent()
+	public function testInvalidParent(): void
 	{
 		$this->expectException(TypeError::class);
 
@@ -113,7 +113,7 @@ class StructureObjectTest extends TestCase
 		]);
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$content = [
 			'title' => 'Title',

--- a/tests/Cms/Structures/StructureTest.php
+++ b/tests/Cms/Structures/StructureTest.php
@@ -6,7 +6,7 @@ use Kirby\Exception\InvalidArgumentException;
 
 class StructureTest extends TestCase
 {
-	public function testCreate()
+	public function testCreate(): void
 	{
 		$structure = Structure::factory([
 			['test' => 'Test']
@@ -16,7 +16,7 @@ class StructureTest extends TestCase
 		$this->assertSame(1, $structure->count());
 	}
 
-	public function testParent()
+	public function testParent(): void
 	{
 		$parent    = new Page(['slug' => 'test']);
 		$structure = Structure::factory([
@@ -26,7 +26,7 @@ class StructureTest extends TestCase
 		$this->assertSame($parent, $structure->first()->parent());
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$data = [
 			['name' => 'A', 'field' => 'C'],
@@ -42,7 +42,7 @@ class StructureTest extends TestCase
 		$this->assertArrayHasKey('id', $structure[1]);
 	}
 
-	public function testGroup()
+	public function testGroup(): void
 	{
 		$structure = Structure::factory([
 			[
@@ -74,7 +74,7 @@ class StructureTest extends TestCase
 		$this->assertSame('B', $grouped->last()->first()->name()->value());
 	}
 
-	public function testSiblings()
+	public function testSiblings(): void
 	{
 		$structure = Structure::factory([
 			['name' => 'A'],
@@ -102,7 +102,7 @@ class StructureTest extends TestCase
 		$this->assertFalse($structure->first()->isLast());
 	}
 
-	public function testWithInvalidData()
+	public function testWithInvalidData(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid data for Kirby\Cms\StructureObject');

--- a/tests/Cms/System/LicenseTest.php
+++ b/tests/Cms/System/LicenseTest.php
@@ -4,11 +4,11 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
 
-/**
- * @coversDefaultClass \Kirby\Cms\License
- */
+#[CoversClass(License::class)]
 class LicenseTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/LicenseTest';
@@ -36,10 +36,7 @@ class LicenseTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::activation
-	 */
-	public function testActivation()
+	public function testActivation(): void
 	{
 		$license = new License(
 			activation: $date = '2023-12-01'
@@ -50,10 +47,7 @@ class LicenseTest extends TestCase
 		$this->assertSame('1/12/2023 00:00', $license->activation('d/M/yyyy HH:mm', 'intl'));
 	}
 
-	/**
-	 * @covers ::code
-	 */
-	public function testCode()
+	public function testCode(): void
 	{
 		$license = new License(
 			code: $code = $this->code(LicenseType::Enterprise)
@@ -63,11 +57,7 @@ class LicenseTest extends TestCase
 		$this->assertSame('K-ENT-1234XXXXXXXXXXXXXXXXXXXXXX', $license->code(true));
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::content
-	 */
-	public function testContent()
+	public function testContent(): void
 	{
 		$license = new License(
 			code: $code = $this->code(LicenseType::Enterprise)
@@ -84,10 +74,7 @@ class LicenseTest extends TestCase
 		], $license->content());
 	}
 
-	/**
-	 * @covers ::date
-	 */
-	public function testDate()
+	public function testDate(): void
 	{
 		$license = new License(
 			date: $date = '2023-12-01'
@@ -98,10 +85,7 @@ class LicenseTest extends TestCase
 		$this->assertSame('1/12/2023 00:00', $license->date('d/M/yyyy HH:mm', 'intl'));
 	}
 
-	/**
-	 * @covers ::domain
-	 */
-	public function testDomain()
+	public function testDomain(): void
 	{
 		$license = new License(
 			domain: $domain = 'getkirby.com'
@@ -110,10 +94,7 @@ class LicenseTest extends TestCase
 		$this->assertSame($domain, $license->domain());
 	}
 
-	/**
-	 * @covers ::email
-	 */
-	public function testEmail()
+	public function testEmail(): void
 	{
 		$license = new License(
 			email: $email = 'mail@getkirby.com'
@@ -122,10 +103,7 @@ class LicenseTest extends TestCase
 		$this->assertSame($email, $license->email());
 	}
 
-	/**
-	 * @covers ::hasValidEmailAddress
-	 */
-	public function testHasValidEmailAddress()
+	public function testHasValidEmailAddress(): void
 	{
 		$license = new License(
 			email: 'mail@getkirby.com'
@@ -140,18 +118,12 @@ class LicenseTest extends TestCase
 		$this->assertFalse($license->hasValidEmailAddress());
 	}
 
-	/**
-	 * @covers ::hub
-	 */
-	public function testHub()
+	public function testHub(): void
 	{
 		$this->assertSame('https://hub.getkirby.com', License::hub());
 	}
 
-	/**
-	 * @covers ::isComplete
-	 */
-	public function testIsComplete()
+	public function testIsComplete(): void
 	{
 		// incomplete
 		$license = new License();
@@ -170,10 +142,7 @@ class LicenseTest extends TestCase
 		$this->assertTrue($license->isComplete());
 	}
 
-	/**
-	 * @covers ::isInactive
-	 */
-	public function testIsInactive()
+	public function testIsInactive(): void
 	{
 		MockTime::$time = strtotime('now');
 
@@ -194,10 +163,7 @@ class LicenseTest extends TestCase
 		MockTime::reset();
 	}
 
-	/**
-	 * @covers ::isLegacy
-	 */
-	public function testIsLegacy()
+	public function testIsLegacy(): void
 	{
 		// legacy license type
 		$license = new License(
@@ -230,10 +196,7 @@ class LicenseTest extends TestCase
 		$this->assertFalse($license->isLegacy());
 	}
 
-	/**
-	 * @covers ::isOnCorrectDomain
-	 */
-	public function testIsOnCorrectDomain()
+	public function testIsOnCorrectDomain(): void
 	{
 		$this->app = new App([
 			'roots' => [
@@ -262,20 +225,13 @@ class LicenseTest extends TestCase
 		$this->assertTrue($license->isOnCorrectDomain());
 	}
 
-	/**
-	 * @covers ::label
-	 */
-	public function testLabel()
+	public function testLabel(): void
 	{
 		$license = new License();
 		$this->assertSame('Unregistered', $license->label());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::normalizeEmail
-	 */
-	public function testNormalize()
+	public function testNormalize(): void
 	{
 		$code = $this->code(LicenseType::Enterprise);
 
@@ -288,11 +244,8 @@ class LicenseTest extends TestCase
 		$this->assertSame('mail@getkirby.com', $license->email());
 	}
 
-	/**
-	 * @covers ::normalizeDomain
-	 * @dataProvider providerForLicenseUrls
-	 */
-	public function testNormalizeDomain(string $domain, string $expected)
+	#[DataProvider('providerForLicenseUrls')]
+	public function testNormalizeDomain(string $domain, string $expected): void
 	{
 		$reflector = new ReflectionClass(License::class);
 		$normalize = $reflector->getMethod('normalizeDomain');
@@ -303,10 +256,7 @@ class LicenseTest extends TestCase
 		$this->assertSame($expected, $normalize->invoke($license, $domain));
 	}
 
-	/**
-	 * @covers ::order
-	 */
-	public function testOrder()
+	public function testOrder(): void
 	{
 		$license = new License(
 			order: $order = '123456'
@@ -315,10 +265,7 @@ class LicenseTest extends TestCase
 		$this->assertSame($order, $license->order());
 	}
 
-	/**
-	 * @covers ::polyfill
-	 */
-	public function testPolyfill()
+	public function testPolyfill(): void
 	{
 		$this->assertSame([
 			'activation' => null,
@@ -334,10 +281,7 @@ class LicenseTest extends TestCase
 		]));
 	}
 
-	/**
-	 * @covers ::read
-	 */
-	public function testRead()
+	public function testRead(): void
 	{
 		// existing license
 		$this->app = new App([
@@ -361,10 +305,7 @@ class LicenseTest extends TestCase
 		$this->assertNull($license->code());
 	}
 
-	/**
-	 * @covers ::register
-	 */
-	public function testRegisterWithInvalidDomain()
+	public function testRegisterWithInvalidDomain(): void
 	{
 		$license = new License(
 			code: $this->code(),
@@ -377,10 +318,7 @@ class LicenseTest extends TestCase
 		$license->register();
 	}
 
-	/**
-	 * @covers ::register
-	 */
-	public function testRegisterWithInvalidEmail()
+	public function testRegisterWithInvalidEmail(): void
 	{
 		$license = new License(
 			code: $this->code(),
@@ -393,10 +331,7 @@ class LicenseTest extends TestCase
 		$license->register();
 	}
 
-	/**
-	 * @covers ::register
-	 */
-	public function testRegisterWithInvalidLicenseKey()
+	public function testRegisterWithInvalidLicenseKey(): void
 	{
 		$license = new License();
 
@@ -406,10 +341,7 @@ class LicenseTest extends TestCase
 		$license->register();
 	}
 
-	/**
-	 * @covers ::renewal
-	 */
-	public function testRenewal()
+	public function testRenewal(): void
 	{
 		// activated
 		$license = new License(
@@ -425,10 +357,7 @@ class LicenseTest extends TestCase
 		$this->assertNull($license->renewal('Y-m-d'));
 	}
 
-	/**
-	 * @covers ::save
-	 */
-	public function testSaveWhenNotActivatable()
+	public function testSaveWhenNotActivatable(): void
 	{
 		$license = new License();
 
@@ -438,10 +367,7 @@ class LicenseTest extends TestCase
 		$license->save();
 	}
 
-	/**
-	 * @covers ::signature
-	 */
-	public function testSignature()
+	public function testSignature(): void
 	{
 		$license = new License(
 			signature: 'secret'
@@ -450,19 +376,13 @@ class LicenseTest extends TestCase
 		$this->assertSame('secret', $license->signature());
 	}
 
-	/**
-	 * @covers ::status
-	 */
-	public function testStatus()
+	public function testStatus(): void
 	{
 		$license = new License();
 		$this->assertSame(LicenseStatus::Missing, $license->status());
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeKirby3()
+	public function testTypeKirby3(): void
 	{
 		$license = new License(
 			code: $this->code(LicenseType::Legacy)
@@ -471,10 +391,7 @@ class LicenseTest extends TestCase
 		$this->assertSame(LicenseType::Legacy, $license->type());
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeKirbyBasic()
+	public function testTypeKirbyBasic(): void
 	{
 		$license = new License(
 			code: $this->code()
@@ -483,10 +400,7 @@ class LicenseTest extends TestCase
 		$this->assertSame(LicenseType::Basic, $license->type());
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeKirbyEnterprise()
+	public function testTypeKirbyEnterprise(): void
 	{
 		$license = new License(
 			code: $this->code(LicenseType::Enterprise)
@@ -495,10 +409,7 @@ class LicenseTest extends TestCase
 		$this->assertSame(LicenseType::Enterprise, $license->type());
 	}
 
-	/**
-	 * @covers ::type
-	 */
-	public function testTypeUnregistered()
+	public function testTypeUnregistered(): void
 	{
 		$license = new License();
 

--- a/tests/Cms/System/SystemTest.php
+++ b/tests/Cms/System/SystemTest.php
@@ -7,10 +7,10 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Cms\System
- */
+#[CoversClass(System::class)]
 class SystemTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/SystemTest';
@@ -135,11 +135,7 @@ class SystemTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::exposedFileUrl
-	 * @covers ::folderUrl
-	 */
-	public function testFolderUrlForContentFolder()
+	public function testFolderUrlForContentFolder(): void
 	{
 		$system = new System($this->app->clone([
 			'roots' => [
@@ -159,11 +155,7 @@ class SystemTest extends TestCase
 		$this->assertSame('/content/site.txt', $system->exposedFileUrl('content'));
 	}
 
-	/**
-	 * @covers ::exposedFileUrl
-	 * @covers ::folderUrl
-	 */
-	public function testFolderUrlForGitFolder()
+	public function testFolderUrlForGitFolder(): void
 	{
 		$system = new System($this->app->clone([
 			'roots' => [
@@ -182,11 +174,7 @@ class SystemTest extends TestCase
 		$this->assertSame('/.git/config', $system->exposedFileUrl('git'));
 	}
 
-	/**
-	 * @covers ::exposedFileUrl
-	 * @covers ::folderUrl
-	 */
-	public function testFolderUrlForInsignificantFolder()
+	public function testFolderUrlForInsignificantFolder(): void
 	{
 		$system = new System($this->app->clone([
 			'roots' => [
@@ -201,11 +189,7 @@ class SystemTest extends TestCase
 		$this->assertNull($system->exposedFileUrl('media'));
 	}
 
-	/**
-	 * @covers ::exposedFileUrl
-	 * @covers ::folderUrl
-	 */
-	public function testFolderUrlForKirbyFolder()
+	public function testFolderUrlForKirbyFolder(): void
 	{
 		$system = new System($this->app->clone([
 			'roots' => [
@@ -225,11 +209,7 @@ class SystemTest extends TestCase
 		$this->assertSame('/kirby/LICENSE.md', $system->exposedFileUrl('kirby'));
 	}
 
-	/**
-	 * @covers ::exposedFileUrl
-	 * @covers ::folderUrl
-	 */
-	public function testFolderUrlForSiteFolder()
+	public function testFolderUrlForSiteFolder(): void
 	{
 		$system = new System($this->app->clone([
 			'roots' => [
@@ -264,11 +244,7 @@ class SystemTest extends TestCase
 		$this->assertSame('/site/snippets/header.php', $system->exposedFileUrl('site'));
 	}
 
-	/**
-	 * @covers ::exposedFileUrl
-	 * @covers ::folderUrl
-	 */
-	public function testFolderUrlForUnknownFolder()
+	public function testFolderUrlForUnknownFolder(): void
 	{
 		$system = new System($this->app->clone([
 			'roots' => [
@@ -280,11 +256,8 @@ class SystemTest extends TestCase
 		$this->assertNull($system->exposedFileUrl('unknown'));
 	}
 
-	/**
-	 * @covers ::indexUrl
-	 * @dataProvider providerForIndexUrls
-	 */
-	public function testIndexUrl($indexUrl, $expected)
+	#[DataProvider('providerForIndexUrls')]
+	public function testIndexUrl($indexUrl, $expected): void
 	{
 		$system = new System($this->app->clone([
 			'options' => [
@@ -295,10 +268,10 @@ class SystemTest extends TestCase
 	}
 
 	/**
-	 * @dataProvider providerForRoots
-	 * @throws \Kirby\Exception\PermissionException
+	 * @throws PermissionException
 	 */
-	public function testInitPermission($root)
+	#[DataProvider('providerForRoots')]
+	public function testInitPermission($root): void
 	{
 		$this->subTmp = static::TMP . '/' . ucfirst($root) . 'Test';
 
@@ -322,10 +295,7 @@ class SystemTest extends TestCase
 		new System($app);
 	}
 
-	/**
-	 * @covers ::info
-	 */
-	public function testInfo()
+	public function testInfo(): void
 	{
 		$app = $this->app->clone([
 			'languages' => [
@@ -342,10 +312,7 @@ class SystemTest extends TestCase
 		$this->assertSame(['en', 'de'], $info['languages']);
 	}
 
-	/**
-	 * @covers ::is2FA
-	 */
-	public function testIs2FA()
+	public function testIs2FA(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -368,10 +335,7 @@ class SystemTest extends TestCase
 		$this->assertTrue($system->is2FA());
 	}
 
-	/**
-	 * @covers ::is2FAwithTOTP
-	 */
-	public function testIs2FAWithTOTP()
+	public function testIs2FAWithTOTP(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -405,10 +369,7 @@ class SystemTest extends TestCase
 		$this->assertFalse($system->is2FAWithTOTP());
 	}
 
-	/**
-	 * @covers ::isInstallable
-	 */
-	public function testIsInstallableOnLocalhost()
+	public function testIsInstallableOnLocalhost(): void
 	{
 		$app = $this->app->clone([
 			'server' => [
@@ -421,10 +382,7 @@ class SystemTest extends TestCase
 		$this->assertTrue($system->isInstallable());
 	}
 
-	/**
-	 * @covers ::isInstallable
-	 */
-	public function testIsInstallableOnPublicServer()
+	public function testIsInstallableOnPublicServer(): void
 	{
 		$app = $this->app->clone([
 			'server' => [
@@ -437,10 +395,7 @@ class SystemTest extends TestCase
 		$this->assertFalse($system->isInstallable());
 	}
 
-	/**
-	 * @covers ::isInstallable
-	 */
-	public function testIsInstallableOnPublicServerWithOverride()
+	public function testIsInstallableOnPublicServerWithOverride(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -458,10 +413,7 @@ class SystemTest extends TestCase
 		$this->assertTrue($system->isInstallable());
 	}
 
-	/**
-	 * @covers ::isInstalled
-	 */
-	public function testIsInstalled()
+	public function testIsInstalled(): void
 	{
 		$system = new System($this->app);
 		$this->assertFalse($system->isInstalled());
@@ -474,10 +426,7 @@ class SystemTest extends TestCase
 		$this->assertTrue($system->isInstalled());
 	}
 
-	/**
-	 * @covers ::isLocal
-	 */
-	public function testIsLocal()
+	public function testIsLocal(): void
 	{
 		// yep
 		$app = $this->app->clone([
@@ -502,10 +451,7 @@ class SystemTest extends TestCase
 		$this->assertFalse($system->isLocal());
 	}
 
-	/**
-	 * @covers ::isOk
-	 */
-	public function testIsOk()
+	public function testIsOk(): void
 	{
 		$app = $this->app->clone([
 			'server' => [
@@ -519,10 +465,7 @@ class SystemTest extends TestCase
 		$this->assertTrue($system->isOk());
 	}
 
-	/**
-	 * @covers ::isOk
-	 */
-	public function testIsOkContentMissingPermissions()
+	public function testIsOkContentMissingPermissions(): void
 	{
 		// reset permissions in `tearDown()`
 		$this->subTmp = static::TMP . '/content';
@@ -534,28 +477,19 @@ class SystemTest extends TestCase
 		$this->assertFalse($system->isOk());
 	}
 
-	/**
-	 * @covers ::license
-	 */
-	public function testLicense()
+	public function testLicense(): void
 	{
 		$system = new System($this->app);
 		$this->assertInstanceOf(License::class, $system->license());
 	}
 
-	/**
-	 * @covers ::loginMethods
-	 */
-	public function testLoginMethods()
+	public function testLoginMethods(): void
 	{
 		$this->assertSame(['password' => []], $this->app->system()->loginMethods());
 	}
 
-	/**
-	 * @covers ::loginMethods
-	 * @dataProvider providerForLoginMethods
-	 */
-	public function testLoginMethodsCustom($option, $expected)
+	#[DataProvider('providerForLoginMethods')]
+	public function testLoginMethodsCustom($option, $expected): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -565,10 +499,7 @@ class SystemTest extends TestCase
 		$this->assertSame($expected, $app->system()->loginMethods());
 	}
 
-	/**
-	 * @covers ::loginMethods
-	 */
-	public function testLoginMethodsDebug1()
+	public function testLoginMethodsDebug1(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -582,10 +513,7 @@ class SystemTest extends TestCase
 		$app->system()->loginMethods();
 	}
 
-	/**
-	 * @covers ::loginMethods
-	 */
-	public function testLoginMethodsDebug2()
+	public function testLoginMethodsDebug2(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -602,10 +530,7 @@ class SystemTest extends TestCase
 		$app->system()->loginMethods();
 	}
 
-	/**
-	 * @covers ::loginMethods
-	 */
-	public function testLoginMethodsDebug3()
+	public function testLoginMethodsDebug3(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -622,19 +547,13 @@ class SystemTest extends TestCase
 		$app->system()->loginMethods();
 	}
 
-	/**
-	 * @covers ::plugins
-	 */
-	public function testPlugins()
+	public function testPlugins(): void
 	{
 		$system = new System($this->app);
 		$this->assertInstanceOf(Collection::class, $system->plugins());
 	}
 
-	/**
-	 * @covers ::serverSoftware
-	 */
-	public function testServerSoftware()
+	public function testServerSoftware(): void
 	{
 		$app = $this->app->clone([
 			'server' => [
@@ -646,10 +565,7 @@ class SystemTest extends TestCase
 		$this->assertSame($software, $system->serverSoftware());
 	}
 
-	/**
-	 * @covers ::serverSoftware
-	 */
-	public function testServerSoftwareInvalid()
+	public function testServerSoftwareInvalid(): void
 	{
 		$app = $this->app->clone([
 			'server' => [
@@ -661,10 +577,7 @@ class SystemTest extends TestCase
 		$this->assertSame('–', $system->serverSoftware());
 	}
 
-	/**
-	 * @covers ::serverSoftwareShort
-	 */
-	public function testServerSoftwareShort()
+	public function testServerSoftwareShort(): void
 	{
 		$app = $this->app->clone([
 			'server' => [
@@ -685,19 +598,7 @@ class SystemTest extends TestCase
 		$this->assertSame('Apache/2.4.7', $system->serverSoftwareShort());
 	}
 
-	/**
-	 * @covers ::accounts
-	 * @covers ::content
-	 * @covers ::curl
-	 * @covers ::sessions
-	 * @covers ::mbstring
-	 * @covers ::media
-	 * @covers ::php
-	 * @covers ::status
-	 * @covers ::toArray
-	 * @covers ::__debugInfo
-	 */
-	public function testStatus()
+	public function testStatus(): void
 	{
 		$system = new System($this->app);
 
@@ -715,11 +616,7 @@ class SystemTest extends TestCase
 		$this->assertSame($expected, $system->__debugInfo());
 	}
 
-	/**
-	 * @covers ::content
-	 * @covers ::status
-	 */
-	public function testStatusContentMissingPermissions()
+	public function testStatusContentMissingPermissions(): void
 	{
 		// reset permissions in `tearDown()`
 		$this->subTmp = static::TMP . '/content';
@@ -742,10 +639,7 @@ class SystemTest extends TestCase
 		$this->assertSame($expected, $system->__debugInfo());
 	}
 
-	/**
-	 * @covers ::title
-	 */
-	public function testTitle()
+	public function testTitle(): void
 	{
 		$app = $this->app->clone([
 			'blueprints' => [
@@ -768,10 +662,7 @@ class SystemTest extends TestCase
 		$this->assertSame($expected, $app->system()->title());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatus()
+	public function testUpdateStatus(): void
 	{
 		$system       = new System($this->app);
 		$updateStatus = $system->updateStatus();
@@ -787,10 +678,7 @@ class SystemTest extends TestCase
 		$this->assertSame('88888.8.8', $updateStatus->targetVersion());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatusDisabled1()
+	public function testUpdateStatusDisabled1(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -806,10 +694,7 @@ class SystemTest extends TestCase
 		$this->assertNull($updateStatus);
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatusDisabled2()
+	public function testUpdateStatusDisabled2(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -823,10 +708,7 @@ class SystemTest extends TestCase
 		$this->assertNull($updateStatus);
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatusSecurity1()
+	public function testUpdateStatusSecurity1(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -850,10 +732,7 @@ class SystemTest extends TestCase
 		$this->assertNull($updateStatus->targetVersion());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatusSecurity2()
+	public function testUpdateStatusSecurity2(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -875,10 +754,7 @@ class SystemTest extends TestCase
 		$this->assertNull($updateStatus->targetVersion());
 	}
 
-	/**
-	 * @covers ::updateStatus
-	 */
-	public function testUpdateStatusCustomData()
+	public function testUpdateStatusCustomData(): void
 	{
 		$system       = new System($this->app);
 		$updateStatus = $system->updateStatus([

--- a/tests/Cms/System/UpdateStatusTest.php
+++ b/tests/Cms/System/UpdateStatusTest.php
@@ -7,11 +7,12 @@ use Kirby\Data\Json;
 use Kirby\Filesystem\Dir;
 use Kirby\Plugin\Plugin;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 
-/**
- * @coversDefaultClass \Kirby\Cms\System\UpdateStatus
- */
+#[CoversClass(UpdateStatus::class)]
+#[CoversClass(UpdateStatus::class)]
 class UpdateStatusTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/UpdateStatusTest';
@@ -36,10 +37,7 @@ class UpdateStatusTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::loadData
-	 */
-	public function testLoadData()
+	public function testLoadData(): void
 	{
 		$app = $this->app('88888.8.5');
 
@@ -80,10 +78,7 @@ class UpdateStatusTest extends TestCase
 		], $app->cache('updates')->get('security'));
 	}
 
-	/**
-	 * @covers ::loadData
-	 */
-	public function testLoadDataCacheKirby()
+	public function testLoadDataCacheKirby(): void
 	{
 		$app = $this->app('88888.8.5');
 		$app->cache('updates')->set('security', [
@@ -152,10 +147,7 @@ class UpdateStatusTest extends TestCase
 		], $app->cache('updates')->get('security'));
 	}
 
-	/**
-	 * @covers ::loadData
-	 */
-	public function testLoadDataCachePlugin()
+	public function testLoadDataCachePlugin(): void
 	{
 		$app = $this->app('88888.8.5');
 		$app->cache('updates')->set('plugins/getkirby/public', [
@@ -227,10 +219,7 @@ class UpdateStatusTest extends TestCase
 		], $app->cache('updates')->get('plugins/getkirby/public'));
 	}
 
-	/**
-	 * @covers ::loadData
-	 */
-	public function testLoadDataCacheInvalid()
+	public function testLoadDataCacheInvalid(): void
 	{
 		$app = $this->app('88888.8.5');
 		$app->cache('updates')->set('security', 12345);
@@ -272,10 +261,7 @@ class UpdateStatusTest extends TestCase
 		], $app->cache('updates')->get('security'));
 	}
 
-	/**
-	 * @covers ::loadData
-	 */
-	public function testLoadDataCacheDisabled()
+	public function testLoadDataCacheDisabled(): void
 	{
 		$app = $this->app('88888.8.5')->clone([
 			'options' => [
@@ -292,10 +278,7 @@ class UpdateStatusTest extends TestCase
 		], $updateStatus->exceptionMessages());
 	}
 
-	/**
-	 * @covers ::loadData
-	 */
-	public function testLoadDataNotFound()
+	public function testLoadDataNotFound(): void
 	{
 		$app    = $this->app('88888.8.8');
 		$plugin = new Plugin('getkirby/test', [
@@ -326,10 +309,7 @@ class UpdateStatusTest extends TestCase
 		], $updateStatus->exceptionMessages());
 	}
 
-	/**
-	 * @covers ::loadData
-	 */
-	public function testLoadDataNotJson()
+	public function testLoadDataNotJson(): void
 	{
 		$app    = $this->app('88888.8.8');
 		$plugin = new Plugin('getkirby/invalid-json', [
@@ -357,17 +337,14 @@ class UpdateStatusTest extends TestCase
 		], $updateStatus->exceptionMessages());
 	}
 
-	/**
-	 * @covers \Kirby\Cms\System\UpdateStatus
-	 * @dataProvider logicProvider
-	 */
+	#[DataProvider('logicProvider')]
 	public function testLogic(
 		string $packageType,
 		array $packageData,
 		bool $securityOnly,
 		array|null $data,
 		array $expected
-	) {
+	): void {
 		$package      = $this->$packageType(...$packageData);
 		$updateStatus = new UpdateStatus($package, $securityOnly, $data);
 
@@ -1656,10 +1633,7 @@ class UpdateStatusTest extends TestCase
 		];
 	}
 
-	/**
-	 * @covers ::messages
-	 */
-	public function testMessagesCache()
+	public function testMessagesCache(): void
 	{
 		$updateStatus = new UpdateStatus($this->app('77777.6.0'), false, static::data('basic'));
 

--- a/tests/Cms/Translations/TranslationTest.php
+++ b/tests/Cms/Translations/TranslationTest.php
@@ -2,14 +2,14 @@
 
 namespace Kirby\Cms;
 
-/**
- * @coversDefaultClass \Kirby\Cms\Translation
- */
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Translation::class)]
 class TranslationTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	public function testProps()
+	public function testProps(): void
 	{
 		$translation = new Translation('en', [
 			'translation.author'    => 'Kirby',
@@ -26,7 +26,7 @@ class TranslationTest extends TestCase
 		$this->assertSame('Test', $translation->get('test'));
 	}
 
-	public function testLoad()
+	public function testLoad(): void
 	{
 		$translation = Translation::load('de', static::FIXTURES . '/translations/de.json');
 
@@ -40,7 +40,7 @@ class TranslationTest extends TestCase
 		$this->assertSame([], $translation->data());
 	}
 
-	public function testToArray()
+	public function testToArray(): void
 	{
 		$translation = Translation::load('de', static::FIXTURES . '/translations/de.json');
 

--- a/tests/Cms/Translations/TranslationsTest.php
+++ b/tests/Cms/Translations/TranslationsTest.php
@@ -6,7 +6,7 @@ class TranslationsTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures';
 
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$translations = Translations::factory([
 			'de' => [
@@ -22,7 +22,7 @@ class TranslationsTest extends TestCase
 		$this->assertTrue($translations->has('en'));
 	}
 
-	public function testLoad()
+	public function testLoad(): void
 	{
 		$translations = Translations::load(static::FIXTURES . '/translations');
 

--- a/tests/Cms/User/UserChangePasswordTest.php
+++ b/tests/Cms/User/UserChangePasswordTest.php
@@ -51,7 +51,7 @@ class UserChangePasswordTest extends ModelTestCase
 		$this->assertSame(3, $calls);
 	}
 
-	public function testChangePasswordHooksCurrentUser()
+	public function testChangePasswordHooksCurrentUser(): void
 	{
 		$calls = 0;
 		$phpunit = $this;

--- a/tests/Cms/User/UserCreateTest.php
+++ b/tests/Cms/User/UserCreateTest.php
@@ -211,7 +211,7 @@ class UserCreateTest extends ModelTestCase
 		$this->assertSame(2, $calls);
 	}
 
-	public function testCreateWithTranslations()
+	public function testCreateWithTranslations(): void
 	{
 		$this->app = $this->app->clone([
 			'languages' => [
@@ -249,7 +249,7 @@ class UserCreateTest extends ModelTestCase
 		$this->assertSame('Title DE', $user->content('de')->title()->value());
 	}
 
-	public function testCreateWithTranslationsAndContent()
+	public function testCreateWithTranslationsAndContent(): void
 	{
 		$this->app = $this->app->clone([
 			'languages' => [

--- a/tests/Cms/User/UserRulesTest.php
+++ b/tests/Cms/User/UserRulesTest.php
@@ -165,7 +165,7 @@ class UserRulesTest extends ModelTestCase
 		UserRules::changeRole($user, 'editor');
 	}
 
-	public function testChangeRoleFromAdminByNonAdmin()
+	public function testChangeRoleFromAdminByNonAdmin(): void
 	{
 		$this->expectException(PermissionException::class);
 		$this->expectExceptionCode('error.user.changeRole.permission');
@@ -398,7 +398,7 @@ class UserRulesTest extends ModelTestCase
 		], $input);
 	}
 
-	public function testDelete()
+	public function testDelete(): void
 	{
 		$this->expectNotToPerformAssertions();
 
@@ -437,7 +437,7 @@ class UserRulesTest extends ModelTestCase
 		UserRules::delete($user);
 	}
 
-	public function testDeletePermissions()
+	public function testDeletePermissions(): void
 	{
 		$permissions = $this->createMock(UserPermissions::class);
 		$permissions->method('can')->with('delete')->willReturn(false);

--- a/tests/Cms/User/UserUpdateTest.php
+++ b/tests/Cms/User/UserUpdateTest.php
@@ -9,7 +9,7 @@ class UserUpdateTest extends ModelTestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.UserUpdate';
 
-	public function testUpdate()
+	public function testUpdate(): void
 	{
 		$user = new User(['email' => 'editor@domain.com']);
 		$user = $user->update([

--- a/tests/Cms/Users/UsersTest.php
+++ b/tests/Cms/Users/UsersTest.php
@@ -6,7 +6,7 @@ use Kirby\Exception\InvalidArgumentException;
 
 class UsersTest extends TestCase
 {
-	public function testAddUser()
+	public function testAddUser(): void
 	{
 		$users = Users::factory([
 			['email' => 'a@getkirby.com']
@@ -23,7 +23,7 @@ class UsersTest extends TestCase
 		$this->assertSame('b@getkirby.com', $result->nth(1)->email());
 	}
 
-	public function testAddCollection()
+	public function testAddCollection(): void
 	{
 		$a = Users::factory([
 			['email' => 'a@getkirby.com']
@@ -42,7 +42,7 @@ class UsersTest extends TestCase
 		$this->assertSame('c@getkirby.com', $c->nth(2)->email());
 	}
 
-	public function testAddById()
+	public function testAddById(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -68,7 +68,7 @@ class UsersTest extends TestCase
 		$this->assertSame('c@getkirby.com', $users->nth(2)->email());
 	}
 
-	public function testAddNull()
+	public function testAddNull(): void
 	{
 		$users = new Users();
 		$this->assertCount(0, $users);
@@ -78,7 +78,7 @@ class UsersTest extends TestCase
 		$this->assertCount(0, $users);
 	}
 
-	public function testAddFalse()
+	public function testAddFalse(): void
 	{
 		$users = new Users();
 		$this->assertCount(0, $users);
@@ -88,7 +88,7 @@ class UsersTest extends TestCase
 		$this->assertCount(0, $users);
 	}
 
-	public function testAddInvalidObject()
+	public function testAddInvalidObject(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('You must pass a Users or User object or an ID of an existing user to the Users collection');
@@ -98,7 +98,7 @@ class UsersTest extends TestCase
 		$users->add($site);
 	}
 
-	public function testFiles()
+	public function testFiles(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -127,7 +127,7 @@ class UsersTest extends TestCase
 		$this->assertSame('c.jpg', $files->find('user-c/c.jpg')->filename());
 	}
 
-	public function testFind()
+	public function testFind(): void
 	{
 		$users = new Users([
 			new User(['email' => 'a@getkirby.com']),
@@ -143,7 +143,7 @@ class UsersTest extends TestCase
 		$this->assertSame($last, $users->find($last->email()));
 	}
 
-	public function testFindByEmail()
+	public function testFindByEmail(): void
 	{
 		$users = new Users([
 			new User(['email' => 'a@getkirby.com']),
@@ -156,7 +156,7 @@ class UsersTest extends TestCase
 		$this->assertSame('b@getkirby.com', $users->find('b@getkirby.com')->email());
 	}
 
-	public function testFindByUuid()
+	public function testFindByUuid(): void
 	{
 		$app = new App([
 			'users' => [
@@ -173,7 +173,7 @@ class UsersTest extends TestCase
 		$this->assertSame($b, $app->user('user://foo')->email());
 	}
 
-	public function testCustomMethods()
+	public function testCustomMethods(): void
 	{
 		Users::$methods = [
 			'test' => function () {
@@ -195,7 +195,7 @@ class UsersTest extends TestCase
 		Users::$methods = [];
 	}
 
-	public function testRoles()
+	public function testRoles(): void
 	{
 		$app = new App([
 			'users' => [

--- a/tests/Cms/VirtualPage/VirtualPageTest.php
+++ b/tests/Cms/VirtualPage/VirtualPageTest.php
@@ -14,7 +14,7 @@ class VirtualPageTest extends ModelTestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.VirtualPage';
 
-	public function testContent()
+	public function testContent(): void
 	{
 		$page = new VirtualPage([
 			'slug'    => 'test',
@@ -26,7 +26,7 @@ class VirtualPageTest extends ModelTestCase
 		$this->assertSame('Title', $page->title()->value());
 	}
 
-	public function testContentWithIgnoredTextFile()
+	public function testContentWithIgnoredTextFile(): void
 	{
 		$page = new VirtualPage([
 			'slug'    => 'test',
@@ -42,7 +42,7 @@ class VirtualPageTest extends ModelTestCase
 		$this->assertSame('Title (virtual)', $page->title()->value());
 	}
 
-	public function testUpdate()
+	public function testUpdate(): void
 	{
 		$page = new VirtualPage([
 			'slug'    => 'test',

--- a/tests/Cms/VirtualPage/VirtualPageWithChildrenTest.php
+++ b/tests/Cms/VirtualPage/VirtualPageWithChildrenTest.php
@@ -20,7 +20,7 @@ class VirtualPageWithChildrenTest extends ModelTestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.VirtualPageWithChildren';
 
-	public function testChildren()
+	public function testChildren(): void
 	{
 		$page = new VirtualPageWithChildren([
 			'slug' => 'mother'

--- a/tests/Cms/VirtualPage/VirtualPageWithPlainTextFieldTest.php
+++ b/tests/Cms/VirtualPage/VirtualPageWithPlainTextFieldTest.php
@@ -27,7 +27,7 @@ class VirtualPageWithPlainTextFieldTest extends ModelTestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.VirtualPageWithPlainTextField';
 
-	public function testContent()
+	public function testContent(): void
 	{
 		$page = new VirtualPageWithPlainTextField([
 			'slug'    => 'test',

--- a/tests/Cms/VirtualPage/VirtualPageWithStaticContentTest.php
+++ b/tests/Cms/VirtualPage/VirtualPageWithStaticContentTest.php
@@ -25,7 +25,7 @@ class VirtualPageWithStaticContentTest extends ModelTestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.VirtualPageWithStaticContent';
 
-	public function testContent()
+	public function testContent(): void
 	{
 		$page = new VirtualPageWithStaticContent();
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Cms',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
