### PR TITLE
test: Replace deprecated `$mock->addMethods()`

### DIFF
--- a/tests/Cms/Emails/EmailTest.php
+++ b/tests/Cms/Emails/EmailTest.php
@@ -4,6 +4,8 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\NotFoundException;
 use PHPMailer\PHPMailer\PHPMailer as Mailer;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 class EmailTest extends TestCase
 {
@@ -214,10 +216,8 @@ class EmailTest extends TestCase
 		], $email->toArray()['to']);
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState(false)]
 	public function testUserData(): void
 	{
 		$app = new App([

--- a/tests/Cms/File/FileRulesTest.php
+++ b/tests/Cms/File/FileRulesTest.php
@@ -350,13 +350,12 @@ class FileRulesTest extends ModelTestCase
 
 		$file = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['permissions', 'blueprint', 'filename'])
-			->addMethods(['extension'])
+			->onlyMethods(['permissions', 'blueprint', 'filename', '__call'])
 			->getMock();
 		$file->method('blueprint')->willReturn($blueprint);
-		$file->method('extension')->willReturn('svg');
-		$file->method('filename')->willReturn('test.svg');
 		$file->method('permissions')->willReturn($permissions);
+		$file->method('filename')->willReturn('test.svg');
+		$file->method('__call')->with('extension')->willReturn('svg');
 
 		$upload = new BaseFile(static::FIXTURES . '/test.svg');
 
@@ -420,12 +419,13 @@ class FileRulesTest extends ModelTestCase
 
 		$file = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['permissions'])
-			->addMethods(['mime', 'extension'])
+			->onlyMethods(['permissions', '__call'])
 			->getMock();
 		$file->method('permissions')->willReturn($permissions);
-		$file->method('mime')->willReturn('image/jpeg');
-		$file->method('extension')->willReturn('jpg');
+		$file->method('__call')->willReturnCallback(fn ($method, $args = []) => match ($method) {
+			'mime'      => 'image/jpeg',
+			'extension' => 'jpg'
+		});
 
 		$upload = $this->createMock(BaseFile::class);
 		$upload->method('mime')->willReturn('image/png');
@@ -447,13 +447,14 @@ class FileRulesTest extends ModelTestCase
 		$file = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['__call', 'permissions', 'blueprint', 'filename'])
-			->addMethods(['extension'])
 			->getMock();
-		$file->method('__call')->with('mime')->willReturn('image/svg+xml');
-		$file->method('blueprint')->willReturn($blueprint);
-		$file->method('extension')->willReturn('svg');
-		$file->method('filename')->willReturn('test.svg');
-		$file->method('permissions')->willReturn($permissions);
+			$file->method('blueprint')->willReturn($blueprint);
+			$file->method('filename')->willReturn('test.svg');
+			$file->method('permissions')->willReturn($permissions);
+			$file->method('__call')->with('mime')->willReturnCallback(fn ($method, $args = []) => match ($method) {
+				'extension' => 'svg',
+				'mime'      => 'image/svg+xml'
+			});
 
 		$upload = new BaseFile(static::FIXTURES . '/test.svg');
 
@@ -569,12 +570,14 @@ class FileRulesTest extends ModelTestCase
 	): void {
 		$file = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['filename'])
-			->addMethods(['mime', 'extension'])
+			->onlyMethods(['filename', '__call'])
 			->getMock();
 		$file->method('filename')->willReturn($filename);
-		$file->method('extension')->willReturn($extension);
-		$file->method('mime')->willReturn($mime);
+		$file->method('__call')
+			->willReturnCallback(fn ($method, $args = []) => match ($method) {
+				'extension' => $extension,
+				'mime'      => $mime
+			});
 
 		if ($expected === false) {
 			$this->expectException(InvalidArgumentException::class);
@@ -590,12 +593,13 @@ class FileRulesTest extends ModelTestCase
 	{
 		$file = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
-			->onlyMethods(['filename'])
-			->addMethods(['mime', 'extension'])
+			->onlyMethods(['filename', '__call'])
 			->getMock();
 		$file->method('filename')->willReturn('test.jpg');
-		$file->method('extension')->willReturn('jpg');
-		$file->method('mime')->willReturn('text/html');
+		$file->method('__call')->willReturnCallback(fn ($method, $args = []) => match ($method) {
+			'extension' => 'jpg',
+			'mime'      => 'text/html'
+		});
 
 		FileRules::validFile($file, false);
 

--- a/tests/Cms/File/FileRulesTest.php
+++ b/tests/Cms/File/FileRulesTest.php
@@ -448,13 +448,13 @@ class FileRulesTest extends ModelTestCase
 			->disableOriginalConstructor()
 			->onlyMethods(['__call', 'permissions', 'blueprint', 'filename'])
 			->getMock();
-			$file->method('blueprint')->willReturn($blueprint);
-			$file->method('filename')->willReturn('test.svg');
-			$file->method('permissions')->willReturn($permissions);
-			$file->method('__call')->with('mime')->willReturnCallback(fn ($method, $args = []) => match ($method) {
-				'extension' => 'svg',
-				'mime'      => 'image/svg+xml'
-			});
+		$file->method('blueprint')->willReturn($blueprint);
+		$file->method('filename')->willReturn('test.svg');
+		$file->method('permissions')->willReturn($permissions);
+		$file->method('__call')->with('mime')->willReturnCallback(fn ($method, $args = []) => match ($method) {
+			'extension' => 'svg',
+			'mime'      => 'image/svg+xml'
+		});
 
 		$upload = new BaseFile(static::FIXTURES . '/test.svg');
 

--- a/tests/Cms/Helpers/HelperFunctionsTest.php
+++ b/tests/Cms/Helpers/HelperFunctionsTest.php
@@ -878,10 +878,13 @@ class HelperFunctionsTest extends HelpersTestCase
 		$file = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['__call'])
-			->addMethods(['extension'])
 			->getMock();
-		$file->method('__call')->willReturn('test');
-		$file->method('extension')->willReturn('svg');
+
+		$file->method('__call')
+			->willReturnCallback(fn ($method, $args = []) => match ($method) {
+				'extension' => 'svg',
+				default    => 'test'
+			});
 
 		$this->assertSame('test', svg($file));
 	}

--- a/tests/Cms/Html/HtmlTest.php
+++ b/tests/Cms/Html/HtmlTest.php
@@ -177,10 +177,13 @@ class HtmlTest extends TestCase
 		$file = $this->getMockBuilder(File::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['__call'])
-			->addMethods(['extension'])
 			->getMock();
-		$file->method('__call')->willReturn('test');
-		$file->method('extension')->willReturn('svg');
+
+		$file->method('__call')
+			->willReturnCallback(fn ($method) => match ($method) {
+				'extension' => 'svg',
+				default    => 'test'
+			});
 
 		$this->assertSame('test', Html::svg($file));
 	}


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

`MockBuilder::addMethods()` will be removed from PHPUnit. I have tried to come up with alternative ways.

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature