### PR TITLE
Unlock button and dialog

### DIFF
--- a/config/api/routes/changes.php
+++ b/config/api/routes/changes.php
@@ -34,4 +34,13 @@ return [
 			);
 		}
 	],
+	[
+		'pattern' => '(:all)/changes/unlock',
+		'method'  => 'POST',
+		'action'  => function (string $path) {
+			return Changes::unlock(
+				model: Find::parent($path),
+			);
+		}
+	]
 ];

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -519,6 +519,7 @@
 	"lock.unsaved.users": "Unsaved accounts",
 	"lock.isLocked": "Unsaved changes by {email}",
 	"lock.unlock": "Unlock",
+	"lock.unlock.confirm": "You will take over the changes from <strong>{{ email }}</strong>. They will then be unable to edit the content.",
 	"lock.unlock.submit": "Unlock and overwrite unsaved changes by <strong>{email}</strong>",
 	"lock.isUnlocked": "Was unlocked by another user",
 

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -102,6 +102,8 @@
 	"error.content.lock.replace": "The version is locked and cannot be replaced",
 	"error.content.lock.update": "The version is locked and cannot be updated",
 
+	"error.content.unlock.invalidVersion": "Only the changes version can be unlocked",
+
 	"error.entries.max.plural": "You must not add more than {max} entries",
 	"error.entries.max.singular": "You must not add more than one entry",
 	"error.entries.min.plural": "You must add at least {min} entries",

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -143,6 +143,7 @@
 	"error.file.type.forbidden": "You are not allowed to upload {type} files",
 	"error.file.type.invalid": "Invalid file type: {type}",
 	"error.file.undefined": "The file cannot be found",
+	"error.file.unlock.permission": "You are not allowed to unlock the content of the file",
 
 	"error.form.incomplete": "Please fix all form errors…",
 	"error.form.notSaved": "The form could not be saved",
@@ -202,6 +203,7 @@
 	"error.page.sort.permission": "The page \"{slug}\" cannot be sorted",
 	"error.page.status.invalid": "Please set a valid page status",
 	"error.page.undefined": "The page cannot be found",
+	"error.page.unlock.permission": "You are not allowed to unlock the content for the page",
 	"error.page.update.permission": "You are not allowed to update \"{slug}\"",
 
 	"error.section.files.max.plural": "You must not add more than {max} files to the \"{section}\" section",
@@ -219,6 +221,7 @@
 
 	"error.site.changeTitle.empty": "The title must not be empty",
 	"error.site.changeTitle.permission": "You are not allowed to change the title of the site",
+	"error.site.unlock.permission": "You are not allowed to unlock the content of the site",
 	"error.site.update.permission": "You are not allowed to update the site",
 
 	"error.structure.validation": "There's an error on the \"{field}\" field in row {index}",
@@ -250,6 +253,7 @@
 	"error.user.password.wrong": "Wrong password",
 	"error.user.role.invalid": "Please enter a valid role",
 	"error.user.undefined": "The user cannot be found",
+	"error.user.unlock.permission": "You are not allowed to unlock the content of the user",
 	"error.user.update.permission": "You are not allowed to update the user \"{name}\"",
 
 	"error.validation.accepted": "Please confirm",

