### PR TITLE
fix: Pass sorting permission to file dropdown

### DIFF
--- a/panel/src/components/Sections/FilesSection.vue
+++ b/panel/src/components/Sections/FilesSection.vue
@@ -37,8 +37,9 @@ export default {
 					},
 					options: this.$dropdown(file.link, {
 						query: {
-							view: "list",
-							delete: deletable
+							delete: deletable,
+							sort: sortable,
+							view: "list"
 						}
 					}),
 					selectable: this.isSelecting && deletable,

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -130,7 +130,7 @@ class File extends Model
 	{
 		$file     = $this->model;
 		$request  = $file->kirby()->request();
-		$defaults = $request->get(['view', 'delete']);
+		$defaults = $request->get(['delete', 'sort', 'view']);
 		$options  = [...$defaults, ...$options];
 
 		$permissions = $this->options(['preview']);


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Pass `sortable` state of files sections to the file dropdown to correctly disable the sorting option. https://github.com/getkirby/kirby/issues/7334

### Breaking changes

None

## Sandbox

Added a new sandbox test tab for sorted files sections: https://sandbox.test/panel/pages/sections+files?tab=sorting

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
