### PR TITLE
chore: Remove vite's `splitVendorChunkPlugin `

### DIFF
--- a/panel/vite.config.mjs
+++ b/panel/vite.config.mjs
@@ -1,7 +1,7 @@
 /* eslint-env node */
 import path from "path";
 
-import { defineConfig, loadEnv, splitVendorChunkPlugin } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import { minify } from "terser";
 import vue from "@vitejs/plugin-vue2";
 import { viteStaticCopy } from "vite-plugin-static-copy";
@@ -59,7 +59,7 @@ function createCustomServer() {
  * depending on the mode (development or build)
  */
 function createPlugins(mode) {
-	const plugins = [vue(), splitVendorChunkPlugin(), kirby()];
+	const plugins = [vue(), kirby()];
 
 	// when building…
 	if (mode === "production") {
@@ -140,7 +140,18 @@ export default defineConfig(({ mode }) => {
 				output: {
 					entryFileNames: "js/[name].min.js",
 					chunkFileNames: "js/[name].min.js",
-					assetFileNames: "[ext]/[name].min.[ext]"
+					assetFileNames: "[ext]/[name].min.[ext]",
+					manualChunks(id) {
+						if (id.includes("sortablejs")) {
+							return "sortable";
+						}
+
+						if (id.includes("node_modules")) {
+							return "vendor";
+						}
+
+						return null;
+					}
 				}
 			}
 		},


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- Remove the deprecated `splitVendorChunkPlugin` from site.config
- `manualChunks` option should produce the same split as when using the deprecated plugin.
- Vite 7 removes the deprecated plugin which is why we should loose it. 