--- a/panel/src/components/Forms/FormControls.vue
+++ b/panel/src/components/Forms/FormControls.vue
@@ -83,7 +83,7 @@ export const props = {
  */
 export default {
 	mixins: [props],
-	emits: ["discard", "submit"],
+	emits: ["discard", "submit", "unlock"],
 	computed: {
 		buttons() {
 			if (this.isLocked === true) {

--- a/panel/src/components/Forms/FormControls.vue
+++ b/panel/src/components/Forms/FormControls.vue
@@ -47,6 +47,12 @@
 					{{ $t("form.preview") }}
 				</k-dropdown-item>
 			</template>
+			<template v-if="isLocked && isUnlockable">
+				<hr />
+				<k-dropdown-item icon="lock" @click="unlock">
+					{{ $t("lock.unlock") }}
+				</k-dropdown-item>
+			</template>
 		</k-dropdown-content>
 	</div>
 </template>
@@ -58,6 +64,7 @@ export const props = {
 		hasDiff: Boolean,
 		isLocked: Boolean,
 		isProcessing: Boolean,
+		isUnlockable: Boolean,
 		modified: [String, Date],
 		/**
 		 * Preview URL for changes
@@ -134,6 +141,28 @@ export default {
 				on: {
 					submit: () => {
 						this.$emit("discard");
+					}
+				}
+			});
+		},
+		unlock() {
+			this.$panel.dialog.open({
+				component: "k-text-dialog",
+				props: {
+					size: "small",
+					submitButton: {
+						icon: "lock",
+						theme: "negative",
+						text: this.$t("lock.unlock")
+					},
+					text: this.$t("lock.unlock.confirm", {
+						email: this.editor
+					})
+				},
+				on: {
+					submit: () => {
+						this.$panel.dialog.close();
+						this.$emit("unlock");
 					}
 				}
 			});

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -27,6 +27,7 @@
 							:modified="modified"
 							@discard="onDiscard"
 							@submit="onSubmit"
+							@unlock="onUnlock"
 						/>
 					</template>
 				</k-view-buttons>

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -103,6 +103,14 @@ export default {
 				this.$panel.error(e);
 			}
 		},
+		async onUnlock() {
+			await this.$panel.content.unlock({
+				api: this.api,
+				language: this.$panel.language.code
+			});
+
+			this.$panel.view.refresh();
+		},
 		onInput(values) {
 			// update the content for the current view
 			// this will also refresh the content prop

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -28,6 +28,7 @@
 							:preview="permissions.preview ? api + '/preview/changes' : false"
 							@discard="onDiscard"
 							@submit="onSubmit"
+							@unlock="onUnlock"
 						/>
 					</template>
 				</k-view-buttons>

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -32,6 +32,7 @@
 							:preview="permissions.preview ? api + '/preview/changes' : false"
 							@discard="onDiscard"
 							@submit="onSubmit"
+							@unlock="onUnlock"
 						/>
 					</template>
 				</k-view-buttons>

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -35,6 +35,7 @@
 							:modified="modified"
 							@discard="onDiscard"
 							@submit="onSubmit"
+							@unlock="onUnlock"
 						/>
 					</template>
 				</k-view-buttons>

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -341,26 +341,12 @@ export default (panel) => {
 				throw new Error("The content is not locked");
 			}
 
-			// Cancel any ongoing save requests.
-			// The discard request will throw those
-			// changes away anyway.
-			this.cancelSaving();
-
 			// Start processing the request
 			this.isProcessing = true;
 
 			try {
 				await this.request("unlock", {}, env);
-
 				this.emit("unlock", {}, env);
-			} catch (error) {
-				// handle locked states
-				if (error.key?.startsWith("error.content.lock")) {
-					return this.lockDialog(error.details);
-				}
-
-				// let our regular error handler take over
-				throw error;
 			} finally {
 				this.isProcessing = false;
 			}

--- a/src/Api/Controller/Changes.php
+++ b/src/Api/Controller/Changes.php
@@ -153,4 +153,16 @@ class Changes
 			'status' => 'ok'
 		];
 	}
+
+	/**
+	 * Unlocks the content for the current user
+	 */
+	public static function unlock(ModelWithContent $model): array
+	{
+		$model->version('changes')->unlock();
+
+		return [
+			'status' => 'ok'
+		];
+	}
 }

--- a/src/Cms/FileBlueprint.php
+++ b/src/Cms/FileBlueprint.php
@@ -42,6 +42,7 @@ class FileBlueprint extends Blueprint
 				'read'       	 => null,
 				'replace'    	 => null,
 				'sort'           => null,
+				'unlock'         => null,
 				'update'     	 => null,
 			]
 		);

--- a/src/Cms/PageBlueprint.php
+++ b/src/Cms/PageBlueprint.php
@@ -39,6 +39,7 @@ class PageBlueprint extends Blueprint
 				'preview'        => null,
 				'read'           => null,
 				'sort'           => null,
+				'unlock'         => null,
 				'update'         => null,
 			],
 			// aliases (from v2)

--- a/src/Cms/Permissions.php
+++ b/src/Cms/Permissions.php
@@ -38,6 +38,7 @@ class Permissions
 			'read'           => true,
 			'replace'        => true,
 			'sort'           => true,
+			'unlock'         => true,
 			'update'         => true
 		],
 		'languages' => [
@@ -59,10 +60,12 @@ class Permissions
 			'preview'        => true,
 			'read'           => true,
 			'sort'           => true,
+			'unlock'         => true,
 			'update'         => true
 		],
 		'site' => [
 			'changeTitle' => true,
+			'unlock'      => true,
 			'update'      => true
 		],
 		'users' => [
@@ -73,6 +76,7 @@ class Permissions
 			'changeRole'     => true,
 			'create'         => true,
 			'delete'         => true,
+			'unlock'         => true,
 			'update'         => true
 		],
 		'user' => [
@@ -82,6 +86,7 @@ class Permissions
 			'changePassword' => true,
 			'changeRole'     => true,
 			'delete'         => true,
+			'unlock'         => true,
 			'update'         => true
 		]
 	];

