### PR TITLE
refact!: Move `$panel` logic out of `k-panel-menu`

### DIFF
--- a/panel/lab/components/menu/index.php
+++ b/panel/lab/components/menu/index.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'docs' => 'k-panel-menu',
+];

--- a/panel/lab/components/menu/index.vue
+++ b/panel/lab/components/menu/index.vue
@@ -9,7 +9,7 @@
 			<k-panel-menu :items="items" />
 		</k-lab-example>
 		<k-lab-example label="Has search">
-			<k-panel-menu :items="items" :searches="searches" />
+			<k-panel-menu :items="items" :has-search="true" />
 		</k-lab-example>
 		<k-lab-example label="Open/Close (and hovered)">
 			<div class="k-panel" :data-menu="isOpen">
@@ -69,11 +69,6 @@ export default {
 					icon: "logout"
 				}
 			];
-		},
-		searches() {
-			return {
-				shops: {}
-			};
 		}
 	}
 };

--- a/panel/lab/components/menu/index.vue
+++ b/panel/lab/components/menu/index.vue
@@ -1,0 +1,91 @@
+<template>
+	<k-lab-examples>
+		<k-box theme="info">
+			Try these examples with the actual Panel menu collapsed as otherwise the
+			global open state will overwrite the local example state.
+		</k-box>
+
+		<k-lab-example label="Sections">
+			<k-panel-menu :items="items" />
+		</k-lab-example>
+		<k-lab-example label="Has search">
+			<k-panel-menu :items="items" :searches="searches" />
+		</k-lab-example>
+		<k-lab-example label="Open/Close (and hovered)">
+			<div class="k-panel" :data-menu="isOpen">
+				<k-panel-menu
+					:items="items"
+					:is-hovered="isHovered"
+					:is-open="isOpen"
+					@hover="isHovered = $event"
+					@toggle="isOpen = !isOpen"
+				/>
+			</div>
+		</k-lab-example>
+		<k-lab-example label="License: missing">
+			<k-panel-menu :items="items" license="missing" />
+		</k-lab-example>
+		<k-lab-example label="License: legacy">
+			<k-panel-menu :items="items" license="legacy" />
+		</k-lab-example>
+	</k-lab-examples>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			isHovered: true,
+			isOpen: true
+		};
+	},
+	computed: {
+		items() {
+			return [
+				{
+					text: "Site",
+					icon: "home",
+					current: true
+				},
+				{
+					text: "Users",
+					icon: "users"
+				},
+				{
+					text: "Settings",
+					icon: "settings"
+				},
+				"-",
+				{
+					text: "Changes",
+					icon: "edit-line"
+				},
+				{
+					text: "Account",
+					icon: "account"
+				},
+				{
+					text: "Sign out",
+					icon: "logout"
+				}
+			];
+		},
+		searches() {
+			return {
+				shops: {}
+			};
+		}
+	}
+};
+</script>
+
+<style>
+.k-lab-example-canvas {
+	position: relative;
+	min-height: 20rem;
+}
+.k-lab-example-canvas .k-panel-menu {
+	position: absolute;
+	z-index: var(--z-content);
+}
+</style>

--- a/panel/src/components/View/Inside.vue
+++ b/panel/src/components/View/Inside.vue
@@ -1,6 +1,16 @@
 <template>
 	<k-panel class="k-panel-inside">
-		<k-panel-menu />
+		<k-panel-menu
+			:items="$panel.menu.entries"
+			:is-hovered="$panel.menu.hover"
+			:is-open="$panel.menu.isOpen"
+			:license="$panel.license"
+			:searches="$panel.searches"
+			@hover="$panel.menu.hover = $event"
+			@search="$panel.search()"
+			@toggle="$panel.menu.toggle()"
+		/>
+
 		<main class="k-panel-main">
 			<k-topbar :breadcrumb="$panel.view.breadcrumb" :view="$panel.view">
 				<!-- @slot Additional content for the Topbar  -->

--- a/panel/src/components/View/Inside.vue
+++ b/panel/src/components/View/Inside.vue
@@ -1,11 +1,11 @@
 <template>
 	<k-panel class="k-panel-inside">
 		<k-panel-menu
+			:has-search="$panel.hasSearch"
 			:items="$panel.menu.entries"
 			:is-hovered="$panel.menu.hover"
 			:is-open="$panel.menu.isOpen"
 			:license="$panel.license"
-			:searches="$panel.searches"
 			@hover="$panel.menu.hover = $event"
 			@search="$panel.search()"
 			@toggle="$panel.menu.toggle()"

