### PR TITLE
refact!: Remove `$` prefix from Fiber

### DIFF
--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -141,7 +141,7 @@ return [
 			return [
 				'event'  => 'user.changeLanguage',
 				'reload' => [
-					'globals' => '$translation'
+					'globals' => 'translation'
 				]
 			];
 		}

--- a/panel/src/panel/feature.js
+++ b/panel/src/panel/feature.js
@@ -185,7 +185,7 @@ export default (panel, key, defaults) => {
 			options.url = options.url ?? this.url();
 
 			const response = await panel.get(options.url, options);
-			const state = response["$" + this.key()];
+			const state = response[this.key()];
 
 			// the state cannot be updated
 			if (!state || state.component !== this.component) {

--- a/panel/src/panel/feature.test.js
+++ b/panel/src/panel/feature.test.js
@@ -91,7 +91,7 @@ describe.concurrent("panel/feature.js", () => {
 	});
 
 	it("should set state with event listeners", async () => {
-		const feature = Feature(Panel(), "$test", defaults());
+		const feature = Feature(Panel(), "test", defaults());
 
 		const listeners = {
 			submit: () => {}
@@ -126,7 +126,7 @@ describe.concurrent("panel/feature.js", () => {
 	});
 
 	it.skip("should open with state", async () => {
-		const feature = Feature(Panel(), "$test", defaults());
+		const feature = Feature(Panel(), "test", defaults());
 
 		const state = {
 			component: "k-test-component",
@@ -143,7 +143,7 @@ describe.concurrent("panel/feature.js", () => {
 	});
 
 	it("should open with submitter", async () => {
-		const feature = Feature(Panel(), "$test", defaults());
+		const feature = Feature(Panel(), "test", defaults());
 		const submitter = () => {};
 
 		await feature.open("/some/path", submitter);
@@ -152,7 +152,7 @@ describe.concurrent("panel/feature.js", () => {
 	});
 
 	it("should return the full URL", async () => {
-		const feature = Feature(Panel(), "$test", defaults());
+		const feature = Feature(Panel(), "test", defaults());
 
 		// would only work with a full panel object
 		feature.set({

--- a/panel/src/panel/modal.js
+++ b/panel/src/panel/modal.js
@@ -180,16 +180,16 @@ export default (panel, key, defaults) => {
 				return response;
 			}
 
-			// get details from the response object.
-			// I.e. { $dialog: { ... } }
+			// Get details from the response object,
+			// i.e. { dialog: { ... } }
 			// pass it forward to the success handler
 			// to react on elements in the response
-			return this.success(response["$" + this.key()] ?? {});
+			return this.success(response[this.key()] ?? {});
 		},
 
 		/**
 		 * This is rebuilding the previous
-		 * behaviours from the dialog mixin.
+		 * behaviors from the dialog mixin.
 		 * Most of the response handling should
 		 * be redone. But we keep it for compatibility
 		 *

--- a/panel/src/panel/notification.js
+++ b/panel/src/panel/notification.js
@@ -78,7 +78,7 @@ export default (panel = {}) => {
 				// get the broken element in the response json that
 				// has an error message. This can be deprecated later
 				// when the server always sends back a simple error
-				// response without nesting it in $dropdown, $dialog, etc.
+				// response without nesting it in dropdown, dialog, etc.
 				const broken = Object.values(error.response.json).find(
 					(element) => typeof element?.error === "string"
 				);

--- a/panel/src/panel/panel.js
+++ b/panel/src/panel/panel.js
@@ -314,19 +314,7 @@ export default {
 	 * @param {Object} state
 	 */
 	set(state = {}) {
-		/**
-		 * Old fiber requests use $ as key prefix
-		 * This will remove the dollar sign in keys first
-		 * @todo remove this as soon as fiber requests
-		 * no longer use $ as prefix.
-		 */
-		state = Object.fromEntries(
-			Object.entries(state).map(([k, v]) => [k.replace("$", ""), v])
-		);
-
-		/**
-		 * Register all globals
-		 */
+		// Register all globals
 		for (const global in globals) {
 			// 1. check for a new state
 			// 2. jump back to the previous

--- a/panel/src/panel/panel.test.js
+++ b/panel/src/panel/panel.test.js
@@ -38,18 +38,6 @@ describe.concurrent("panel", () => {
 		expect(state.user).toStrictEqual(panel.user.state());
 	});
 
-	it("should replace $ in state keys", async () => {
-		const panel = Panel.create(Vue);
-
-		expect(panel.license).toStrictEqual("missing");
-
-		panel.set({
-			$license: "valid"
-		});
-
-		expect(panel.license).toStrictEqual("valid");
-	});
-
 	it("should return the correct debug mode", async () => {
 		const panel = Panel.create(Vue);
 

--- a/panel/src/panel/request.globals.test.js
+++ b/panel/src/panel/request.globals.test.js
@@ -7,13 +7,13 @@ import { globals } from "./request.js";
 
 describe.concurrent("request globals", () => {
 	it("should create globals from string", async () => {
-		const result = globals("$language");
-		expect(result).toStrictEqual("$language");
+		const result = globals("language");
+		expect(result).toStrictEqual("language");
 	});
 
 	it("should create globals from array", async () => {
-		const result = globals(["$language"]);
-		expect(result).toStrictEqual("$language");
+		const result = globals(["language"]);
+		expect(result).toStrictEqual("language");
 	});
 
 	it("should skip globals", async () => {

--- a/panel/src/panel/request.headers.test.js
+++ b/panel/src/panel/request.headers.test.js
@@ -41,7 +41,7 @@ describe.concurrent("request headers", () => {
 			{},
 			{
 				csrf: "dev",
-				globals: ["$language"],
+				globals: ["language"],
 				referrer: "/test"
 			}
 		);
@@ -50,7 +50,7 @@ describe.concurrent("request headers", () => {
 			"content-type": "application/json",
 			"x-csrf": "dev",
 			"x-fiber": true,
-			"x-fiber-globals": "$language",
+			"x-fiber-globals": "language",
 			"x-fiber-referrer": "/test"
 		};
 

--- a/panel/src/panel/state.js
+++ b/panel/src/panel/state.js
@@ -12,7 +12,7 @@ import { isObject } from "@/helpers/object";
  * @since 4.0.0
  *
  * @param {Object} panel The panel singleton
- * @param {String} key Sets the $key for the state used by backend responses
+ * @param {String} key Sets the key for the state used by backend responses
  * @param {Object} defaults Sets the default state
  */
 export default (key, defaults = {}) => {

--- a/panel/src/panel/state.test.js
+++ b/panel/src/panel/state.test.js
@@ -7,8 +7,8 @@ import State from "./state.js";
 
 describe.concurrent("state", () => {
 	it("should set & get a key", async () => {
-		const state = State("$test");
-		expect(state.key()).toStrictEqual("$test");
+		const state = State("test");
+		expect(state.key()).toStrictEqual("test");
 	});
 
 	it("should set & get defaults", async () => {
@@ -16,7 +16,7 @@ describe.concurrent("state", () => {
 			message: null
 		};
 
-		const state = State("$test", defaults);
+		const state = State("test", defaults);
 
 		expect(state.defaults()).toStrictEqual(defaults);
 		expect(state.state()).toStrictEqual(defaults);
@@ -29,7 +29,7 @@ describe.concurrent("state", () => {
 			isOpen: false
 		};
 
-		const state = State("$test", defaults);
+		const state = State("test", defaults);
 
 		state.set({ message: "Hello" });
 
@@ -43,7 +43,7 @@ describe.concurrent("state", () => {
 			message: null
 		};
 
-		const state = State("$test", defaults);
+		const state = State("test", defaults);
 
 		state.set({ message: "Hello" });
 		state.reset();
@@ -52,13 +52,13 @@ describe.concurrent("state", () => {
 	});
 
 	it("should validate state", async () => {
-		const state = State("$test");
+		const state = State("test");
 
 		// invalid state
 		try {
 			state.validateState("foo");
 		} catch (error) {
-			expect(error.message).toStrictEqual("Invalid $test state");
+			expect(error.message).toStrictEqual("Invalid test state");
 		}
 
 		// valid state

--- a/src/Panel/Assets.php
+++ b/src/Panel/Assets.php
@@ -3,7 +3,6 @@
 namespace Kirby\Panel;
 
 use Kirby\Cms\App;
-use Kirby\Cms\Helpers;
 use Kirby\Cms\Url;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;

--- a/src/Panel/Dialog.php
+++ b/src/Panel/Dialog.php
@@ -18,7 +18,7 @@ use Kirby\Http\Response;
  */
 class Dialog extends Json
 {
-	protected static string $key = '$dialog';
+	protected static string $key = 'dialog';
 
 	/**
 	 * Renders dialogs

--- a/src/Panel/Document.php
+++ b/src/Panel/Document.php
@@ -46,7 +46,7 @@ class Document
 		$uri = new Uri($kirby->url('panel'));
 
 		// proper response code
-		$code = $fiber['$view']['code'] ?? 200;
+		$code = $fiber['view']['code'] ?? 200;
 
 		// load the main Panel view template
 		$body = Tpl::load($kirby->root('kirby') . '/views/panel.php', [

--- a/src/Panel/Drawer.php
+++ b/src/Panel/Drawer.php
@@ -17,5 +17,5 @@ use Kirby\Http\Response;
  */
 class Drawer extends Dialog
 {
-	protected static string $key = '$drawer';
+	protected static string $key = 'drawer';
 }

--- a/src/Panel/Dropdown.php
+++ b/src/Panel/Dropdown.php
@@ -19,7 +19,7 @@ use Kirby\Http\Response;
  */
 class Dropdown extends Json
 {
-	protected static string $key = '$dropdown';
+	protected static string $key = 'dropdown';
 
 	/**
 	 * Renders dropdowns

--- a/src/Panel/Json.php
+++ b/src/Panel/Json.php
@@ -22,7 +22,7 @@ use Throwable;
  */
 abstract class Json
 {
-	protected static string $key = '$response';
+	protected static string $key = 'response';
 
 	/**
 	 * Renders the error response with the provided message

--- a/src/Panel/Search.php
+++ b/src/Panel/Search.php
@@ -18,7 +18,7 @@ use Kirby\Http\Response;
  */
 class Search extends Json
 {
-	protected static string $key = '$search';
+	protected static string $key = 'search';
 
 	public static function response($data, array $options = []): Response
 	{

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -36,13 +36,14 @@ class View
 		$request = App::instance()->request();
 		$only    = $request->header('X-Fiber-Only') ?? $request->get('_only');
 
-		if (empty($only) === false) {
-			return static::applyOnly($data, $only);
-		}
-
 		$globals =
 			$request->header('X-Fiber-Globals') ??
 			$request->get('_globals');
+
+
+		if (empty($only) === false) {
+			return static::applyOnly($data, $only);
+		}
 
 		if (empty($globals) === false) {
 			return static::applyGlobals($data, $globals);
@@ -103,12 +104,16 @@ class View
 		}
 
 		// otherwise filter data based on
-		// dot notation, e.g. `$props.tab.columns`
+		// dot notation, e.g. `props.tab.columns`
 		$result = [];
 
-		// check if globals are requested and need to be merged
-		if (Str::contains($only, '$')) {
-			$data = array_merge_recursive(static::globals(), $data);
+		// take care of potentially requested globals
+		$globals     = static::globals();
+		$keysEntries = A::map($onlyKeys, fn ($key) => Str::split($key, '.')[0]);
+
+		// check if the keys from `_only` include any global id as entry
+		if (array_intersect($keysEntries, array_keys($globals)) !== []) {
+			$data = array_merge_recursive($globals, $data);
 		}
 
 		// make sure the data is already resolved to make
@@ -148,7 +153,7 @@ class View
 
 		// shared data for all requests
 		return [
-			'$direction' => function () use ($kirby, $multilang, $language, $user) {
+			'direction' => function () use ($kirby, $multilang, $language, $user) {
 				if ($multilang === true && $language && $user) {
 					$default = $kirby->defaultLanguage();
 
@@ -160,19 +165,19 @@ class View
 					}
 				}
 			},
-			'$dialog'   => null,
-			'$drawer'   => null,
-			'$language' => fn () => match ($multilang) {
+			'dialog'   => null,
+			'drawer'   => null,
+			'language' => fn () => match ($multilang) {
 				false => null,
 				true  => $language?->toArray()
 			},
-			'$languages' => fn (): array => match ($multilang) {
+			'languages' => fn (): array => match ($multilang) {
 				false => [],
 				true  => $kirby->languages()->values(
 					fn ($language) => $language->toArray()
 				)
 			},
-			'$menu'       => function () use ($options, $permissions) {
+			'menu'       => function () use ($options, $permissions) {
 				$menu = new Menu(
 					$options['areas'] ?? [],
 					$permissions,
@@ -180,12 +185,12 @@ class View
 				);
 				return $menu->entries();
 			},
-			'$permissions' => $permissions,
-			'$license'     => $kirby->system()->license()->status()->value(),
-			'$multilang'   => $multilang,
-			'$searches'    => static::searches($options['areas'] ?? [], $permissions),
-			'$url'         => $kirby->request()->url()->toString(),
-			'$user'        => fn () => match ($user) {
+			'permissions' => $permissions,
+			'license'     => $kirby->system()->license()->status()->value(),
+			'multilang'   => $multilang,
+			'searches'    => static::searches($options['areas'] ?? [], $permissions),
+			'url'         => $kirby->request()->url()->toString(),
+			'user'        => fn () => match ($user) {
 				null    => null,
 				default =>  [
 					'email'    => $user->email(),
@@ -195,7 +200,7 @@ class View
 					'username' => $user->username(),
 				]
 			},
-			'$view' => function () use ($kirby, $options, $view) {
+			'view' => function () use ($kirby, $options, $view) {
 				$defaults = [
 					'breadcrumb' => [],
 					'code'       => 200,
@@ -260,7 +265,7 @@ class View
 		$kirby = App::instance();
 
 		return [
-			'$config' => fn () => [
+			'config' => fn () => [
 				'api'         => [
 					'methodOverride' => $kirby->option('api.methodOverride', true)
 				],
@@ -269,7 +274,7 @@ class View
 				'translation' => $kirby->option('panel.language', 'en'),
 				'upload'      => Upload::chunkSize(),
 			],
-			'$system' => function () use ($kirby) {
+			'system' => function () use ($kirby) {
 				$locales = [];
 
 				foreach ($kirby->translations() as $translation) {
@@ -285,7 +290,7 @@ class View
 					'title'   => $kirby->site()->title()->or('Kirby Panel')->toString()
 				];
 			},
-			'$translation' => function () use ($kirby) {
+			'translation' => function () use ($kirby) {
 				$translation = match ($user = $kirby->user()) {
 					null    => $kirby->translation($kirby->panelLanguage()),
 					default => $kirby->translation($user->language())
@@ -299,7 +304,7 @@ class View
 					'weekday'   => Date::firstWeekday($translation->locale())
 				];
 			},
-			'$urls' => fn () => [
+			'urls' => fn () => [
 				'api'  => $kirby->url('api'),
 				'site' => $kirby->url('index')
 			]
@@ -340,7 +345,7 @@ class View
 			// query parameters are set
 			$fiber = static::apply($fiber);
 
-			return Panel::json($fiber, $fiber['$view']['code'] ?? 200);
+			return Panel::json($fiber, $fiber['view']['code'] ?? 200);
 		}
 
 		// load globals for the full document response

--- a/tests/Panel/Areas/AccountDialogsTest.php
+++ b/tests/Panel/Areas/AccountDialogsTest.php
@@ -58,7 +58,7 @@ class AccountDialogsTest extends AreaTestCase
 		$dialog = $this->dialog('account/changeLanguage');
 
 		$this->assertSame('user.changeLanguage', $dialog['event']);
-		$this->assertSame(['globals' => '$translation'], $dialog['reload']);
+		$this->assertSame(['globals' => 'translation'], $dialog['reload']);
 		$this->assertSame(200, $dialog['code']);
 
 		$this->assertSame('de', $this->app->user('test')->language());

--- a/tests/Panel/Areas/AreaTestCase.php
+++ b/tests/Panel/Areas/AreaTestCase.php
@@ -103,12 +103,12 @@ abstract class AreaTestCase extends TestCase
 
 	protected function dialog(string $path): array
 	{
-		return $this->response('dialogs/' . $path, true)['$dialog'];
+		return $this->response('dialogs/' . $path, true)['dialog'];
 	}
 
 	protected function dropdown(string $path): array
 	{
-		return $this->response('dropdowns/' . $path, true)['$dropdown'];
+		return $this->response('dropdowns/' . $path, true)['dropdown'];
 	}
 
 	protected function enableMultilang(): void
@@ -219,7 +219,7 @@ abstract class AreaTestCase extends TestCase
 
 	protected function search(string $path): array
 	{
-		return $this->response('search/' . $path, true)['$search'];
+		return $this->response('search/' . $path, true)['search'];
 	}
 
 	protected function submit(array $data): void
@@ -237,6 +237,6 @@ abstract class AreaTestCase extends TestCase
 
 	protected function view(string|null $path = null): array
 	{
-		return $this->response($path, true)['$view'];
+		return $this->response($path, true)['view'];
 	}
 }

--- a/tests/Panel/Areas/LanguagesTest.php
+++ b/tests/Panel/Areas/LanguagesTest.php
@@ -24,7 +24,7 @@ class LanguagesTest extends AreaTestCase
 		$props = $view['props'];
 
 		$response = $this->response('languages', true);
-		$this->assertTrue($response['$multilang']);
+		$this->assertTrue($response['multilang']);
 
 		$this->assertSame('languages', $view['id']);
 		$this->assertSame('Languages', $view['title']);
@@ -39,7 +39,7 @@ class LanguagesTest extends AreaTestCase
 		$this->login();
 
 		$response = $this->response('languages', true);
-		$view     = $response['$view'];
+		$view     = $response['view'];
 		$props    = $view['props'];
 
 		$languages = [
@@ -59,7 +59,7 @@ class LanguagesTest extends AreaTestCase
 			]
 		];
 
-		$this->assertTrue($response['$multilang']);
+		$this->assertTrue($response['multilang']);
 		$this->assertSame($languages, $props['languages']);
 	}
 }

--- a/tests/Panel/Areas/UsersDialogsTest.php
+++ b/tests/Panel/Areas/UsersDialogsTest.php
@@ -121,7 +121,7 @@ class UsersDialogsTest extends AreaTestCase
 		$dialog = $this->dialog('users/test/changeLanguage');
 
 		$this->assertSame('user.changeLanguage', $dialog['event']);
-		$this->assertSame(['globals' => '$translation'], $dialog['reload']);
+		$this->assertSame(['globals' => 'translation'], $dialog['reload']);
 		$this->assertSame(200, $dialog['code']);
 
 		$this->assertSame('de', $this->app->user('test')->language());

--- a/tests/Panel/DialogTest.php
+++ b/tests/Panel/DialogTest.php
@@ -61,7 +61,7 @@ class DialogTest extends TestCase
 		]);
 
 		$expected = [
-			'$dialog' => [
+			'dialog' => [
 				'test'     => 'Test',
 				'code'     => 200,
 				'path'     => null,
@@ -79,7 +79,7 @@ class DialogTest extends TestCase
 	{
 		$response = Dialog::response(true);
 		$expected = [
-			'$dialog' => [
+			'dialog' => [
 				'code'     => 200,
 				'path'     => null,
 				'query'    => [],
@@ -94,7 +94,7 @@ class DialogTest extends TestCase
 	{
 		$response = Dialog::response(1234);
 		$expected = [
-			'$dialog' => [
+			'dialog' => [
 				'code'     => 500,
 				'error'    => 'Invalid response',
 				'path'     => null,
@@ -111,7 +111,7 @@ class DialogTest extends TestCase
 		$exception = new Exception('Test');
 		$response  = Dialog::response($exception);
 		$expected  = [
-			'$dialog' => [
+			'dialog' => [
 				'code'     => 500,
 				'error'    => 'Test',
 				'path'     => null,
@@ -128,7 +128,7 @@ class DialogTest extends TestCase
 		$exception = new NotFoundException(message: 'Test');
 		$response  = Dialog::response($exception);
 		$expected  = [
-			'$dialog' => [
+			'dialog' => [
 				'code'     => 404,
 				'error'    => 'Test',
 				'path'     => null,

--- a/tests/Panel/DropdownTest.php
+++ b/tests/Panel/DropdownTest.php
@@ -61,7 +61,7 @@ class DropdownTest extends TestCase
 		]);
 
 		$expected = [
-			'$dropdown' => [
+			'dropdown' => [
 				'options'  => ['Test'],
 				'code'     => 200,
 				'path'     => null,
@@ -79,7 +79,7 @@ class DropdownTest extends TestCase
 	{
 		$response = Dropdown::response(1234);
 		$expected = [
-			'$dropdown' => [
+			'dropdown' => [
 				'code'     => 500,
 				'error'    => 'Invalid response',
 				'path'     => null,
@@ -96,7 +96,7 @@ class DropdownTest extends TestCase
 		$exception = new Exception('Test');
 		$response  = Dropdown::response($exception);
 		$expected  = [
-			'$dropdown' => [
+			'dropdown' => [
 				'code'     => 500,
 				'error'    => 'Test',
 				'path'     => null,
@@ -113,7 +113,7 @@ class DropdownTest extends TestCase
 		$exception = new NotFoundException(message: 'Test');
 		$response  = Dropdown::response($exception);
 		$expected  = [
-			'$dropdown' => [
+			'dropdown' => [
 				'code'     => 404,
 				'error'    => 'Test',
 				'path'     => null,

--- a/tests/Panel/JsonTest.php
+++ b/tests/Panel/JsonTest.php
@@ -22,8 +22,8 @@ class JsonTest extends TestCase
 		$body     = json_decode($response->body(), true);
 
 		$this->assertSame(200, $response->code());
-		$this->assertSame(200, $body['$response']['code']);
-		$this->assertSame('https://getkirby.com', $body['$response']['redirect']);
+		$this->assertSame(200, $body['response']['code']);
+		$this->assertSame('https://getkirby.com', $body['response']['redirect']);
 	}
 
 	public function testResponseThrowable(): void

--- a/tests/Panel/PanelTest.php
+++ b/tests/Panel/PanelTest.php
@@ -390,16 +390,16 @@ class PanelTest extends TestCase
 		$json     = json_decode($response->body(), true);
 
 		$this->assertSame(404, $response->code());
-		$this->assertSame('k-error-view', $json['$view']['component']);
-		$this->assertSame('The data could not be found', $json['$view']['props']['error']);
+		$this->assertSame('k-error-view', $json['view']['component']);
+		$this->assertSame('The data could not be found', $json['view']['props']['error']);
 
 		// false is interpreted as 404
 		$response = Panel::response(false);
 		$json     = json_decode($response->body(), true);
 
 		$this->assertSame(404, $response->code());
-		$this->assertSame('k-error-view', $json['$view']['component']);
-		$this->assertSame('The data could not be found', $json['$view']['props']['error']);
+		$this->assertSame('k-error-view', $json['view']['component']);
+		$this->assertSame('The data could not be found', $json['view']['props']['error']);
 	}
 
 	public function testResponseFromString(): void
@@ -418,8 +418,8 @@ class PanelTest extends TestCase
 		$json     = json_decode($response->body(), true);
 
 		$this->assertSame(500, $response->code());
-		$this->assertSame('k-error-view', $json['$view']['component']);
-		$this->assertSame('Test', $json['$view']['props']['error']);
+		$this->assertSame('k-error-view', $json['view']['component']);
+		$this->assertSame('Test', $json['view']['props']['error']);
 	}
 
 	public function testRouterWithDisabledPanel(): void

--- a/tests/Panel/Ui/Buttons/PageStatusButtonTest.php
+++ b/tests/Panel/Ui/Buttons/PageStatusButtonTest.php
@@ -16,7 +16,7 @@ class PageStatusButtonTest extends TestCase
 		$page   = new Page(['slug' => 'test', 'isDraft' => true]);
 		$button = new PageStatusButton($page);
 
-		$this->assertSame('k-status-view-button', $button->component);
+		$this->assertSame('k-view-button', $button->component);
 		$this->assertSame('k-status-view-button k-page-status-button', $button->class);
 		$this->assertSame('/pages/test/changeStatus', $button->dialog);
 		$this->assertTrue($button->disabled);

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Panel;
 
+use Closure;
 use Exception;
 use Kirby\Cms\App;
 use Kirby\Cms\Language;
@@ -60,31 +61,31 @@ class ViewTest extends TestCase
 	{
 		// not included
 		$data = View::apply([]);
-		$this->assertArrayNotHasKey('$translation', $data);
+		$this->assertArrayNotHasKey('translation', $data);
 
 		// via query
 		$this->app = $this->app->clone([
 			'request' => [
 				'query' => [
-					'_globals' => '$translation'
+					'_globals' => 'translation'
 				]
 			]
 		]);
 
 		$data = View::apply([]);
-		$this->assertArrayHasKey('$translation', $data);
+		$this->assertArrayHasKey('translation', $data);
 
 		// via header
 		$this->app = $this->app->clone([
 			'request' => [
 				'headers' => [
-					'X-Fiber-Globals' => '$translation'
+					'X-Fiber-Globals' => 'translation'
 				]
 			]
 		]);
 
 		$data = View::apply([]);
-		$this->assertArrayHasKey('$translation', $data);
+		$this->assertArrayHasKey('translation', $data);
 
 		// empty globals
 		$data = ['foo' => 'bar'];
@@ -140,7 +141,7 @@ class ViewTest extends TestCase
 		$this->app = $this->app->clone([
 			'request' => [
 				'query' => [
-					'_only' => 'a,$urls',
+					'_only' => 'a,urls',
 				]
 			]
 		]);
@@ -154,7 +155,7 @@ class ViewTest extends TestCase
 
 		$expected = [
 			'a' => 'A',
-			'$urls' => [
+			'urls' => [
 				'api' => '/api',
 				'site' => '/'
 			]
@@ -198,7 +199,7 @@ class ViewTest extends TestCase
 		$this->app = $this->app->clone([
 			'request' => [
 				'query' => [
-					'_only' => 'a,$urls.site',
+					'_only' => 'a,urls.site',
 				]
 			]
 		]);
@@ -212,7 +213,7 @@ class ViewTest extends TestCase
 
 		$expected = [
 			'a' => 'A',
-			'$urls' => [
+			'urls' => [
 				'site' => '/'
 			]
 		];
@@ -225,19 +226,19 @@ class ViewTest extends TestCase
 		// without custom data
 		$data = View::data();
 
-		$this->assertInstanceOf('Closure', $data['$menu']);
-		$this->assertInstanceOf('Closure', $data['$direction']);
-		$this->assertInstanceOf('Closure', $data['$language']);
-		$this->assertInstanceOf('Closure', $data['$languages']);
-		$this->assertSame([], $data['$permissions']);
-		$this->assertSame('missing', $data['$license']);
-		$this->assertFalse($data['$multilang']);
-		$this->assertSame('/', $data['$url']);
-		$this->assertInstanceOf('Closure', $data['$user']);
-		$this->assertInstanceOf('Closure', $data['$view']);
+		$this->assertInstanceOf('Closure', $data['menu']);
+		$this->assertInstanceOf('Closure', $data['direction']);
+		$this->assertInstanceOf('Closure', $data['language']);
+		$this->assertInstanceOf('Closure', $data['languages']);
+		$this->assertSame([], $data['permissions']);
+		$this->assertSame('missing', $data['license']);
+		$this->assertFalse($data['multilang']);
+		$this->assertSame('/', $data['url']);
+		$this->assertInstanceOf('Closure', $data['user']);
+		$this->assertInstanceOf('Closure', $data['view']);
 
 		// default view settings
-		$view = A::apply($data)['$view'];
+		$view = A::apply($data)['view'];
 
 		$this->assertSame([], $view['breadcrumb']);
 		$this->assertSame(200, $view['code']);
@@ -265,7 +266,7 @@ class ViewTest extends TestCase
 		// without custom data
 		$data = View::data();
 
-		$this->assertSame('https://localhost.com:8888/foo/bar?foo=bar', $data['$url']);
+		$this->assertSame('https://localhost.com:8888/foo/bar?foo=bar', $data['url']);
 	}
 
 	public function testDataWithCustomProps(): void
@@ -278,7 +279,7 @@ class ViewTest extends TestCase
 
 		$data = A::apply($data);
 
-		$this->assertSame($props, $data['$view']['props']);
+		$this->assertSame($props, $data['view']['props']);
 	}
 
 	public function testDataWithLanguages(): void
@@ -299,7 +300,7 @@ class ViewTest extends TestCase
 		// resolve lazy data
 		$data = A::apply($data);
 
-		$this->assertTrue($data['$multilang']);
+		$this->assertTrue($data['multilang']);
 
 		$expected = [
 			[
@@ -322,9 +323,9 @@ class ViewTest extends TestCase
 			]
 		];
 
-		$this->assertSame($expected, $data['$languages']);
-		$this->assertSame($expected[0], $data['$language']);
-		$this->assertNull($data['$direction']);
+		$this->assertSame($expected, $data['languages']);
+		$this->assertSame($expected[0], $data['language']);
+		$this->assertNull($data['direction']);
 	}
 
 	public function testDataWithDirection(): void
@@ -353,7 +354,7 @@ class ViewTest extends TestCase
 		$data = A::apply($data);
 
 
-		$this->assertSame('rtl', $data['$direction']);
+		$this->assertSame('rtl', $data['direction']);
 	}
 
 	public function testDataWithAuthenticatedUser(): void
@@ -376,8 +377,8 @@ class ViewTest extends TestCase
 			'username' => 'kirby@getkirby.com'
 		];
 
-		$this->assertSame($expected, $data['$user']);
-		$this->assertSame($this->app->user()->role()->permissions()->toArray(), $data['$permissions']);
+		$this->assertSame($expected, $data['user']);
+		$this->assertSame($this->app->user()->role()->permissions()->toArray(), $data['permissions']);
 	}
 
 	public function testError(): void
@@ -422,18 +423,18 @@ class ViewTest extends TestCase
 		// defaults
 		$globals = View::globals();
 
-		$this->assertInstanceOf('Closure', $globals['$config']);
-		$this->assertInstanceOf('Closure', $globals['$system']);
-		$this->assertInstanceOf('Closure', $globals['$system']);
-		$this->assertInstanceOf('Closure', $globals['$translation']);
-		$this->assertInstanceOf('Closure', $globals['$urls']);
+		$this->assertInstanceOf(Closure::class, $globals['config']);
+		$this->assertInstanceOf(Closure::class, $globals['system']);
+		$this->assertInstanceOf(Closure::class, $globals['system']);
+		$this->assertInstanceOf(Closure::class, $globals['translation']);
+		$this->assertInstanceOf(Closure::class, $globals['urls']);
 
 		// defaults after apply
 		$globals     = A::apply($globals);
-		$config      = $globals['$config'];
-		$system      = $globals['$system'];
-		$translation = $globals['$translation'];
-		$urls        = $globals['$urls'];
+		$config      = $globals['config'];
+		$system      = $globals['system'];
+		$translation = $globals['translation'];
+		$urls        = $globals['urls'];
 
 		// $config
 		$this->assertFalse($config['debug']);
@@ -475,7 +476,7 @@ class ViewTest extends TestCase
 		$this->app->impersonate('test@getkirby.com');
 		$globals = View::globals();
 		$globals = A::apply($globals);
-		$this->assertSame('de', $globals['$translation']['code']);
+		$this->assertSame('de', $globals['translation']['code']);
 	}
 
 	public function testResponseAsHTML(): void
@@ -550,8 +551,8 @@ class ViewTest extends TestCase
 		$json      = json_decode($response->body(), true);
 
 		$this->assertSame(404, $response->code());
-		$this->assertSame('k-error-view', $json['$view']['component']);
-		$this->assertSame('Test', $json['$view']['props']['error']);
+		$this->assertSame('k-error-view', $json['view']['component']);
+		$this->assertSame('Test', $json['view']['props']['error']);
 	}
 
 	public function testResponseFromException(): void
@@ -570,8 +571,8 @@ class ViewTest extends TestCase
 		$json      = json_decode($response->body(), true);
 
 		$this->assertSame(500, $response->code());
-		$this->assertSame('k-error-view', $json['$view']['component']);
-		$this->assertSame('Test', $json['$view']['props']['error']);
+		$this->assertSame('k-error-view', $json['view']['component']);
+		$this->assertSame('Test', $json['view']['props']['error']);
 	}
 
 	public function testResponseFromUnsupportedResult(): void
@@ -589,8 +590,8 @@ class ViewTest extends TestCase
 		$json     = json_decode($response->body(), true);
 
 		$this->assertSame(500, $response->code());
-		$this->assertSame('k-error-view', $json['$view']['component']);
-		$this->assertSame('Invalid Panel response', $json['$view']['props']['error']);
+		$this->assertSame('k-error-view', $json['view']['component']);
+		$this->assertSame('Invalid Panel response', $json['view']['props']['error']);
 	}
 
 	public function testSearches(): void


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Breaking changes
- Fiber data: keys aren't prefixed with `$` anymore. Use without prefix. This also affects Panel plugins reloading the Panel by defining only specific keys to be reloaded.


## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
