### PR TITLE
feat: Improve detectLanguage to support locales

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -580,7 +580,16 @@ class App
 		$visitor   = $this->visitor();
 
 		foreach ($visitor->acceptedLanguages() as $acceptedLang) {
-			$closure = static function ($language) use ($acceptedLang) {
+			// Find locale matches (e.g. en_GB => en_GB)
+			$matchLocale = function ($language) use ($acceptedLang) {
+				$languageLocale = $language->locale(LC_ALL);
+				$acceptedLocale = $acceptedLang->locale();
+
+				return Str::substr($languageLocale, 0, 5) === Str::substr($acceptedLocale, 0, 5);
+			};
+
+			// Find language matches (e.g. en_GB => en)
+			$matchLanguage = function ($language) use ($acceptedLang) {
 				$languageLocale = $language->locale(LC_ALL);
 				$acceptedLocale = $acceptedLang->locale();
 
@@ -589,7 +598,11 @@ class App
 					$acceptedLocale === Str::substr($languageLocale, 0, 2);
 			};
 
-			if ($language = $languages->filter($closure)?->first()) {
+			if ($language = $languages->filter($matchLocale)?->first()) {
+				return $language;
+			}
+
+			if ($language = $languages->filter($matchLanguage)?->first()) {
 				return $language;
 			}
 		}

--- a/tests/Cms/App/AppLanguagesTest.php
+++ b/tests/Cms/App/AppLanguagesTest.php
@@ -103,4 +103,55 @@ class AppLanguagesTest extends TestCase
 
 		$this->assertSame($expected, $app->detectedLanguage()->code());
 	}
+
+	public static function detectedLanguageWithLocaleProvider(): array
+	{
+		return [
+			['en', 'en'],
+			['en-GB', 'en'],
+			['en-US', 'en-us'],
+			['de', 'de'],
+			['fr', 'en'],
+			['en-US, en;q=0.5', 'en-us'],
+			['en-US;q=0.5, de;q=0.8, fr;q=0.9', 'de'],
+		];
+	}
+
+	/**
+	 * @backupGlobals enabled
+	 */
+	#[DataProvider('detectedLanguageWithLocaleProvider')]
+	public function testDetectedLanguageWithLocale($accept, $expected): void
+	{
+		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = $accept;
+
+		$app = new App([
+			'languages' => [
+				[
+					'code'    => 'en',
+					'name'    => 'English',
+					'default' => true,
+					'locale'  => 'en_GB'
+				],
+				[
+					'code'    => 'de',
+					'name'    => 'Deutsch',
+					'default' => false,
+					'locale'  => 'de_DE'
+				],
+				[
+					'code'    => 'en-us',
+					'name'    => 'English',
+					'default' => false,
+					'locale'  => 'en_US'
+				]
+			],
+			'options' => [
+				'languages' => true,
+				'languages.detect' => true
+			]
+		]);
+
+		$this->assertSame($expected, $app->detectedLanguage()->code());
+	}
 }


### PR DESCRIPTION
## Description

@tobiasfabian provided an excellent solution to support locales in our language detector. I've basically just added his code and added unit tests. 

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- Our language detector will now correctly detect languages based on locales. You can now easily set up two English locales for example and the detector will pick the right one and redirect correctly. (thanks to @tobiasfabian) 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion