### PR TITLE
refact: Allow folders inside `site/controllers`

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -443,15 +443,15 @@ class App
 		array $arguments = [],
 		string $contentType = 'html'
 	): array {
-		$name = basename(strtolower($name));
+		$name = strtolower($name);
 		$data = [];
 
 		// always use the site controller as defaults, if available
-		$site   = $this->controllerLookup('site', $contentType);
-		$site ??= $this->controllerLookup('site');
-
-		if ($site !== null) {
-			$data = (array)$site->call($this, $arguments);
+		// (unless the controller is a snippet controller)
+		if (strpos($name, '/') === false) {
+			$site   = $this->controllerLookup('site', $contentType);
+			$site ??= $this->controllerLookup('site');
+			$data   = (array)$site?->call($this, $arguments) ?? [];
 		}
 
 		// try to find a specific representation controller
@@ -460,14 +460,10 @@ class App
 		// let's try the html controller instead
 		$controller ??= $this->controllerLookup($name);
 
-		if ($controller !== null) {
-			return [
-				...$data,
-				...(array)$controller->call($this, $arguments)
-			];
-		}
-
-		return $data;
+		return [
+			...$data,
+			...(array)$controller?->call($this, $arguments) ?? []
+		];
 	}
 
 	/**
@@ -482,7 +478,11 @@ class App
 		}
 
 		// controller from site root
-		$controller   = Controller::load($this->root('controllers') . '/' . $name . '.php', $this->root('controllers'));
+		$controller = Controller::load(
+			file: $this->root('controllers') . '/' . $name . '.php',
+			in:   $this->root('controllers')
+		);
+
 		// controller from extension
 		$controller ??= $this->extension('controllers', $name);
 

--- a/src/Template/Snippet.php
+++ b/src/Template/Snippet.php
@@ -38,22 +38,10 @@ class Snippet extends Tpl
 	protected array $capture = [];
 
 	/**
-	 * Associative array with variables that
-	 * will be set inside the snippet
-	 */
-	protected array $data;
-
-	/**
 	 * An empty dummy slots object used for snippets
 	 * that were loaded without passing slots
 	 */
 	protected static Slots|null $dummySlots = null;
-
-	/**
-	 * Full path to the PHP file of the snippet;
-	 * can be `null` for "dummy" snippets that don't exist
-	 */
-	protected string|null $file;
 
 	/**
 	 * Keeps track of the state of the snippet
@@ -73,11 +61,17 @@ class Snippet extends Tpl
 
 	/**
 	 * Creates a new snippet
+	 *
+	 * @param string|null $file Full path to the PHP file of the snippet;
+	 *                          can be `null` for "dummy" snippets
+	 *                          that don't exist
+	 * @param array $data Associative array with variables that
+	 *                    will be set inside the snippet
 	 */
-	public function __construct(string|null $file, array $data = [])
-	{
-		$this->file = $file;
-		$this->data = $data;
+	public function __construct(
+		protected string|null $file,
+		protected array $data = []
+	) {
 	}
 
 	/**
@@ -158,9 +152,9 @@ class Snippet extends Tpl
 		array $data = [],
 		bool $slots = false
 	): static|string {
-		// instead of returning empty string when `$name` is null
-		// allow rest of code to run, otherwise the wrong snippet would be closed
-		// and potential issues for nested snippets may occur
+		// instead of returning empty string when `$name` is null,
+		// allow rest of code to run, otherwise the wrong snippet would
+		// be closed and potential issues for nested snippets may occur
 		$file = $name !== null ? static::file($name) : null;
 
 		// for snippets with slots, make sure to open a new
@@ -171,7 +165,8 @@ class Snippet extends Tpl
 
 		// for snippets without slots, directly load and return
 		// the snippet's template file
-		return static::load($file, static::scope($data));
+		$data = static::scope($data);
+		return static::load($file, $data);
 	}
 
 	/**
@@ -244,10 +239,14 @@ class Snippet extends Tpl
 			$this->slots[$slotName] = new Slot($slotName, $slotContent);
 		}
 
-		// custom data overrides for the data that was passed to the snippet instance
+		// custom data overrides the data from the controller
+		// as well as the data passed to the Snippet instance
 		$data = array_replace_recursive($this->data, $data);
 
-		return static::load($this->file, static::scope($data, $this->slots()));
+		return static::load(
+			file: $this->file,
+			data: static::scope($data, $this->slots())
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

This PR changes `App::controller()` to also allow controllers noted in subfolders inside `site/controllers`. This change enables us to add snippet and block controllers (https://feedback.getkirby.com/213) via a custom plugin then:

```php
<?php

use Kirby\Cms\App;
use Kirby\Template\Snippet;
use Kirby\Toolkit\Str;

class SnippetWithController extends Snippet
{
  protected static $controllers = [];

  public static function controller(
    string|null $file,
    array $data = []
  ): array {
    if (
      $file === null ||
      str_starts_with($file, static::root()) === false
    ) {
      return $data;
    }

    if (isset(static::$controllers[$file])) {
      return array_replace_recursive(
        $data,
        static::$controllers[$file]
      );
    }

    $name = ltrim(Str::before(Str::after($file, static::root()), '.php'), '/');

    // if the snippet has a name, we can load the controller
    // and merge the data with the controller's data
    if ($name !== null) {
      $data = array_replace_recursive(
        $data,
        static::$controllers[$file] = App::instance()->controller('snippets/' . $name, $data)
      );
    }

    return $data;
  }

  public static function factory(
    string|array|null $name,
    array $data = [],
    bool $slots = false
  ): static|string {
    $file = $name !== null ? static::file($name) : null;
    $data = static::controller($file, $data);
    return parent::factory($name, $data, $slots);
  }

  public function render(array $data = [], array $slots = []): string
  {
    $data = array_replace_recursive(
      static::controller($this->file, $data),
      $data
    );

    return parent::render($data, $slots);
  }
}

App::plugin('getkirby/snippet-controllers', [
  'components' => [
    'snippet' => function (
      App $kirby,
      string|array|null $name,
      array $data = [],
      bool $slots = false
    ): Snippet|string {
      return SnippetWithController::factory($name, $data, $slots);
    },
  ]
]);
```

With this plugin place, one can add a controller for e.g. `site/snippets/header.php` to `site/controllers/snippets/header.php`. And since blocks are also just snippets: `site/controllers/snippets/blocks/video.php` (though this currently just works if a custom blocks snippet has been added, not for the default ones).

Choosing to go down the plugin path as it can have quite the performance impact if every snippet checks for the existence of a controller. Maybe you have also ideas how to improve that performance.


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Refactored
- Support `App::controller()` to return controllers nested in subfolders inside `site/controllers`

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
