### PR TITLE
feat: Batch delete mode for structure fields

### DIFF
--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -20,6 +20,13 @@ return [
 		'placeholder' => null,
 
 		/**
+		 * Whether to enable batch editing
+		 */
+		'batch' => function (bool $batch = false) {
+			return $batch;
+		},
+
+		/**
 		 * Optional columns definition to only show selected fields in the structure table.
 		 */
 		'columns' => function (array $columns = []) {

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -376,6 +376,7 @@
 
 	"field.structure.delete.confirm": "Do you really want to delete this row?",
 	"field.structure.delete.confirm.all": "Do you really want to delete all entries?",
+	"field.structure.delete.confirm.selected": "Do you really want to delete the selected entries?",
 	"field.structure.empty": "No entries yet",
 
 	"field.users.empty": "No users selected yet",

--- a/panel/src/components/Layout/Table.vue
+++ b/panel/src/components/Layout/Table.vue
@@ -558,7 +558,7 @@ export default {
 	--table-color-hover: var(--table-color-back);
 }
 .k-table .k-table-select-checkbox {
-	height: 100%;
+	height: var(--table-row-height);
 	display: grid;
 	place-items: center;
 }

--- a/panel/src/components/Sections/ModelsSection.vue
+++ b/panel/src/components/Sections/ModelsSection.vue
@@ -51,9 +51,10 @@
 <script>
 import debounce from "@/helpers/debounce";
 import section from "@/mixins/section";
+import batchEditing from "@/mixins/batchEditing";
 
 export default {
-	mixins: [section],
+	mixins: [section, batchEditing],
 	inheritAttrs: false,
 	props: {
 		column: String
@@ -64,7 +65,6 @@ export default {
 			error: null,
 			isLoading: false,
 			isProcessing: false,
-			isSelecting: false,
 			options: {
 				batch: false,
 				columns: {},
@@ -82,50 +82,26 @@ export default {
 				page: null
 			},
 			searchterm: null,
-			searching: false,
-			selected: []
+			searching: false
 		};
 	},
 	computed: {
 		addIcon() {
 			return "add";
 		},
+		batchDeleteConfirmMessage() {
+			return this.$t(`${this.type}.delete.confirm.selected`, {
+				count: this.selected.length
+			});
+		},
+		batchEditingEvent() {
+			return "section.selecting";
+		},
 		buttons() {
 			let buttons = [];
 
 			if (this.isSelecting) {
-				buttons.push({
-					disabled: this.selected.length === 0,
-					icon: "trash",
-					text: this.$t("delete") + ` (${this.selected.length})`,
-					theme: "negative",
-					click: () => {
-						this.$panel.dialog.open({
-							component: "k-remove-dialog",
-							props: {
-								text: this.$t(`${this.type}.delete.confirm.selected`, {
-									count: this.selected.length
-								})
-							},
-							on: {
-								submit: () => {
-									this.$panel.dialog.close();
-									this.deleteSelected();
-								}
-							}
-						});
-					},
-					responsive: true
-				});
-
-				buttons.push({
-					icon: "cancel",
-					text: this.$t("cancel"),
-					click: this.onSelectToggle,
-					responsive: true
-				});
-
-				return buttons;
+				return this.batchEditingButtons;
 			}
 
 			if (this.canSearch) {
@@ -138,12 +114,7 @@ export default {
 			}
 
 			if (this.canSelect) {
-				buttons.push({
-					icon: "checklist",
-					click: this.onSelectToggle,
-					title: this.$t("select"),
-					responsive: true
-				});
+				buttons.push(this.batchEditingToggle);
 			}
 
 			if (this.canAdd) {
@@ -237,11 +208,9 @@ export default {
 	},
 	created() {
 		this.$events.on("model.update", this.reload);
-		this.$events.on("section.selecting", this.stopSelectingCollision);
 	},
 	destroyed() {
 		this.$events.off("model.update", this.reload);
-		this.$events.off("section.selecting", this.stopSelectingCollision);
 	},
 	mounted() {
 		this.search = debounce(this.search, 200);
@@ -297,9 +266,11 @@ export default {
 				this.isLoading = false;
 			}
 		},
-
 		onAction() {},
 		onAdd() {},
+		onBatchDelete() {
+			this.deleteSelected();
+		},
 		onChange() {},
 		onDrop() {},
 		onPaginate(pagination) {
@@ -312,33 +283,7 @@ export default {
 			this.searching = !this.searching;
 			this.searchterm = null;
 		},
-		onSelect(item) {
-			if (this.selected.includes(item)) {
-				this.selected = this.selected.filter(
-					(selected) => selected.id !== item.id
-				);
-			} else {
-				this.selected.push(item);
-			}
-		},
-		onSelectToggle() {
-			this.isSelecting ? this.stopSelecting() : this.startSelecting();
-		},
 		onSort() {},
-		startSelecting() {
-			this.isSelecting = true;
-			this.selected = [];
-			this.$events.emit("section.selecting", this.name);
-		},
-		stopSelecting() {
-			this.isSelecting = false;
-			this.selected = [];
-		},
-		stopSelectingCollision(name) {
-			if (name !== this.name) {
-				this.stopSelecting();
-			}
-		},
 		async reload() {
 			// reset batch mode
 			this.stopSelecting();

--- a/panel/src/mixins/batchEditing.js
+++ b/panel/src/mixins/batchEditing.js
@@ -1,0 +1,115 @@
+/**
+ * The Batch Editing mixin is intended for all components
+ * that want to introduce batch editing capabilities. It provides the
+ * necessary methods and computed properties to handle item selection,
+ * batch mode buttons and delete action.
+ */
+export default {
+	data: () => ({
+		isSelecting: false,
+		selected: []
+	}),
+	created() {
+		this.$events.on(this.batchEditingEvent, this.stopSelectingCollision);
+	},
+	destroyed() {
+		this.$events.off(this.batchEditingEvent, this.stopSelectingCollision);
+	},
+	computed: {
+		batchDeleteConfirmMessage() {
+			return this.$t(`${this.type}.delete.confirm.selected`, {
+				count: this.selected.length
+			});
+		},
+		batchEditingButtons() {
+			const buttons = [];
+
+			buttons.push({
+				disabled: this.selected.length === 0,
+				icon: "trash",
+				text: this.$t("delete") + ` (${this.selected.length})`,
+				theme: "negative",
+				click: () => {
+					this.$panel.dialog.open({
+						component: "k-remove-dialog",
+						props: {
+							text: this.batchDeleteConfirmMessage
+						},
+						on: {
+							submit: async () => {
+								this.$panel.dialog.close();
+
+								if (this.selected.length === 0) {
+									return;
+								}
+
+								await this.onBatchDelete();
+								this.stopSelecting();
+							}
+						}
+					});
+				},
+				responsive: true
+			});
+
+			buttons.push({
+				icon: "cancel",
+				text: this.$t("cancel"),
+				click: this.onSelectToggle,
+				responsive: true
+			});
+
+			return buttons;
+		},
+		batchEditingEvent() {
+			return "selecting";
+		},
+		batchEditingIdentifier() {
+			return "id";
+		},
+		batchEditingToggle() {
+			return {
+				icon: "checklist",
+				click: this.onSelectToggle,
+				title: this.$t("select"),
+				responsive: true
+			};
+		},
+		canSelect() {
+			return true;
+		}
+	},
+	methods: {
+		onBatchDelete() {
+			throw new Error("Not implemented");
+		},
+		onSelect(item) {
+			if (this.selected.includes(item)) {
+				this.selected = this.selected.filter(
+					(selected) =>
+						selected[this.batchEditingIdentifier] !==
+						item[this.batchEditingIdentifier]
+				);
+			} else {
+				this.selected.push(item);
+			}
+		},
+		onSelectToggle() {
+			this.isSelecting ? this.stopSelecting() : this.startSelecting();
+		},
+		startSelecting() {
+			this.isSelecting = true;
+			this.selected = [];
+			this.$events.emit(this.batchEditingEvent, this.name);
+		},
+		stopSelecting() {
+			this.isSelecting = false;
+			this.selected = [];
+		},
+		stopSelectingCollision(name) {
+			if (name !== this.name) {
+				this.stopSelecting();
+			}
+		}
+	}
+};


### PR DESCRIPTION
## Description

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features

New batch mode for structure fields to delete multiple rows at once. You can activate it by using the new `batch` option in your blueprint: 

```yaml
structure: 
  batch: true
  fields: 
    text: 
      type: text
```

https://github.com/user-attachments/assets/97227ae6-acb9-4f0e-b902-4b336a31d0dc

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful) https://github.com/getkirby/sandbox/pull/19
- [x] Add changes & docs to release notes draft in Notion