### PR TITLE
fix: Remove `$` leftovers from globals

### DIFF
--- a/panel/src/components/View/Buttons/LanguagesDropdown.vue
+++ b/panel/src/components/View/Buttons/LanguagesDropdown.vue
@@ -76,7 +76,7 @@ export default {
 	},
 	methods: {
 		change(language) {
-			this.$reload({
+			this.$panel.reload({
 				query: {
 					language: language.code
 				}

--- a/panel/src/components/Views/Installation/InstallationView.vue
+++ b/panel/src/components/Views/Installation/InstallationView.vue
@@ -94,7 +94,7 @@
 						size="lg"
 						theme="positive"
 						variant="filled"
-						@click="$reload"
+						@click="$panel.reload"
 					/>
 				</div>
 			</k-dialog-body>
@@ -162,8 +162,8 @@ export default {
 		async install() {
 			try {
 				await this.$api.system.install(this.user);
-				await this.$reload({
-					globals: ["$system", "$translation"]
+				await this.$panel.reload({
+					globals: ["system", "translation"]
 				});
 
 				this.$panel.notification.success({

--- a/panel/src/components/Views/Login/LoginCodeForm.vue
+++ b/panel/src/components/Views/Login/LoginCodeForm.vue
@@ -105,7 +105,7 @@ export default {
 				if (this.mode === "password-reset") {
 					this.$go("reset-password");
 				} else {
-					this.$reload();
+					this.$panel.reload();
 				}
 			} catch (error) {
 				this.$emit("error", error);

--- a/panel/src/components/Views/Login/LoginForm.vue
+++ b/panel/src/components/Views/Login/LoginForm.vue
@@ -180,8 +180,8 @@ export default {
 			try {
 				await this.$api.auth.login(user);
 
-				this.$reload({
-					globals: ["$system", "$translation"]
+				this.$panel.reload({
+					globals: ["system", "translation"]
 				});
 
 				this.$panel.notification.success({

--- a/panel/src/components/Views/Login/LoginView.vue
+++ b/panel/src/components/Views/Login/LoginView.vue
@@ -78,8 +78,8 @@ export default {
 
 			if (error.details.challengeDestroyed === true) {
 				// reset from the LoginCode component back to Login
-				await this.$reload({
-					globals: ["$system"]
+				await this.$panel.reload({
+					globals: ["system"]
 				});
 			}
 

--- a/panel/src/components/Views/Users/UserAvatar.vue
+++ b/panel/src/components/Views/Users/UserAvatar.vue
@@ -50,7 +50,7 @@ export default {
 		async remove() {
 			await this.$api.users.deleteAvatar(this.id);
 			this.$panel.notification.success();
-			this.$reload();
+			this.$panel.reload();
 		},
 		upload() {
 			this.$panel.upload.pick({

--- a/panel/src/components/Views/Users/UsersView.vue
+++ b/panel/src/components/Views/Users/UsersView.vue
@@ -72,7 +72,7 @@ export default {
 			});
 		},
 		paginate(pagination) {
-			this.$reload({
+			this.$panel.reload({
 				query: {
 					page: pagination.page
 				}


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

I overlooked these in the previous PR, but I think they need to be changed as well:
- Removed `$` prefix when reloading globals
- Use `$panel.reload` instead deprecated `$reload`