### PR TITLE
Fix `Panel::url()` throwing when called with default args

### DIFF
--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -619,7 +619,7 @@ class Panel
 		if (Url::isAbsolute($url) === false) {
 			$kirby = App::instance();
 			$slug  = $kirby->option('panel.slug', 'panel');
-			$path  = trim($url, '/');
+			$path  = trim($url ?? '', '/');
 
 			$baseUri  = new Uri($kirby->url());
 			$basePath = trim($baseUri->path()->toString(), '/');


### PR DESCRIPTION
## Description
Calling `Panel::url()` (with no arguments) throws a deprecation error on the line `trim($url, '/')`: 

> trim(): Passing null to parameter #1 ($string) of type string is deprecated

### Summary of changes
This PR makes sure to replace null with an empty string before passing it to `trim()`.

### Reasoning
I would expect `Panel::url()` to give me the url to the panel main url when called without arguments.

### Additional context
Passing `''` to `trim()` does the same thing it did in earlier PHP versions when `trim(null)` wasn't deprecated. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
