### PR TITLE
fix: Correctly add space before and after tags in `Str::excerpt()`

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -477,7 +477,11 @@ class Str
 		if ($strip === true) {
 			// ensure that opening tags are preceded by a space, so that
 			// when tags are skipped we can be sure that words stay separate
-			$string = preg_replace('#\s*<([^\/])#', ' <${1}', $string);
+			// but only if there's a word character directly before it
+			$string = preg_replace('#(\w)<([^/][^>]*)>#', '${1} <${2}>', $string);
+
+			// add space after closing tag if there's a word character directly after it
+			$string = preg_replace('#</([^>]+)>(\w)#', '</${1}> ${2}', $string);
 
 			// in strip mode, we always return plain text
 			$string = strip_tags($string);

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -364,6 +364,27 @@ class StrTest extends TestCase
 		$this->assertSame($expected, $result);
 	}
 
+	public function testExcerptWithWordCharactersAroundTags(): void
+	{
+		// Test case from issue #7306: word characters directly adjacent to tags
+		$string   = 'A link in the middle of a word: Ultra<a href="/">Link</a>Modern.';
+		$expected = 'A link in the middle of a word: Ultra Link Modern.';
+		$result   = Str::excerpt($string, 200);
+		$this->assertSame($expected, $result);
+
+		// Test brackets around tags (should not add extra spaces)
+		$string   = '[<a href="/">Link</a>]';
+		$expected = '[Link]';
+		$result   = Str::excerpt($string, 200);
+		$this->assertSame($expected, $result);
+
+		// Test parentheses around tags (should not add extra spaces)
+		$string   = '(<a href="/">Link</a>)';
+		$expected = '(Link)';
+		$result   = Str::excerpt($string, 200);
+		$this->assertSame($expected, $result);
+	}
+
 	public function testFloat(): void
 	{
 		$this->assertSame('0', Str::float(false));


### PR DESCRIPTION
## Description

We need to check for adjacent word-characters when adding spaces before or after HTML tags in the excerpt method. 

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Add a space before or after HTML tags before applying strip_tags, but only if they are adjacent to word characters. https://github.com/getkirby/kirby/issues/7306

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion