### PR TITLE
test: Use PHPUnit attributes for `Kirby\Panel`

### DIFF
--- a/tests/Panel/Areas/AccountDropdownsTest.php
+++ b/tests/Panel/Areas/AccountDropdownsTest.php
@@ -53,7 +53,7 @@ class AccountDropdownsTest extends AreaTestCase
 		$this->assertSame('Delete your account', $delete['text']);
 	}
 
-	public function testAccountLanguageDropdown()
+	public function testAccountLanguageDropdown(): void
 	{
 		$this->app([
 			'languages' => [

--- a/tests/Panel/Areas/FileDropdownsTest.php
+++ b/tests/Panel/Areas/FileDropdownsTest.php
@@ -183,28 +183,28 @@ class FileDropdownsTest extends AreaTestCase
 		$this->assertSame('Delete', $options[5]['text']);
 	}
 
-	public function testFileLanguageDropdownForAccountFile()
+	public function testFileLanguageDropdownForAccountFile(): void
 	{
 		$this->createUserFile();
 		$this->login();
 		$this->assertLanguageDropdown('account/files/test.jpg/languages');
 	}
 
-	public function testFileLanguageDropdownForPageFile()
+	public function testFileLanguageDropdownForPageFile(): void
 	{
 		$this->createPageFile();
 		$this->login();
 		$this->assertLanguageDropdown('pages/test/files/test.jpg/languages');
 	}
 
-	public function testFileLanguageDropdownForSiteFile()
+	public function testFileLanguageDropdownForSiteFile(): void
 	{
 		$this->createSiteFile();
 		$this->login();
 		$this->assertLanguageDropdown('site/files/test.jpg/languages');
 	}
 
-	public function testFileLanguageDropdownForUserFile()
+	public function testFileLanguageDropdownForUserFile(): void
 	{
 		$this->createUserFile();
 		$this->login();

--- a/tests/Panel/Areas/InstallationTest.php
+++ b/tests/Panel/Areas/InstallationTest.php
@@ -4,17 +4,17 @@ namespace Kirby\Panel\Areas;
 
 class InstallationTest extends AreaTestCase
 {
-	public function testInstallationRedirectFromHome()
+	public function testInstallationRedirectFromHome(): void
 	{
 		$this->assertRedirect('/', 'installation');
 	}
 
-	public function testInstallationRedirectFromAnywhere()
+	public function testInstallationRedirectFromAnywhere(): void
 	{
 		$this->assertRedirect('somewhere', 'installation');
 	}
 
-	public function testInstallation()
+	public function testInstallation(): void
 	{
 		$view = $this->view('installation');
 
@@ -42,7 +42,7 @@ class InstallationTest extends AreaTestCase
 		$this->assertArrayHasKey('value', $view['props']['translations'][0]);
 	}
 
-	public function testInstallationWhenReady()
+	public function testInstallationWhenReady(): void
 	{
 		$this->installable();
 
@@ -53,13 +53,13 @@ class InstallationTest extends AreaTestCase
 		$this->assertTrue($view['props']['isOk']);
 	}
 
-	public function testInstallationWhenInstalled()
+	public function testInstallationWhenInstalled(): void
 	{
 		$this->install();
 		$this->assertRedirect('installation', 'login');
 	}
 
-	public function testInstallationWhenAuthenticated()
+	public function testInstallationWhenAuthenticated(): void
 	{
 		$this->install();
 		$this->login();

--- a/tests/Panel/Areas/SiteDropdownsTest.php
+++ b/tests/Panel/Areas/SiteDropdownsTest.php
@@ -98,7 +98,7 @@ class SiteDropdownsTest extends AreaTestCase
 		$this->assertSame('Open', $preview['text']);
 	}
 
-	public function testPageLanguageDropdown()
+	public function testPageLanguageDropdown(): void
 	{
 		$this->app([
 			'site' => [
@@ -122,7 +122,7 @@ class SiteDropdownsTest extends AreaTestCase
 		$this->assertLanguageDropdown('pages/test/languages');
 	}
 
-	public function testSiteLanguageDropdown()
+	public function testSiteLanguageDropdown(): void
 	{
 		$this->app([
 			'languages' => [

--- a/tests/Panel/Areas/UserDropdownsTest.php
+++ b/tests/Panel/Areas/UserDropdownsTest.php
@@ -53,7 +53,7 @@ class UserDropdownsTest extends AreaTestCase
 		$this->assertSame('Delete this user', $delete['text']);
 	}
 
-	public function testUserLanguageDropdown()
+	public function testUserLanguageDropdown(): void
 	{
 		$this->app([
 			'languages' => [

--- a/tests/Panel/AssetsTest.php
+++ b/tests/Panel/AssetsTest.php
@@ -69,7 +69,7 @@ class AssetsTest extends TestCase
 		]);
 	}
 
-	public function setDevMode()
+	public function setDevMode(): void
 	{
 		// dev mode
 		$app = $this->app->clone([
@@ -448,7 +448,7 @@ class AssetsTest extends TestCase
 		$this->assertFalse($link);
 	}
 
-	public function testVue()
+	public function testVue(): void
 	{
 		$assets = new Assets();
 		$vue    = $assets->vue();
@@ -456,7 +456,7 @@ class AssetsTest extends TestCase
 		$this->assertSame('/media/panel/' . $this->app->versionHash() . '/js/vue.esm.browser.min.js', $vue);
 	}
 
-	public function testVueInDevMode()
+	public function testVueInDevMode(): void
 	{
 		$this->setDevMode();
 
@@ -466,7 +466,7 @@ class AssetsTest extends TestCase
 		$this->assertSame('http://sandbox.test:3000/node_modules/vue/dist/vue.esm.browser.js', $vue);
 	}
 
-	public function testVueWithDisabledTemplateCompiler()
+	public function testVueWithDisabledTemplateCompiler(): void
 	{
 		$this->app->clone([
 			'options' => [

--- a/tests/Panel/ChangesDialogTest.php
+++ b/tests/Panel/ChangesDialogTest.php
@@ -6,11 +6,9 @@ use Kirby\Cms\Pages;
 use Kirby\Content\Changes;
 use Kirby\Panel\Areas\AreaTestCase;
 use Kirby\Uuid\Uuids;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\ChangesDialog
- * @covers ::__construct
- */
+#[CoversClass(ChangesDialog::class)]
 class ChangesDialogTest extends AreaTestCase
 {
 	protected Changes $changes;
@@ -60,9 +58,6 @@ class ChangesDialogTest extends AreaTestCase
 		Uuids::populate();
 	}
 
-	/**
-	 * @covers ::files
-	 */
 	public function testFiles(): void
 	{
 		$this->setUpModels();
@@ -83,18 +78,12 @@ class ChangesDialogTest extends AreaTestCase
 		$this->assertSame('/pages/test/files/test.jpg', $files[0]['link']);
 	}
 
-	/**
-	 * @covers ::files
-	 */
 	public function testFilesWithoutChanges(): void
 	{
 		$dialog = new ChangesDialog();
 		$this->assertSame([], $dialog->files());
 	}
 
-	/**
-	 * @covers ::items
-	 */
 	public function testItems(): void
 	{
 		$this->setUpModels();
@@ -112,9 +101,6 @@ class ChangesDialogTest extends AreaTestCase
 		$this->assertSame('/pages/test', $items[0]['link']);
 	}
 
-	/**
-	 * @covers ::load
-	 */
 	public function testLoad(): void
 	{
 		$dialog = new ChangesDialog();
@@ -131,9 +117,6 @@ class ChangesDialogTest extends AreaTestCase
 		$this->assertSame($expected, $dialog->load());
 	}
 
-	/**
-	 * @covers ::pages
-	 */
 	public function testPages(): void
 	{
 		$this->setUpModels();
@@ -149,18 +132,12 @@ class ChangesDialogTest extends AreaTestCase
 		$this->assertSame('/pages/test', $pages[0]['link']);
 	}
 
-	/**
-	 * @covers ::pages
-	 */
 	public function testPagesWithoutChanges(): void
 	{
 		$dialog = new ChangesDialog();
 		$this->assertSame([], $dialog->pages());
 	}
 
-	/**
-	 * @covers ::users
-	 */
 	public function testUsers(): void
 	{
 		$this->setUpModels();
@@ -176,9 +153,6 @@ class ChangesDialogTest extends AreaTestCase
 		$this->assertSame('/users/test', $users[0]['link']);
 	}
 
-	/**
-	 * @covers ::users
-	 */
 	public function testUsersWithoutChanges(): void
 	{
 		$dialog = new ChangesDialog();

--- a/tests/Panel/Controller/PageTreeTest.php
+++ b/tests/Panel/Controller/PageTreeTest.php
@@ -4,11 +4,9 @@ namespace Kirby\Panel\Controller;
 
 use Kirby\Cms\App;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Controller\PageTree
- * @covers ::__construct
- */
+#[CoversClass(PageTree::class)]
 class PageTreeTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Controller.PageTree';
@@ -78,9 +76,6 @@ class PageTreeTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::children
-	 */
 	public function testChildrenForSite(): void
 	{
 		$children = $this->tree->children(null);
@@ -89,9 +84,6 @@ class PageTreeTest extends TestCase
 		$this->assertSame('site://', $children[0]['value']);
 	}
 
-	/**
-	 * @covers ::children
-	 */
 	public function testChildrenForPage(): void
 	{
 		$children = $this->tree->children('/pages/articles');
@@ -105,9 +97,6 @@ class PageTreeTest extends TestCase
 		$this->assertFalse($children[2]['disabled']);
 	}
 
-	/**
-	 * @covers ::children
-	 */
 	public function testChildrenWithMoving(): void
 	{
 		$children = $this->tree->children(
@@ -124,9 +113,6 @@ class PageTreeTest extends TestCase
 		$this->assertTrue($children[2]['disabled']);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
 	public function testEntryWithSite(): void
 	{
 		$entry = $this->tree->entry($this->app->site());
@@ -143,9 +129,6 @@ class PageTreeTest extends TestCase
 		$this->assertSame('site://', $entry['value']);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
 	public function testEntryWithPage(): void
 	{
 		$entry = $this->tree->entry($this->app->page('articles'));
@@ -162,9 +145,6 @@ class PageTreeTest extends TestCase
 		$this->assertSame('page://articles', $entry['value']);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
 	public function testEntryWithMoving(): void
 	{
 		$entry = $this->tree->entry(
@@ -182,9 +162,6 @@ class PageTreeTest extends TestCase
 		$this->assertTrue($entry['disabled']);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
 	public function testEntryWhenUuidsDisabled(): void
 	{
 		$this->app = $this->app->clone([
@@ -202,9 +179,6 @@ class PageTreeTest extends TestCase
 		$this->assertSame('articles', $entry['value']);
 	}
 
-	/**
-	 * @covers ::parents
-	 */
 	public function testParents(): void
 	{
 		$parents = $this->tree->parents(
@@ -228,9 +202,6 @@ class PageTreeTest extends TestCase
 		], $parents['data']);
 	}
 
-	/**
-	 * @covers ::parents
-	 */
 	public function testParentsWhenUuidsDisabled(): void
 	{
 		$this->app = $this->app->clone([

--- a/tests/Panel/Controller/SearchTest.php
+++ b/tests/Panel/Controller/SearchTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Panel\Controller;
 
 use Kirby\Cms\App;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Controller\Search
- */
+#[CoversClass(Search::class)]
 class SearchTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Controller.Search';
@@ -61,9 +60,6 @@ class SearchTest extends TestCase
 		App::destroy();
 	}
 
-	/**
-	 * @covers ::files
-	 */
 	public function testFiles(): void
 	{
 		$result = Search::files('fish');
@@ -87,9 +83,6 @@ class SearchTest extends TestCase
 		$this->assertCount(0, $result['results']);
 	}
 
-	/**
-	 * @covers ::files
-	 */
 	public function testFilesNotListable(): void
 	{
 		$this->app = new App([
@@ -147,9 +140,6 @@ class SearchTest extends TestCase
 		], array_column($result['results'], 'text'));
 	}
 
-	/**
-	 * @covers ::files
-	 */
 	public function testFilesPaginated(): void
 	{
 		$result = Search::files('fish', limit: 1);
@@ -169,9 +159,6 @@ class SearchTest extends TestCase
 		$this->assertSame(5, $result['pagination']['total']);
 	}
 
-	/**
-	 * @covers ::pages
-	 */
 	public function testPages(): void
 	{
 		$result = Search::pages('beautiful');
@@ -193,9 +180,6 @@ class SearchTest extends TestCase
 		$this->assertCount(0, $result['results']);
 	}
 
-	/**
-	 * @covers ::pages
-	 */
 	public function testPagesNotListable(): void
 	{
 		$this->app = new App([
@@ -256,9 +240,6 @@ class SearchTest extends TestCase
 		], array_column($result['results'], 'text'));
 	}
 
-	/**
-	 * @covers ::pages
-	 */
 	public function testPagesPaginated(): void
 	{
 		$result = Search::pages('beautiful', limit: 1);
@@ -278,9 +259,6 @@ class SearchTest extends TestCase
 		$this->assertSame(3, $result['pagination']['total']);
 	}
 
-	/**
-	 * @covers ::users
-	 */
 	public function testUsers(): void
 	{
 		$result = Search::users('simpson');
@@ -301,9 +279,6 @@ class SearchTest extends TestCase
 		$this->assertCount(0, $result['results']);
 	}
 
-	/**
-	 * @covers ::users
-	 */
 	public function testUsersPaginated(): void
 	{
 		$result = Search::users('simpson', limit: 1);

--- a/tests/Panel/DialogTest.php
+++ b/tests/Panel/DialogTest.php
@@ -7,10 +7,9 @@ use Kirby\Cms\App;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Dialog
- */
+#[CoversClass(Dialog::class)]
 class DialogTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Dialog';
@@ -40,9 +39,6 @@ class DialogTest extends TestCase
 		unset($_SERVER['SERVER_SOFTWARE']);
 	}
 
-	/**
-	 * @covers ::error
-	 */
 	public function testError(): void
 	{
 		// default
@@ -58,9 +54,6 @@ class DialogTest extends TestCase
 		$this->assertSame('Test', $error['error']);
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponse(): void
 	{
 		$response = Dialog::response([
@@ -82,9 +75,6 @@ class DialogTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromTrue(): void
 	{
 		$response = Dialog::response(true);
@@ -100,9 +90,6 @@ class DialogTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromInvalidData(): void
 	{
 		$response = Dialog::response(1234);
@@ -119,9 +106,6 @@ class DialogTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromException(): void
 	{
 		$exception = new Exception('Test');
@@ -139,9 +123,6 @@ class DialogTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromKirbyException(): void
 	{
 		$exception = new NotFoundException(message: 'Test');
@@ -159,9 +140,6 @@ class DialogTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::routes
-	 */
 	public function testRoutes(): void
 	{
 		$area = [
@@ -197,9 +175,6 @@ class DialogTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::routes
-	 */
 	public function testRoutesWithoutHandlers(): void
 	{
 		$area = [

--- a/tests/Panel/DocumentTest.php
+++ b/tests/Panel/DocumentTest.php
@@ -6,10 +6,9 @@ use Kirby\Cms\App;
 use Kirby\Filesystem\Dir;
 use Kirby\Http\Response;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Document
- */
+#[CoversClass(Document::class)]
 class DocumentTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Document';
@@ -40,9 +39,6 @@ class DocumentTest extends TestCase
 	}
 
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponse(): void
 	{
 		// create panel dist files first to avoid redirect
@@ -61,9 +57,6 @@ class DocumentTest extends TestCase
 		$this->assertNotNull($response->body());
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFrameAncestorsSelf(): void
 	{
 		$this->app = $this->app->clone([
@@ -92,9 +85,6 @@ class DocumentTest extends TestCase
 		$this->assertNotNull($response->body());
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFrameAncestorsArray(): void
 	{
 		$this->app = $this->app->clone([
@@ -125,9 +115,6 @@ class DocumentTest extends TestCase
 		$this->assertNotNull($response->body());
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFrameAncestorsString(): void
 	{
 		$this->app = $this->app->clone([

--- a/tests/Panel/DropdownTest.php
+++ b/tests/Panel/DropdownTest.php
@@ -7,10 +7,9 @@ use Kirby\Cms\App;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Dropdown
- */
+#[CoversClass(Dropdown::class)]
 class DropdownTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Dropdown';
@@ -40,9 +39,6 @@ class DropdownTest extends TestCase
 		unset($_SERVER['SERVER_SOFTWARE']);
 	}
 
-	/**
-	 * @covers ::error
-	 */
 	public function testError(): void
 	{
 		// default
@@ -58,9 +54,6 @@ class DropdownTest extends TestCase
 		$this->assertSame('Test', $error['error']);
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponse(): void
 	{
 		$response = Dropdown::response([
@@ -82,9 +75,6 @@ class DropdownTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromInvalidData(): void
 	{
 		$response = Dropdown::response(1234);
@@ -101,9 +91,6 @@ class DropdownTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromException(): void
 	{
 		$exception = new Exception('Test');
@@ -121,9 +108,6 @@ class DropdownTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseFromKirbyException(): void
 	{
 		$exception = new NotFoundException(message: 'Test');
@@ -141,9 +125,6 @@ class DropdownTest extends TestCase
 		$this->assertSame($expected, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::routes
-	 */
 	public function testRoutes(): void
 	{
 		$dropdown = [
@@ -176,9 +157,6 @@ class DropdownTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::routes
-	 */
 	public function testRoutesForDropdownsWithOptions(): void
 	{
 		$area = [
@@ -210,9 +188,6 @@ class DropdownTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::routes
-	 */
 	public function testRoutesForDropdownsWithShortcut(): void
 	{
 		$area = [

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -5,10 +5,9 @@ namespace Kirby\Panel;
 use Kirby\Cms\App;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Field
- */
+#[CoversClass(Field::class)]
 class FieldTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Field';
@@ -32,9 +31,6 @@ class FieldTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::email
-	 */
 	public function testEmail(): void
 	{
 		// default
@@ -55,9 +51,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::filePosition
-	 */
 	public function testFilePosition(): void
 	{
 		$this->app = $this->app->clone([
@@ -108,18 +101,12 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::hidden
-	 */
 	public function testHidden(): void
 	{
 		$field = Field::hidden();
 		$this->assertSame(['hidden' => true], $field);
 	}
 
-	/**
-	 * @covers ::pagePosition
-	 */
 	public function testPagePosition(): void
 	{
 		$this->app = $this->app->clone([
@@ -170,9 +157,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::pagePosition
-	 */
 	public function testPagePositionWithNotEnoughOptions(): void
 	{
 		$this->app = $this->app->clone([
@@ -190,9 +174,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['hidden']);
 	}
 
-	/**
-	 * @covers ::password
-	 */
 	public function testPassword(): void
 	{
 		// default
@@ -212,9 +193,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::role
-	 */
 	public function testRole(): void
 	{
 		$field = Field::role();
@@ -295,9 +273,6 @@ class FieldTest extends TestCase
 		$this->assertSame($expected, $field);
 	}
 
-	/**
-	 * @covers ::slug
-	 */
 	public function testSlug(): void
 	{
 		// default
@@ -318,9 +293,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::title
-	 */
 	public function testTitle(): void
 	{
 		// default
@@ -341,9 +313,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::template
-	 */
 	public function testTemplate(): void
 	{
 		// default = no templates available
@@ -407,9 +376,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::translation
-	 */
 	public function testTranslation(): void
 	{
 		// default
@@ -429,9 +395,6 @@ class FieldTest extends TestCase
 		$this->assertTrue($field['required']);
 	}
 
-	/**
-	 * @covers ::username
-	 */
 	public function testUsername(): void
 	{
 		// default

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -10,6 +10,7 @@ use Kirby\Cms\User as ModelUser;
 use Kirby\Content\Lock;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class FileForceLocked extends ModelFile
 {
@@ -22,9 +23,8 @@ class FileForceLocked extends ModelFile
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Panel\File
- */
+#[CoversClass(\Kirby\Panel\File::class)]
+#[CoversClass(Model::class)]
 class FileTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.File';
@@ -56,9 +56,6 @@ class FileTest extends TestCase
 		return new File($page->file('test.jpg'));
 	}
 
-	/**
-	 * @covers ::breadcrumb
-	 */
 	public function testBreadcrumbForSiteFile(): void
 	{
 		$site = new ModelSite([
@@ -76,9 +73,6 @@ class FileTest extends TestCase
 		], $file->breadcrumb());
 	}
 
-	/**
-	 * @covers ::breadcrumb
-	 */
 	public function testBreadcrumbForPageFile(): void
 	{
 		$page = new ModelPage([
@@ -104,9 +98,6 @@ class FileTest extends TestCase
 		], $file->breadcrumb());
 	}
 
-	/**
-	 * @covers ::breadcrumb
-	 */
 	public function testBreadcrumbForUserFile(): void
 	{
 		$user = new ModelUser([
@@ -130,10 +121,7 @@ class FileTest extends TestCase
 		], $file->breadcrumb());
 	}
 
-	/**
-	 * @covers ::buttons
-	 */
-	public function testButtons()
+	public function testButtons(): void
 	{
 		$this->assertSame([
 			'k-open-view-button',
@@ -142,10 +130,7 @@ class FileTest extends TestCase
 		], array_column($this->panel()->buttons(), 'component'));
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
-	public function testDragText()
+	public function testDragText(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test',
@@ -175,10 +160,7 @@ class FileTest extends TestCase
 		$this->assertSame('(image: file://test-jpg)', $panel->dragText());
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
-	public function testDragTextMarkdown()
+	public function testDragTextMarkdown(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -219,10 +201,7 @@ class FileTest extends TestCase
 		$this->assertSame('[test.pdf](//@/file/test-pdf)', $file->panel()->dragText());
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
-	public function testDragTextCustomMarkdown()
+	public function testDragTextCustomMarkdown(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -267,10 +246,7 @@ class FileTest extends TestCase
 		$this->assertSame('![](//@/file/test-heic)', $panel->dragText());
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
-	public function testDragTextCustomKirbytext()
+	public function testDragTextCustomKirbytext(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -314,10 +290,7 @@ class FileTest extends TestCase
 		$this->assertSame('(image: file://test-heic)', $panel->dragText());
 	}
 
-	/**
-	 * @covers ::dropdownOption
-	 */
-	public function testDropdownOption()
+	public function testDropdownOption(): void
 	{
 		$page = new ModelPage([
 			'slug' => 'test',
@@ -334,13 +307,7 @@ class FileTest extends TestCase
 		$this->assertSame('/pages/test/files/test.jpg', $option['link']);
 	}
 
-	/**
-	 * @covers ::imageDefaults
-	 * @covers ::imageColor
-	 * @covers ::imageIcon
-	 * @covers ::imageSource
-	 */
-	public function testImage()
+	public function testImage(): void
 	{
 		$page = new ModelPage([
 			'slug' => 'test'
@@ -358,11 +325,7 @@ class FileTest extends TestCase
 		$this->assertArrayHasKey('url', $image);
 	}
 
-	/**
-	 * @covers ::imageSource
-	 * @covers ::imageSrcset
-	 */
-	public function testImageCover()
+	public function testImageCover(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -400,10 +363,7 @@ class FileTest extends TestCase
 		], $panel->image(['cover' => true]));
 	}
 
-	/**
-	 * @covers ::imageSource
-	 */
-	public function testImageStringQuery()
+	public function testImageStringQuery(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test',
@@ -418,10 +378,7 @@ class FileTest extends TestCase
 		$this->assertNotEmpty($image);
 	}
 
-	/**
-	 * @covers ::isFocusable
-	 */
-	public function testIsFocusable()
+	public function testIsFocusable(): void
 	{
 		$this->app->clone([
 			'blueprints' => [
@@ -497,10 +454,7 @@ class FileTest extends TestCase
 		$this->assertFalse((new File($file))->isFocusable());
 	}
 
-	/**
-	 * @covers ::options
-	 */
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$page = new ModelPage([
 			'slug' => 'test'
@@ -530,10 +484,7 @@ class FileTest extends TestCase
 		$this->assertSame($expected, $panel->options());
 	}
 
-	/**
-	 * @covers ::options
-	 */
-	public function testOptionsWithLockedFile()
+	public function testOptionsWithLockedFile(): void
 	{
 		$page = new ModelPage([
 			'slug' => 'test'
@@ -580,10 +531,7 @@ class FileTest extends TestCase
 		$this->assertSame($expected, $panel->options(['delete']));
 	}
 
-	/**
-	 * @covers ::options
-	 */
-	public function testOptionsDefaultReplaceOption()
+	public function testOptionsDefaultReplaceOption(): void
 	{
 		$page = new ModelPage([
 			'slug' => 'test'
@@ -612,10 +560,7 @@ class FileTest extends TestCase
 		$this->assertSame($expected, $panel->options());
 	}
 
-	/**
-	 * @covers ::options
-	 */
-	public function testOptionsAllowedReplaceOption()
+	public function testOptionsAllowedReplaceOption(): void
 	{
 		$this->app->clone([
 			'blueprints' => [
@@ -655,10 +600,7 @@ class FileTest extends TestCase
 		$this->assertSame($expected, $panel->options());
 	}
 
-	/**
-	 * @covers ::options
-	 */
-	public function testOptionsDisabledReplaceOption()
+	public function testOptionsDisabledReplaceOption(): void
 	{
 		$this->app->clone([
 			'blueprints' => [
@@ -700,10 +642,7 @@ class FileTest extends TestCase
 		$this->assertSame($expected, $panel->options());
 	}
 
-	/**
-	 * @covers ::path
-	 */
-	public function testPath()
+	public function testPath(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test',
@@ -716,11 +655,7 @@ class FileTest extends TestCase
 		$this->assertSame('files/test.jpg', $panel->path());
 	}
 
-	/**
-	 * @covers ::pickerData
-	 * @covers \Kirby\Panel\Model::pickerData
-	 */
-	public function testPickerDataDefault()
+	public function testPickerDataDefault(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test',
@@ -742,10 +677,7 @@ class FileTest extends TestCase
 		$this->assertSame('test.jpg', $data['text']);
 	}
 
-	/**
-	 * @covers ::pickerData
-	 */
-	public function testPickerDataWithParams()
+	public function testPickerDataWithParams(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test',
@@ -772,10 +704,7 @@ class FileTest extends TestCase
 		$this->assertSame('From foo to the bar', $data['text']);
 	}
 
-	/**
-	 * @covers ::pickerData
-	 */
-	public function testPickerDataSameModel()
+	public function testPickerDataSameModel(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test',
@@ -794,10 +723,7 @@ class FileTest extends TestCase
 		$this->assertSame('test.jpg', $data['id']);
 	}
 
-	/**
-	 * @covers ::pickerData
-	 */
-	public function testPickerDataDifferentModel()
+	public function testPickerDataDifferentModel(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test',
@@ -816,10 +742,7 @@ class FileTest extends TestCase
 		$this->assertSame('(image: file://test-file)', $data['dragText']);
 	}
 
-	/**
-	 * @covers ::props
-	 */
-	public function testProps()
+	public function testProps(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test',
@@ -853,11 +776,7 @@ class FileTest extends TestCase
 		$this->assertArrayHasKey('versions', $props);
 	}
 
-	/**
-	 * @covers ::props
-	 * @covers ::prevNext
-	 */
-	public function testPropsPrevNext()
+	public function testPropsPrevNext(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test',
@@ -881,11 +800,7 @@ class FileTest extends TestCase
 		$this->assertNull($props['next']());
 	}
 
-	/**
-	 * @covers ::props
-	 * @covers ::prevNext
-	 */
-	public function testPropsPrevNextWithSort()
+	public function testPropsPrevNextWithSort(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test',
@@ -909,11 +824,7 @@ class FileTest extends TestCase
 		$this->assertNull($props['next']());
 	}
 
-	/**
-	 * @covers ::prevNext
-	 * @covers ::toPrevNextLink
-	 */
-	public function testPropsPrevNextWithTab()
+	public function testPropsPrevNextWithTab(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test',
@@ -933,10 +844,7 @@ class FileTest extends TestCase
 		$_GET = [];
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrl()
+	public function testUrl(): void
 	{
 		$app = $this->app->clone([
 			'urls' => [
@@ -994,10 +902,7 @@ class FileTest extends TestCase
 		$this->assertSame('/users/test/files/user-file.jpg', $panel->url(true));
 	}
 
-	/**
-	 * @covers ::prevNext
-	 */
-	public function testPrevNext()
+	public function testPrevNext(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test',
@@ -1021,10 +926,7 @@ class FileTest extends TestCase
 		$this->assertNull($prevNext['next']());
 	}
 
-	/**
-	 * @covers ::view
-	 */
-	public function testView()
+	public function testView(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test',

--- a/tests/Panel/HomeTest.php
+++ b/tests/Panel/HomeTest.php
@@ -9,10 +9,10 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Http\Uri;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Home
- */
+#[CoversClass(Home::class)]
 class HomeTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Home';
@@ -45,10 +45,7 @@ class HomeTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::alternative
-	 */
-	public function testAlternative()
+	public function testAlternative(): void
 	{
 		$this->app = $this->app->clone([
 			'users' => [
@@ -61,10 +58,7 @@ class HomeTest extends TestCase
 		$this->assertSame('/panel/site', Home::alternative($user));
 	}
 
-	/**
-	 * @covers ::alternative
-	 */
-	public function testAlternativeWithLimitedAccess()
+	public function testAlternativeWithLimitedAccess(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [
@@ -92,10 +86,7 @@ class HomeTest extends TestCase
 		$this->assertSame('/panel/users', Home::alternative($user));
 	}
 
-	/**
-	 * @covers ::alternative
-	 */
-	public function testAlternativeWithOnlyAccessToAccounts()
+	public function testAlternativeWithOnlyAccessToAccounts(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [
@@ -125,10 +116,7 @@ class HomeTest extends TestCase
 		$this->assertSame('/panel/account', Home::alternative($user));
 	}
 
-	/**
-	 * @covers ::alternative
-	 */
-	public function testAlternativeWithoutPanelAccess()
+	public function testAlternativeWithoutPanelAccess(): void
 	{
 		$this->app = $this->app->clone([
 			'blueprints' => [
@@ -151,10 +139,7 @@ class HomeTest extends TestCase
 		$this->assertSame('/', Home::alternative($user));
 	}
 
-	/**
-	 * @covers ::alternative
-	 */
-	public function testAlternativeWithoutViewAccess()
+	public function testAlternativeWithoutViewAccess(): void
 	{
 		$this->app = $this->app->clone([
 			'blueprints' => [
@@ -184,10 +169,7 @@ class HomeTest extends TestCase
 		Home::alternative($user);
 	}
 
-	/**
-	 * @covers ::hasAccess
-	 */
-	public function testHasAccess()
+	public function testHasAccess(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [
@@ -218,10 +200,7 @@ class HomeTest extends TestCase
 		$this->assertTrue(Home::hasAccess($user, 'browser'));
 	}
 
-	/**
-	 * @covers ::hasAccess
-	 */
-	public function testHasAccessWithLimitedAccess()
+	public function testHasAccessWithLimitedAccess(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [
@@ -252,10 +231,7 @@ class HomeTest extends TestCase
 		$this->assertTrue(Home::hasAccess($user, 'account'));
 	}
 
-	/**
-	 * @covers ::hasValidDomain
-	 */
-	public function testHasValidDomain()
+	public function testHasValidDomain(): void
 	{
 		$uri = Uri::current();
 		$this->assertTrue(Home::hasValidDomain($uri));
@@ -267,47 +243,32 @@ class HomeTest extends TestCase
 		$this->assertFalse(Home::hasValidDomain($uri));
 	}
 
-	/**
-	 * @covers ::isPanelUrl
-	 */
-	public function testIsPanelUrl()
+	public function testIsPanelUrl(): void
 	{
 		$this->assertTrue(Home::isPanelUrl('/panel'));
 		$this->assertTrue(Home::isPanelUrl('/panel/pages/test'));
 		$this->assertFalse(Home::isPanelUrl('test'));
 	}
 
-	/**
-	 * @covers ::panelPath
-	 */
-	public function testPanelPath()
+	public function testPanelPath(): void
 	{
 		$this->assertSame('site', Home::panelPath('/panel/site'));
 		$this->assertSame('pages/test', Home::panelPath('/panel/pages/test'));
 		$this->assertSame('', Home::panelPath('/test/page'));
 	}
 
-	/**
-	 * @covers ::remembered
-	 */
-	public function testRemembered()
+	public function testRemembered(): void
 	{
 		$this->assertNull(Home::remembered());
 	}
 
-	/**
-	 * @covers ::remembered
-	 */
-	public function testRememberedFromSession()
+	public function testRememberedFromSession(): void
 	{
 		$this->app->session()->set('panel.path', 'users');
 		$this->assertSame('/panel/users', Home::remembered());
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrl()
+	public function testUrl(): void
 	{
 		$this->app = $this->app->clone([
 			'users' => [
@@ -339,10 +300,8 @@ class HomeTest extends TestCase
 		];
 	}
 
-	/**
-	 * @dataProvider customHomeProvider
-	 */
-	public function testUrlWithCustomHome($url, $expected, $index = '/')
+	#[DataProvider('customHomeProvider')]
+	public function testUrlWithCustomHome($url, $expected, $index = '/'): void
 	{
 		$this->app = $this->app->clone([
 			'urls' => [
@@ -369,10 +328,7 @@ class HomeTest extends TestCase
 		$this->assertSame($expected, Home::url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrlWithInvalidCustomHome()
+	public function testUrlWithInvalidCustomHome(): void
 	{
 		$this->app = $this->app->clone([
 			'urls' => [
@@ -402,10 +358,7 @@ class HomeTest extends TestCase
 		Home::url();
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrlWithRememberedPath()
+	public function testUrlWithRememberedPath(): void
 	{
 		$this->app = $this->app->clone([
 			'users' => [
@@ -419,10 +372,7 @@ class HomeTest extends TestCase
 		$this->assertSame('/panel/users', Home::url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrlWithInvalidRememberedPath()
+	public function testUrlWithInvalidRememberedPath(): void
 	{
 		$this->app = $this->app->clone([
 			'users' => [
@@ -436,10 +386,7 @@ class HomeTest extends TestCase
 		$this->assertSame('/panel/site', Home::url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrlWithMissingSiteAccess()
+	public function testUrlWithMissingSiteAccess(): void
 	{
 		$this->app = $this->app->clone([
 			'blueprints' => [
@@ -461,10 +408,7 @@ class HomeTest extends TestCase
 		$this->assertSame('/panel/users', Home::url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrlWithAccountAccessOnly()
+	public function testUrlWithAccountAccessOnly(): void
 	{
 		$this->app = $this->app->clone([
 			'blueprints' => [
@@ -489,10 +433,7 @@ class HomeTest extends TestCase
 		$this->assertSame('/panel/account', Home::url());
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrlWithoutUser()
+	public function testUrlWithoutUser(): void
 	{
 		$this->assertSame('/panel/login', Home::url());
 	}

--- a/tests/Panel/JsonTest.php
+++ b/tests/Panel/JsonTest.php
@@ -4,25 +4,18 @@ namespace Kirby\Panel;
 
 use Exception;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Json
- */
+#[CoversClass(Json::class)]
 class JsonTest extends TestCase
 {
-	/**
-	 * @covers ::response
-	 */
-	public function testResponseEmptyArray()
+	public function testResponseEmptyArray(): void
 	{
 		$response = Json::response([]);
 		$this->assertSame(404, $response->code());
 	}
 
-	/**
-	 * @covers ::response
-	 */
-	public function testResponseRedirect()
+	public function testResponseRedirect(): void
 	{
 		$redirect = new Redirect('https://getkirby.com');
 		$response = Json::response($redirect);
@@ -33,20 +26,14 @@ class JsonTest extends TestCase
 		$this->assertSame('https://getkirby.com', $body['$response']['redirect']);
 	}
 
-	/**
-	 * @covers ::response
-	 */
-	public function testResponseThrowable()
+	public function testResponseThrowable(): void
 	{
 		$data     = new Exception();
 		$response = Json::response($data);
 		$this->assertSame(500, $response->code());
 	}
 
-	/**
-	 * @covers ::response
-	 */
-	public function testResponseNoArray()
+	public function testResponseNoArray(): void
 	{
 		$data     = 'foo';
 		$response = Json::response($data);

--- a/tests/Panel/MenuTest.php
+++ b/tests/Panel/MenuTest.php
@@ -5,11 +5,9 @@ namespace Kirby\Panel;
 use Kirby\Cms\App;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Menu
- * @covers ::__construct
- */
+#[CoversClass(Menu::class)]
 class MenuTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Menu';
@@ -39,10 +37,7 @@ class MenuTest extends TestCase
 		unset($_SERVER['SERVER_SOFTWARE']);
 	}
 
-	/**
-	 * @covers ::areas
-	 */
-	public function testAreas()
+	public function testAreas(): void
 	{
 		$menu  = new Menu(
 			[
@@ -57,10 +52,7 @@ class MenuTest extends TestCase
 		$this->assertSame('site', $areas[0]['id']);
 	}
 
-	/**
-	 * @covers ::areas
-	 */
-	public function testAreasDefaultOrder()
+	public function testAreasDefaultOrder(): void
 	{
 		$menu  = new Menu(
 			[
@@ -79,10 +71,7 @@ class MenuTest extends TestCase
 		$this->assertSame(['site', 'foo'], array_column($areas, 'id'));
 	}
 
-	/**
-	 * @covers ::areas
-	 */
-	public function testAreasConfigOption()
+	public function testAreasConfigOption(): void
 	{
 		$this->app->clone([
 			'options' => [
@@ -132,10 +121,7 @@ class MenuTest extends TestCase
 		$this->assertSame('Buddies', $areas[3]['label']);
 	}
 
-	/**
-	 * @covers ::areas
-	 */
-	public function testAreasConfigOptionClosure()
+	public function testAreasConfigOptionClosure(): void
 	{
 		$test = $this;
 
@@ -155,10 +141,7 @@ class MenuTest extends TestCase
 		$this->assertCount(0, $areas);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
-	public function testEntry()
+	public function testEntry(): void
 	{
 		$menu = new Menu([], [], 'account');
 		$this->assertTrue($menu->hasPermission('account'));
@@ -176,10 +159,7 @@ class MenuTest extends TestCase
 		], $entry);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
-	public function testEntryDialog()
+	public function testEntryDialog(): void
 	{
 		$menu = new Menu([], [], 'account');
 
@@ -197,10 +177,7 @@ class MenuTest extends TestCase
 		], $entry);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
-	public function testEntryMenu()
+	public function testEntryMenu(): void
 	{
 		$menu = new Menu([], [], 'account');
 		$this->assertFalse($menu->entry(['id' => 'account']));
@@ -224,19 +201,13 @@ class MenuTest extends TestCase
 		$this->assertTrue($entry['disabled']);
 	}
 
-	/**
-	 * @covers ::entry
-	 */
-	public function testEntryNoPermission()
+	public function testEntryNoPermission(): void
 	{
 		$menu = new Menu([], ['access' => ['account' => false]]);
 		$this->assertFalse($menu->entry(['id' => 'account']));
 	}
 
-	/**
-	 * @covers ::entry
-	 */
-	public function testEntryMultiLanguage()
+	public function testEntryMultiLanguage(): void
 	{
 		$menu = new Menu([], [], 'account');
 
@@ -256,10 +227,7 @@ class MenuTest extends TestCase
 		], $entry);
 	}
 
-	/**
-	 * @covers ::entries
-	 */
-	public function testEntries()
+	public function testEntries(): void
 	{
 		$menu = new Menu(
 			[
@@ -282,10 +250,7 @@ class MenuTest extends TestCase
 		$this->assertSame('logout', $entries[4]['link']);
 	}
 
-	/**
-	 * @covers ::hasPermission
-	 */
-	public function testHasPermission()
+	public function testHasPermission(): void
 	{
 		$menu = new Menu([], []);
 		$this->assertTrue($menu->hasPermission('account'));
@@ -297,10 +262,7 @@ class MenuTest extends TestCase
 		$this->assertFalse($menu->hasPermission('account'));
 	}
 
-	/**
-	 * @covers ::isCurrent
-	 */
-	public function testIsCurrent()
+	public function testIsCurrent(): void
 	{
 		$menu = new Menu([], [], 'account');
 
@@ -319,10 +281,7 @@ class MenuTest extends TestCase
 	}
 
 
-	/**
-	 * @covers ::options
-	 */
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$changes = [
 			'icon'     => 'edit-line',

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -9,6 +9,7 @@ use Kirby\Cms\Site as ModelSite;
 use Kirby\Filesystem\Asset;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class CustomPanelModel extends Model
 {
@@ -41,9 +42,7 @@ class ModelSiteWithImageMethod extends ModelSite
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Panel\Model
- */
+#[CoversClass(Model::class)]
 class ModelTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Model';
@@ -70,11 +69,7 @@ class ModelTest extends TestCase
 		return new CustomPanelModel($site);
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::content
-	 */
-	public function testContent()
+	public function testContent(): void
 	{
 		$panel = $this->panel([
 			'content' => $content = [
@@ -85,11 +80,7 @@ class ModelTest extends TestCase
 		$this->assertSame($content, $panel->content());
 	}
 
-	/**
-	 * @covers ::__construct
-	 * @covers ::content
-	 */
-	public function testContentWithChanges()
+	public function testContentWithChanges(): void
 	{
 		$panel = new CustomPanelModel(
 			new ModelPage(['slug' => 'test'])
@@ -108,10 +99,7 @@ class ModelTest extends TestCase
 		], $panel->content());
 	}
 
-	/**
-	 * @covers ::dragTextFromCallback
-	 */
-	public function testDragTextFromCallbackMarkdown()
+	public function testDragTextFromCallbackMarkdown(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -151,10 +139,7 @@ class ModelTest extends TestCase
 		$this->assertSame('![](test/test.heic)', $panel->dragTextFromCallback('markdown', $file, $file->filename()));
 	}
 
-	/**
-	 * @covers ::dragTextFromCallback
-	 */
-	public function testDragTextFromCallbackKirbytext()
+	public function testDragTextFromCallbackKirbytext(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -194,10 +179,7 @@ class ModelTest extends TestCase
 		$this->assertSame('(image: test/test.heic)', $panel->dragTextFromCallback('kirbytext', $file, $file->filename()));
 	}
 
-	/**
-	 * @covers ::dragTextType
-	 */
-	public function testDragTextType()
+	public function testDragTextType(): void
 	{
 		$panel = $this->panel();
 
@@ -218,7 +200,7 @@ class ModelTest extends TestCase
 		new App();
 	}
 
-	public function testDropdown()
+	public function testDropdown(): void
 	{
 		$model  = new CustomPanelModel(new ModelSite());
 		$option = $model->dropdownOption();
@@ -237,13 +219,7 @@ class ModelTest extends TestCase
 		$this->assertSame($expected, $option);
 	}
 
-	/**
-	 * @covers ::image
-	 * @covers ::imageDefaults
-	 * @covers ::imageSource
-	 * @covers ::imageSrcset
-	 */
-	public function testImage()
+	public function testImage(): void
 	{
 		$panel = $this->panel([
 			'files' => [
@@ -337,10 +313,7 @@ class ModelTest extends TestCase
 		$this->assertStringContainsString('test-1408x939-crop.jpg 1408w', $image['srcset']);
 	}
 
-	/**
-	 * @covers ::image
-	 */
-	public function testImageWithNonResizableAsset()
+	public function testImageWithNonResizableAsset(): void
 	{
 		$site  = new ModelSiteWithImageMethod([]);
 		$panel = new CustomPanelModel($site);
@@ -349,10 +322,7 @@ class ModelTest extends TestCase
 		$this->assertSame('/tmp/test.svg', $image['src']);
 	}
 
-	/**
-	 * @covers ::image
-	 */
-	public function testImageWithBlueprint()
+	public function testImageWithBlueprint(): void
 	{
 		$app  = $this->app->clone([
 			'blueprints' => [
@@ -384,10 +354,7 @@ class ModelTest extends TestCase
 		$this->assertArrayNotHasKey('url', $image);
 	}
 
-	/**
-	 * @covers ::image
-	 */
-	public function testImageWithBlueprintFalse()
+	public function testImageWithBlueprintFalse(): void
 	{
 		$app  = $this->app->clone([
 			'blueprints' => [
@@ -416,10 +383,7 @@ class ModelTest extends TestCase
 		$this->assertNull($image);
 	}
 
-	/**
-	 * @covers ::image
-	 */
-	public function testImageWithBlueprintString()
+	public function testImageWithBlueprintString(): void
 	{
 		$app  = $this->app->clone([
 			'blueprints' => [
@@ -445,10 +409,7 @@ class ModelTest extends TestCase
 		$this->assertStringEndsWith('test.jpg', $image['url']);
 	}
 
-	/**
-	 * @covers ::image
-	 */
-	public function testImageWithQuery()
+	public function testImageWithQuery(): void
 	{
 		$site  = new ModelSiteWithImageMethod();
 		$panel = new CustomPanelModel($site);
@@ -456,28 +417,19 @@ class ModelTest extends TestCase
 		$this->assertSame('blue', $image['back']);
 	}
 
-	/**
-	 * @covers ::imagePlaceholder
-	 */
-	public function testImagePlaceholder()
+	public function testImagePlaceholder(): void
 	{
 		$this->assertIsString(Model::imagePlaceholder());
 		$this->assertStringStartsWith('data:image/gif;base64,', Model::imagePlaceholder());
 	}
 
-	/**
-	 * @covers ::model
-	 */
-	public function testModel()
+	public function testModel(): void
 	{
 		$panel  = $this->panel();
 		$this->assertInstanceOf(ModelSite::class, $panel->model());
 	}
 
-	/**
-	 * @covers ::props
-	 */
-	public function testProps()
+	public function testProps(): void
 	{
 		$site = [
 			'blueprint' => [
@@ -515,10 +467,7 @@ class ModelTest extends TestCase
 		$this->assertSame('main', $props['tab']['name']);
 	}
 
-	/**
-	 * @covers ::toLink
-	 */
-	public function testToLink()
+	public function testToLink(): void
 	{
 		$panel = $this->panel([
 			'content' => [
@@ -536,19 +485,13 @@ class ModelTest extends TestCase
 		$this->assertSame($author, $toLink['title']);
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrl()
+	public function testUrl(): void
 	{
 		$this->assertSame('/panel/custom', $this->panel()->url());
 		$this->assertSame('/custom', $this->panel()->url(true));
 	}
 
-	/**
-	 * @covers ::versions
-	 */
-	public function testVersions()
+	public function testVersions(): void
 	{
 		$panel = $this->panel([]);
 

--- a/tests/Panel/PageCreateDialogTest.php
+++ b/tests/Panel/PageCreateDialogTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Panel;
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Panel\Areas\AreaTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\PageCreateDialog
- */
+#[CoversClass(PageCreateDialog::class)]
 class PageCreateDialogTest extends AreaTestCase
 {
 	public function setUp(): void
@@ -17,9 +16,6 @@ class PageCreateDialogTest extends AreaTestCase
 		$this->login();
 	}
 
-	/**
-	 * @covers ::coreFields
-	 */
 	public function testCoreFields(): void
 	{
 		$dialog = new PageCreateDialog(
@@ -36,9 +32,6 @@ class PageCreateDialogTest extends AreaTestCase
 		$this->assertSame('/', $fields['slug']['path']);
 	}
 
-	/**
-	 * @covers ::coreFields
-	 */
 	public function testCoreFieldWithoutTitleSlug(): void
 	{
 		$this->app([
@@ -65,9 +58,6 @@ class PageCreateDialogTest extends AreaTestCase
 		$this->assertArrayNotHasKey('slug', $fields);
 	}
 
-	/**
-	 * @covers ::coreFields
-	 */
 	public function testCoreFieldInvalidTitleSlug(): void
 	{
 		$this->app([
@@ -93,9 +83,6 @@ class PageCreateDialogTest extends AreaTestCase
 		$dialog->coreFields();
 	}
 
-	/**
-	 * @covers ::resolveFieldTemplates
-	 */
 	public function testResolveFieldTemplates(): void
 	{
 		$this->app([
@@ -129,9 +116,6 @@ class PageCreateDialogTest extends AreaTestCase
 		], $input);
 	}
 
-	/**
-	 * @covers ::sanitize
-	 */
 	public function testSanitize(): void
 	{
 		$this->app([
@@ -179,9 +163,6 @@ class PageCreateDialogTest extends AreaTestCase
 		], $input);
 	}
 
-	/**
-	 * @covers ::validate
-	 */
 	public function testValidateInvalidTitle(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -197,9 +178,6 @@ class PageCreateDialogTest extends AreaTestCase
 		$dialog->validate(['content' => ['title' => '']]);
 	}
 
-	/**
-	 * @covers ::validate
-	 */
 	public function testValidateInvalidSlug(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -218,9 +196,6 @@ class PageCreateDialogTest extends AreaTestCase
 		]);
 	}
 
-	/**
-	 * @covers ::validate
-	 */
 	public function testValidateInvalidFields(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -253,9 +228,6 @@ class PageCreateDialogTest extends AreaTestCase
 		], 'listed');
 	}
 
-	/**
-	 * @covers ::validate
-	 */
 	public function testValidateValidFields(): void
 	{
 		$this->app([
@@ -286,9 +258,6 @@ class PageCreateDialogTest extends AreaTestCase
 		$this->assertTrue($valid);
 	}
 
-	/**
-	 * @covers ::value
-	 */
 	public function testValue(): void
 	{
 		$this->app([

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -10,6 +10,7 @@ use Kirby\Content\Lock;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class PageForceLocked extends ModelPage
 {
@@ -22,9 +23,8 @@ class PageForceLocked extends ModelPage
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Panel\Page
- */
+#[CoversClass(\Kirby\Panel\Page::class)]
+#[CoversClass(Model::class)]
 class PageTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Page';
@@ -51,9 +51,6 @@ class PageTest extends TestCase
 		return new Page($page);
 	}
 
-	/**
-	 * @covers ::breadcrumb
-	 */
 	public function testBreadcrumb(): void
 	{
 		$site = new ModelSite([
@@ -97,10 +94,7 @@ class PageTest extends TestCase
 		], $page->breadcrumb());
 	}
 
-	/**
-	 * @covers ::buttons
-	 */
-	public function testButtons()
+	public function testButtons(): void
 	{
 		$this->assertSame([
 			'k-open-view-button',
@@ -111,10 +105,7 @@ class PageTest extends TestCase
 		], array_column($this->panel()->buttons(), 'component'));
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
-	public function testDragText()
+	public function testDragText(): void
 	{
 		$page = new ModelPage([
 			'slug' => 'test',
@@ -137,10 +128,7 @@ class PageTest extends TestCase
 		$this->assertSame('(link: page://test-page text: Test Title)', $panel->dragText());
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
-	public function testDragTextMarkdown()
+	public function testDragTextMarkdown(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -172,10 +160,7 @@ class PageTest extends TestCase
 		$this->assertSame('[Test Title](//@/page/my-b)', $panel->dragText());
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
-	public function testDragTextCustomMarkdown()
+	public function testDragTextCustomMarkdown(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -204,10 +189,7 @@ class PageTest extends TestCase
 		$this->assertSame('Links sind toll: /test', $panel->dragText());
 	}
 
-	/**
-	 * @covers ::dragText
-	 */
-	public function testDragTextCustomKirbytext()
+	public function testDragTextCustomKirbytext(): void
 	{
 		$app = $this->app->clone([
 			'options' => [
@@ -235,10 +217,7 @@ class PageTest extends TestCase
 		$this->assertSame('Links sind toll: /test', $panel->dragText());
 	}
 
-	/**
-	 * @covers ::dropdownOption
-	 */
-	public function testDropdownOption()
+	public function testDropdownOption(): void
 	{
 		$page = new ModelPage([
 			'slug'    => 'test',
@@ -255,10 +234,7 @@ class PageTest extends TestCase
 		$this->assertSame('/pages/test', $option['link']);
 	}
 
-	/**
-	 * @covers ::image
-	 */
-	public function testIconFromBlueprint()
+	public function testIconFromBlueprint(): void
 	{
 		$page = new ModelPage([
 			'slug' => 'test',
@@ -272,10 +248,7 @@ class PageTest extends TestCase
 		$this->assertSame('test', $image['icon']);
 	}
 
-	/**
-	 * @covers ::id
-	 */
-	public function testId()
+	public function testId(): void
 	{
 		$parent = new ModelPage(['slug' => 'foo']);
 		$page   = new ModelPage([
@@ -287,10 +260,7 @@ class PageTest extends TestCase
 		$this->assertSame('foo+bar', $id);
 	}
 
-	/**
-	 * @covers ::imageSource
-	 */
-	public function testImage()
+	public function testImage(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test',
@@ -304,11 +274,7 @@ class PageTest extends TestCase
 		$this->assertTrue(Str::endsWith($image['url'], '/test.jpg'));
 	}
 
-	/**
-	 * @covers ::image
-	 * @covers ::imageDefaults
-	 */
-	public function testImageBlueprintIconWithEmoji()
+	public function testImageBlueprintIconWithEmoji(): void
 	{
 		$page = new ModelPage([
 			'slug' => 'test',
@@ -322,11 +288,7 @@ class PageTest extends TestCase
 		$this->assertSame($emoji, $image['icon']);
 	}
 
-	/**
-	 * @covers ::imageSource
-	 * @covers \Kirby\Panel\Model::imageSrcset
-	 */
-	public function testImageCover()
+	public function testImageCover(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -370,10 +332,7 @@ class PageTest extends TestCase
 		], $panel->image(['cover' => true]));
 	}
 
-	/**
-	 * @covers \Kirby\Panel\Model::options
-	 */
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$page = new ModelPage([
 			'slug' => 'test',
@@ -402,10 +361,7 @@ class PageTest extends TestCase
 		$this->assertSame($expected, $panel->options());
 	}
 
-	/**
-	 * @covers \Kirby\Panel\Model::options
-	 */
-	public function testOptionsWithLockedPage()
+	public function testOptionsWithLockedPage(): void
 	{
 		$page = new PageForceLocked([
 			'slug' => 'test',
@@ -455,10 +411,7 @@ class PageTest extends TestCase
 		$this->assertSame($expected, $panel->options(['preview']));
 	}
 
-	/**
-	 * @covers ::path
-	 */
-	public function testPath()
+	public function testPath(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test'
@@ -468,11 +421,7 @@ class PageTest extends TestCase
 		$this->assertSame('pages/test', $panel->path());
 	}
 
-	/**
-	 * @covers ::pickerData
-	 * @covers \Kirby\Panel\Model::pickerData
-	 */
-	public function testPickerDataDefault()
+	public function testPickerDataDefault(): void
 	{
 		$page = new ModelPage([
 			'slug' => 'test',
@@ -491,10 +440,7 @@ class PageTest extends TestCase
 		$this->assertSame('Test Title', $data['text']);
 	}
 
-	/**
-	 * @covers ::position
-	 */
-	public function testPosition()
+	public function testPosition(): void
 	{
 		$page = new ModelPage([
 			'slug' => 'test',
@@ -518,10 +464,7 @@ class PageTest extends TestCase
 		$this->assertSame(4, $panel->position());
 	}
 
-	/**
-	 * @covers ::props
-	 */
-	public function testProps()
+	public function testProps(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test'
@@ -549,11 +492,7 @@ class PageTest extends TestCase
 		$this->assertNull($props['prev']());
 	}
 
-	/**
-	 * @covers ::props
-	 * @covers ::prevNext
-	 */
-	public function testPropsPrevNext()
+	public function testPropsPrevNext(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -579,11 +518,7 @@ class PageTest extends TestCase
 		$this->assertNull($props['next']());
 	}
 
-	/**
-	 * @covers ::props
-	 * @covers ::prevNext
-	 */
-	public function testPropsPrevNextWithSameTemplate()
+	public function testPropsPrevNextWithSameTemplate(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -607,11 +542,7 @@ class PageTest extends TestCase
 		$this->assertSame('/pages/foo', $props['prev']()['link']);
 	}
 
-	/**
-	 * @covers ::props
-	 * @covers ::prevNext
-	 */
-	public function testPropsPrevNextWithSameStatus()
+	public function testPropsPrevNextWithSameStatus(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -635,11 +566,7 @@ class PageTest extends TestCase
 		$this->assertSame('/pages/foo', $props['prev']()['link']);
 	}
 
-	/**
-	 * @covers ::prevNext
-	 * @covers ::toPrevNextLink
-	 */
-	public function testPropsPrevNextWithTab()
+	public function testPropsPrevNextWithTab(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -661,10 +588,7 @@ class PageTest extends TestCase
 		$_GET = [];
 	}
 
-	/**
-	 * @covers ::view
-	 */
-	public function testView()
+	public function testView(): void
 	{
 		$page = new ModelPage([
 			'slug'  => 'test',
@@ -679,10 +603,7 @@ class PageTest extends TestCase
 		$this->assertSame('test', $view['breadcrumb'][0]['label']);
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrl()
+	public function testUrl(): void
 	{
 		$app = $this->app->clone([
 			'urls' => [
@@ -709,10 +630,7 @@ class PageTest extends TestCase
 		$this->assertSame('/pages/mother+child', $panel->url(true));
 	}
 
-	/**
-	 * @covers ::prevNext
-	 */
-	public function testPrevNextOne()
+	public function testPrevNextOne(): void
 	{
 		$app = $this->app->clone([
 			'roots' => [
@@ -775,10 +693,7 @@ class PageTest extends TestCase
 		$this->assertSame($expectedPrev->panel()->toLink(), $prevNext['prev']());
 	}
 
-	/**
-	 * @covers ::prevNext
-	 */
-	public function testPrevNextTwo()
+	public function testPrevNextTwo(): void
 	{
 		$app = $this->app->clone([
 			'roots' => [
@@ -854,10 +769,7 @@ class PageTest extends TestCase
 		$this->assertSame($expectedPrev->panel()->toLink(), $prevNext['prev']());
 	}
 
-	/**
-	 * @covers ::prevNext
-	 */
-	public function testPrevNextThree()
+	public function testPrevNextThree(): void
 	{
 		$app = $this->app->clone([
 			'roots' => [
@@ -933,10 +845,7 @@ class PageTest extends TestCase
 		$this->assertSame($expectedPrev->panel()->toLink(), $prevNext['prev']());
 	}
 
-	/**
-	 * @covers ::prevNext
-	 */
-	public function testPrevNextFour()
+	public function testPrevNextFour(): void
 	{
 		$app = $this->app->clone([
 			'roots' => [

--- a/tests/Panel/PanelTest.php
+++ b/tests/Panel/PanelTest.php
@@ -8,10 +8,9 @@ use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Http\Response;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Panel
- */
+#[CoversClass(Panel::class)]
 class PanelTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Panel';
@@ -51,9 +50,6 @@ class PanelTest extends TestCase
 		unset($_SERVER['SERVER_SOFTWARE']);
 	}
 
-	/**
-	 * @covers ::area
-	 */
 	public function testArea(): void
 	{
 		// defaults
@@ -72,9 +68,6 @@ class PanelTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::areas
-	 */
 	public function testAreas(): void
 	{
 		// unauthenticated / uninstalled
@@ -130,9 +123,6 @@ class PanelTest extends TestCase
 		$this->assertCount(8, $areas);
 	}
 
-	/**
-	 * @covers ::buttons
-	 */
 	public function testButtons(): void
 	{
 		$this->app = $this->app->clone([
@@ -167,10 +157,6 @@ class PanelTest extends TestCase
 		$this->assertSame(['component' => 'test-a'], array_pop($withCustoms));
 	}
 
-	/**
-	 * @covers ::firewall
-	 * @covers ::hasAccess
-	 */
 	public function testFirewallWithoutUser(): void
 	{
 		$this->expectException(PermissionException::class);
@@ -181,10 +167,6 @@ class PanelTest extends TestCase
 		Panel::firewall();
 	}
 
-	/**
-	 * @covers ::firewall
-	 * @covers ::hasAccess
-	 */
 	public function testFirewallWithoutAcceptedUser(): void
 	{
 		$this->expectException(PermissionException::class);
@@ -197,9 +179,6 @@ class PanelTest extends TestCase
 		Panel::firewall($this->app->user());
 	}
 
-	/**
-	 * @covers ::firewall
-	 */
 	public function testFirewallWithAcceptedUser(): void
 	{
 		// accepted user
@@ -220,10 +199,6 @@ class PanelTest extends TestCase
 		$this->assertTrue($result);
 	}
 
-	/**
-	 * @covers ::firewall
-	 * @covers ::hasAccess
-	 */
 	public function testFirewallAreaAccess(): void
 	{
 		$app = $this->app->clone([
@@ -268,10 +243,7 @@ class PanelTest extends TestCase
 		Panel::firewall($app->user(), 'system');
 	}
 
-	/**
-	 * @covers ::go
-	 */
-	public function testGo()
+	public function testGo(): void
 	{
 		$thrown = false;
 		try {
@@ -284,10 +256,7 @@ class PanelTest extends TestCase
 		$this->assertTrue($thrown);
 	}
 
-	/**
-	 * @covers ::go
-	 */
-	public function testGoWithCustomCode()
+	public function testGoWithCustomCode(): void
 	{
 		try {
 			Panel::go('test', 301);
@@ -296,10 +265,7 @@ class PanelTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::go
-	 */
-	public function testGoWithCustomSlug()
+	public function testGoWithCustomSlug(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -317,9 +283,6 @@ class PanelTest extends TestCase
 		}
 	}
 
-	/**
-	 * @covers ::isFiberRequest
-	 */
 	public function testIsFiberRequest(): void
 	{
 		// standard request
@@ -361,9 +324,6 @@ class PanelTest extends TestCase
 		$this->assertFalse($result);
 	}
 
-	/**
-	 * @covers ::json
-	 */
 	public function testJson(): void
 	{
 		$response = Panel::json($data = ['foo' => 'bar']);
@@ -373,10 +333,7 @@ class PanelTest extends TestCase
 		$this->assertSame($data, json_decode($response->body(), true));
 	}
 
-	/**
-	 * @covers ::multilang
-	 */
-	public function testMultilang()
+	public function testMultilang(): void
 	{
 		$this->app = $this->app->clone([
 			'options' => [
@@ -387,10 +344,7 @@ class PanelTest extends TestCase
 		$this->assertTrue(Panel::multilang());
 	}
 
-	/**
-	 * @covers ::multilang
-	 */
-	public function testMultilangWithImplicitLanguageInstallation()
+	public function testMultilangWithImplicitLanguageInstallation(): void
 	{
 		$this->app = $this->app->clone([
 			'languages' => [
@@ -407,18 +361,12 @@ class PanelTest extends TestCase
 		$this->assertTrue(Panel::multilang());
 	}
 
-	/**
-	 * @covers ::multilang
-	 */
-	public function testMultilangDisabled()
+	public function testMultilangDisabled(): void
 	{
 		$this->assertFalse(Panel::multilang());
 	}
 
-	/**
-	 * @covers ::response
-	 */
-	public function testResponse()
+	public function testResponse(): void
 	{
 		$response = new Response('Test');
 
@@ -426,10 +374,7 @@ class PanelTest extends TestCase
 		$this->assertSame($response, Panel::response($response));
 	}
 
-	/**
-	 * @covers ::response
-	 */
-	public function testResponseFromNullOrFalse()
+	public function testResponseFromNullOrFalse(): void
 	{
 		// fake json request for easier assertions
 		$this->app = $this->app->clone([
@@ -457,10 +402,7 @@ class PanelTest extends TestCase
 		$this->assertSame('The data could not be found', $json['$view']['props']['error']);
 	}
 
-	/**
-	 * @covers ::response
-	 */
-	public function testResponseFromString()
+	public function testResponseFromString(): void
 	{
 		// fake json request for easier assertions
 		$this->app = $this->app->clone([
@@ -480,9 +422,6 @@ class PanelTest extends TestCase
 		$this->assertSame('Test', $json['$view']['props']['error']);
 	}
 
-	/**
-	 * @covers ::router
-	 */
 	public function testRouterWithDisabledPanel(): void
 	{
 		$app = $this->app->clone([
@@ -496,10 +435,7 @@ class PanelTest extends TestCase
 		$this->assertNull($result);
 	}
 
-	/**
-	 * @covers ::routes
-	 */
-	public function testRoutes()
+	public function testRoutes(): void
 	{
 		$routes = Panel::routes([]);
 
@@ -510,9 +446,6 @@ class PanelTest extends TestCase
 	}
 
 
-	/**
-	 * @covers ::routesForDialogs
-	 */
 	public function testRoutesForDialogs(): void
 	{
 		$area = [
@@ -547,9 +480,6 @@ class PanelTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::routesForDialogs
-	 */
 	public function testRoutesForDialogsWithoutHandlers(): void
 	{
 		$area = [
@@ -564,9 +494,6 @@ class PanelTest extends TestCase
 		$this->assertSame('The submit handler is missing', $routes[1]['action']());
 	}
 
-	/**
-	 * @covers ::routesForDropdowns
-	 */
 	public function testRoutesForDropdowns(): void
 	{
 		$area = [
@@ -598,9 +525,6 @@ class PanelTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::routesForDropdowns
-	 */
 	public function testRoutesForDropdownsWithOptions(): void
 	{
 		$area = [
@@ -632,9 +556,6 @@ class PanelTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::routesForDropdowns
-	 */
 	public function testRoutesForDropdownsWithShortcut(): void
 	{
 		$area = [
@@ -663,9 +584,6 @@ class PanelTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::routesForViews
-	 */
 	public function testRoutesForViews(): void
 	{
 		$area = [
@@ -692,9 +610,6 @@ class PanelTest extends TestCase
 		$this->assertSame($expected, $routes);
 	}
 
-	/**
-	 * @covers ::setLanguage
-	 */
 	public function testSetLanguageWithoutRequest(): void
 	{
 		$this->app = $this->app->clone([
@@ -724,9 +639,6 @@ class PanelTest extends TestCase
 		$this->assertNull($this->app->session()->get('panel.language'));
 	}
 
-	/**
-	 * @covers ::setLanguage
-	 */
 	public function testSetLanguage(): void
 	{
 		$this->app = $this->app->clone([
@@ -761,9 +673,6 @@ class PanelTest extends TestCase
 		$this->assertSame('de', $this->app->session()->get('panel.language'));
 	}
 
-	/**
-	 * @covers ::setLanguage
-	 */
 	public function testSetLanguageWithCustomDefault(): void
 	{
 		$this->app = $this->app->clone([
@@ -790,9 +699,6 @@ class PanelTest extends TestCase
 		$this->assertSame('de', $this->app->language()->code());
 	}
 
-	/**
-	 * @covers ::setLanguage
-	 */
 	public function testSetLanguageViaGet(): void
 	{
 		// switch via get request
@@ -824,9 +730,6 @@ class PanelTest extends TestCase
 		$this->assertSame('de', $this->app->language()->code());
 	}
 
-	/**
-	 * @covers ::setLanguage
-	 */
 	public function testSetLanguageInSingleLanguageSite(): void
 	{
 		$language = Panel::setLanguage();
@@ -835,9 +738,6 @@ class PanelTest extends TestCase
 		$this->assertNull($this->app->language());
 	}
 
-	/**
-	 * @covers ::setTranslation
-	 */
 	public function testSetTranslation(): void
 	{
 		$translation = Panel::setTranslation($this->app);

--- a/tests/Panel/PluginsTest.php
+++ b/tests/Panel/PluginsTest.php
@@ -6,10 +6,9 @@ use Kirby\Cms\App;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Plugins
- */
+#[CoversClass(Plugins::class)]
 class PluginsTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Plugins';
@@ -74,10 +73,7 @@ class PluginsTest extends TestCase
 		Dir::remove(static::TMP);
 	}
 
-	/**
-	 * @covers ::files
-	 */
-	public function testFiles()
+	public function testFiles(): void
 	{
 		$this->createPlugins();
 
@@ -102,19 +98,13 @@ class PluginsTest extends TestCase
 		$this->assertSame($expected, $plugins->files());
 	}
 
-	/**
-	 * @covers ::modified
-	 */
-	public function testModifiedWithoutFiles()
+	public function testModifiedWithoutFiles(): void
 	{
 		$plugins = new Plugins();
 		$this->assertSame(0, $plugins->modified());
 	}
 
-	/**
-	 * @covers ::modified
-	 */
-	public function testModifiedWithFiles()
+	public function testModifiedWithFiles(): void
 	{
 		$time = $this->createPlugins();
 
@@ -125,10 +115,7 @@ class PluginsTest extends TestCase
 		$this->assertSame($time, $plugins->modified());
 	}
 
-	/**
-	 * @covers ::read
-	 */
-	public function testRead()
+	public function testRead(): void
 	{
 		$this->createPlugins();
 
@@ -150,10 +137,7 @@ class PluginsTest extends TestCase
 		$this->assertSame($expected, $plugins->read('mjs'));
 	}
 
-	/**
-	 * @covers ::read
-	 */
-	public function testReadWithDevMjs()
+	public function testReadWithDevMjs(): void
 	{
 		$this->createPlugins(true);
 
@@ -175,10 +159,7 @@ class PluginsTest extends TestCase
 		$this->assertSame($expected, $plugins->read('mjs'));
 	}
 
-	/**
-	 * @covers ::url
-	 */
-	public function testUrl()
+	public function testUrl(): void
 	{
 		// css
 		$plugins  = new Plugins();

--- a/tests/Panel/RedirectTest.php
+++ b/tests/Panel/RedirectTest.php
@@ -3,16 +3,12 @@
 namespace Kirby\Panel;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Redirect
- */
+#[CoversClass(Redirect::class)]
 class RedirectTest extends TestCase
 {
-	/**
-	 * @covers ::code
-	 */
-	public function testCode()
+	public function testCode(): void
 	{
 		// default
 		$redirect = new Redirect('https://getkirby.com');
@@ -27,10 +23,7 @@ class RedirectTest extends TestCase
 		$this->assertSame(302, $redirect->code());
 	}
 
-	/**
-	 * @covers ::location
-	 */
-	public function testLocation()
+	public function testLocation(): void
 	{
 		$redirect = new Redirect('https://getkirby.com');
 		$this->assertSame('https://getkirby.com', $redirect->location());

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -7,10 +7,10 @@ use Kirby\Cms\Site as ModelSite;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Site
- */
+#[CoversClass(\Kirby\Panel\Site::class)]
+#[CoversClass(Model::class)]
 class SiteTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.Site';
@@ -37,10 +37,7 @@ class SiteTest extends TestCase
 		return new Site($site);
 	}
 
-	/**
-	 * @covers ::buttons
-	 */
-	public function testButtons()
+	public function testButtons(): void
 	{
 		$this->assertSame([
 			'k-open-view-button',
@@ -49,9 +46,6 @@ class SiteTest extends TestCase
 		], array_column($this->panel()->buttons(), 'component'));
 	}
 
-	/**
-	 * @covers ::dropdownOption
-	 */
 	public function testDropdownOption(): void
 	{
 		$model = $this->panel([
@@ -67,10 +61,7 @@ class SiteTest extends TestCase
 		$this->assertSame('/site', $option['link']);
 	}
 
-	/**
-	 * @covers ::imageSource
-	 */
-	public function testImage()
+	public function testImage(): void
 	{
 		$panel = $this->panel([
 			'files' => [
@@ -83,13 +74,7 @@ class SiteTest extends TestCase
 		$this->assertTrue(Str::endsWith($image['url'], '/test.jpg'));
 	}
 
-	/**
-	 * @covers ::imageSource
-	 * @covers \Kirby\Panel\Model::image
-	 * @covers \Kirby\Panel\Model::imageSource
-	 * @covers \Kirby\Panel\Model::imageSrcset
-	 */
-	public function testImageCover()
+	public function testImageCover(): void
 	{
 		$app = $this->app->clone([
 			'site' => [
@@ -128,18 +113,12 @@ class SiteTest extends TestCase
 		], $panel->image(['cover' => true]));
 	}
 
-	/**
-	 * @covers ::path
-	 */
-	public function testPath()
+	public function testPath(): void
 	{
 		$this->assertSame('site', $this->panel()->path());
 	}
 
-	/**
-	 * @covers ::props
-	 */
-	public function testProps()
+	public function testProps(): void
 	{
 		$props = $this->panel()->props();
 
@@ -156,14 +135,14 @@ class SiteTest extends TestCase
 		$this->assertArrayHasKey('versions', $props);
 	}
 
-	public function testPreviewPermissionsWithoutHomePage()
+	public function testPreviewPermissionsWithoutHomePage(): void
 	{
 		$props = $this->panel()->props();
 
 		$this->assertFalse($props['permissions']['preview']);
 	}
 
-	public function testPreviewPermissionsWithHomePage()
+	public function testPreviewPermissionsWithHomePage(): void
 	{
 		$this->app = $this->app->clone([
 			'site' => [
@@ -186,10 +165,7 @@ class SiteTest extends TestCase
 		$this->assertTrue($props['permissions']['preview']);
 	}
 
-	/**
-	 * @covers ::view
-	 */
-	public function testView()
+	public function testView(): void
 	{
 		$view = $this->panel()->view();
 		$this->assertArrayHasKey('props', $view);

--- a/tests/Panel/Ui/ButtonTest.php
+++ b/tests/Panel/Ui/ButtonTest.php
@@ -3,17 +3,12 @@
 namespace Kirby\Panel\Ui;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Button
- * @covers ::__construct
- */
+#[CoversClass(Button::class)]
 class ButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
-	public function testAttrs()
+	public function testAttrs(): void
 	{
 		$button = new Button(
 			text: 'Attrs',
@@ -28,10 +23,7 @@ class ButtonTest extends TestCase
 		], array_filter($button->props()));
 	}
 
-	/**
-	 * @covers ::props
-	 */
-	public function testProps()
+	public function testProps(): void
 	{
 		$component = new Button(
 			icon: 'smile',
@@ -63,10 +55,7 @@ class ButtonTest extends TestCase
 		], $component->props());
 	}
 
-	/**
-	 * @covers ::props
-	 */
-	public function testPropsWithI18n()
+	public function testPropsWithI18n(): void
 	{
 		$component = new Button(
 			text: [

--- a/tests/Panel/Ui/Buttons/LanguageCreateButtonTest.php
+++ b/tests/Panel/Ui/Buttons/LanguageCreateButtonTest.php
@@ -4,16 +4,12 @@ namespace Kirby\Panel\Ui\Buttons;
 
 use Kirby\Cms\App;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\LanguageCreateButton
- */
+#[CoversClass(LanguageCreateButton::class)]
 class LanguageCreateButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
-	public function testButton()
+	public function testButton(): void
 	{
 		$button = new LanguageCreateButton();
 
@@ -21,10 +17,7 @@ class LanguageCreateButtonTest extends TestCase
 		$this->assertSame('Add a new language', $button->text);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testDisabled()
+	public function testDisabled(): void
 	{
 		$app = new App([
 			'blueprints' => [

--- a/tests/Panel/Ui/Buttons/LanguageDeleteButtonTest.php
+++ b/tests/Panel/Ui/Buttons/LanguageDeleteButtonTest.php
@@ -5,16 +5,12 @@ namespace Kirby\Panel\Ui\Buttons;
 use Kirby\Cms\App;
 use Kirby\Cms\Language;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\LanguageDeleteButton
- */
+#[CoversClass(LanguageDeleteButton::class)]
 class LanguageDeleteButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
-	public function testButton()
+	public function testButton(): void
 	{
 		$language = new Language(['code' => 'en']);
 		$button   = new LanguageDeleteButton($language);
@@ -22,10 +18,7 @@ class LanguageDeleteButtonTest extends TestCase
 		$this->assertSame('languages/en/delete', $button->dialog);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testDisabled()
+	public function testDisabled(): void
 	{
 		$app = new App([
 			'blueprints' => [

--- a/tests/Panel/Ui/Buttons/LanguageSettingsButtonTest.php
+++ b/tests/Panel/Ui/Buttons/LanguageSettingsButtonTest.php
@@ -5,16 +5,12 @@ namespace Kirby\Panel\Ui\Buttons;
 use Kirby\Cms\App;
 use Kirby\Cms\Language;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\LanguageSettingsButton
- */
+#[CoversClass(LanguageSettingsButton::class)]
 class LanguageSettingsButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
-	public function testButton()
+	public function testButton(): void
 	{
 		$language = new Language(['code' => 'en']);
 		$button   = new LanguageSettingsButton($language);
@@ -22,10 +18,7 @@ class LanguageSettingsButtonTest extends TestCase
 		$this->assertSame('languages/en/update', $button->dialog);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testDisabled()
+	public function testDisabled(): void
 	{
 		$app = new App([
 			'blueprints' => [

--- a/tests/Panel/Ui/Buttons/LanguagesDropdownTest.php
+++ b/tests/Panel/Ui/Buttons/LanguagesDropdownTest.php
@@ -5,17 +5,12 @@ namespace Kirby\Panel\Ui\Buttons;
 use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\Panel\Areas\AreaTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\LanguagesDropdown
- * @covers ::__construct
- */
+#[CoversClass(LanguagesDropdown::class)]
 class LanguagesDropdownTest extends AreaTestCase
 {
-	/**
-	 * @covers ::hasDiff
-	 */
-	public function testHasDiff()
+	public function testHasDiff(): void
 	{
 		$this->install();
 		$this->installLanguages();
@@ -37,10 +32,7 @@ class LanguagesDropdownTest extends AreaTestCase
 		$this->assertTrue($button->hasDiff());
 	}
 
-	/**
-	 * @covers ::option
-	 */
-	public function testOption()
+	public function testOption(): void
 	{
 		$page     = new Page(['slug' => 'test']);
 		$button   = new LanguagesDropdown($page);
@@ -55,21 +47,14 @@ class LanguagesDropdownTest extends AreaTestCase
 		], $button->option($language));
 	}
 
-	/**
-	 * @covers ::options
-	 * @
-	 */
-	public function testOptionsSingleLang()
+	public function testOptionsSingleLang(): void
 	{
 		$page   = new Page(['slug' => 'test']);
 		$button = new LanguagesDropdown($page);
 		$this->assertSame([], $button->options());
 	}
 
-	/**
-	 * @covers ::options
-	 */
-	public function testOptionsMultiLang()
+	public function testOptionsMultiLang(): void
 	{
 		$this->enableMultilang();
 		$this->installLanguages();
@@ -97,10 +82,7 @@ class LanguagesDropdownTest extends AreaTestCase
 		], $button->options());
 	}
 
-	/**
-	 * @covers ::props
-	 */
-	public function testProps()
+	public function testProps(): void
 	{
 		$page   = new Page(['slug' => 'test']);
 		$button = new LanguagesDropdown($page);
@@ -108,20 +90,14 @@ class LanguagesDropdownTest extends AreaTestCase
 		$this->assertFalse($props['hasDiff']);
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderDefault()
+	public function testRenderDefault(): void
 	{
 		$page   = new Page(['slug' => 'test']);
 		$button = new LanguagesDropdown($page);
 		$this->assertNull($button->render());
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderSingleLang()
+	public function testRenderSingleLang(): void
 	{
 		$this->enableMultilang();
 		$this->app([
@@ -139,11 +115,7 @@ class LanguagesDropdownTest extends AreaTestCase
 		$this->assertNull($button->render());
 	}
 
-	/**
-	 * @covers ::props
-	 * @covers ::render
-	 */
-	public function testRenderMultiLang()
+	public function testRenderMultiLang(): void
 	{
 		$this->enableMultilang();
 		$this->installLanguages();

--- a/tests/Panel/Ui/Buttons/OpenButtonTest.php
+++ b/tests/Panel/Ui/Buttons/OpenButtonTest.php
@@ -3,16 +3,12 @@
 namespace Kirby\Panel\Ui\Buttons;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\OpenButton
- */
+#[CoversClass(OpenButton::class)]
 class OpenButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
-	public function testButton()
+	public function testButton(): void
 	{
 		$button = new OpenButton(link: 'https://getkirby.com');
 

--- a/tests/Panel/Ui/Buttons/PageStatusButtonTest.php
+++ b/tests/Panel/Ui/Buttons/PageStatusButtonTest.php
@@ -5,16 +5,12 @@ namespace Kirby\Panel\Ui\Buttons;
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\PageStatusButton
- */
+#[CoversClass(PageStatusButton::class)]
 class PageStatusButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
-	public function testButtonDraftDisabled()
+	public function testButtonDraftDisabled(): void
 	{
 
 		$page   = new Page(['slug' => 'test', 'isDraft' => true]);
@@ -31,10 +27,7 @@ class PageStatusButtonTest extends TestCase
 		$this->assertSame('negative-icon', $button->theme);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testButtonUnlisted()
+	public function testButtonUnlisted(): void
 	{
 		App::instance()->impersonate('kirby');
 		$page   = new Page(['slug' => 'test']);

--- a/tests/Panel/Ui/Buttons/PreviewButtonTest.php
+++ b/tests/Panel/Ui/Buttons/PreviewButtonTest.php
@@ -3,16 +3,12 @@
 namespace Kirby\Panel\Ui\Buttons;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\PreviewButton
- */
+#[CoversClass(PreviewButton::class)]
 class PreviewButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
-	public function testButton()
+	public function testButton(): void
 	{
 		$button = new PreviewButton(link: 'https://getkirby.com');
 

--- a/tests/Panel/Ui/Buttons/SettingsButtonTest.php
+++ b/tests/Panel/Ui/Buttons/SettingsButtonTest.php
@@ -4,16 +4,12 @@ namespace Kirby\Panel\Ui\Buttons;
 
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\SettingsButton
- */
+#[CoversClass(SettingsButton::class)]
 class SettingsButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
-	public function testButton()
+	public function testButton(): void
 	{
 		$page   = new Page(['slug' => 'test']);
 		$button = new SettingsButton(model: $page);

--- a/tests/Panel/Ui/Buttons/VersionsButtonTest.php
+++ b/tests/Panel/Ui/Buttons/VersionsButtonTest.php
@@ -5,16 +5,12 @@ namespace Kirby\Panel\Ui\Buttons;
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\VersionsButton
- */
+#[CoversClass(VersionsButton::class)]
 class VersionsButtonTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
-	public function testButton()
+	public function testButton(): void
 	{
 		// needed to load the translations
 		new App();

--- a/tests/Panel/Ui/Buttons/ViewButtonTest.php
+++ b/tests/Panel/Ui/Buttons/ViewButtonTest.php
@@ -5,11 +5,9 @@ namespace Kirby\Panel\Ui\Buttons;
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\Panel\Areas\AreaTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\ViewButton
- * @covers ::__construct
- */
+#[CoversClass(ViewButton::class)]
 class ViewButtonTest extends AreaTestCase
 {
 	public function setUp(): void
@@ -19,10 +17,7 @@ class ViewButtonTest extends AreaTestCase
 		$this->login();
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testAttrs()
+	public function testAttrs(): void
 	{
 		$button = new ViewButton(
 			text: 'Attrs',
@@ -39,10 +34,7 @@ class ViewButtonTest extends AreaTestCase
 		], array_filter($button->props()));
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactoryFromClosure()
+	public function testFactoryFromClosure(): void
 	{
 		$button = ViewButton::factory(
 			button: fn (string $name) => [
@@ -56,10 +48,7 @@ class ViewButtonTest extends AreaTestCase
 		$this->assertSame('k-foo-view-button', $button->component);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactoryFromDefinition()
+	public function testFactoryFromDefinition(): void
 	{
 		$button = ViewButton::factory(
 			button: ['component' => 'k-test-view-button'],
@@ -70,10 +59,7 @@ class ViewButtonTest extends AreaTestCase
 		$this->assertSame('k-test-view-button', $button->component);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactoryFromStringName()
+	public function testFactoryFromStringName(): void
 	{
 		$app = $this->app->clone([
 			'areas' => [
@@ -102,10 +88,7 @@ class ViewButtonTest extends AreaTestCase
 		$this->assertNull($button);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactoryWithNameArg()
+	public function testFactoryWithNameArg(): void
 	{
 		$button = ViewButton::factory(
 			button: [],
@@ -117,10 +100,7 @@ class ViewButtonTest extends AreaTestCase
 		$this->assertSame('k-foo-view-button', $button->component);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactoryFromBooleanButton()
+	public function testFactoryFromBooleanButton(): void
 	{
 		// Default
 		$button = ViewButton::factory(
@@ -140,9 +120,6 @@ class ViewButtonTest extends AreaTestCase
 		$this->assertNull($button);
 	}
 
-	/**
-	 * @covers ::find
-	 */
 	public function testFind(): void
 	{
 		$app = $this->app->clone([
@@ -172,9 +149,6 @@ class ViewButtonTest extends AreaTestCase
 		$this->assertSame(['component' => 'k-foo-view-button'], $result);
 	}
 
-	/**
-	 * @covers ::normalize
-	 */
 	public function testNormalize(): void
 	{
 		$result = ViewButton::normalize([
@@ -197,10 +171,7 @@ class ViewButtonTest extends AreaTestCase
 		], $result);
 	}
 
-	/**
-	 * @covers ::props
-	 */
-	public function testProps()
+	public function testProps(): void
 	{
 		$component = new ViewButton(
 			icon: 'smile',
@@ -234,10 +205,7 @@ class ViewButtonTest extends AreaTestCase
 		], $component->props());
 	}
 
-	/**
-	 * @covers ::props
-	 */
-	public function testPropsWithQueries()
+	public function testPropsWithQueries(): void
 	{
 		$model     = new Page(['slug' => 'test']);
 		$component = new ViewButton(
@@ -251,9 +219,6 @@ class ViewButtonTest extends AreaTestCase
 		$this->assertSame('https://getkirby.com/test', $props['link']);
 	}
 
-	/**
-	 * @covers ::resolve
-	 */
 	public function testResolve(): void
 	{
 		$test   = $this;

--- a/tests/Panel/Ui/Buttons/ViewButtonsTest.php
+++ b/tests/Panel/Ui/Buttons/ViewButtonsTest.php
@@ -4,10 +4,9 @@ namespace Kirby\Panel\Ui\Buttons;
 
 use Kirby\Cms\Page;
 use Kirby\Panel\Areas\AreaTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Buttons\ViewButtons
- */
+#[CoversClass(ViewButtons::class)]
 class ViewButtonsTest extends AreaTestCase
 {
 	public function setUp(): void
@@ -31,10 +30,7 @@ class ViewButtonsTest extends AreaTestCase
 		]);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testConstruct()
+	public function testConstruct(): void
 	{
 		// no buttons
 		$buttons = new ViewButtons('test', buttons: []);
@@ -49,10 +45,7 @@ class ViewButtonsTest extends AreaTestCase
 		$this->assertCount(4, $buttons->buttons);
 	}
 
-	/**
-	 * @covers ::bind
-	 */
-	public function testBind()
+	public function testBind(): void
 	{
 		$buttons = new ViewButtons('foo');
 		$this->assertSame([], $buttons->data);
@@ -65,10 +58,7 @@ class ViewButtonsTest extends AreaTestCase
 		$this->assertSame(['foo' => 'bar', 'homer' => 'simpson'], $buttons->data);
 	}
 
-	/**
-	 * @covers ::defaults
-	 */
-	public function testDefaults()
+	public function testDefaults(): void
 	{
 		$buttons = new ViewButtons('foo');
 		$this->assertCount(0, $buttons->buttons ?? []);
@@ -77,10 +67,7 @@ class ViewButtonsTest extends AreaTestCase
 		$this->assertCount(2, $buttons->buttons);
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRender()
+	public function testRender(): void
 	{
 		$buttons = new ViewButtons('test', buttons: ['a', 'y']);
 		$result  = $buttons->render();
@@ -90,10 +77,7 @@ class ViewButtonsTest extends AreaTestCase
 		$this->assertSame('k-y-view-button', $result[1]['component']);
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderFromConfig()
+	public function testRenderFromConfig(): void
 	{
 		$buttons = new ViewButtons('test');
 		$result  = $buttons->render();
@@ -104,19 +88,13 @@ class ViewButtonsTest extends AreaTestCase
 		$this->assertSame('result-c', $result[2]['component']);
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRenderNoButtons()
+	public function testRenderNoButtons(): void
 	{
 		$buttons = new ViewButtons('test', buttons: false);
 		$this->assertSame([], $buttons->render());
 	}
 
-	/**
-	 * @covers ::view
-	 */
-	public function testView()
+	public function testView(): void
 	{
 		// view name
 		$buttons = ViewButtons::view('page');

--- a/tests/Panel/Ui/ComponentTest.php
+++ b/tests/Panel/Ui/ComponentTest.php
@@ -4,21 +4,16 @@ namespace Kirby\Panel\Ui;
 
 use Exception;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class UiComponent extends Component
 {
 }
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\Component
- * @covers ::__construct
- */
+#[CoversClass(Component::class)]
 class ComponentTest extends TestCase
 {
-	/**
-	 * @covers ::__construct
-	 */
-	public function testAttrs()
+	public function testAttrs(): void
 	{
 		$props = [
 			'component' => 'k-text',
@@ -35,10 +30,7 @@ class ComponentTest extends TestCase
 		], $component->props());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
-	public function testGetterSetter()
+	public function testGetterSetter(): void
 	{
 		$component = new UiComponent(component: 'k-test');
 
@@ -49,10 +41,7 @@ class ComponentTest extends TestCase
 		$this->assertSame('my-class', $component->class());
 	}
 
-	/**
-	 * @covers ::__call
-	 */
-	public function testGetterSetterInvalid()
+	public function testGetterSetterInvalid(): void
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('The property "foo" does not exist on the UI component "k-test"');
@@ -60,10 +49,7 @@ class ComponentTest extends TestCase
 		$component->foo('my-class');
 	}
 
-	/**
-	 * @covers ::key
-	 */
-	public function testKey()
+	public function testKey(): void
 	{
 		$component = new UiComponent(component: 'k-test');
 
@@ -71,10 +57,7 @@ class ComponentTest extends TestCase
 		$this->assertSame($component->render()['key'], $component->key());
 	}
 
-	/**
-	 * @covers ::props
-	 */
-	public function testProps()
+	public function testProps(): void
 	{
 		$component = new UiComponent(
 			component: 'k-test',
@@ -87,10 +70,7 @@ class ComponentTest extends TestCase
 		], $component->props());
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRender()
+	public function testRender(): void
 	{
 		$component = new UiComponent(
 			component: 'k-test',

--- a/tests/Panel/Ui/FilePreviewTest.php
+++ b/tests/Panel/Ui/FilePreviewTest.php
@@ -8,6 +8,7 @@ use Kirby\Cms\Page;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Panel\Ui\FilePreviews\DefaultFilePreview;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class DummyFilePreview extends FilePreview
 {
@@ -27,10 +28,7 @@ class InvalidFilePreview
 {
 }
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\FilePreview
- * @covers ::__construct
- */
+#[CoversClass(FilePreview::class)]
 class FilePreviewTest extends TestCase
 {
 	public function setUp(): void
@@ -45,10 +43,7 @@ class FilePreviewTest extends TestCase
 		$this->app->impersonate('kirby');
 	}
 
-	/**
-	 * @covers ::details
-	 */
-	public function testDetails()
+	public function testDetails(): void
 	{
 		$page    = new Page(['slug' => 'test']);
 		$file    = new File(['filename' => 'test.jpg', 'parent' => $page]);
@@ -77,10 +72,7 @@ class FilePreviewTest extends TestCase
 		], $details);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$page = new Page(['slug' => 'test']);
 		$file = new File(['filename' => 'test.docx', 'parent' => $page]);
@@ -89,10 +81,7 @@ class FilePreviewTest extends TestCase
 		$this->assertInstanceOf(DefaultFilePreview::class, $preview);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactoryWithCustomHandler()
+	public function testFactoryWithCustomHandler(): void
 	{
 		new App([
 			'roots' => [
@@ -114,10 +103,7 @@ class FilePreviewTest extends TestCase
 		$this->assertInstanceOf(DummyFilePreview::class, $preview);
 	}
 
-	/**
-	 * @covers ::factory
-	 */
-	public function testFactoryWithCustomHandlerInvalid()
+	public function testFactoryWithCustomHandlerInvalid(): void
 	{
 		new App([
 			'roots' => [
@@ -138,10 +124,7 @@ class FilePreviewTest extends TestCase
 		FilePreview::factory($file);
 	}
 
-	/**
-	 * @covers ::image
-	 */
-	public function testImage()
+	public function testImage(): void
 	{
 		$page    = new Page(['slug' => 'test']);
 		$file    = new File(['filename' => 'test.jpg', 'parent' => $page]);
@@ -153,10 +136,7 @@ class FilePreviewTest extends TestCase
 		$this->assertIsString($image['src']);
 	}
 
-	/**
-	 * @covers ::props
-	 */
-	public function testProps()
+	public function testProps(): void
 	{
 		$page    = new Page(['slug' => 'test']);
 		$file    = new File(['filename' => 'test.jpg', 'parent' => $page]);
@@ -168,10 +148,7 @@ class FilePreviewTest extends TestCase
 		$this->assertIsString($props['url']);
 	}
 
-	/**
-	 * @covers ::render
-	 */
-	public function testRender()
+	public function testRender(): void
 	{
 		$page    = new Page(['slug' => 'test']);
 		$file    = new File(['filename' => 'test.jpg', 'parent' => $page]);

--- a/tests/Panel/Ui/FilePreviews/AudioFilePreviewTest.php
+++ b/tests/Panel/Ui/FilePreviews/AudioFilePreviewTest.php
@@ -6,16 +6,12 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Panel\Ui\FilePreview;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\FilePreviews\AudioFilePreview
- */
+#[CoversClass(AudioFilePreview::class)]
 class AudioFilePreviewTest extends TestCase
 {
-	/**
-	 * @covers ::accepts
-	 */
-	public function testAccepts()
+	public function testAccepts(): void
 	{
 		$page = new Page(['slug' => 'test']);
 
@@ -26,10 +22,7 @@ class AudioFilePreviewTest extends TestCase
 		$this->assertFalse(AudioFilePreview::accepts($file));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$page    = new Page(['slug' => 'test']);
 		$file    = new File(['filename' => 'test.mp3', 'parent' => $page]);

--- a/tests/Panel/Ui/FilePreviews/DefaultFilePreviewTest.php
+++ b/tests/Panel/Ui/FilePreviews/DefaultFilePreviewTest.php
@@ -6,17 +6,12 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Panel\Ui\FilePreview;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\FilePreviews\DefaultFilePreview
- * @covers ::__construct
- */
+#[CoversClass(DefaultFilePreview::class)]
 class DefaultFilePreviewTest extends TestCase
 {
-	/**
-	 * @covers ::accepts
-	 */
-	public function testAccepts()
+	public function testAccepts(): void
 	{
 		$page = new Page(['slug' => 'test']);
 		$file = new File(['filename' => 'test.jpg', 'parent' => $page]);
@@ -24,10 +19,7 @@ class DefaultFilePreviewTest extends TestCase
 		$this->assertTrue(DefaultFilePreview::accepts($file));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$page    = new Page(['slug' => 'test']);
 		$file    = new File(['filename' => 'test.zip', 'parent' => $page]);
@@ -37,11 +29,7 @@ class DefaultFilePreviewTest extends TestCase
 		$this->assertSame('k-default-file-preview', $preview->component);
 	}
 
-	/**
-	 * @covers ::image
-	 * @covers ::props
-	 */
-	public function testProps()
+	public function testProps(): void
 	{
 		$page      = new Page(['slug' => 'test']);
 		$file      = new File(['filename' => 'test.jpg', 'parent' => $page]);

--- a/tests/Panel/Ui/FilePreviews/ImageFilePreviewTest.php
+++ b/tests/Panel/Ui/FilePreviews/ImageFilePreviewTest.php
@@ -6,16 +6,12 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Panel\Ui\FilePreview;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\FilePreviews\ImageFilePreview
- */
+#[CoversClass(ImageFilePreview::class)]
 class ImageFilePreviewTest extends TestCase
 {
-	/**
-	 * @covers ::accepts
-	 */
-	public function testAccepts()
+	public function testAccepts(): void
 	{
 		$page = new Page(['slug' => 'test']);
 
@@ -26,10 +22,7 @@ class ImageFilePreviewTest extends TestCase
 		$this->assertFalse(ImageFilePreview::accepts($file));
 	}
 
-	/**
-	 * @covers ::details
-	 */
-	public function testDetails()
+	public function testDetails(): void
 	{
 		$page    = new Page(['slug' => 'test']);
 		$file    = new File(['filename' => 'test.jpg', 'parent' => $page]);
@@ -43,10 +36,7 @@ class ImageFilePreviewTest extends TestCase
 		$this->assertSame('Dimensions', $detail['title']);
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$page    = new Page(['slug' => 'test']);
 		$file    = new File(['filename' => 'test.jpg', 'parent' => $page]);
@@ -56,10 +46,7 @@ class ImageFilePreviewTest extends TestCase
 		$this->assertSame('k-image-file-preview', $preview->component);
 	}
 
-	/**
-	 * @covers ::props
-	 */
-	public function testProps()
+	public function testProps(): void
 	{
 		$page    = new Page(['slug' => 'test']);
 		$file    = new File(['filename' => 'test.xls', 'parent' => $page]);

--- a/tests/Panel/Ui/FilePreviews/PdfFilePreviewTest.php
+++ b/tests/Panel/Ui/FilePreviews/PdfFilePreviewTest.php
@@ -6,16 +6,12 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Panel\Ui\FilePreview;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\FilePreviews\PdfFilePreview
- */
+#[CoversClass(PdfFilePreview::class)]
 class PdfFilePreviewTest extends TestCase
 {
-	/**
-	 * @covers ::accepts
-	 */
-	public function testAccepts()
+	public function testAccepts(): void
 	{
 		$page = new Page(['slug' => 'test']);
 
@@ -26,10 +22,7 @@ class PdfFilePreviewTest extends TestCase
 		$this->assertFalse(PdfFilePreview::accepts($file));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$page    = new Page(['slug' => 'test']);
 		$file    = new File(['filename' => 'test.pdf', 'parent' => $page]);

--- a/tests/Panel/Ui/FilePreviews/VideoFilePreviewTest.php
+++ b/tests/Panel/Ui/FilePreviews/VideoFilePreviewTest.php
@@ -6,16 +6,12 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Panel\Ui\FilePreview;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\Ui\FilePreviews\VideoFilePreview
- */
+#[CoversClass(VideoFilePreview::class)]
 class VideoFilePreviewTest extends TestCase
 {
-	/**
-	 * @covers ::accepts
-	 */
-	public function testAccepts()
+	public function testAccepts(): void
 	{
 		$page = new Page(['slug' => 'test']);
 
@@ -26,10 +22,7 @@ class VideoFilePreviewTest extends TestCase
 		$this->assertFalse(VideoFilePreview::accepts($file));
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
-	public function testFactory()
+	public function testFactory(): void
 	{
 		$page    = new Page(['slug' => 'test']);
 		$file    = new File(['filename' => 'test.mp4', 'parent' => $page]);

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -9,6 +9,7 @@ use Kirby\Content\Lock;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
 
 class UserForceLocked extends ModelUser
 {
@@ -21,9 +22,8 @@ class UserForceLocked extends ModelUser
 	}
 }
 
-/**
- * @coversDefaultClass \Kirby\Panel\User
- */
+#[CoversClass(\Kirby\Panel\User::class)]
+#[CoversClass(Model::class)]
 class UserTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.User';
@@ -53,9 +53,6 @@ class UserTest extends TestCase
 		return new User($user);
 	}
 
-	/**
-	 * @covers ::breadcrumb
-	 */
 	public function testBreadcrumb(): void
 	{
 		$model = new ModelUser([
@@ -67,10 +64,7 @@ class UserTest extends TestCase
 		$this->assertStringStartsWith('/users/', $breadcrumb[0]['link']);
 	}
 
-	/**
-	 * @covers ::buttons
-	 */
-	public function testButtons()
+	public function testButtons(): void
 	{
 		$this->assertSame([
 			'k-theme-view-button',
@@ -79,9 +73,6 @@ class UserTest extends TestCase
 		], array_column($this->panel()->buttons(), 'component'));
 	}
 
-	/**
-	 * @covers ::dropdown
-	 */
 	public function testDropdownTotp(): void
 	{
 		$this->app = new App([
@@ -110,9 +101,6 @@ class UserTest extends TestCase
 		$this->assertSame('/account/totp/disable', $dropdown[7]['dialog']);
 	}
 
-	/**
-	 * @covers ::dropdownOption
-	 */
 	public function testDropdownOption(): void
 	{
 		$model = new ModelUser([
@@ -126,10 +114,7 @@ class UserTest extends TestCase
 		$this->assertSame('/users/test', $option['link']);
 	}
 
-	/**
-	 * @covers ::home
-	 */
-	public function testHome()
+	public function testHome(): void
 	{
 		$user = new ModelUser([
 			'email' => 'test@getkirby.com',
@@ -139,10 +124,7 @@ class UserTest extends TestCase
 		$this->assertSame('/panel/site', $panel->home());
 	}
 
-	/**
-	 * @covers ::home
-	 */
-	public function testHomeWithCustomPath()
+	public function testHomeWithCustomPath(): void
 	{
 		$this->app = new App([
 			'roots' => [
@@ -165,10 +147,7 @@ class UserTest extends TestCase
 		$this->assertSame('/blog', $panel->home());
 	}
 
-	/**
-	 * @covers ::home
-	 */
-	public function testHomeWithCustomPathQuery()
+	public function testHomeWithCustomPathQuery(): void
 	{
 		$this->app = new App([
 			'roots' => [
@@ -196,11 +175,7 @@ class UserTest extends TestCase
 		$this->assertSame('/panel/pages/test', $panel->home());
 	}
 
-	/**
-	 * @covers ::imageDefaults
-	 * @covers ::imageSource
-	 */
-	public function testImage()
+	public function testImage(): void
 	{
 		$user = new ModelUser([
 			'email' => 'test@getkirby.com',
@@ -211,10 +186,7 @@ class UserTest extends TestCase
 		$this->assertFalse(isset($image['url']));
 	}
 
-	/**
-	 * @covers ::imageSource
-	 */
-	public function testImageStringQuery()
+	public function testImageStringQuery(): void
 	{
 		$user = new ModelUser([
 			'email' => 'test@getkirby.com',
@@ -225,13 +197,7 @@ class UserTest extends TestCase
 		$this->assertNotEmpty($image);
 	}
 
-	/**
-	 * @covers ::imageSource
-	 * @covers \Kirby\Panel\Model::image
-	 * @covers \Kirby\Panel\Model::imageSource
-	 * @covers \Kirby\Panel\Model::imageSrcset
-	 */
-	public function testImageCover()
+	public function testImageCover(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -278,10 +244,7 @@ class UserTest extends TestCase
 		], $panel->image(['cover' => true]));
 	}
 
-	/**
-	 * @covers \Kirby\Panel\Model::options
-	 */
-	public function testOptions()
+	public function testOptions(): void
 	{
 		$user = new ModelUser([
 			'email' => 'test@getkirby.com',
@@ -304,10 +267,7 @@ class UserTest extends TestCase
 		$this->assertSame($expected, $panel->options());
 	}
 
-	/**
-	 * @covers \Kirby\Panel\Model::options
-	 */
-	public function testOptionsWithLockedUser()
+	public function testOptionsWithLockedUser(): void
 	{
 		$user = new UserForceLocked([
 			'email' => 'test@getkirby.com',
@@ -345,10 +305,7 @@ class UserTest extends TestCase
 		$this->assertSame($expected, $panel->options(['changeEmail']));
 	}
 
-	/**
-	 * @covers ::path
-	 */
-	public function testPath()
+	public function testPath(): void
 	{
 		$user = new ModelUser([
 			'email' => 'test@getkirby.com',
@@ -358,11 +315,7 @@ class UserTest extends TestCase
 		$this->assertTrue(Str::startsWith($panel->path(), 'users/'));
 	}
 
-	/**
-	 * @covers ::pickerData
-	 * @covers \Kirby\Panel\Model::pickerData
-	 */
-	public function testPickerDataDefault()
+	public function testPickerDataDefault(): void
 	{
 		$user = new ModelUser([
 			'email' => 'test@getkirby.com',
@@ -376,10 +329,7 @@ class UserTest extends TestCase
 		$this->assertSame('test@getkirby.com', $data['text']);
 	}
 
-	/**
-	 * @covers ::props
-	 */
-	public function testProps()
+	public function testProps(): void
 	{
 		$user = new ModelUser([
 			'email'    => 'test@getkirby.com',
@@ -410,10 +360,7 @@ class UserTest extends TestCase
 		$this->assertNull($props['prev']());
 	}
 
-	/**
-	 * @covers ::props
-	 */
-	public function testPropsPrevNext()
+	public function testPropsPrevNext(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -436,10 +383,7 @@ class UserTest extends TestCase
 		$this->assertNull($props['next']());
 	}
 
-	/**
-	 * @covers ::translation
-	 */
-	public function testTranslation()
+	public function testTranslation(): void
 	{
 		// existing
 		$user = new ModelUser([
@@ -464,10 +408,7 @@ class UserTest extends TestCase
 		$this->assertNull($translations->get('translation.name'));
 	}
 
-	/**
-	 * @covers ::prevNext
-	 */
-	public function testPrevNext()
+	public function testPrevNext(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -490,11 +431,7 @@ class UserTest extends TestCase
 		$this->assertNull($prevNext['next']());
 	}
 
-	/**
-	 * @covers ::prevNext
-	 * @covers ::toPrevNextLink
-	 */
-	public function testPrevNextWithTab()
+	public function testPrevNextWithTab(): void
 	{
 		$app = $this->app->clone([
 			'users' => [
@@ -513,10 +450,7 @@ class UserTest extends TestCase
 		$_GET = [];
 	}
 
-	/**
-	 * @covers ::view
-	 */
-	public function testView()
+	public function testView(): void
 	{
 		$user = new ModelUser([
 			'email' => 'test@getkirby.com',

--- a/tests/Panel/UserTotpDisableDialogTest.php
+++ b/tests/Panel/UserTotpDisableDialogTest.php
@@ -8,10 +8,9 @@ use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 use Kirby\Toolkit\Totp;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\UserTotpDisableDialog
- */
+#[CoversClass(UserTotpDisableDialog::class)]
 class UserTotpDisableDialogTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.UserTotpDisableDialog';
@@ -50,9 +49,6 @@ class UserTotpDisableDialogTest extends TestCase
 		$_GET = [];
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstruct(): void
 	{
 		$dialog = new UserTotpDisableDialog();
@@ -63,9 +59,6 @@ class UserTotpDisableDialogTest extends TestCase
 		$this->assertSame('homer@simpson.com', $dialog->user->email());
 	}
 
-	/**
-	 * @covers ::load
-	 */
 	public function testLoad(): void
 	{
 		// current admin user for themselves
@@ -85,9 +78,6 @@ class UserTotpDisableDialogTest extends TestCase
 		$this->assertSame('k-form-dialog', $state['component']);
 	}
 
-	/**
-	 * @covers ::submit
-	 */
 	public function testSubmit(): void
 	{
 		$user     = $this->app->user();
@@ -106,9 +96,6 @@ class UserTotpDisableDialogTest extends TestCase
 		$this->assertIsString($state['message']);
 	}
 
-	/**
-	 * @covers ::submit
-	 */
 	public function testSubmitWrongPassword(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -124,9 +111,6 @@ class UserTotpDisableDialogTest extends TestCase
 		$dialog->submit();
 	}
 
-	/**
-	 * @covers ::submit
-	 */
 	public function testSubmitNonAdminAnotherUser(): void
 	{
 		$this->expectException(PermissionException::class);

--- a/tests/Panel/UserTotpEnableDialogTest.php
+++ b/tests/Panel/UserTotpEnableDialogTest.php
@@ -8,10 +8,9 @@ use Kirby\Filesystem\Dir;
 use Kirby\Image\QrCode;
 use Kirby\TestCase;
 use Kirby\Toolkit\Totp;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\UserTotpEnableDialog
- */
+#[CoversClass(UserTotpEnableDialog::class)]
 class UserTotpEnableDialogTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.UserTotpEnableDialog';
@@ -44,9 +43,6 @@ class UserTotpEnableDialogTest extends TestCase
 		$_GET = [];
 	}
 
-	/**
-	 * @covers ::__construct
-	 */
 	public function testConstruct(): void
 	{
 		$dialog = new UserTotpEnableDialog();
@@ -55,11 +51,6 @@ class UserTotpEnableDialogTest extends TestCase
 		$this->assertSame('test@getkirby.com', $dialog->user->email());
 	}
 
-	/**
-	 * @covers ::load
-	 * @covers ::secret
-	 * @covers ::totp
-	 */
 	public function testLoad(): void
 	{
 		$dialog = new UserTotpEnableDialog();
@@ -70,10 +61,6 @@ class UserTotpEnableDialogTest extends TestCase
 		$this->assertIsString($state['props']['qr']);
 	}
 
-	/**
-	 * @covers ::qr
-	 * @covers ::totp
-	 */
 	public function testQr(): void
 	{
 		$dialog = new UserTotpEnableDialog();
@@ -83,10 +70,6 @@ class UserTotpEnableDialogTest extends TestCase
 		$this->assertStringContainsString('otpauth://totp/:test%40getkirby.com?secret=', $qr->data);
 	}
 
-	/**
-	 * @covers ::submit
-	 * @covers ::totp
-	 */
 	public function testSubmit(): void
 	{
 		$totp            = new Totp();
@@ -102,9 +85,6 @@ class UserTotpEnableDialogTest extends TestCase
 		$this->assertIsString($state['message']);
 	}
 
-	/**
-	 * @covers ::submit
-	 */
 	public function testSubmitNoConfirmCode(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -117,9 +97,6 @@ class UserTotpEnableDialogTest extends TestCase
 		$dialog->submit();
 	}
 
-	/**
-	 * @covers ::submit
-	 */
 	public function testSubmitWrongConfirmCode(): void
 	{
 		$this->expectException(InvalidArgumentException::class);

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Panel;
 
+use Exception;
 use Kirby\Cms\App;
 use Kirby\Cms\Language;
 use Kirby\Exception\NotFoundException;
@@ -10,10 +11,9 @@ use Kirby\Http\Response;
 use Kirby\TestCase;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
+use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * @coversDefaultClass \Kirby\Panel\View
- */
+#[CoversClass(View::class)]
 class ViewTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Panel.View';
@@ -43,10 +43,7 @@ class ViewTest extends TestCase
 		unset($_SERVER['SERVER_SOFTWARE']);
 	}
 
-	/**
-	 * @covers ::apply
-	 */
-	public function testApply()
+	public function testApply(): void
 	{
 		$data = [
 			'a' => 'A',
@@ -59,10 +56,6 @@ class ViewTest extends TestCase
 		$this->assertSame($data, $result);
 	}
 
-	/**
-	 * @covers ::apply
-	 * @covers ::applyGlobals
-	 */
 	public function testApplyGlobals(): void
 	{
 		// not included
@@ -98,10 +91,6 @@ class ViewTest extends TestCase
 		$this->assertSame($data, View::applyGlobals($data, ''));
 	}
 
-	/**
-	 * @covers ::apply
-	 * @covers ::applyOnly
-	 */
 	public function testApplyOnly(): void
 	{
 		// via get
@@ -145,10 +134,6 @@ class ViewTest extends TestCase
 		$this->assertSame($data, View::applyOnly($data, ''));
 	}
 
-	/**
-	 * @covers ::apply
-	 * @covers ::applyOnly
-	 */
 	public function testApplyOnlyWithGlobal(): void
 	{
 		// simulate a simple partial request
@@ -178,10 +163,6 @@ class ViewTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::apply
-	 * @covers ::applyOnly
-	 */
 	public function testApplyOnlyWithNestedData(): void
 	{
 		// simulate a simple partial request
@@ -211,10 +192,6 @@ class ViewTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::apply
-	 * @covers ::applyOnly
-	 */
 	public function testApplyOnlyWithNestedGlobal(): void
 	{
 		// simulate a simple partial request
@@ -243,9 +220,6 @@ class ViewTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testData(): void
 	{
 		// without custom data
@@ -276,9 +250,6 @@ class ViewTest extends TestCase
 		$this->assertArrayNotHasKey('dialogs', $view);
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataWithCustomRequestUrl(): void
 	{
 		$this->app = $this->app->clone([
@@ -297,9 +268,6 @@ class ViewTest extends TestCase
 		$this->assertSame('https://localhost.com:8888/foo/bar?foo=bar', $data['$url']);
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataWithCustomProps(): void
 	{
 		$data = View::data([
@@ -313,9 +281,6 @@ class ViewTest extends TestCase
 		$this->assertSame($props, $data['$view']['props']);
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataWithLanguages(): void
 	{
 		$this->app = $this->app->clone([
@@ -362,9 +327,6 @@ class ViewTest extends TestCase
 		$this->assertNull($data['$direction']);
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataWithDirection(): void
 	{
 		$this->app = $this->app->clone([
@@ -394,9 +356,6 @@ class ViewTest extends TestCase
 		$this->assertSame('rtl', $data['$direction']);
 	}
 
-	/**
-	 * @covers ::data
-	 */
 	public function testDataWithAuthenticatedUser(): void
 	{
 		// authenticate pseudo user
@@ -421,9 +380,6 @@ class ViewTest extends TestCase
 		$this->assertSame($this->app->user()->role()->permissions()->toArray(), $data['$permissions']);
 	}
 
-	/**
-	 * @covers ::error
-	 */
 	public function testError(): void
 	{
 		// without user
@@ -455,18 +411,12 @@ class ViewTest extends TestCase
 		$this->assertSame('outside', $error['props']['layout']);
 	}
 
-	/**
-	 * @covers ::error
-	 */
 	public function testErrorWithCustomCode(): void
 	{
 		$error = View::error('Test', 403);
 		$this->assertSame(403, $error['code']);
 	}
 
-	/**
-	 * @covers ::globals
-	 */
 	public function testGlobals(): void
 	{
 		// defaults
@@ -510,9 +460,6 @@ class ViewTest extends TestCase
 		$this->assertSame('/', $urls['site']);
 	}
 
-	/**
-	 * @covers ::globals
-	 */
 	public function testGlobalsWithUser(): void
 	{
 		$this->app = $this->app->clone([
@@ -531,9 +478,6 @@ class ViewTest extends TestCase
 		$this->assertSame('de', $globals['$translation']['code']);
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseAsHTML(): void
 	{
 		// create panel dist files first to avoid redirect
@@ -551,9 +495,6 @@ class ViewTest extends TestCase
 		$this->assertNotNull($response->body());
 	}
 
-	/**
-	 * @covers ::response
-	 */
 	public function testResponseAsJSON(): void
 	{
 		$this->app = $this->app->clone([
@@ -573,10 +514,7 @@ class ViewTest extends TestCase
 		$this->assertSame('true', $response->header('X-Fiber'));
 	}
 
-	/**
-	 * @covers ::response
-	 */
-	public function testResponseFromRedirect()
+	public function testResponseFromRedirect(): void
 	{
 		// fake json request for easier assertions
 		$this->app = $this->app->clone([
@@ -587,7 +525,7 @@ class ViewTest extends TestCase
 			]
 		]);
 
-		$redirect = new \Kirby\Panel\Redirect('https://getkirby.com');
+		$redirect = new Redirect('https://getkirby.com');
 		$response = View::response($redirect);
 
 		$this->assertInstanceOf(Response::class, $response);
@@ -596,10 +534,7 @@ class ViewTest extends TestCase
 		$this->assertSame('https://getkirby.com', $response->header('Location'));
 	}
 
-	/**
-	 * @covers ::response
-	 */
-	public function testResponseFromKirbyException()
+	public function testResponseFromKirbyException(): void
 	{
 		// fake json request for easier assertions
 		$this->app = $this->app->clone([
@@ -619,10 +554,7 @@ class ViewTest extends TestCase
 		$this->assertSame('Test', $json['$view']['props']['error']);
 	}
 
-	/**
-	 * @covers ::response
-	 */
-	public function testResponseFromException()
+	public function testResponseFromException(): void
 	{
 		// fake json request for easier assertions
 		$this->app = $this->app->clone([
@@ -633,7 +565,7 @@ class ViewTest extends TestCase
 			]
 		]);
 
-		$exception = new \Exception('Test');
+		$exception = new Exception('Test');
 		$response  = View::response($exception);
 		$json      = json_decode($response->body(), true);
 
@@ -642,10 +574,7 @@ class ViewTest extends TestCase
 		$this->assertSame('Test', $json['$view']['props']['error']);
 	}
 
-	/**
-	 * @covers ::response
-	 */
-	public function testResponseFromUnsupportedResult()
+	public function testResponseFromUnsupportedResult(): void
 	{
 		// fake json request for easier assertions
 		$this->app = $this->app->clone([
@@ -664,10 +593,7 @@ class ViewTest extends TestCase
 		$this->assertSame('Invalid Panel response', $json['$view']['props']['error']);
 	}
 
-	/**
-	 * @covers ::searches
-	 */
-	public function testSearches()
+	public function testSearches(): void
 	{
 		$areas  = [
 			'a' => [


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Switching over package by package (or smaller units) to PHPUnit PHP annotations to see how the code coverage is affected.

The changes were mostly created automatically with [Rector](https://getrector.com/):
```php
<?php

declare(strict_types = 1);

use Rector\Config\RectorConfig;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\Class_\CoversAnnotationWithValueToAttributeRector;
use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;

return RectorConfig::configure()
	->withImportNames()
	->withPaths([
		__DIR__ . '/tests/Panel',
	])
	->withRules([
		CoversAnnotationWithValueToAttributeRector::class,
		DataProviderAnnotationToAttributeRector::class,
		AddVoidReturnTypeWhereNoReturnRector::class
	]);
```

## Changelog
### 🧹 Housekeeping
- Using PHP attributes for PHPUnit annotations 

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
