### PR TITLE
fix: Layout field disabled styling

### DIFF
--- a/panel/src/components/Forms/Layouts/Layout.vue
+++ b/panel/src/components/Forms/Layouts/Layout.vue
@@ -1,5 +1,6 @@
 <template>
 	<section
+		:data-disabled="disabled"
 		:data-selected="isSelected"
 		class="k-layout"
 		tabindex="0"
@@ -11,6 +12,7 @@
 				:key="column.id"
 				v-bind="{
 					...column,
+					disabled,
 					endpoints,
 					fieldsetGroups,
 					fieldsets
@@ -46,10 +48,9 @@
 
 <script>
 import { props as LayoutColumnProps } from "./LayoutColumn.vue";
-import { disabled } from "@/mixins/props.js";
 
 export const props = {
-	mixins: [LayoutColumnProps, disabled],
+	mixins: [LayoutColumnProps],
 	props: {
 		columns: Array,
 		layouts: {
@@ -183,11 +184,10 @@ export default {
 	--layout-border-color: var(--color-gray-300);
 	--layout-toolbar-width: 2rem;
 	position: relative;
+}
+.k-layout:not([data-disabled="true"]) {
 	padding-inline-end: var(--layout-toolbar-width);
 	box-shadow: var(--shadow);
-}
-[data-disabled="true"] .k-layout {
-	padding-inline-end: 0;
 }
 .k-layout:not(:last-of-type) {
 	margin-bottom: var(--spacing-2);

--- a/panel/src/components/Forms/Layouts/LayoutColumn.vue
+++ b/panel/src/components/Forms/Layouts/LayoutColumn.vue
@@ -9,6 +9,7 @@
 		<k-blocks
 			ref="blocks"
 			v-bind="{
+				disabled,
 				endpoints,
 				fieldsets,
 				fieldsetGroups,
@@ -22,7 +23,10 @@
 </template>
 
 <script>
+import { disabled } from "@/mixins/props.js";
+
 export const props = {
+	mixins: [disabled],
 	props: {
 		/**
 		 * API endpoints


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

The Layout field did not have any disabled styling (when having a value already), it would show like enabled.
This PR adds changes so the styling is consistent with a disabled blocks field.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Layout field: fixed disabled styling 



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [X] In-code documentation (wherever needed)
- [X] Unit tests for fixed bug/feature

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [X] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
