### PR TITLE
feat: `panel.theme` option for default theme

### DIFF
--- a/panel/src/components/View/Buttons/ThemeButton.vue
+++ b/panel/src/components/View/Buttons/ThemeButton.vue
@@ -52,13 +52,13 @@ export default {
 				{
 					text: this.$t("theme.automatic"),
 					icon: "wand",
-					disabled: this.setting === null,
-					click: () => this.$panel.theme.reset()
+					disabled: this.setting === "system",
+					click: () => this.$panel.theme.set("system")
 				}
 			];
 		},
 		setting() {
-			return this.$panel.theme.setting;
+			return this.$panel.theme.setting ?? this.$panel.theme.config;
 		}
 	}
 };

--- a/panel/src/panel/theme.js
+++ b/panel/src/panel/theme.js
@@ -13,14 +13,24 @@ export const defaults = () => {
 /**
  * @since 5.0.0
  */
-export default () => {
+export default (panel) => {
 	const parent = State("theme", defaults());
 
 	const theme = reactive({
 		...parent,
 
+		get config() {
+			return panel.config.theme;
+		},
+
 		get current() {
-			return this.setting ?? this.system;
+			const setting = this.setting ?? this.config;
+
+			if (setting === "system") {
+				return this.system;
+			}
+
+			return setting ?? this.system;
 		},
 
 		reset() {

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -266,6 +266,7 @@ class View
 				],
 				'debug'       => $kirby->option('debug', false),
 				'kirbytext'   => $kirby->option('panel.kirbytext', true),
+				'theme'       => $kirby->option('panel.theme', 'system'),
 				'translation' => $kirby->option('panel.language', 'en'),
 				'upload'      => Upload::chunkSize(),
 			],


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Reference issues from the `kirby` repo 
or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improved a11y of feature X
-->
- New `panel.theme` config option to define the default Panel theme

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

### `panel.theme` 

Sets the default Panel theme that is used when the user has not set any custom setting in their account view. Support values: `"light"`, `"dark"`, `"system"` (default, matches the user's operating system)


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion