### PR TITLE
fix: Theme button for Lab views

### DIFF
--- a/panel/src/components/Lab/DocsView.vue
+++ b/panel/src/components/Lab/DocsView.vue
@@ -1,5 +1,9 @@
 <template>
 	<k-panel-inside class="k-lab-docs-view">
+		<template #topbar>
+			<k-theme-view-button :text="null" :variant="null" size="xs" />
+		</template>
+
 		<k-header>
 			{{ component }}
 

--- a/panel/src/components/Lab/IndexView.vue
+++ b/panel/src/components/Lab/IndexView.vue
@@ -1,5 +1,9 @@
 <template>
 	<k-panel-inside class="k-lab-index-view">
+		<template #topbar>
+			<k-theme-view-button :text="null" :variant="null" size="xs" />
+		</template>
+
 		<k-header>
 			Lab
 

--- a/panel/src/components/Lab/PlaygroundView.vue
+++ b/panel/src/components/Lab/PlaygroundView.vue
@@ -1,5 +1,9 @@
 <template>
 	<k-panel-inside class="k-lab-playground-view">
+		<template #topbar>
+			<k-theme-view-button :text="null" :variant="null" size="xs" />
+		</template>
+
 		<k-header class="k-lab-playground-header">
 			{{ title }}
 

--- a/panel/src/components/View/Buttons/ThemeButton.vue
+++ b/panel/src/components/View/Buttons/ThemeButton.vue
@@ -1,8 +1,8 @@
 <template>
 	<k-view-button
+		v-bind="$props"
 		:icon="current === 'light' ? 'sun' : 'moon'"
 		:options="options"
-		:text="$t('theme')"
 	/>
 </template>
 
@@ -14,6 +14,23 @@
  * @unstable
  */
 export default {
+	props: {
+		/**
+		 * @since 5.0.1
+		 */
+		size: String,
+		/**
+		 * @since 5.0.1
+		 */
+		text: {
+			type: String,
+			default: () => window.panel.t("theme")
+		},
+		/**
+		 * @since 5.0.1
+		 */
+		variant: String
+	},
 	computed: {
 		current() {
 			return this.$panel.theme.current;


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Adds a theme dropdown to the topper of all Lab views, to allow changing theme on lab.getkirby.com

<img width="1087" alt="Screenshot 2025-06-24 at 23 34 35" src="https://github.com/user-attachments/assets/a9b27ea9-797f-4901-8ce6-175cea5ae190" />


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] ~~Unit tests for fixed bug/feature~~

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
