### PR TITLE
fix!: Place sort handle inside `k-item` boundaries

### DIFF
--- a/panel/src/components/Collection/Item.vue
+++ b/panel/src/components/Collection/Item.vue
@@ -212,6 +212,7 @@ export default {
 .k-item-box {
 	position: relative;
 	width: 100%;
+	height: 100%;
 	background: var(--item-color-back);
 	box-shadow: var(--item-shadow);
 	border-radius: var(--rounded);
@@ -276,7 +277,7 @@ export default {
 .k-item[data-layout="list"][data-has-image="true"] .k-item-box {
 	grid-template-columns: var(--item-height) 1fr auto;
 }
-.k-item[data-layout="list"] .k-frame {
+.k-item[data-layout="list"] .k-item-image {
 	--ratio: 1/1;
 	border-start-start-radius: var(--rounded);
 	border-end-start-radius: var(--rounded);
@@ -346,7 +347,7 @@ export default {
 		"image options";
 	grid-template-columns: minmax(0, var(--item-height)) 1fr;
 }
-.k-item[data-layout="cardlets"] .k-frame {
+.k-item[data-layout="cardlets"] .k-item-image {
 	grid-area: image;
 	border-start-start-radius: var(--rounded);
 	border-end-start-radius: var(--rounded);
@@ -367,12 +368,12 @@ export default {
 }
 
 /** Card */
-.k-item[data-layout="cards"] {
+.k-item[data-layout="cards"] .k-item-box {
 	display: flex;
 	flex-direction: column;
 	/* container-type: inline-size; */
 }
-.k-item[data-layout="cards"] .k-frame {
+.k-item[data-layout="cards"] .k-item-image {
 	border-start-start-radius: var(--rounded);
 	border-start-end-radius: var(--rounded);
 }

--- a/panel/src/components/Collection/Item.vue
+++ b/panel/src/components/Collection/Item.vue
@@ -11,67 +11,69 @@
 		@click="onClick"
 		@dragstart="$emit('drag', $event)"
 	>
-		<!-- Image -->
-		<slot name="image">
-			<k-item-image
-				v-if="hasFigure"
-				:image="image"
-				:layout="layout"
-				:width="width"
-			/>
-		</slot>
-
 		<!-- Sort handle -->
 		<k-sort-handle v-if="sortable" class="k-item-sort-handle" tabindex="-1" />
 
-		<!-- Content -->
-		<div class="k-item-content">
-			<h3 class="k-item-title" :title="title(text)">
-				<k-link
-					v-if="link !== false && selecting !== true"
-					:target="target"
-					:to="link"
-				>
-					<!-- eslint-disable-next-line vue/no-v-html -->
-					<span v-html="text ?? '&nbsp;'" />
-				</k-link>
-				<!-- eslint-disable-next-line vue/no-v-html -->
-				<span v-else v-html="text ?? '&nbsp;'" />
-			</h3>
-			<!-- eslint-disable-next-line vue/no-v-html -->
-			<p v-if="info" :title="title(info)" class="k-item-info" v-html="info" />
-		</div>
-
-		<div
-			v-if="buttons?.length || options || $slots.options || selecting"
-			class="k-item-options"
-		>
-			<!-- Buttons -->
-			<k-button
-				v-for="button in buttons"
-				:key="JSON.stringify(button)"
-				v-bind="button"
-			/>
-
-			<label v-if="selecting" class="k-item-options-checkbox" @click.stop>
-				<input
-					ref="selector"
-					:checked="selected"
-					:disabled="!selectable"
-					:type="selectmode === 'single' ? 'radio' : 'checkbox'"
-					@change="$emit('select', $event)"
-				/>
-			</label>
-
-			<!-- Options -->
-			<slot name="options">
-				<k-options-dropdown
-					v-if="options && !selecting"
-					:options="options"
-					class="k-item-options-dropdown"
-					@option="onOption"
+		<div class="k-item-box">
+			<!-- Image -->
+			<slot name="image">
+				<k-item-image
+					v-if="hasFigure"
+					:image="image"
+					:layout="layout"
+					:width="width"
 				/>
 			</slot>
+
+			<!-- Content -->
+			<div class="k-item-content">
+				<h3 class="k-item-title" :title="title(text)">
+					<k-link
+						v-if="link !== false && selecting !== true"
+						:target="target"
+						:to="link"
+					>
+						<!-- eslint-disable-next-line vue/no-v-html -->
+						<span v-html="text ?? '&nbsp;'" />
+					</k-link>
+					<!-- eslint-disable-next-line vue/no-v-html -->
+					<span v-else v-html="text ?? '&nbsp;'" />
+				</h3>
+				<!-- eslint-disable-next-line vue/no-v-html -->
+				<p v-if="info" :title="title(info)" class="k-item-info" v-html="info" />
+			</div>
+
+			<div
+				v-if="buttons?.length || options || $slots.options || selecting"
+				class="k-item-options"
+			>
+				<!-- Buttons -->
+				<k-button
+					v-for="button in buttons"
+					:key="JSON.stringify(button)"
+					v-bind="button"
+				/>
+
+				<label v-if="selecting" class="k-item-options-checkbox" @click.stop>
+					<input
+						ref="selector"
+						:checked="selected"
+						:disabled="!selectable"
+						:type="selectmode === 'single' ? 'radio' : 'checkbox'"
+						@change="$emit('select', $event)"
+					/>
+				</label>
+
+				<!-- Options -->
+				<slot name="options">
+					<k-options-dropdown
+						v-if="options && !selecting"
+						:options="options"
+						class="k-item-options-dropdown"
+						@option="onOption"
+					/>
+				</slot>
+			</div>
 		</div>
 	</div>
 </template>
@@ -199,14 +201,21 @@ export default {
 
 .k-item {
 	position: relative;
-	background: var(--item-color-back);
-	box-shadow: var(--item-shadow);
-	border-radius: var(--rounded);
 	min-height: var(--item-height);
-	container-type: inline-size;
 }
 .k-item:has(a:focus) {
 	outline: 2px solid var(--color-focus);
+}
+.k-item:not(:hover):not(.k-sortable-fallback) .k-item-sort-handle {
+	opacity: 0;
+}
+.k-item-box {
+	position: relative;
+	width: 100%;
+	background: var(--item-color-back);
+	box-shadow: var(--item-shadow);
+	border-radius: var(--rounded);
+	container-type: inline-size;
 }
 
 .k-item-content {
@@ -240,16 +249,16 @@ export default {
 	--button-width: var(--item-button-width);
 }
 
-.k-item .k-sort-button {
-	position: absolute;
-	z-index: 2;
-}
-.k-item:not(:hover):not(.k-sortable-fallback) .k-sort-button {
-	opacity: 0;
-}
-
 /** List */
 .k-item[data-layout="list"] {
+	--item-sort-button-width: calc(1.5rem + var(--spacing-1));
+	display: flex;
+	align-items: center;
+}
+.k-item[data-layout="list"]:has(.k-item-sort-handle) {
+	margin-inline-start: calc(-1 * var(--item-sort-button-width));
+}
+.k-item[data-layout="list"] .k-item-box {
 	--item-height: var(
 		--field-input-height
 	); /* TODO: change back to --height-md after input refactoring */
@@ -260,7 +269,11 @@ export default {
 	align-items: center;
 	grid-template-columns: 1fr auto;
 }
-.k-item[data-layout="list"][data-has-image="true"] {
+.k-item[data-layout="list"] .k-item-sort-handle {
+	--button-width: var(--item-sort-button-width);
+	--button-height: var(--item-height);
+}
+.k-item[data-layout="list"][data-has-image="true"] .k-item-box {
 	grid-template-columns: var(--item-height) 1fr auto;
 }
 .k-item[data-layout="list"] .k-frame {
@@ -288,14 +301,10 @@ export default {
 		flex-direction: column;
 	}
 }
-.k-item[data-layout="list"] .k-sort-button {
-	--button-width: calc(1.5rem + var(--spacing-1));
-	--button-height: var(--item-height);
-	left: calc(-1 * var(--button-width));
-}
 
 /** Cardlet & cards */
-.k-item:is([data-layout="cardlets"], [data-layout="cards"]) .k-sort-button {
+.k-item:is([data-layout="cardlets"], [data-layout="cards"])
+	.k-item-sort-handle {
 	top: var(--spacing-2);
 	inset-inline-start: var(--spacing-2);
 	color: light-dark(var(--color-black), var(--color-white));
@@ -310,13 +319,20 @@ export default {
 }
 
 .k-item:is([data-layout="cardlets"], [data-layout="cards"])
-	.k-sort-button:hover {
+	.k-item-sort-handle {
+	position: absolute;
+	z-index: 2;
+}
+.k-item:is([data-layout="cardlets"], [data-layout="cards"])
+	.k-item-sort-handle:hover {
 	background: hsla(0, 0%, light-dark(100%, 7%), 95%);
 }
 
 /** Cardlet */
 .k-item[data-layout="cardlets"] {
 	--item-height: var(--item-height-cardlet);
+}
+.k-item[data-layout="cardlets"] .k-item-box {
 	display: grid;
 	grid-template-areas:
 		"content"
@@ -324,7 +340,7 @@ export default {
 	grid-template-columns: 1fr;
 	grid-template-rows: 1fr var(--height-md);
 }
-.k-item[data-layout="cardlets"][data-has-image="true"] {
+.k-item[data-layout="cardlets"][data-has-image="true"] .k-item-box {
 	grid-template-areas:
 		"image content"
 		"image options";
@@ -347,6 +363,7 @@ export default {
 }
 .k-item[data-layout="cardlets"] .k-item-options {
 	grid-area: options;
+	justify-content: flex-end;
 }
 
 /** Card */
@@ -385,7 +402,7 @@ export default {
 }
 
 /** Theme: disabled */
-.k-item[data-theme="disabled"] {
+.k-item[data-theme="disabled"] .k-item-box {
 	background: transparent;
 	box-shadow: none;
 	outline: 1px solid var(--color-border);

--- a/panel/src/components/Collection/Item.vue
+++ b/panel/src/components/Collection/Item.vue
@@ -203,7 +203,7 @@ export default {
 	position: relative;
 	min-height: var(--item-height);
 }
-.k-item:has(a:focus) {
+.k-item-box:has(a:focus) {
 	outline: 2px solid var(--color-focus);
 }
 .k-item:not(:hover):not(.k-sortable-fallback) .k-item-sort-handle {


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

- [x] https://github.com/getkirby/kirby/pull/7390
- [x] https://github.com/getkirby/kirby/pull/7516

This PR improves drag'n'drop sorting of `k-items` for list layout: Instead of positioning the sort handle absolute outside of the `k-items` boundaries, it is now positioned relatively inside the container. This is necessary as SortableJS gets tripped up by the absolute positioning outside. To achieve the same look/style as before, a new `.k-item-wrapper` div was added and the main styles applied to this. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements
- Better drag sorting (e.g. pages and files sections) in list layout
#7349 

### Breaking changes
- DOM structure of `k-item` has been changes. An additional wrapper `.k-item-box` div was added.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