--- a/panel/src/components/View/Menu.vue
+++ b/panel/src/components/View/Menu.vue
@@ -2,9 +2,9 @@
 	<nav
 		class="k-panel-menu"
 		:aria-label="$t('menu')"
-		:data-hover="$panel.menu.hover"
-		@mouseenter="$panel.menu.hover = true"
-		@mouseleave="$panel.menu.hover = false"
+		:data-hover="isHovered"
+		@mouseenter="$emit('hover', true)"
+		@mouseleave="$emit('hover', false)"
 	>
 		<div class="k-panel-menu-body">
 			<!-- Search button -->
@@ -13,7 +13,7 @@
 				:text="$t('search')"
 				icon="search"
 				class="k-panel-menu-search k-panel-menu-button"
-				@click="$panel.search()"
+				@click="$emit('search')"
 			/>
 
 			<!-- Menus -->
@@ -40,27 +40,42 @@
 					theme="love"
 					variant="filled"
 				/>
-				<k-activation :status="$panel.license" />
+				<k-activation :status="license" />
 			</menu>
 		</div>
 
 		<!-- Collapse/expand toggle -->
 		<k-button
-			:icon="$panel.menu.isOpen ? 'angle-left' : 'angle-right'"
-			:title="$panel.menu.isOpen ? $t('collapse') : $t('expand')"
+			:icon="isOpen ? 'angle-left' : 'angle-right'"
+			:title="isOpen ? $t('collapse') : $t('expand')"
 			size="xs"
 			class="k-panel-menu-toggle"
-			@click="$panel.menu.toggle()"
+			@click="$emit('toggle')"
 		/>
 	</nav>
 </template>
 
 <script>
 /**
- * @since 4.0.0
+ * @displayName PanelMenu
+ * @since 6.0.0
  * @unstable
  */
 export default {
+	props: {
+		isHovered: Boolean,
+		isOpen: Boolean,
+		items: {
+			type: Array,
+			default: () => []
+		},
+		license: String,
+		searches: {
+			type: Object,
+			default: () => ({})
+		}
+	},
+	emits: ["hover", "search", "toggle"],
 	data() {
 		return {
 			over: false
@@ -68,14 +83,14 @@ export default {
 	},
 	computed: {
 		activationButton() {
-			if (this.$panel.license === "missing") {
+			if (this.license === "missing") {
 				return {
 					click: () => this.$dialog("registration"),
 					text: this.$t("activate")
 				};
 			}
 
-			if (this.$panel.license === "legacy") {
+			if (this.license === "legacy") {
 				return {
 					click: () => this.$dialog("license"),
 					text: this.$t("renew")
@@ -85,10 +100,10 @@ export default {
 			return false;
 		},
 		hasSearch() {
-			return this.$helper.object.length(this.$panel.searches) > 0;
+			return this.$helper.object.length(this.searches) > 0;
 		},
 		menus() {
-			return this.$helper.array.split(this.$panel.menu.entries, "-");
+			return this.$helper.array.split(this.items, "-");
 		}
 	}
 };

--- a/panel/src/components/View/Menu.vue
+++ b/panel/src/components/View/Menu.vue
@@ -63,17 +63,14 @@
  */
 export default {
 	props: {
+		hasSearch: Boolean,
 		isHovered: Boolean,
 		isOpen: Boolean,
 		items: {
 			type: Array,
 			default: () => []
 		},
-		license: String,
-		searches: {
-			type: Object,
-			default: () => ({})
-		}
+		license: String
 	},
 	emits: ["hover", "search", "toggle"],
 	data() {
@@ -98,9 +95,6 @@ export default {
 			}
 
 			return false;
-		},
-		hasSearch() {
-			return this.$helper.object.length(this.searches) > 0;
 		},
 		menus() {
 			return this.$helper.array.split(this.items, "-");

--- a/panel/src/panel/panel.js
+++ b/panel/src/panel/panel.js
@@ -20,7 +20,7 @@ import { redirect, request } from "./request.js";
 import Upload from "./upload.js";
 import User from "./user.js";
 import View from "./view.js";
-import { isObject } from "@/helpers/object.js";
+import { isObject, length } from "@/helpers/object.js";
 import { isEmpty } from "@/helpers/string.js";
 
 /**
@@ -213,6 +213,10 @@ export default {
 		});
 
 		return response?.json ?? {};
+	},
+
+	get hasSearch() {
+		return length(this.searches) > 0;
 	},
 
 	/**


### PR DESCRIPTION
BREAKING CHANGE: `k-menu-panel` requires new props

## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Making the `k-panel-menu` component a bit dumber itself.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Breaking changes
- `<k-panel-menu>` now requires to pass props explicitly instead of using `$panel.menu` itself.


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
