### PR TITLE
docs: fix capitalization of YouTube name

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -640,7 +640,7 @@ if (Helpers::hasOverride('uuid') === false) { // @codeCoverageIgnore
 
 if (Helpers::hasOverride('video') === false) { // @codeCoverageIgnore
 	/**
-	 * Creates a video embed via iframe for Youtube or Vimeo
+	 * Creates a video embed via iframe for YouTube or Vimeo
 	 * videos. The embed Urls are automatically detected from
 	 * the given Url.
 	 */
@@ -680,7 +680,7 @@ if (Helpers::hasOverride('widont') === false) { // @codeCoverageIgnore
 
 if (Helpers::hasOverride('youtube') === false) { // @codeCoverageIgnore
 	/**
-	 * Embeds a Youtube video by URL in an iframe
+	 * Embeds a YouTube video by URL in an iframe
 	 */
 	function youtube(
 		string $url,


### PR DESCRIPTION
## Description

Fixes the capitalization of the term "YouTube" (previously spelled as Youtube).

I also opened an issue (to conform with the branch name convention) but as this is my first PR, I am uncertain whether that's correct (and also whether `develop-patch` is the correct target).

### Summary of changes

Fixes the capitalization of the term "YouTube" (previously spelled as Youtube).

### Reasoning

YouTube > Youtube

### Additional context



## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes



### Breaking changes



## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->



## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [ ] In-code documentation (wherever needed)
- [ ] Unit tests for fixed bug/feature
- [ ] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
