### PR TITLE
Fix: Slow structures

### DIFF
--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -159,7 +159,6 @@ return [
 	'methods' => [
 		'rows' => function ($value) {
 			$rows  = Data::decode($value, 'yaml');
-			$form  = $this->form();
 			$value = [];
 
 			foreach ($rows as $index => $row) {
@@ -167,18 +166,20 @@ return [
 					continue;
 				}
 
-				$value[] = $form->reset()->fill(input: $row, passthrough: true)->toFormValues();
+				$value[] = $this->form()->fill(input: $row, passthrough: true)->toFormValues();
 			}
 
 			return $value;
 		},
 		'form' => function () {
-			return new Form(
+			$this->form ??= new Form(
 				fields: $this->attrs['fields'] ?? [],
 				model: $this->model,
 				language: 'current'
 			);
-		},
+
+			return $this->form->reset();
+		}
 	],
 	'save' => function ($value) {
 		$data     = [];
@@ -214,10 +215,10 @@ return [
 			}
 
 			$values = A::wrap($value);
-			$form   = $this->form();
 
 			foreach ($values as $index => $value) {
-				$form->reset()->submit(input: $value, passthrough: true);
+				$form = $this->form();
+				$form->fill(input: $value);
 
 				foreach ($form->fields() as $field) {
 					$errors = $field->errors();

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -353,19 +353,21 @@ class StructureFieldTest extends TestCase
 		// that the fields are not disabled by default
 		$app->impersonate('kirby');
 
-		$field = $this->field('structure', [
-			'fields' => [
-				'a' => [
-					'type' => 'text'
-				],
-				'b' => [
-					'type' => 'text',
-					'translate' => false
-				]
+		$fields = [
+			'a' => [
+				'type' => 'text'
+			],
+			'b' => [
+				'type' => 'text',
+				'translate' => false
 			]
-		]);
+		];
 
 		$app->setCurrentLanguage('en');
+
+		$field = $this->field('structure', [
+			'fields' => $fields
+		]);
 
 		$props = $field->form()->fields()->toProps();
 
@@ -373,6 +375,10 @@ class StructureFieldTest extends TestCase
 		$this->assertFalse($props['b']['disabled']);
 
 		$app->setCurrentLanguage('de');
+
+		$field = $this->field('structure', [
+			'fields' => $fields
+		]);
 
 		$props = $field->form()->fields()->toProps();
 


### PR DESCRIPTION
## Description

We’ve refactored the structure field to be faster and unfortunately missed one important part. The form method is called for every row and will recreate the entire form instead of reusing a cached variant of the form. This destroys all the hard work that we put in the form refactoring. 

We should finally move the structure field to an extended FieldClass, but we can't do this without keeping the old code around. Otherwise, all structure field extensions would break. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes 

- Fixed performance bottleneck in structure fields 

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
