### PR TITLE
fix: `Panel\Ui\Component` filter `null`, not `[]`

### DIFF
--- a/src/Panel/Ui/Component.php
+++ b/src/Panel/Ui/Component.php
@@ -84,7 +84,10 @@ abstract class Component
 		return [
 			'component' => $this->component,
 			'key'       => $this->key(),
-			'props'     => array_filter($this->props())
+			'props'     => array_filter(
+				$this->props(),
+				fn ($prop) => $prop !== null
+			)
 		];
 	}
 }

--- a/tests/Panel/Ui/ComponentTest.php
+++ b/tests/Panel/Ui/ComponentTest.php
@@ -8,6 +8,23 @@ use PHPUnit\Framework\Attributes\CoversClass;
 
 class UiComponent extends Component
 {
+	public function __construct(
+		public string $component,
+		public string|null $class = null,
+		public string|null $style = null,
+		public array $foo = [],
+		...$attrs
+	) {
+		$this->attrs = $attrs;
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'foo' => $this->foo
+		];
+	}
 }
 
 #[CoversClass(Component::class)]
@@ -18,7 +35,7 @@ class ComponentTest extends TestCase
 		$props = [
 			'component' => 'k-text',
 			'class'     => 'k-test',
-			'foo'       => 'bar'
+			'fox'       => 'bar'
 		];
 
 		$component = new UiComponent(...$props);
@@ -26,7 +43,8 @@ class ComponentTest extends TestCase
 		$this->assertSame([
 			'class' => 'k-test',
 			'style' => null,
-			'foo'   => 'bar',
+			'fox'   => 'bar',
+			'foo'   => []
 		], $component->props());
 	}
 
@@ -44,9 +62,9 @@ class ComponentTest extends TestCase
 	public function testGetterSetterInvalid(): void
 	{
 		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('The property "foo" does not exist on the UI component "k-test"');
+		$this->expectExceptionMessage('The property "fox" does not exist on the UI component "k-test"');
 		$component = new UiComponent(component: 'k-test');
-		$component->foo('my-class');
+		$component->fox('my-class');
 	}
 
 	public function testKey(): void
@@ -66,7 +84,8 @@ class ComponentTest extends TestCase
 
 		$this->assertSame([
 			'class' => 'my-class',
-			'style' => null
+			'style' => null,
+			'foo'   => []
 		], $component->props());
 	}
 
@@ -74,12 +93,23 @@ class ComponentTest extends TestCase
 	{
 		$component = new UiComponent(
 			component: 'k-test',
-			class: 'my-class'
+			class: 'my-class',
+			foo: ['a']
 		);
 
 		$result = $component->render();
 		$this->assertSame('k-test', $result['component']);
 		$this->assertIsString($result['key']);
-		$this->assertSame(['class' => 'my-class'], $result['props']);
+		$this->assertSame(['class' => 'my-class', 'foo' => ['a']], $result['props']);
+	}
+
+	public function testRenderDontFilterEmptyArrayProp(): void
+	{
+		$component = new UiComponent(
+			component: 'k-test',
+		);
+
+		$result = $component->render();
+		$this->assertSame(['foo' => []], $result['props']);
 	}
 }


### PR DESCRIPTION
## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Fixes
- `Kirby\Panel\Ui\Component::render()` now only filters out props that are `null`, not empty arrays

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
