### PR TITLE
fix: Skip fields without value in Fields::reset and Fields::toProps methods

### DIFF
--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -268,6 +268,10 @@ class Fields extends Collection
 
 		// reset the values of each field
 		foreach ($this->data as $field) {
+			if ($field->hasValue() === false) {
+				continue;
+			}
+
 			$field->fill(null);
 		}
 
@@ -362,6 +366,10 @@ class Fields extends Collection
 
 		foreach ($fields as $name => $field) {
 			$props[$name] = $field->toArray();
+
+			if ($field->hasValue() === false) {
+				continue;
+			}
 
 			// the field should be disabled in the form if the user
 			// has no update permissions for the model or if the field


### PR DESCRIPTION
## Description

This is needed when we want better support for fields that return false in their `::hasValue()` method. 

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->

- Skip fields without value in `Fields::reset()` and `Fields::toProps()` methods. 

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->

None

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion