### PR TITLE
refact: Move empty reports handling into `<k-stats>` component

### DIFF
--- a/panel/lab/components/stats/1_stats/index.vue
+++ b/panel/lab/components/stats/1_stats/index.vue
@@ -6,6 +6,9 @@
 		<k-lab-example label="themes">
 			<k-stats :reports="reports" />
 		</k-lab-example>
+		<k-lab-example label="empty">
+			<k-stats :reports="[]" />
+		</k-lab-example>
 	</k-lab-examples>
 </template>
 

--- a/panel/src/components/Layout/Stats.vue
+++ b/panel/src/components/Layout/Stats.vue
@@ -1,7 +1,8 @@
 <template>
-	<dl class="k-stats" :data-size="size">
+	<dl v-if="reports.length > 0" class="k-stats" :data-size="size">
 		<k-stat v-for="(report, id) in reports" :key="id" v-bind="report" />
 	</dl>
+	<k-empty v-else icon="chart">{{ $t("stats.empty") }}</k-empty>
 </template>
 
 <script>
@@ -26,30 +27,6 @@ export default {
 		size: {
 			type: String,
 			default: "large"
-		}
-	},
-	methods: {
-		component(report) {
-			if (this.target(report) !== null) {
-				return "k-link";
-			}
-
-			return "div";
-		},
-		target(report) {
-			if (report.link) {
-				return report.link;
-			}
-
-			if (report.click) {
-				return report.click;
-			}
-
-			if (report.dialog) {
-				return () => this.$dialog(report.dialog);
-			}
-
-			return null;
 		}
 	}
 };

--- a/panel/src/components/Layout/Stats.vue
+++ b/panel/src/components/Layout/Stats.vue
@@ -6,12 +6,7 @@
 </template>
 
 <script>
-/**
- * Grid of reports which can be used to display multiple stats in a row  (e.g. as dashboard for a shop, analytics, etc.)
- *
- * @example <k-stats :reports="[{ value: 50, label: 'days' }, { value: 10, label: 'hours'}]" />
- */
-export default {
+export const props = {
 	props: {
 		/**
 		 * List of stat reports. See `k-stat` for all options of each report.
@@ -29,6 +24,15 @@ export default {
 			default: "large"
 		}
 	}
+};
+
+/**
+ * Grid of reports which can be used to display multiple stats in a row  (e.g. as dashboard for a shop, analytics, etc.)
+ *
+ * @example <k-stats :reports="[{ value: 50, label: 'days' }, { value: 10, label: 'hours'}]" />
+ */
+export default {
+	mixins: [props]
 };
 </script>
 

--- a/panel/src/components/Sections/StatsSection.vue
+++ b/panel/src/components/Sections/StatsSection.vue
@@ -4,8 +4,7 @@
 		:headline="headline"
 		class="k-stats-section"
 	>
-		<k-stats v-if="reports.length > 0" :reports="reports" :size="size" />
-		<k-empty v-else icon="chart"> {{ $t("stats.empty") }}</k-empty>
+		<k-stats :reports="reports" :size="size" />
 	</k-section>
 </template>
 


### PR DESCRIPTION
## Description

This is part of the series of PRs to get rid of sections, but can be merged independently of the rest. It will move empty reports handling into the `<k-stats>` component to minimize the logic parts in the `<k-stats-section>`. It also removes some unused left-over code from `<k-stats>`

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Refactoring

- Remove unused methods from `<k-stats>`
- Move empty reports handling from `<k-stats-section>` to `<k-stats>`
- Export props from `<k-stats>`

### Breaking changes

None

## Ready?
<!--
If you can help to check off the following tasks, that'd be great.
If not, don't worry - we will take care of it.
-->

- [x] In-code documentation (wherever needed)
- [x] Unit tests for fixed bug/feature
- [x] Tests and CI checks all pass

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
