### PR TITLE
fix: Use site URL as base in preview browser to fix relative URL creation

### DIFF
--- a/panel/src/components/Views/Preview/PreviewBrowser.vue
+++ b/panel/src/components/Views/Preview/PreviewBrowser.vue
@@ -42,7 +42,7 @@ export default {
 	emits: ["discard", "submit"],
 	computed: {
 		srcWithPreviewParam() {
-			const uri = new URL(this.src);
+			const uri = new URL(this.src, this.$panel.urls.site);
 			uri.searchParams.append("_preview", true);
 			return uri.toString();
 		}


### PR DESCRIPTION
## Description

We need to set a base in the new Url constructor to make sure that relative URLs work as expected. 

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- The preview browser now accepts relative URLs. https://github.com/getkirby/kirby/issues/7348

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion