### PR TITLE
fix: Allow submitting inactive fields

### DIFF
--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -120,10 +120,6 @@ trait Value
 			return false;
 		}
 
-		if ($this->isActive() === false) {
-			return false;
-		}
-
 		return true;
 	}
 

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -417,7 +417,45 @@ class FieldClassTest extends TestCase
 			],
 		]);
 
-		$this->assertFalse($field->isSubmittable($language));
+		$this->assertTrue($field->isSubmittable($language));
+	}
+
+	public function testIsSubmittableWithWhenQueryAndTwoFields()
+	{
+		$language = Language::ensure('current');
+
+		$fields = new Fields([
+			new TestField([
+				'name'  => 'a',
+				'value' => 'a',
+				'when'  => [
+					'b' => 'b'
+				]
+			]),
+			new TestField([
+				'name'  => 'b',
+				'value' => 'b',
+				'when'  => [
+					'a' => 'a'
+				]
+			]),
+		]);
+
+		$a = $fields->get('a');
+		$b = $fields->get('b');
+
+		$this->assertTrue($a->isSubmittable($language));
+		$this->assertTrue($b->isSubmittable($language));
+
+		$fields->submit([
+			'a' => 'a submitted',
+			'b' => 'b submitted'
+		]);
+
+		$this->assertSame([
+			'a' => 'a submitted',
+			'b' => 'b submitted'
+		], $fields->toFormValues());
 	}
 
 	/**


### PR DESCRIPTION
## Description

Our `$field->isSubmittable()` check was too strict and did not allow to submit inactive when query fields that could still contain data though. This could lead to data loss. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes

- Inactive fiels (due to non-matching when queries) can be submitted again https://github.com/getkirby/kirby/issues/7333 https://github.com/getkirby/kirby/issues/7370

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
