### PR TITLE
fix: Hide placeholder on disabled string, number & textarea inputs

### DIFF
--- a/panel/src/components/Forms/Input/NumberInput.vue
+++ b/panel/src/components/Forms/Input/NumberInput.vue
@@ -146,4 +146,7 @@ export default {
 .k-number-input:focus {
 	outline: 0;
 }
+.k-number-input:disabled::placeholder {
+	opacity: 0;
+}
 </style>

--- a/panel/src/components/Forms/Input/StringInput.vue
+++ b/panel/src/components/Forms/Input/StringInput.vue
@@ -96,4 +96,7 @@ export default {
 .k-string-input[data-font="monospace"] {
 	font-family: var(--font-mono);
 }
+.k-string-input:disabled::placeholder {
+	opacity: 0;
+}
 </style>

--- a/panel/src/components/Forms/Input/TextInput.vue
+++ b/panel/src/components/Forms/Input/TextInput.vue
@@ -21,19 +21,3 @@ export default {
 	mixins: [StringInput, props]
 };
 </script>
-
-<style>
-.k-text-input {
-	padding: var(--input-padding);
-	border-radius: var(--input-rounded);
-}
-.k-text-input:focus {
-	outline: 0;
-}
-.k-text-input[data-font="monospace"] {
-	font-family: var(--font-mono);
-}
-.k-text-input:disabled::placeholder {
-	opacity: 0;
-}
-</style>

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -390,6 +390,9 @@ export default {
 .k-textarea-input-native[data-font="monospace"] {
 	font-family: var(--font-mono);
 }
+.k-textarea-input-native:disabled::placeholder {
+	opacity: 0;
+}
 
 /* Input Context */
 .k-input[data-type="textarea"] .k-input-element {


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Some inputs (date, text) would hide the placeholder when disabled, while others (e.g. email) would still show it. This PR fixes hiding the placeholder for all disabled string, number and texturea inputs.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- Inputs: Hide placeholder text when disabled



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
