### PR TITLE
fix: Don’t ping the API if the panel is offline

### DIFF
--- a/panel/src/api/index.js
+++ b/panel/src/api/index.js
@@ -32,7 +32,14 @@ export default (panel) => {
 	// clear and restart the auth beacon
 	const ping = () => {
 		clearInterval(api.ping);
-		api.ping = setInterval(api.auth.ping, 5 * 60 * 1000);
+		api.ping = setInterval(
+			() => {
+				if (panel.isOffline === false) {
+					api.auth.ping();
+				}
+			},
+			5 * 60 * 1000
+		);
 	};
 
 	// setup the main request method


### PR DESCRIPTION
## Description
I found an additional part for the "Failed to fetch" request issue. We ping the API to keep the session alive, but when the panel is offline, this is causing an issue. We should not keep pinging while the panel is offline. 

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Don’t ping the API if the panel is offline https://github.com/getkirby/kirby/issues/6077

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion