### PR TITLE
feat: Load panel translation from query parameter

### DIFF
--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -88,6 +88,12 @@ trait AppTranslations
 	 */
 	public function panelLanguage(): string
 	{
+		$translation = $this->request()->get('translation');
+
+		if ($translation !== null && $this->translations()->find($translation)) {
+			return $translation;
+		}
+
 		if ($this->multilang() === true) {
 			$defaultCode = $this->defaultLanguage()->code();
 

--- a/tests/Cms/App/AppTranslationsTest.php
+++ b/tests/Cms/App/AppTranslationsTest.php
@@ -493,5 +493,33 @@ class AppTranslationsTest extends TestCase
 			]
 		]);
 		$this->assertSame('it', $app->panelLanguage());
+
+		// override with the translation query parameter
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'request' => [
+				'query' => [
+					'translation' => 'it'
+				]
+			]
+		]);
+
+		$this->assertSame('it', $app->panelLanguage());
+
+		// override with invalid translation query parameter
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'request' => [
+				'query' => [
+					'translation' => 'does-not-exist'
+				]
+			]
+		]);
+
+		$this->assertSame('en', $app->panelLanguage());
 	}
 }


### PR DESCRIPTION
## Description

It sometimes might be really helpful to override the panel interface translation with a query parameter. Especially if you want to send users to a translated login (see: https://github.com/getkirby/kirby/issues/6616)

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements

- You can now set the Panel interface translation on demand with the new `translation` query parameter. E.g. `https://example.com/panel/login?translation=it` https://github.com/getkirby/kirby/issues/6616

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion