### PR TITLE
feat: Allow class controller for dialog/drawer routes

### DIFF
--- a/src/Panel/Dialog.php
+++ b/src/Panel/Dialog.php
@@ -50,6 +50,20 @@ class Dialog extends Json
 		$pattern = trim($prefix . '/' . ($options['pattern'] ?? $id), '/');
 		$type    = str_replace('$', '', static::$key);
 
+		// create load/submit events from controller class
+		if ($controller = $options['controller'] ?? null) {
+			if (is_string($controller) === true) {
+				if (method_exists($controller, 'for') === true) {
+					$controller = $controller::for(...);
+				} else {
+					$controller = fn (...$args) => new $controller(...$args);
+				}
+			}
+
+			$options['load']   ??= fn (...$args) => $controller(...$args)->load();
+			$options['submit'] ??= fn (...$args) => $controller(...$args)->submit();
+		}
+
 		// load event
 		$routes[] = [
 			'pattern' => $pattern,


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

If we want to use backend classes for dialogs and drawers (https://github.com/getkirby/kirby/pull/7380), we need an easy way to use them inside the dialog/drawer routes config. 

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Enhancements
- Dialog and drawer routes: support passing a `controller` class name or closure hat returns an object with `::load()` and `::submit()` methods that will be used then as `load`/`submit` event actions. Ideally used with returning a `Kirby\Panel\Controller\Dialog`/`Kirby\Panel\Controller\Drawer` object. If the named class also defines a static `::for()` method, it will be used to create an instance of the class.

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
-->

Instead of a `load` and `submit` callback, you can also define a class of  `Kirby\Panel\Controller\Dialog`/`Kirby\Panel\Controller\Drawer` as `controller` for the route:

```php
[
	'pattern' => 'my/drawer',
	'controller' => fn () => new MyDrawer()
],
[
	'pattern'    => ''another/drawer',
	'controller' => MyDrawer::class
]
```



### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