--- a/src/Cms/SiteBlueprint.php
+++ b/src/Cms/SiteBlueprint.php
@@ -28,6 +28,7 @@ class SiteBlueprint extends Blueprint
 			// defaults
 			[
 				'changeTitle' => null,
+				'unlock'      => null,
 				'update'      => null,
 			],
 			// aliases

--- a/src/Cms/UserBlueprint.php
+++ b/src/Cms/UserBlueprint.php
@@ -39,6 +39,7 @@ class UserBlueprint extends Blueprint
 				'changePassword' => null,
 				'changeRole'     => null,
 				'delete'         => null,
+				'unlock'         => null,
 				'update'         => null,
 			]
 		);

--- a/src/Content/VersionRules.php
+++ b/src/Content/VersionRules.php
@@ -153,7 +153,7 @@ class VersionRules
 
 		if ($version->id()->is('changes') === false) {
 			throw new LogicException(
-				message: 'Only the changes version can be unlocked'
+				key: 'content.unlock.invalidVersion'
 			);
 		}
 

--- a/src/Content/VersionRules.php
+++ b/src/Content/VersionRules.php
@@ -5,6 +5,7 @@ namespace Kirby\Content;
 use Kirby\Cms\Language;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
+use Kirby\Exception\PermissionException;
 
 /**
  * The VersionRules class handles the validation for all
@@ -142,6 +143,25 @@ class VersionRules
 		Language $language
 	): void {
 		static::ensure($version, $language);
+	}
+
+	public static function unlock(
+		Version $version,
+		Language $language
+	): void {
+		static::ensure($version, $language);
+
+		if ($version->id()->is('changes') === false) {
+			throw new LogicException(
+				message: 'Only the changes version can be unlocked'
+			);
+		}
+
+		if ($version->model()->permissions()->can('unlock') !== true) {
+			throw new PermissionException(
+				key: $version->model()::CLASS_ALIAS . '.unlock.permission',
+			);
+		}
 	}
 
 	public static function update(

--- a/tests/Api/Controller/ChangesTest.php
+++ b/tests/Api/Controller/ChangesTest.php
@@ -37,6 +37,24 @@ class ChangesTest extends TestCase
 		$this->page = $this->app->page('article');
 	}
 
+	public function setUpUsers(): void
+	{
+		$this->app = $this->app->clone([
+			'users' => [
+				'admin' => [
+					'id'    => 'admin',
+					'email' => 'admin@getkirby.com',
+					'role'  => 'admin'
+				],
+				'editor' => [
+					'id'    => 'editor',
+					'email' => 'editor@getkirby.com',
+					'role'  => 'editor'
+				]
+			],
+		]);
+	}
+
 	public function tearDown(): void
 	{
 		$this->tearDownTmp();
@@ -205,5 +223,39 @@ class ChangesTest extends TestCase
 		$this->expectExceptionMessage('You are not allowed to change this version');
 
 		Changes::save($this->page, []);
+	}
+
+	public function testUnlock(): void
+	{
+		$this->setUpUsers();
+
+		// latest version
+		Data::write($this->page->root() . '/article.txt', [
+			// title and uuid should be passed through
+			'title' => 'Test',
+			'uuid'  => 'test'
+		]);
+
+		// locked changes version
+		Data::write($this->page->root() . '/_changes/article.txt', [
+			'title' => 'Test',
+			'uuid'  => 'test',
+			'lock'  => 'editor'
+		]);
+
+		$this->app->impersonate('admin@getkirby.com');
+
+		$response = Changes::unlock($this->page);
+
+		$this->assertSame(['status' => 'ok'], $response);
+
+		// the changes file should have the changes
+		$changes = Data::read($this->page->root() . '/_changes/article.txt');
+
+		$this->assertSame([
+			'title' => 'Test',
+			'uuid'  => 'test',
+			'lock'  => 'admin'
+		], $changes);
 	}
 }

--- a/tests/Cms/Blueprints/FileBlueprintTest.php
+++ b/tests/Cms/Blueprints/FileBlueprintTest.php
@@ -103,6 +103,7 @@ class FileBlueprintTest extends TestCase
 			'read'       	 => null,
 			'replace'    	 => null,
 			'sort'           => null,
+			'unlock'         => null,
 			'update'     	 => null,
 		];
 

--- a/tests/Cms/Blueprints/PageBlueprintTest.php
+++ b/tests/Cms/Blueprints/PageBlueprintTest.php
@@ -34,6 +34,7 @@ class PageBlueprintTest extends TestCase
 			'read'           => null,
 			'preview'        => null,
 			'sort'           => null,
+			'unlock'         => null,
 			'update'         => null,
 			'move'			 => null
 		];
@@ -72,6 +73,7 @@ class PageBlueprintTest extends TestCase
 			'read'           => null,
 			'preview'        => null,
 			'sort'           => null,
+			'unlock'         => null,
 			'update'         => null,
 			'move'			 => null
 		];
@@ -113,6 +115,7 @@ class PageBlueprintTest extends TestCase
 			'read'           => null,
 			'preview'        => null,
 			'sort'           => null,
+			'unlock'         => null,
 			'update'         => null,
 			'move'			 => null
 		];

--- a/tests/Cms/Blueprints/SiteBlueprintTest.php
+++ b/tests/Cms/Blueprints/SiteBlueprintTest.php
@@ -15,6 +15,7 @@ class SiteBlueprintTest extends TestCase
 
 		$expected = [
 			'changeTitle' => null,
+			'unlock'      => null,
 			'update'      => null,
 		];
 

--- a/tests/Cms/Blueprints/UserBlueprintTest.php
+++ b/tests/Cms/Blueprints/UserBlueprintTest.php
@@ -39,6 +39,7 @@ class UserBlueprintTest extends TestCase
 			'changePassword' => null,
 			'changeRole'     => null,
 			'delete'         => null,
+			'unlock'         => null,
 			'update'         => null,
 		];
 

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -533,6 +533,7 @@ class FileTest extends TestCase
 			'read'           => true,
 			'replace'        => true,
 			'sort'           => true,
+			'unlock'         => true,
 			'update'         => true,
 		];
 
@@ -564,6 +565,7 @@ class FileTest extends TestCase
 			'read'           => false,
 			'replace'        => false,
 			'sort'           => false,
+			'unlock'         => false,
 			'update'         => false,
 		];
 
@@ -581,6 +583,7 @@ class FileTest extends TestCase
 			'read'           => false,
 			'replace'        => false,
 			'sort'           => false,
+			'unlock'         => false,
 			'update'         => false,
 		];
 
@@ -609,6 +612,7 @@ class FileTest extends TestCase
 			'read'           => true,
 			'replace'        => false,
 			'sort'           => true,
+			'unlock'         => true,
 			'update'         => true,
 		];
 
@@ -649,6 +653,7 @@ class FileTest extends TestCase
 			'read'           => true,
 			'replace'        => true,
 			'sort'           => true,
+			'unlock'         => true,
 			'update'         => true,
 		];
 
@@ -691,6 +696,7 @@ class FileTest extends TestCase
 			'read'           => true,
 			'replace'        => false,
 			'sort'           => true,
+			'unlock'         => true,
 			'update'         => true,
 		];
 

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -456,6 +456,7 @@ class ModelTest extends TestCase
 			'link' => '/site',
 			'permissions' => [
 				'changeTitle' => false,
+				'unlock' => false,
 				'update' => false,
 			],
 			'text' => '',

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -360,6 +360,7 @@ class PageTest extends TestCase
 			'preview'        => true,
 			'read'           => true,
 			'sort'           => false, // drafts cannot be sorted
+			'unlock'         => true,
 			'update'         => true,
 		];
 
@@ -390,6 +391,7 @@ class PageTest extends TestCase
 			'preview'        => false,
 			'read'           => false,
 			'sort'           => false,
+			'unlock'         => false,
 			'update'         => false,
 		];
 
@@ -411,6 +413,7 @@ class PageTest extends TestCase
 			'preview'        => true,
 			'read'           => false,
 			'sort'           => false,
+			'unlock'         => false,
 			'update'         => false,
 		];
 

--- a/tests/Panel/Ui/Item/UserItemTest.php
+++ b/tests/Panel/Ui/Item/UserItemTest.php
@@ -48,6 +48,7 @@ class UserItemTest extends TestCase
 				'changePassword' => false,
 				'changeRole'     => false,
 				'delete'         => false,
+				'unlock'         => false,
 				'update'         => false,
 			],
 			'text'         => 'test@getkirby.com',

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -266,6 +266,7 @@ class UserTest extends TestCase
 			'changePassword' => true,
 			'changeRole'     => true,
 			'delete'         => true,
+			'unlock'         => true,
 			'update'         => true,
 		];
 
@@ -290,6 +291,7 @@ class UserTest extends TestCase
 			'changePassword' => false,
 			'changeRole'     => false,
 			'delete'         => false,
+			'unlock'         => false,
 			'update'         => false,
 		];
 
@@ -305,6 +307,7 @@ class UserTest extends TestCase
 			'changePassword' => false,
 			'changeRole'     => false,
 			'delete'         => false,
+			'unlock'         => false,
 			'update'         => false,
 		];
 


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features

#### New option to unlock changes
In some cases, the unlock expiry time of 10 minutes might be too long and you really want to take over the changes of another user. The new unlock button in the dropdown will make this possible. It's now bound to a new unlock permission for fine-grained control. In comparison to Kirby 4, this will no longer destroy and overwrite the existing changes. The unlocking user can simply pick off where the editor left and either keep on editing or discard those changes. 

https://github.com/user-attachments/assets/d40e8797-15d4-4da7-9dc8-87afc8b880a9

This feature includes the following additions and enhancements to the core and panel: 

- New `Kirby\Content\Version::unlock()` method
- New `Kirby\Content\VersionRules::unlock()` method
- New `POST: /api/(:all)/changes/unlock` route.
- New async `panel.content.unlock()` method.
- New `is-unlockable` prop for the `<k-form-controls>` component
- New `onUnlock` method for the `ModelView` base component
- All model view components pass the unlock permission to the form controls and hook up the unlock dialog.  

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->

None

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

- New `unlock` permission and blueprint option for all models.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion