### PR TITLE
feat: Backend classes for dialogs and drawers

### DIFF
--- a/config/areas/site/requests.php
+++ b/config/areas/site/requests.php
@@ -1,13 +1,13 @@
 <?php
 
 use Kirby\Cms\App;
-use Kirby\Panel\Controller\PageTree;
+use Kirby\Panel\Controller\PageTreeController;
 
 return [
 	'tree' => [
 		'pattern' => 'site/tree',
 		'action'  => function () {
-			return (new PageTree())->children(
+			return (new PageTreeController())->children(
 				parent: App::instance()->request()->get('parent'),
 				moving: App::instance()->request()->get('move')
 			);
@@ -16,7 +16,7 @@ return [
 	'tree.parents' => [
 		'pattern' => 'site/tree/parents',
 		'action'  => function () {
-			return (new PageTree())->parents(
+			return (new PageTreeController())->parents(
 				page: App::instance()->request()->get('page'),
 				includeSite: App::instance()->request()->get('root') === 'true',
 			);

--- a/config/areas/site/searches.php
+++ b/config/areas/site/searches.php
@@ -1,17 +1,17 @@
 <?php
 
-use Kirby\Panel\Controller\Search;
+use Kirby\Panel\Controller\SearchController;
 use Kirby\Toolkit\I18n;
 
 return [
 	'pages' => [
 		'label' => I18n::translate('pages'),
 		'icon'  => 'page',
-		'query' => fn (string|null $query, int $limit, int $page) => Search::pages($query, $limit, $page)
+		'query' => fn (string|null $query, int $limit, int $page) => SearchController::pages($query, $limit, $page)
 	],
 	'files' => [
 		'label' => I18n::translate('files'),
 		'icon'  => 'image',
-		'query' => fn (string|null $query, int $limit, int $page) => Search::files($query, $limit, $page)
+		'query' => fn (string|null $query, int $limit, int $page) => SearchController::files($query, $limit, $page)
 	]
 ];

--- a/config/areas/users/searches.php
+++ b/config/areas/users/searches.php
@@ -1,12 +1,12 @@
 <?php
 
-use Kirby\Panel\Controller\Search;
+use Kirby\Panel\Controller\SearchController;
 use Kirby\Toolkit\I18n;
 
 return [
 	'users' => [
 		'label' => I18n::translate('users'),
 		'icon'  => 'users',
-		'query' => fn (string|null $query, int $limit, int $page) => Search::users($query, $limit, $page)
+		'query' => fn (string|null $query, int $limit, int $page) => SearchController::users($query, $limit, $page)
 	]
 ];

--- a/src/Panel/Controller/Dialog.php
+++ b/src/Panel/Controller/Dialog.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Kirby\Panel\Controller;
+
+use Kirby\Cms\App;
+use Kirby\Http\Request;
+
+/**
+ * @package   Kirby Panel
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ * @unstable
+ *
+ * @codeCoverageIgnore
+ */
+abstract class Dialog
+{
+	protected App $kirby;
+	protected Request $request;
+
+	public function __construct()
+	{
+		$this->kirby   = App::instance();
+		$this->request = $this->kirby->request();
+	}
+
+	abstract public function load(): array;
+
+	/**
+	 * Submit successfully by default to allow for submit-less dialogs
+	 */
+	public function submit()
+	{
+		return true;
+	}
+}

--- a/src/Panel/Controller/DialogController.php
+++ b/src/Panel/Controller/DialogController.php
@@ -16,7 +16,7 @@ use Kirby\Http\Request;
  *
  * @codeCoverageIgnore
  */
-abstract class Dialog
+abstract class DialogController
 {
 	protected App $kirby;
 	protected Request $request;

--- a/src/Panel/Controller/Drawer.php
+++ b/src/Panel/Controller/Drawer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kirby\Panel\Controller;
+
+/**
+ * @package   Kirby Panel
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ * @unstable
+ *
+ * @codeCoverageIgnore
+ */
+abstract class Drawer extends Dialog
+{
+}

--- a/src/Panel/Controller/DrawerController.php
+++ b/src/Panel/Controller/DrawerController.php
@@ -13,6 +13,6 @@ namespace Kirby\Panel\Controller;
  *
  * @codeCoverageIgnore
  */
-abstract class Drawer extends Dialog
+abstract class DrawerController extends DialogController
 {
 }

--- a/src/Panel/Controller/PageTreeController.php
+++ b/src/Panel/Controller/PageTreeController.php
@@ -9,7 +9,7 @@ use Kirby\Cms\Site;
 use Kirby\Toolkit\I18n;
 
 /**
- * The PageTree controller takes care of the request logic
+ * The PageTreeController takes care of the request logic
  * for the `k-page-tree` component and similar
  *
  * @package   Kirby Panel
@@ -18,7 +18,7 @@ use Kirby\Toolkit\I18n;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  */
-class PageTree
+class PageTreeController
 {
 	protected Site $site;
 

--- a/src/Panel/Controller/SearchController.php
+++ b/src/Panel/Controller/SearchController.php
@@ -6,7 +6,7 @@ use Kirby\Cms\App;
 use Kirby\Toolkit\Escape;
 
 /**
- * The Search controller takes care of the logic
+ * The SearchController takes care of the logic
  * for delivering Panel search results
  *
  * @package   Kirby Panel
@@ -16,7 +16,7 @@ use Kirby\Toolkit\Escape;
  * @license   https://getkirby.com/license
  * @unstable
  */
-class Search
+class SearchController
 {
 	public static function files(
 		string|null $query = null,

--- a/src/Panel/Ui/Dialog.php
+++ b/src/Panel/Ui/Dialog.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+/**
+ * @package   Kirby Panel
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ * @unstable
+ */
+class Dialog extends Component
+{
+	public function __construct(
+		string $component = 'k-dialog',
+		public string|array|bool|null $cancelButton = null,
+		string|null $class = null,
+		public string|null $size = null,
+		string|null $style = null,
+		public string|array|bool|null $submitButton = null,
+		...$attrs
+	) {
+		parent::__construct(...[
+			...$attrs,
+			'component' => $component,
+			'class'     => $class,
+			'style'     => $style
+		]);
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'cancelButton' => $this->cancelButton,
+			'size'         => $this->size,
+			'submitButton' => $this->submitButton,
+		];
+	}
+}

--- a/src/Panel/Ui/Dialogs/ErrorDialog.php
+++ b/src/Panel/Ui/Dialogs/ErrorDialog.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Kirby\Panel\Ui\Dialogs;
+
+use Kirby\Panel\Ui\Dialog;
+
+/**
+ * Dialog to display an error message
+ * and related details
+ *
+ * @package   Kirby Panel
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ * @unstable
+ */
+class ErrorDialog extends Dialog
+{
+	public function __construct(
+		string|null $component = 'k-error-dialog',
+		public array|null $details = null,
+		public string|null $message = null,
+		string|null $size = 'medium'
+	) {
+		parent::__construct(
+			component: $component,
+			cancelButton: false,
+			size: $size,
+			submitButton: false
+		);
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'details' => $this->details,
+			'message' => $this->message
+		];
+	}
+}

--- a/src/Panel/Ui/Dialogs/FormDialog.php
+++ b/src/Panel/Ui/Dialogs/FormDialog.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Kirby\Panel\Ui\Dialogs;
+
+use Kirby\Panel\Ui\Dialog;
+
+/**
+ * Dialog that contains a set of fields
+ *
+ * @package   Kirby Panel
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ * @unstable
+ */
+class FormDialog extends Dialog
+{
+	public function __construct(
+		string|null $component = 'k-form-dialog',
+		string|array|bool|null $cancelButton = null,
+		public array $fields = [],
+		string|null $size = 'medium',
+		string|array|bool|null $submitButton = null,
+		public string|null $text = null,
+		public array $value = []
+	) {
+		parent::__construct(
+			component: $component,
+			cancelButton: $cancelButton,
+			size: $size,
+			submitButton: $submitButton
+		);
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'fields' => $this->fields,
+			'text'   => $this->text,
+			'value'  => $this->value
+		];
+	}
+}

--- a/src/Panel/Ui/Dialogs/RemoveDialog.php
+++ b/src/Panel/Ui/Dialogs/RemoveDialog.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Kirby\Panel\Ui\Dialogs;
+
+/**
+ * Dialog that removes something
+ *
+ * @package   Kirby Panel
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ * @unstable
+ */
+class RemoveDialog extends TextDialog
+{
+	public function __construct(
+		string|null $component = 'k-remove-dialog',
+		string|array|bool|null $cancelButton = null,
+		string|null $size = 'medium',
+		string|array|bool|null $submitButton = null,
+		public string|null $text = null
+	) {
+		parent::__construct(
+			component: $component,
+			cancelButton: $cancelButton,
+			size: $size,
+			submitButton: $submitButton ?? [
+				'icon'  => 'trash',
+				'theme' => 'negative'
+			],
+			text: $text
+		);
+	}
+}

--- a/src/Panel/Ui/Dialogs/TextDialog.php
+++ b/src/Panel/Ui/Dialogs/TextDialog.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Kirby\Panel\Ui\Dialogs;
+
+use Kirby\Panel\Ui\Dialog;
+
+/**
+ * Dialog that displays some text
+ *
+ * @package   Kirby Panel
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ * @unstable
+ */
+class TextDialog extends Dialog
+{
+	public function __construct(
+		string|null $component = 'k-text-dialog',
+		string|array|bool|null $cancelButton = null,
+		string|null $size = 'medium',
+		string|array|bool|null $submitButton = null,
+		public string|null $text = null
+	) {
+		parent::__construct(
+			component: $component,
+			cancelButton: $cancelButton,
+			size: $size,
+			submitButton: $submitButton
+		);
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'text' => $this->text
+		];
+	}
+}

--- a/src/Panel/Ui/Drawer.php
+++ b/src/Panel/Ui/Drawer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+/**
+ * @package   Kirby Panel
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ * @unstable
+ */
+class Drawer extends Component
+{
+	public function __construct(
+		string $component = 'k-drawer',
+		string|null $class = null,
+		public bool $disabled = false,
+		public string|null $icon = null,
+		public array|null $options = null,
+		string|null $style = null,
+		public string|null $title = null,
+		...$attrs
+	) {
+		parent::__construct(...[
+			...$attrs,
+			'component' => $component,
+			'class'     => $class,
+			'style'     => $style
+		]);
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'disabled' => $this->disabled,
+			'icon'     => $this->icon,
+			'options'  => $this->options,
+			'title'    => $this->title,
+		];
+	}
+}

--- a/src/Panel/Ui/Drawers/TextDrawer.php
+++ b/src/Panel/Ui/Drawers/TextDrawer.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Kirby\Panel\Ui\Drawers;
+
+use Kirby\Panel\Ui\Drawer;
+
+/**
+ * Drawer that displays some text
+ *
+ * @package   Kirby Panel
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ * @unstable
+ */
+class TextDrawer extends Drawer
+{
+	public function __construct(
+		string|null $class = null,
+		bool $disabled = false,
+		string|null $icon = null,
+		array|null $options = null,
+		public string|null $text = null,
+		string|null $style = null,
+		string|null $title = null,
+	) {
+		parent::__construct(
+			component: 'k-text-drawer',
+			class: $class,
+			disabled: $disabled,
+			icon: $icon,
+			options: $options,
+			style: $style,
+			title: $title,
+		);
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'text' => $this->text
+		];
+	}
+}

--- a/tests/Panel/Controller/PageTreeControllerTest.php
+++ b/tests/Panel/Controller/PageTreeControllerTest.php
@@ -6,11 +6,11 @@ use Kirby\Cms\App;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
-#[CoversClass(PageTree::class)]
-class PageTreeTest extends TestCase
+#[CoversClass(PageTreeController::class)]
+class PageTreeControllerTest extends TestCase
 {
-	public const TMP = KIRBY_TMP_DIR . '/Panel.Controller.PageTree';
-	public PageTree $tree;
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Controller.PageTreeController';
+	public PageTreeController $tree;
 
 	public function setUp(): void
 	{
@@ -67,7 +67,7 @@ class PageTreeTest extends TestCase
 		]);
 
 		$this->app->impersonate('kirby');
-		$this->tree = new PageTree($this->app->site());
+		$this->tree = new PageTreeController($this->app->site());
 	}
 
 	public function tearDown(): void

--- a/tests/Panel/Controller/SearchControllerTest.php
+++ b/tests/Panel/Controller/SearchControllerTest.php
@@ -6,10 +6,10 @@ use Kirby\Cms\App;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
-#[CoversClass(Search::class)]
-class SearchTest extends TestCase
+#[CoversClass(SearchController::class)]
+class SearchControllerTest extends TestCase
 {
-	public const TMP = KIRBY_TMP_DIR . '/Panel.Controller.Search';
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Controller.SearchController';
 
 	public function setUp(): void
 	{
@@ -62,7 +62,7 @@ class SearchTest extends TestCase
 
 	public function testFiles(): void
 	{
-		$result = Search::files('fish');
+		$result = SearchController::files('fish');
 
 		$this->assertCount(5, $result['results']);
 		$this->assertArrayHasKey('image', $result['results'][0]);
@@ -79,7 +79,7 @@ class SearchTest extends TestCase
 		$this->assertNull($result['pagination']);
 
 		// without query
-		$result = Search::files();
+		$result = SearchController::files();
 		$this->assertCount(0, $result['results']);
 	}
 
@@ -125,14 +125,14 @@ class SearchTest extends TestCase
 		]);
 
 		$this->app->impersonate('homer@simpson.com');
-		$result = Search::files('fish');
+		$result = SearchController::files('fish');
 		$this->assertCount(1, $result['results']);
 		$this->assertEqualsCanonicalizing([
 			'blue-fish.jpg'
 		], array_column($result['results'], 'text'));
 
 		$this->app->impersonate('kirby');
-		$result = Search::files('fish');
+		$result = SearchController::files('fish');
 		$this->assertCount(2, $result['results']);
 		$this->assertEqualsCanonicalizing([
 			'blue-fish.jpg',
@@ -142,7 +142,7 @@ class SearchTest extends TestCase
 
 	public function testFilesPaginated(): void
 	{
-		$result = Search::files('fish', limit: 1);
+		$result = SearchController::files('fish', limit: 1);
 		$this->assertCount(1, $result['results']);
 		$this->assertSame(1, $result['pagination']['page']);
 		$this->assertSame(5, $result['pagination']['pages']);
@@ -150,7 +150,7 @@ class SearchTest extends TestCase
 		$this->assertSame(1, $result['pagination']['limit']);
 		$this->assertSame(5, $result['pagination']['total']);
 
-		$result = Search::files('fish', limit: 1, page: 2);
+		$result = SearchController::files('fish', limit: 1, page: 2);
 		$this->assertCount(1, $result['results']);
 		$this->assertSame(2, $result['pagination']['page']);
 		$this->assertSame(5, $result['pagination']['pages']);
@@ -161,7 +161,7 @@ class SearchTest extends TestCase
 
 	public function testPages(): void
 	{
-		$result = Search::pages('beautiful');
+		$result = SearchController::pages('beautiful');
 
 		$this->assertCount(3, $result['results']);
 		$this->assertArrayHasKey('image', $result['results'][0]);
@@ -176,7 +176,7 @@ class SearchTest extends TestCase
 		$this->assertNull($result['pagination']);
 
 		// without query
-		$result = Search::pages();
+		$result = SearchController::pages();
 		$this->assertCount(0, $result['results']);
 	}
 
@@ -225,14 +225,14 @@ class SearchTest extends TestCase
 		]);
 
 		$this->app->impersonate('homer@simpson.com');
-		$result = Search::pages('friend');
+		$result = SearchController::pages('friend');
 		$this->assertCount(1, $result['results']);
 		$this->assertEqualsCanonicalizing([
 			'A friend'
 		], array_column($result['results'], 'text'));
 
 		$this->app->impersonate('kirby');
-		$result = Search::pages('friend');
+		$result = SearchController::pages('friend');
 		$this->assertCount(2, $result['results']);
 		$this->assertEqualsCanonicalizing([
 			'A friend',
@@ -242,7 +242,7 @@ class SearchTest extends TestCase
 
 	public function testPagesPaginated(): void
 	{
-		$result = Search::pages('beautiful', limit: 1);
+		$result = SearchController::pages('beautiful', limit: 1);
 		$this->assertCount(1, $result['results']);
 		$this->assertSame(1, $result['pagination']['page']);
 		$this->assertSame(3, $result['pagination']['pages']);
@@ -250,7 +250,7 @@ class SearchTest extends TestCase
 		$this->assertSame(1, $result['pagination']['limit']);
 		$this->assertSame(3, $result['pagination']['total']);
 
-		$result = Search::pages('beautiful', limit: 1, page: 2);
+		$result = SearchController::pages('beautiful', limit: 1, page: 2);
 		$this->assertCount(1, $result['results']);
 		$this->assertSame(2, $result['pagination']['page']);
 		$this->assertSame(3, $result['pagination']['pages']);
@@ -261,7 +261,7 @@ class SearchTest extends TestCase
 
 	public function testUsers(): void
 	{
-		$result = Search::users('simpson');
+		$result = SearchController::users('simpson');
 
 		$this->assertCount(2, $result['results']);
 		$this->assertArrayHasKey('image', $result['results'][0]);
@@ -275,13 +275,13 @@ class SearchTest extends TestCase
 		$this->assertNull($result['pagination']);
 
 		// without query
-		$result = Search::users();
+		$result = SearchController::users();
 		$this->assertCount(0, $result['results']);
 	}
 
 	public function testUsersPaginated(): void
 	{
-		$result = Search::users('simpson', limit: 1);
+		$result = SearchController::users('simpson', limit: 1);
 		$this->assertCount(1, $result['results']);
 		$this->assertSame(1, $result['pagination']['page']);
 		$this->assertSame(2, $result['pagination']['pages']);
@@ -289,7 +289,7 @@ class SearchTest extends TestCase
 		$this->assertSame(1, $result['pagination']['limit']);
 		$this->assertSame(2, $result['pagination']['total']);
 
-		$result = Search::users('simpson', limit: 1, page: 2);
+		$result = SearchController::users('simpson', limit: 1, page: 2);
 		$this->assertCount(1, $result['results']);
 		$this->assertSame(2, $result['pagination']['page']);
 		$this->assertSame(2, $result['pagination']['pages']);

--- a/tests/Panel/Ui/DialogTest.php
+++ b/tests/Panel/Ui/DialogTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Dialog::class)]
+class DialogTest extends TestCase
+{
+	public function testProps(): void
+	{
+		$dialog = new Dialog(
+			class:        'k-my-dialog',
+			size:         'large',
+			submitButton: 'Confirm'
+		);
+
+		$this->assertSame([
+			'class'        => 'k-my-dialog',
+			'style'        => null,
+			'cancelButton' => null,
+			'size'         => 'large',
+			'submitButton' => 'Confirm'
+		], $dialog->props());
+	}
+
+	public function testRender(): void
+	{
+		$dialog = new Dialog(
+			component: 'k-test',
+		);
+
+		$result = $dialog->render();
+		$this->assertSame('k-test', $result['component']);
+	}
+}

--- a/tests/Panel/Ui/Dialogs/ErrorDialogTest.php
+++ b/tests/Panel/Ui/Dialogs/ErrorDialogTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Kirby\Panel\Ui\Dialogs;
+
+use Kirby\Panel\Ui\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(ErrorDialog::class)]
+class ErrorDialogTest extends TestCase
+{
+	public function testProps(): void
+	{
+		$dialog = new ErrorDialog(
+			message: 'A little error',
+			details: ['file' => 'foo.php']
+		);
+
+		$this->assertSame([
+			'class'        => null,
+			'style'        => null,
+			'cancelButton' => false,
+			'size'         => 'medium',
+			'submitButton' => false,
+			'details'      => ['file' => 'foo.php'],
+			'message'      => 'A little error',
+		], $dialog->props());
+	}
+
+	public function testRender(): void
+	{
+		$dialog = new ErrorDialog(
+			message: 'A little error',
+		);
+
+		$result = $dialog->render();
+		$this->assertSame('k-error-dialog', $result['component']);
+	}
+}

--- a/tests/Panel/Ui/Dialogs/FormDialogTest.php
+++ b/tests/Panel/Ui/Dialogs/FormDialogTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Kirby\Panel\Ui\Dialogs;
+
+use Kirby\Panel\Ui\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(FormDialog::class)]
+class FormDialogTest extends TestCase
+{
+	public function testProps(): void
+	{
+		$dialog = new FormDialog(
+			fields: $fields = [
+				'a' => [
+					'type' => 'text'
+				]
+			],
+			value: $value = [
+				'a' => 'foo'
+			]
+		);
+
+		$this->assertSame([
+			'class'        => null,
+			'style'        => null,
+			'cancelButton' => null,
+			'size'         => 'medium',
+			'submitButton' => null,
+			'fields'       => $fields,
+			'text'         => null,
+			'value'        => $value
+		], $dialog->props());
+	}
+
+	public function testRender(): void
+	{
+		$dialog = new FormDialog();
+		$result = $dialog->render();
+		$this->assertSame('k-form-dialog', $result['component']);
+	}
+}

--- a/tests/Panel/Ui/Dialogs/RemoveDialogTest.php
+++ b/tests/Panel/Ui/Dialogs/RemoveDialogTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Kirby\Panel\Ui\Dialogs;
+
+use Kirby\Panel\Ui\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(RemoveDialog::class)]
+class RemoveDialogTest extends TestCase
+{
+	public function testProps(): void
+	{
+		$dialog = new RemoveDialog(
+			text: 'A little text'
+		);
+
+		$this->assertSame([
+			'class'        => null,
+			'style'        => null,
+			'cancelButton' => null,
+			'size'         => 'medium',
+			'submitButton' => [
+				'icon'  => 'trash',
+				'theme' => 'negative'
+			],
+			'text'         => 'A little text',
+		], $dialog->props());
+	}
+
+	public function testRender(): void
+	{
+		$dialog = new RemoveDialog();
+		$result = $dialog->render();
+		$this->assertSame('k-remove-dialog', $result['component']);
+	}
+}

--- a/tests/Panel/Ui/Dialogs/TextDialogTest.php
+++ b/tests/Panel/Ui/Dialogs/TextDialogTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Kirby\Panel\Ui\Dialogs;
+
+use Kirby\Panel\Ui\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(TextDialog::class)]
+class TextDialogTest extends TestCase
+{
+	public function testProps(): void
+	{
+		$dialog = new TextDialog(
+			text: 'A little text'
+		);
+
+		$this->assertSame([
+			'class'        => null,
+			'style'        => null,
+			'cancelButton' => null,
+			'size'         => 'medium',
+			'submitButton' => null,
+			'text'         => 'A little text',
+		], $dialog->props());
+	}
+
+	public function testRender(): void
+	{
+		$dialog = new TextDialog();
+		$result = $dialog->render();
+		$this->assertSame('k-text-dialog', $result['component']);
+	}
+}

--- a/tests/Panel/Ui/DrawerTest.php
+++ b/tests/Panel/Ui/DrawerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Drawer::class)]
+class DrawerTest extends TestCase
+{
+	public function testProps(): void
+	{
+		$drawer = new Drawer(
+			class: 'k-my-drawer',
+			title: 'My Drawer'
+		);
+
+		$this->assertSame([
+			'class'    => 'k-my-drawer',
+			'style'    => null,
+			'disabled' => false,
+			'icon'     => null,
+			'options'  => null,
+			'title'    => 'My Drawer'
+		], $drawer->props());
+	}
+
+	public function testRender(): void
+	{
+		$drawer = new Drawer(
+			component: 'k-test',
+		);
+
+		$result = $drawer->render();
+		$this->assertSame('k-test', $result['component']);
+	}
+}

--- a/tests/Panel/Ui/Drawers/TextDrawerTest.php
+++ b/tests/Panel/Ui/Drawers/TextDrawerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kirby\Panel\Ui\Drawers;
+
+use Kirby\Panel\Ui\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(TextDrawer::class)]
+class TextDrawerTest extends TestCase
+{
+	public function testProps(): void
+	{
+		$drawer = new TextDrawer(
+			text: 'A little text'
+		);
+
+		$this->assertSame([
+			'class'    => null,
+			'style'    => null,
+			'disabled' => false,
+			'icon'     => null,
+			'options'  => null,
+			'title'    => null,
+			'text'     => 'A little text',
+		], $drawer->props());
+	}
+
+	public function testRender(): void
+	{
+		$drawer = new TextDrawer();
+		$result = $drawer->render();
+		$this->assertSame('k-text-drawer', $result['component']);
+	}
+}

--- a/tests/Panel/Ui/TestCase.php
+++ b/tests/Panel/Ui/TestCase.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+use Kirby\Cms\App;
+use Kirby\Cms\Blueprint;
+use Kirby\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Ui';
+
+	protected function setUp(): void
+	{
+		$this->setUpTmp();
+
+		$this->app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'users' => [
+				[
+					'id'    => 'test',
+					'email' => 'test@getkirby.com',
+					'role'  => 'admin'
+				]
+			],
+			'user' => 'test@getkirby.com'
+		]);
+	}
+
+	protected function tearDown(): void
+	{
+		// clear session file first
+		$this->app->session()->destroy();
+
+		App::destroy();
+
+		Blueprint::$loaded = [];
+
+		$this->tearDownTmp();
+
+		// clear fake json requests
+		$_GET = [];
+	}
+}


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Adds the basic PHP backend classes that we can use to build classes for the specific dialogs and drawers (to get rid of the code in `config/areas/`).

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements
- Backend classes for dialogs and drawer (in `Kirby\Panel\Controller` and `Kirby\Panel\Ui`)

### Breaking changes
- Renamed `Kirby\Panel\Controller\PageTree` to `Kirby\Panel\Controller\PageTreeController`
- Renamed `Kirby\Panel\Controller\Search` to `Kirby\Panel\Controller\SearchController`

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
