### PR TITLE
fix!: Remove `reset` prop from `k-radio-input`

### DIFF
--- a/panel/src/components/Forms/Input/RadioInput.vue
+++ b/panel/src/components/Forms/Input/RadioInput.vue
@@ -15,7 +15,6 @@
 				<li v-for="(choice, index) in choices" :key="index">
 					<k-choice-input
 						v-bind="choice"
-						@click.stop="toggle(choice.value)"
 						@input="$emit('input', choice.value)"
 					/>
 				</li>
@@ -34,10 +33,6 @@ export const props = {
 		columns: {
 			default: 1,
 			type: Number
-		},
-		reset: {
-			default: true,
-			type: Boolean
 		},
 		theme: String,
 		value: [String, Number, Boolean]
@@ -70,11 +65,6 @@ export default {
 		},
 		select() {
 			this.focus();
-		},
-		toggle(value) {
-			if (value === this.value && this.reset && !this.required) {
-				this.$emit("input", "");
-			}
 		}
 	}
 };


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v5/develop`

How to contribute: https://contribute.getkirby.com
-->

Better matches the native radio input behavior.

## Changelog
<!--
Add relevant release notes: Features, Enhancements, Fixes, Deprecated.
Reference issues from the `kirby` repo or ideas from `feedback.getkirby.com`.
Always mention whether your PR introduces breaking changes.
-->

### Breaking changes
- Radio input does not support `reset` option anymore. User toggles input instead.


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
