### PR TITLE
feat: New `buttons` prop for the `<k-field>` component

### DIFF
--- a/panel/lab/components/field/index.vue
+++ b/panel/lab/components/field/index.vue
@@ -7,40 +7,49 @@
 		</k-lab-example>
 		<k-lab-example label="Required">
 			<k-field input="b" :required="true" label="Label">
-				<k-input :value="value" id="b" type="text" @input="value = $event" />
+				<k-input id="b" :value="value" type="text" @input="value = $event" />
+			</k-field>
+		</k-lab-example>
+		<k-lab-example label="Buttons">
+			<k-field
+				input="c"
+				:buttons="[{ icon: 'add', text: 'Add' }]"
+				label="Label"
+			>
+				<k-input id="c" :value="value" type="text" @input="value = $event" />
 			</k-field>
 		</k-lab-example>
 		<k-lab-example label="Counter">
 			<k-field
 				:counter="{ min: 5, max: 10, count: value?.length }"
-				input="c"
+				input="d"
 				label="Label"
 			>
-				<k-input :value="value" id="c" type="text" @input="value = $event" />
+				<k-input id="d" :value="value" type="text" @input="value = $event" />
 			</k-field>
 		</k-lab-example>
 		<k-lab-example label="Options Slot">
-			<k-field input="d" label="Label">
+			<k-field input="e" label="Label">
 				<k-button icon="add" size="xs" slot="options" variant="filled">
 					Add
 				</k-button>
-				<k-input :value="value" id="d" type="text" @input="value = $event" />
+				<k-input id="e" :value="value" type="text" @input="value = $event" />
 			</k-field>
 		</k-lab-example>
 		<k-lab-example label="Options Slot & excessive label">
 			<k-field
-				input="d"
+				input="f"
 				label="This is a very very long label that could push the options aside and break stuff"
 			>
 				<k-button icon="add" size="xs" slot="options" variant="filled">
 					Add
 				</k-button>
-				<k-input :value="value" id="d" type="text" @input="value = $event" />
+				<k-input id="f" :value="value" type="text" @input="value = $event" />
 			</k-field>
 		</k-lab-example>
 		<k-lab-example label="Help">
-			<k-field input="e" help="This is some help" label="Label">
-				<k-input :value="value" id="e" type="text" @input="value = $event" />
+			<k-field input="g" help="This is some help" label="Label">
+				<k-input id="g" :value="value" type="text" @input="value = $event" />
 			</k-field>
 		</k-lab-example>
 	</k-lab-examples>

--- a/panel/src/components/Forms/Field.vue
+++ b/panel/src/components/Forms/Field.vue
@@ -27,7 +27,15 @@
 						{{ label }}
 					</k-label>
 				</slot>
-				<slot name="options" />
+				<slot name="options">
+					<k-button-group
+						v-if="buttons"
+						:buttons="buttons"
+						size="xs"
+						variant="filled"
+						class="k-field-buttons"
+					/>
+				</slot>
 				<slot name="counter">
 					<k-counter
 						v-if="counter"
@@ -55,6 +63,7 @@ import { disabled, help, id, label, name, required } from "@/mixins/props.js";
 export const props = {
 	mixins: [disabled, help, id, label, name, required],
 	props: {
+		buttons: Array,
 		counter: [Boolean, Object],
 		endpoints: Object,
 		input: [String, Number],
@@ -89,6 +98,9 @@ export default {
 	margin-bottom: var(--spacing-2);
 }
 .k-field-options {
+	flex-shrink: 0;
+}
+.k-field-buttons {
 	flex-shrink: 0;
 }
 .k-field-counter {


### PR DESCRIPTION
## Description

This is part of the series of PRs to get rid of sections, but can be merged independently of the rest. It will bring `<k-field>` and `<k-section>` closer together, by introducing a new `buttons` prop for the field component, which the section component already had for quite some time. 


## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements

- New `buttons` prop for the `<k-field>` component

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
