### PR TITLE
feat: `Kirby\Panel\Ui\Stat` backend component

### DIFF
--- a/config/sections/stats.php
+++ b/config/sections/stats.php
@@ -1,6 +1,7 @@
 <?php
 
-use Kirby\Toolkit\I18n;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Panel\Ui\Stat;
 
 return [
 	'mixins' => [
@@ -34,32 +35,20 @@ return [
 	],
 	'computed' => [
 		'reports' => function () {
-			$reports  = [];
-			$model    = $this->model();
-			$toString = fn ($value) => $value === null ? null : $model->toString($value);
+			$reports = [];
+			$model   = $this->model();
 
 			foreach ($this->reports as $report) {
-				if (is_string($report) === true) {
-					$report = $model->query($report);
-				}
-
-				if (is_array($report) === false) {
+				try {
+					$stat = Stat::from(
+						model: $model,
+						input: $report
+					);
+				} catch (InvalidArgumentException) {
 					continue;
 				}
 
-				$info  = $report['info'] ?? null;
-				$label = $report['label'] ?? null;
-				$link  = $report['link'] ?? null;
-				$value = $report['value'] ?? null;
-
-				$reports[] = [
-					'icon'  => $toString($report['icon'] ?? null),
-					'info'  => $toString(I18n::translate($info, $info)),
-					'label' => $toString(I18n::translate($label, $label)),
-					'link'  => $toString(I18n::translate($link, $link)),
-					'theme' => $toString($report['theme'] ?? null),
-					'value' => $toString(I18n::translate($value, $value))
-				];
+				$reports[] = $stat->props();
 			}
 
 			return $reports;

--- a/src/Panel/Ui/Stat.php
+++ b/src/Panel/Ui/Stat.php
@@ -69,27 +69,27 @@ class Stat extends Component
 
 	public function icon(): string|null
 	{
-		return $this->query($this->icon);
+		return $this->stringTemplate($this->icon);
 	}
 
 	public function info(): string|null
 	{
-		return $this->query(
-			$this->translate($this->info)
+		return $this->stringTemplate(
+			$this->i18n($this->info)
 		);
 	}
 
 	public function label(): string
 	{
-		return $this->query(
-			$this->translate($this->label)
+		return $this->stringTemplate(
+			$this->i18n($this->label)
 		);
 	}
 
 	public function link(): string|null
 	{
-		return $this->query(
-			$this->translate($this->link)
+		return $this->stringTemplate(
+			$this->i18n($this->link)
 		);
 	}
 
@@ -105,29 +105,29 @@ class Stat extends Component
 		];
 	}
 
-	protected function query(string|null $query): string|null
+	protected function stringTemplate(string|null $string = null): string|null
 	{
-		return $query === null ? null : $this->model->toString($query);
+		if ($string !== null) {
+			return $this->model->toString($string);
+		}
+
+		return null;
 	}
 
 	public function theme(): string|null
 	{
-		return $this->query($this->theme);
+		return $this->stringTemplate($this->theme);
 	}
 
-	protected function translate(array|string|null $prop): string|null
+	protected function i18n(string|array|null $param = null): string|null
 	{
-		if ($prop === null) {
-			return $prop;
-		}
-
-		return I18n::translate($prop, $prop);
+		return empty($param) === false ? I18n::translate($param, $param) : null;
 	}
 
 	public function value(): string
 	{
-		return $this->query(
-			$this->translate($this->value)
+		return $this->stringTemplate(
+			$this->i18n($this->value)
 		);
 	}
 }

--- a/src/Panel/Ui/Stat.php
+++ b/src/Panel/Ui/Stat.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+use Kirby\Cms\ModelWithContent;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Toolkit\I18n;
+
+/**
+ * @package   Kirby Panel
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ */
+class Stat extends Component
+{
+	public function __construct(
+		public ModelWithContent $model,
+		public string $component = 'k-stat',
+		public string|null $icon = null,
+		public array|string|null $info = null,
+		public array|string|null $label = null,
+		public array|string|null $link = null,
+		public string|null $theme = null,
+		public array|string|null $value = null,
+	) {
+	}
+
+	public static function from(
+		ModelWithContent $model,
+		array|string $input
+	): static {
+		if (is_string($input) === true) {
+			return static::fromQuery(
+				model: $model,
+				query: $input
+			);
+		}
+
+		return new static(...[
+			...$input,
+			'model' => $model
+		]);
+	}
+
+	public static function fromQuery(
+		ModelWithContent $model,
+		string $query
+	): static {
+		$stat = $model->query($query);
+
+		if (is_array($stat) === false) {
+			throw new InvalidArgumentException(
+				message: 'Invalid data from stat query. The query must return an array.'
+			);
+		}
+
+		return new static(...[
+			...$stat,
+			'model' => $model
+		]);
+	}
+
+	public function icon(): string|null
+	{
+		return $this->query($this->icon);
+	}
+
+	public function info(): string|null
+	{
+		return $this->query(
+			$this->translate($this->info)
+		);
+	}
+
+	public function label(): string|null
+	{
+		return $this->query(
+			$this->translate($this->label)
+		);
+	}
+
+	public function link(): string|null
+	{
+		return $this->query(
+			$this->translate($this->link)
+		);
+	}
+
+	public function props(): array
+	{
+		return [
+			'icon'  => $this->icon(),
+			'info'  => $this->info(),
+			'label' => $this->label(),
+			'link'  => $this->link(),
+			'theme' => $this->theme(),
+			'value' => $this->value(),
+		];
+	}
+
+	protected function query(string|null $query): string|null
+	{
+		return $query === null ? null : $this->model->toString($query);
+	}
+
+	public function theme(): string|null
+	{
+		return $this->query($this->theme);
+	}
+
+	protected function translate(array|string|null $prop): string|null
+	{
+		if ($prop === null) {
+			return $prop;
+		}
+
+		return I18n::translate($prop, $prop);
+	}
+
+	public function value(): string|null
+	{
+		return $this->query(
+			$this->translate($this->value)
+		);
+	}
+}

--- a/src/Panel/Ui/Stat.php
+++ b/src/Panel/Ui/Stat.php
@@ -29,40 +29,25 @@ class Stat extends Component
 	}
 
 	/**
- 	 * @psalm-suppress TooFewArguments
+	 * @psalm-suppress TooFewArguments
 	 */
 	public static function from(
 		ModelWithContent $model,
 		array|string $input
 	): static {
 		if (is_string($input) === true) {
-			return static::fromQuery(
-				model: $model,
-				query: $input
-			);
+			$input = $model->query($input);
+
+			if (is_array($input) === false) {
+				throw new InvalidArgumentException(
+					message: 'Invalid data from stat query. The query must return an array.'
+				);
+			}
 		}
 
 		$input['model'] = $model;
 
 		return new static(...$input);
-	}
-
-	public static function fromQuery(
-		ModelWithContent $model,
-		string $query
-	): static {
-		$stat = $model->query($query);
-
-		if (is_array($stat) === false) {
-			throw new InvalidArgumentException(
-				message: 'Invalid data from stat query. The query must return an array.'
-			);
-		}
-
-		return static::from(
-			model: $model,
-			input: $stat
-		);
 	}
 
 	public function icon(): string|null

--- a/src/Panel/Ui/Stat.php
+++ b/src/Panel/Ui/Stat.php
@@ -28,6 +28,9 @@ class Stat extends Component
 	) {
 	}
 
+	/**
+ 	 * @psalm-suppress TooFewArguments
+	 */
 	public static function from(
 		ModelWithContent $model,
 		array|string $input
@@ -39,12 +42,9 @@ class Stat extends Component
 			);
 		}
 
-		return new static(...[
-			...$input,
-			'model' => $model,
-			'label' => $input['label'],
-			'value' => $input['value'],
-		]);
+		$input['model'] = $model;
+
+		return new static(...$input);
 	}
 
 	public static function fromQuery(
@@ -59,12 +59,10 @@ class Stat extends Component
 			);
 		}
 
-		return new static(...[
-			...$stat,
-			'model' => $model,
-			'label' => $stat['label'],
-			'value' => $stat['value'],
-		]);
+		return static::from(
+			model: $model,
+			input: $stat
+		);
 	}
 
 	public function icon(): string|null

