### PR TITLE
Add $collection->join()

### DIFF
--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -626,6 +626,14 @@ class Collection extends Iterator implements Stringable
 	}
 
 	/**
+	 * Joins the collection elements into a string, optionally running a closure over elements
+	 */
+	public function join(string $glue = '', Closure|null $as = null): string {
+		$values = $this->toArray($as);
+		return implode($glue, $values);
+	}
+
+	/**
 	 * Returns the last element
 	 *
 	 * @return TValue

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -628,7 +628,8 @@ class Collection extends Iterator implements Stringable
 	/**
 	 * Joins the collection elements into a string, optionally running a closure over elements
 	 */
-	public function join(string $glue = '', Closure|null $as = null): string {
+	public function join(string $glue = '', Closure|null $as = null): string
+	{
 		$values = $this->toArray($as);
 		return implode($glue, $values);
 	}

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -489,6 +489,27 @@ class CollectionTest extends TestCase
 		$this->assertFalse(isset($this->collection->super));
 	}
 
+	public function testJoin(): void
+	{
+		$collection = new Collection([
+			'a' => 'd',
+			'b' => 'e',
+			'c' => 'f',
+		]);
+
+		$this->assertSame('def', $collection->join());
+		$this->assertSame('d-e-f', $collection->join('-'));
+
+		$collection = new Collection([
+			'a' => ['d'],
+			'b' => ['e'],
+			'c' => ['f'],
+		]);
+
+		$this->assertSame('def', $collection->join(as: fn($e) => $e[0]));
+		$this->assertSame('d-e-f', $collection->join('-', fn($e) => $e[0]));
+	}
+
 	public function testKeyOf(): void
 	{
 		$this->assertSame('second', $this->collection->keyOf('My second element'));

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -506,8 +506,8 @@ class CollectionTest extends TestCase
 			'c' => ['f'],
 		]);
 
-		$this->assertSame('def', $collection->join(as: fn($e) => $e[0]));
-		$this->assertSame('d-e-f', $collection->join('-', fn($e) => $e[0]));
+		$this->assertSame('def', $collection->join(as: fn ($e) => $e[0]));
+		$this->assertSame('d-e-f', $collection->join('-', fn ($e) => $e[0]));
 	}
 
 	public function testKeyOf(): void


### PR DESCRIPTION
## Description
Adds a method to join collection into a string, supporting mapping and custom glue.

Helps to simplify mapping and joining a collection:

```php
$x = $page->children()->map(fn($p)=>snippet('some', ['page'=>$page], return: true);
$x = $x->toArray();
$x = A::join($x, '');
```

```php
$x = $page->children()->join(as: fn($p)=>snippet('some', ['page'=>$page], return: true);
```

### Summary of changes
- new Collection method

### Reasoning
- collection joining is the second most used function after foreach, IMO. This even replaces some foreach calls

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
