### PR TITLE
fix: Toggles field disabled styling

### DIFF
--- a/panel/src/components/Forms/Input/TogglesInput.vue
+++ b/panel/src/components/Forms/Input/TogglesInput.vue
@@ -120,19 +120,23 @@ export default {
 	padding: 0 var(--spacing-3);
 	height: 100%;
 }
-.k-toggles-input li:has(input[disabled]) label {
-	color: var(--color-text-dimmed);
-	background: var(--panel-color-back);
-}
-.k-toggles-input .k-icon + .k-toggles-text {
-	margin-inline-start: var(--spacing-2);
-}
-.k-toggles-input input:focus:not(:checked) + label {
-	background: light-dark(var(--color-blue-200), var(--color-blue-800));
-}
 
 .k-toggles-input input:checked + label {
 	background: light-dark(var(--color-black), var(--color-gray-950));
 	color: var(--color-white);
+}
+.k-toggles-input input:focus:not(:checked) + label {
+	background: light-dark(var(--color-blue-200), var(--color-blue-800));
+}
+.k-toggles-input input[disabled]:checked + label {
+	background: light-dark(var(--color-gray-600), var(--color-gray-850));
+}
+.k-toggles-input input[disabled]:not(:checked) + label {
+	color: var(--color-text-dimmed);
+	background: var(--panel-color-back);
+}
+
+.k-toggles-input .k-icon + .k-toggles-text {
+	margin-inline-start: var(--spacing-2);
 }
 </style>


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

The toggles field would not show any value, even if selected, when disabled. This PR fixes that:

<img width="1248" height="108" alt="Screenshot 2025-07-10 at 21 37 38" src="https://github.com/user-attachments/assets/fb58632e-3e4f-40a2-8cb5-b13bf20539e2" />

I followed the same styling/color as a disabled tag (which is also full black when not disabled).


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Toggles field: Highlight selected value even when disabled.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
  Just added an example to every field in the Lab environment.
- [x] Add changes & docs to release notes draft in Notion
