### PR TITLE
fix: Disabled styling for choice input fields

### DIFF
--- a/panel/src/components/Forms/Input/ChoiceInput.vue
+++ b/panel/src/components/Forms/Input/ChoiceInput.vue
@@ -101,8 +101,14 @@ export default {
 	border-radius: var(--input-rounded);
 }
 
-:where(.k-checkboxes-field, .k-radio-field) .k-choice-input {
+:where(.k-checkboxes-field, .k-radio-field):not([data-disabled="true"])
+	.k-choice-input {
 	background: var(--item-color-back);
 	box-shadow: var(--shadow);
+}
+
+:where(.k-checkboxes-field, .k-radio-field)[data-disabled="true"]
+	.k-choice-input {
+	border: 1px solid var(--color-border);
 }
 </style>


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Currently, disabled checkboxes, radio etc. fields still show a white background (k-item treatment) even when disabled. This is inconsistent to other field's disabled styling. This PR tries to fix this:

<img width="481" height="353" alt="Screenshot 2025-07-11 at 00 25 58" src="https://github.com/user-attachments/assets/63df35bc-8a95-4d9d-9b77-49dd3a38f28c" />
<img width="279" height="363" alt="Screenshot 2025-07-11 at 00 26 04" src="https://github.com/user-attachments/assets/b3ad05f6-1741-4ffa-85b8-8e373843cf6e" />




## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Radio and checkboxes field: fixed styling when disabled


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