--- a/src/Panel/Ui/Stat.php
+++ b/src/Panel/Ui/Stat.php
@@ -18,13 +18,13 @@ class Stat extends Component
 {
 	public function __construct(
 		public ModelWithContent $model,
+		public array|string $label,
+		public array|string $value,
 		public string $component = 'k-stat',
 		public string|null $icon = null,
 		public array|string|null $info = null,
-		public array|string|null $label = null,
 		public array|string|null $link = null,
 		public string|null $theme = null,
-		public array|string|null $value = null,
 	) {
 	}
 
@@ -41,7 +41,9 @@ class Stat extends Component
 
 		return new static(...[
 			...$input,
-			'model' => $model
+			'model' => $model,
+			'label' => $input['label'],
+			'value' => $input['value'],
 		]);
 	}
 
@@ -59,7 +61,9 @@ class Stat extends Component
 
 		return new static(...[
 			...$stat,
-			'model' => $model
+			'model' => $model,
+			'label' => $stat['label'],
+			'value' => $stat['value'],
 		]);
 	}
 
@@ -75,7 +79,7 @@ class Stat extends Component
 		);
 	}
 
-	public function label(): string|null
+	public function label(): string
 	{
 		return $this->query(
 			$this->translate($this->label)
@@ -120,7 +124,7 @@ class Stat extends Component
 		return I18n::translate($prop, $prop);
 	}
 
-	public function value(): string|null
+	public function value(): string
 	{
 		return $this->query(
 			$this->translate($this->value)

--- a/tests/Panel/Ui/StatTest.php
+++ b/tests/Panel/Ui/StatTest.php
@@ -25,6 +25,8 @@ class StatTest extends TestCase
 	): void {
 		$stat = new Stat(
 			...[
+				'label' => 'Test Label',
+				'value' => 'Test Value',
 				'model' => $this->model,
 				$prop => 'Test'
 			]
@@ -33,7 +35,11 @@ class StatTest extends TestCase
 		$this->assertSame('Test', $stat->$prop());
 
 		if ($nullable === true) {
-			$stat = new Stat(model: $this->model);
+			$stat = new Stat(
+				model: $this->model,
+				label: 'Test Label',
+				value: 'Test Value',
+			);
 			$this->assertNull($stat->$prop());
 		}
 
@@ -41,6 +47,8 @@ class StatTest extends TestCase
 			$stat = new Stat(
 				...[
 					'model' => $this->model,
+					'label' => 'Test Label',
+					'value' => 'Test Value',
 					$prop => [
 						'en' => 'Test'
 					]
@@ -54,6 +62,8 @@ class StatTest extends TestCase
 			$stat = new Stat(
 				...[
 					'model' => $this->model,
+					'label' => 'Test Label',
+					'value' => 'Test Value',
 					$prop => '{{ page.slug }}'
 				]
 			);
@@ -64,10 +74,20 @@ class StatTest extends TestCase
 
 	public function testComponent(): void
 	{
-		$stat = new Stat(model: $this->model);
+		$stat = new Stat(
+			model: $this->model,
+			label: 'Test Label',
+			value: 'Test Value'
+		);
 		$this->assertSame('k-stat', $stat->component());
 
-		$stat = new Stat(model: $this->model, component: 'k-stat-test');
+		$stat = new Stat(
+			model: $this->model,
+			label: 'Test Label',
+			value: 'Test Value',
+			component: 'k-stat-test'
+		);
+
 		$this->assertSame('k-stat-test', $stat->component());
 	}
 
@@ -95,7 +115,7 @@ class StatTest extends TestCase
 	{
 		$this->assertProp(
 			prop: 'label',
-			nullable: true,
+			nullable: false,
 			translatable: true,
 			queryable: true
 		);
@@ -125,9 +145,9 @@ class StatTest extends TestCase
 	{
 		$this->assertProp(
 			prop: 'value',
-			nullable: true,
+			nullable: false,
 			translatable: true,
-			queryable: true
+			queryable: true,
 		);
 	}
 }

--- a/tests/Panel/Ui/StatTest.php
+++ b/tests/Panel/Ui/StatTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Page;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Stat::class)]
+class StatTest extends TestCase
+{
+	protected ModelWithContent $model;
+
+	public function setUp(): void
+	{
+		$this->model = new Page(['slug' => 'test']);
+	}
+
+	public function assertProp(
+		string $prop,
+		bool $translatable = true,
+		bool $queryable = true,
+		bool $nullable = true
+	): void {
+		$stat = new Stat(
+			...[
+				'model' => $this->model,
+				$prop => 'Test'
+			]
+		);
+
+		$this->assertSame('Test', $stat->$prop());
+
+		if ($nullable === true) {
+			$stat = new Stat(model: $this->model);
+			$this->assertNull($stat->$prop());
+		}
+
+		if ($translatable === true) {
+			$stat = new Stat(
+				...[
+					'model' => $this->model,
+					$prop => [
+						'en' => 'Test'
+					]
+				]
+			);
+
+			$this->assertSame('Test', $stat->$prop());
+		}
+
+		if ($queryable === true) {
+			$stat = new Stat(
+				...[
+					'model' => $this->model,
+					$prop => '{{ page.slug }}'
+				]
+			);
+
+			$this->assertSame('test', $stat->$prop());
+		}
+	}
+
+	public function testComponent(): void
+	{
+		$stat = new Stat(model: $this->model);
+		$this->assertSame('k-stat', $stat->component());
+
+		$stat = new Stat(model: $this->model, component: 'k-stat-test');
+		$this->assertSame('k-stat-test', $stat->component());
+	}
+
+	public function testIcon(): void
+	{
+		$this->assertProp(
+			prop: 'icon',
+			nullable: true,
+			translatable: false,
+			queryable: true
+		);
+	}
+
+	public function testInfo(): void
+	{
+		$this->assertProp(
+			prop: 'info',
+			nullable: true,
+			translatable: true,
+			queryable: true
+		);
+	}
+
+	public function testLabel(): void
+	{
+		$this->assertProp(
+			prop: 'label',
+			nullable: true,
+			translatable: true,
+			queryable: true
+		);
+	}
+
+	public function testLink(): void
+	{
+		$this->assertProp(
+			prop: 'link',
+			nullable: true,
+			translatable: true,
+			queryable: true
+		);
+	}
+
+	public function testTheme(): void
+	{
+		$this->assertProp(
+			prop: 'theme',
+			nullable: true,
+			translatable: false,
+			queryable: true
+		);
+	}
+
+	public function testValue(): void
+	{
+		$this->assertProp(
+			prop: 'value',
+			nullable: true,
+			translatable: true,
+			queryable: true
+		);
+	}
+}


### PR DESCRIPTION
## Description

The new class is used in the stats section to clean up the code and can later be used in our new stats field as well to simplify migration between sections and fields. 

This is a first PR in a series of steps to get rid of sections. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New `Kirby\Panel\Ui\Stat` backend component, which is used to create the correct information for the `<k-stat>` Vue component. 
### Refactoring

- The `stats` field uses the new `Kirby\Panel\Ui\Stat` class to clean up the props generation for the frontend.

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
