### PR TITLE
feat: New `<k-stats-field>` component

### DIFF
--- a/panel/lab/components/fields/stats/index.php
+++ b/panel/lab/components/fields/stats/index.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'docs' => 'k-stats-field',
+];

--- a/panel/lab/components/fields/stats/index.vue
+++ b/panel/lab/components/fields/stats/index.vue
@@ -1,0 +1,51 @@
+<template>
+	<k-lab-form>
+		<k-lab-examples>
+			<k-lab-example label="Default">
+				<k-stats-field :reports="reports" label="Stats" name="stats" />
+			</k-lab-example>
+		</k-lab-examples>
+		<k-lab-examples>
+			<k-lab-example label="Size (small)">
+				<k-stats-field
+					:reports="reports"
+					label="Stats"
+					name="stats"
+					size="small"
+				/>
+			</k-lab-example>
+		</k-lab-examples>
+	</k-lab-form>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			reports: [
+				{
+					label: "Views",
+					value: "12.250",
+					info: "+120%",
+					theme: "positive",
+					icon: "preview"
+				},
+				{
+					label: "Visitors",
+					value: "3.500",
+					info: "0%",
+					theme: "info",
+					icon: "users"
+				},
+				{
+					label: "Searches",
+					value: "1.250",
+					info: "-10%",
+					theme: "negative",
+					icon: "search"
+				}
+			]
+		};
+	}
+};
+</script>

--- a/panel/lab/components/fields/stats/index.vue
+++ b/panel/lab/components/fields/stats/index.vue
@@ -4,8 +4,6 @@
 			<k-lab-example label="Default">
 				<k-stats-field :reports="reports" label="Stats" name="stats" />
 			</k-lab-example>
-		</k-lab-examples>
-		<k-lab-examples>
 			<k-lab-example label="Size (small)">
 				<k-stats-field
 					:reports="reports"

--- a/panel/src/components/Forms/Field.vue
+++ b/panel/src/components/Forms/Field.vue
@@ -66,7 +66,7 @@ export const props = {
 		buttons: Array,
 		counter: [Boolean, Object],
 		endpoints: Object,
-		input: [String, Number],
+		input: [String, Number, Boolean],
 		translate: Boolean,
 		type: String
 	}

--- a/panel/src/components/Forms/Field/StatsField.vue
+++ b/panel/src/components/Forms/Field/StatsField.vue
@@ -1,0 +1,24 @@
+<template>
+	<k-field
+		:id="id"
+		:help="help"
+		:input="false"
+		:label="label"
+		:name="name"
+		type="stats"
+	>
+		<k-stats :reports="reports" :size="size" />
+	</k-field>
+</template>
+
+<script>
+import { help, id, label, name } from "@/mixins/props.js";
+import { props as statsProps } from "@/components/Layout/Stats.vue";
+
+/**
+ * @example <k-stats-field label="Stats" :reports="reports" />
+ */
+export default {
+	mixins: [help, id, label, name, statsProps]
+};
+</script>

--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -21,6 +21,7 @@ import RadioField from "./RadioField.vue";
 import RangeField from "./RangeField.vue";
 import SelectField from "./SelectField.vue";
 import SlugField from "./SlugField.vue";
+import StatsField from "./StatsField.vue";
 import StructureField from "./StructureField.vue";
 import TagsField from "./TagsField.vue";
 import TelField from "./TelField.vue";
@@ -58,6 +59,7 @@ export default {
 		app.component("k-range-field", RangeField);
 		app.component("k-select-field", SelectField);
 		app.component("k-slug-field", SlugField);
+		app.component("k-stats-field", StatsField);
 		app.component("k-structure-field", StructureField);
 		app.component("k-tags-field", TagsField);
 		app.component("k-text-field", TextField);

--- a/panel/src/components/Lab/PlaygroundView.vue
+++ b/panel/src/components/Lab/PlaygroundView.vue
@@ -113,10 +113,10 @@ export default {
 </script>
 
 <style>
-.k-lab-examples h2 {
+.k-lab-examples > h2 {
 	margin-bottom: var(--spacing-6);
 }
-.k-lab-examples * + h2 {
+.k-lab-examples > * + h2 {
 	margin-top: var(--spacing-12);
 }
 

--- a/panel/src/components/Text/Label.vue
+++ b/panel/src/components/Text/Label.vue
@@ -12,9 +12,16 @@
 		<span v-else class="k-label-text">
 			<slot />
 		</span>
-
-		<abbr v-if="required" :title="$t(type + '.required')">✶</abbr>
-		<abbr :title="$t(type + '.invalid')" data-theme="negative" class="k-label-invalid">&times;</abbr>
+		<template v-if="input !== false">
+			<abbr v-if="required" :title="$t(type + '.required')">✶</abbr>
+			<abbr
+				:title="$t(type + '.invalid')"
+				data-theme="negative"
+				class="k-label-invalid"
+			>
+				&times;
+			</abbr>
+		</template>
 	</component>
 </template>
 
@@ -28,7 +35,7 @@ export default {
 		 * ID of the input element to which the label belongs
 		 */
 		input: {
-			type: [String, Number]
+			type: [String, Number, Boolean]
 		},
 		/**
 		 * Whether the input value is currently invalid
@@ -60,7 +67,7 @@ export default {
 	},
 	computed: {
 		element() {
-			return this.type === "section" ? "h2" : "label";
+			return this.type === "section" || this.input === false ? "h2" : "label";
 		}
 	}
 };


### PR DESCRIPTION
## Description

The new `<k-stats-field>` component is basically rebuilding what happened in the `<k-stats-section>` but without the API props loading. We can plug it in as soon as the backend code for the field is also there (coming in the next PR) 

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements

- New `<k-stats-field>` component 
- The `<k-label>` component now also accepts `false` for the input prop. This will switch the label element to an h2 and also remove the `<abbr>` for the invalid state. All fields that don't store any values will need this. We can also use it for the info field, which did still create its own headline.

### 🐛 Bug fixes

- Removed destructive CSS rules in the lab for `h2` that easily bleed into component rules.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion