### PR TITLE
fix: Enforce currentColor only for `k-icon` SVGs

### DIFF
--- a/panel/src/components/Misc/Icon.vue
+++ b/panel/src/components/Misc/Icon.vue
@@ -61,6 +61,7 @@ export default {
 	height: var(--icon-size);
 	flex-shrink: 0;
 	color: var(--icon-color);
+	fill: currentColor;
 }
 
 .k-icon[data-type="loader"] {

--- a/panel/src/styles/reset.css
+++ b/panel/src/styles/reset.css
@@ -169,10 +169,6 @@
 	text-align: start;
 }
 
-:where(svg) {
-	fill: currentColor;
-}
-
 body {
 	font-family: var(--font-sans, sans-serif);
 	font-size: var(--text-sm);


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- `currentColor` isn't enforced as fill for all SVGs anymore (only for `.k-icon`)
#7297



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
