### PR TITLE
fix: Make multiselect items removable again

### DIFF
--- a/panel/src/components/Forms/Input/MultiselectInput.vue
+++ b/panel/src/components/Forms/Input/MultiselectInput.vue
@@ -8,6 +8,7 @@
 			<k-tags
 				ref="tags"
 				v-bind="$props"
+				:removable="true"
 				@input="$emit('input', $event)"
 				@click.native.stop="open"
 			>


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Added the `:removable="true"` prop to the k-tags component in MultiselectInput.vue, allowing users to remove items from the input.

Related tags field commit: https://github.com/getkirby/kirby/commit/31554658b69da9c8400326043c9e2b162ed4e798#diff-19bad37a2bd34c9d583f1f9d269c0016e940300a1886cce5909bd86826cae9fd

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Missing delete icon (x) in the multiselect field #7336


### Breaking changes
None


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
