### PR TITLE
lab: Getting rid of sections

### DIFF
--- a/config/areas/users/views.php
+++ b/config/areas/users/views.php
@@ -2,6 +2,7 @@
 
 use Kirby\Cms\App;
 use Kirby\Cms\Find;
+use Kirby\Panel\Collector\UsersCollector;
 use Kirby\Panel\Ui\Buttons\ViewButtons;
 use Kirby\Toolkit\Escape;
 
@@ -31,23 +32,16 @@ return [
 					},
 					'roles' => array_values($roles),
 					'users' => function () use ($kirby, $role) {
-						$users = $kirby->users();
 
-						if (empty($role) === false) {
-							$users = $users->role($role);
-						}
-
-						// sort users alphabetically
-						$users = $users->sortBy('username', 'asc');
-
-						// paginate
-						$users = $users->paginate([
-							'limit' => 20,
-							'page'  => $kirby->request()->get('page')
-						]);
+						$users = new UsersCollector(
+							role: $role,
+							sortBy: 'username asc',
+							page: $kirby->request()->get('page', 1),
+							limit: 20
+						);
 
 						return [
-							'data' => $users->values(fn ($user) => [
+							'data' => $users->paginated()->values(fn ($user) => [
 								'id'    => $user->id(),
 								'image' => $user->panel()->image(),
 								'info'  => Escape::html($user->role()->title()),

--- a/config/areas/users/views.php
+++ b/config/areas/users/views.php
@@ -4,6 +4,7 @@ use Kirby\Cms\App;
 use Kirby\Cms\Find;
 use Kirby\Panel\Collector\UsersCollector;
 use Kirby\Panel\Ui\Buttons\ViewButtons;
+use Kirby\Panel\Ui\UsersCollection;
 use Kirby\Toolkit\Escape;
 
 return [
@@ -32,7 +33,6 @@ return [
 					},
 					'roles' => array_values($roles),
 					'users' => function () use ($kirby, $role) {
-
 						$users = new UsersCollector(
 							role: $role,
 							sortBy: 'username asc',
@@ -40,15 +40,13 @@ return [
 							limit: 20
 						);
 
+						$collection = new UsersCollection(
+							users: $users->all()
+						);
+
 						return [
-							'data' => $users->paginated()->values(fn ($user) => [
-								'id'    => $user->id(),
-								'image' => $user->panel()->image(),
-								'info'  => Escape::html($user->role()->title()),
-								'link'  => $user->panel()->url(true),
-								'text'  => Escape::html($user->username())
-							]),
-							'pagination' => $users->pagination()->toArray()
+							'data'       => $collection->items(),
+							'pagination' => $collection->pagination()
 						];
 					},
 				]

--- a/config/areas/users/views.php
+++ b/config/areas/users/views.php
@@ -5,7 +5,6 @@ use Kirby\Cms\Find;
 use Kirby\Panel\Collector\UsersCollector;
 use Kirby\Panel\Ui\Buttons\ViewButtons;
 use Kirby\Panel\Ui\UsersCollection;
-use Kirby\Toolkit\Escape;
 
 return [
 	'users' => [

--- a/config/areas/users/views.php
+++ b/config/areas/users/views.php
@@ -39,13 +39,13 @@ return [
 							limit: 20
 						);
 
-						$collection = new UsersCollection(
+						$component = new UsersCollection(
 							users: $users->all()
 						);
 
 						return [
-							'data'       => $collection->items(),
-							'pagination' => $collection->pagination()
+							'data'       => $component->items(),
+							'pagination' => $component->pagination()
 						];
 					},
 				]

--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -76,8 +76,8 @@ return [
 		'modelsPaginated' => function (): Files {
 			return $this->collector()->paginated();
 		},
-		'collection' => function (): FilesCollection {
-			return $this->collection ??= new FilesCollection(
+		'component' => function (): FilesCollection {
+			return $this->component ??= new FilesCollection(
 				files: $this->modelsPaginated(),
 				columns: $this->columns(),
 				empty: $this->empty(),
@@ -96,7 +96,7 @@ return [
 			return $this->models();
 		},
 		'data' => function (): array {
-			return $this->collection()->items();
+			return $this->component()->items();
 		},
 		'total' => function (): int {
 			return $this->models()->count();
@@ -130,7 +130,7 @@ return [
 			];
 		},
 		'pagination' => function () {
-			return $this->collection()->pagination();
+			return $this->component()->pagination();
 		},
 		'upload' => function () {
 			if ($this->isFull() === true) {
@@ -187,7 +187,7 @@ return [
 	},
 	// @codeCoverageIgnoreEnd
 	'toArray' => function () {
-		$props      = $this->collection()->props();
+		$props      = $this->component()->props();
 		$items      = $props['items'];
 		$pagination = $props['pagination'];
 

--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -2,8 +2,8 @@
 
 use Kirby\Cms\ModelWithContent;
 use Kirby\Form\Form;
-use Kirby\Toolkit\I18n;
-use Kirby\Toolkit\Str;
+use Kirby\Panel\Ui\ModelsTable;
+use Kirby\Panel\Ui\PagesTable;
 
 return [
 	'props' => [
@@ -36,143 +36,31 @@ return [
 			return $size;
 		},
 	],
-	'computed' => [
+	'methods' => [
 		'columns' => function () {
-			$columns   = [];
-
 			if ($this->layout !== 'table') {
 				return [];
 			}
 
-			if ($this->image !== false) {
-				$columns['image'] = [
-					'label'  => ' ',
-					'mobile' => true,
-					'type'   => 'image',
-					'width'  => 'var(--table-row-height)'
-				];
-			}
-
-			if ($this->text) {
-				$columns['title'] = [
-					'label'  => I18n::translate('title'),
-					'mobile' => true,
-					'type'   => 'url',
-				];
-			}
-
-			if ($this->info) {
-				$columns['info'] = [
-					'label' => I18n::translate('info'),
-					'type'  => 'text',
-				];
-			}
-
-			foreach ($this->columns as $columnName => $column) {
-				if ($column === true) {
-					$column = [];
-				}
-
-				if ($column === false) {
-					continue;
-				}
-
-				// fallback for labels
-				$column['label'] ??= Str::ucfirst($columnName);
-
-				// make sure to translate labels
-				$column['label'] = I18n::translate($column['label'], $column['label']);
-
-				// keep the original column name as id
-				$column['id'] = $columnName;
-
-				// add the custom column to the array
-				// allowing to extend/overwrite existing columns
-				$columns[$columnName] = [
-					...$columns[$columnName] ?? [],
-					...$column
-				];
-			}
-
-			if ($this->type === 'pages') {
-				$columns['flag'] = [
-					'label'  => ' ',
-					'mobile' => true,
-					'type'   => 'flag',
-					'width'  => 'var(--table-row-height)',
-				];
-			}
-
-			return $columns;
+			return $this->table()->columns();
 		},
-	],
-	'methods' => [
 		'columnsWithTypes' => function () {
-			$columns = $this->columns;
-
-			// add the type to the columns for the table layout
-			if ($this->layout === 'table') {
-				$blueprint = $this->models->first()?->blueprint();
-
-				if ($blueprint === null) {
-					return $columns;
-				}
-
-				foreach ($columns as $columnName => $column) {
-					if ($id = $column['id'] ?? null) {
-						$columns[$columnName]['type'] ??= $blueprint->field($id)['type'] ?? null;
-					}
-				}
-			}
-
-			return $columns;
+			return $this->table()->columns();
 		},
 		'columnsValues' => function (array $item, ModelWithContent $model) {
-			$item['title'] = [
-				// override toSafeString() coming from `$item`
-				// because the table cells don't use v-html
-				'text' => $model->toString($this->text),
-				'href' => $model->panel()->url(true)
-			];
+			return $this->table()->row($model, $this->columns());
+		},
+		'table' => function () {
+			$className = $this->type === 'pages' ? PagesTable::class : ModelsTable::class;
 
-			if ($this->info) {
-				// override toSafeString() coming from `$item`
-				// because the table cells don't use v-html
-				$item['info'] = $model->toString($this->info);
-			}
-
-			// if forcing raw values, get those directly from content file
-			// TODO: remove once Form classes have been refactored
-			// @codeCoverageIgnoreStart
-			if ($this->rawvalues === true) {
-				foreach ($this->columns as $columnName => $column) {
-					$item[$columnName] = match (empty($column['value'])) {
-						// if column value defined, resolve the query
-						false   => $model->toString($column['value']),
-						// otherwise use the form value,
-						// but don't overwrite columns
-						default => $item[$columnName] ?? $model->content()->get($column['id'] ?? $columnName)->value()
-					};
-				}
-
-				return $item;
-			}
-			// @codeCoverageIgnoreEnd
-
-			// Use form to get the proper values for the columns
-			$form = Form::for($model)->values();
-
-			foreach ($this->columns as $columnName => $column) {
-				$item[$columnName] = match (empty($column['value'])) {
-					// if column value defined, resolve the query
-					false   => $model->toString($column['value']),
-					// otherwise use the form value,
-					// but don't overwrite columns
-					default => $item[$columnName] ?? $form[$column['id'] ?? $columnName] ?? null
-				};
-			}
-
-			return $item;
-		}
+			return $this->table ??= new $className(
+				models: $this->models(),
+				columns: $this->columns,
+				image: $this->image,
+				info: $this->info,
+				rawValues: $this->rawvalues,
+				text: $this->text,
+			);
+		},
 	],
 ];

--- a/config/sections/mixins/pagination.php
+++ b/config/sections/mixins/pagination.php
@@ -15,7 +15,7 @@ return [
 		 * Sets the default page for the pagination.
 		 */
 		'page' => function (int|null $page = null) {
-			return App::instance()->request()->get('page', $page);
+			return App::instance()->request()->get('page', $page ?? 1);
 		},
 	],
 	'methods' => [

--- a/config/sections/mixins/pagination.php
+++ b/config/sections/mixins/pagination.php
@@ -14,8 +14,8 @@ return [
 		/**
 		 * Sets the default page for the pagination.
 		 */
-		'page' => function (int|null $page = null) {
-			return App::instance()->request()->get('page', $page ?? 1);
+		'page' => function (int $page = 1) {
+			return App::instance()->request()->get('page', $page);
 		},
 	],
 	'methods' => [

--- a/config/sections/mixins/search.php
+++ b/config/sections/mixins/search.php
@@ -13,6 +13,10 @@ return [
 	],
 	'methods' => [
 		'searchterm' => function (): string|null {
+			if ($this->search === false) {
+				return null;
+			}
+
 			return App::instance()->request()->get('searchterm');
 		}
 	]

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -5,6 +5,7 @@ use Kirby\Cms\Page;
 use Kirby\Cms\Pages;
 use Kirby\Cms\Site;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Panel\Ui\PagesCollection;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
 
@@ -167,42 +168,7 @@ return [
 			return $this->models()->count();
 		},
 		'data' => function () {
-			$data = [];
-
-			foreach ($this->modelsPaginated() as $page) {
-				$panel       = $page->panel();
-				$permissions = $page->permissions();
-
-				$item = [
-					'dragText'    => $panel->dragText(),
-					'id'          => $page->id(),
-					'image'       => $panel->image(
-						$this->image,
-						$this->layout === 'table' ? 'list' : $this->layout
-					),
-					'info'        => $page->toSafeString($this->info ?? false),
-					'link'        => $panel->url(true),
-					'parent'      => $page->parentId(),
-					'permissions' => [
-						'delete'       => $permissions->can('delete'),
-						'changeSlug'   => $permissions->can('changeSlug'),
-						'changeStatus' => $permissions->can('changeStatus'),
-						'changeTitle'  => $permissions->can('changeTitle'),
-						'sort'         => $permissions->can('sort'),
-					],
-					'status'      => $page->status(),
-					'template'    => $page->intendedTemplate()->name(),
-					'text'        => $page->toSafeString($this->text),
-				];
-
-				if ($this->layout === 'table') {
-					$item = $this->columnsValues($item, $page);
-				}
-
-				$data[] = $item;
-			}
-
-			return $data;
+			return $this->pagesCollection()->items();
 		},
 		'errors' => function () {
 			$errors = [];
@@ -317,6 +283,22 @@ return [
 
 			return $blueprints;
 		},
+		'pagesCollection' => function () {
+			return new PagesCollection(
+				pages: $this->modelsPaginated(),
+				columns: $this->columns(),
+				empty: $this->empty(),
+				help: $this->help(),
+				image: $this->image(),
+				info: $this->info(),
+				layout: $this->layout(),
+				link: $this->link(),
+				sortable: $this->sortable(),
+				size: $this->size(),
+				text: $this->text(),
+				theme: $this->theme(),
+			);
+		},
 	],
 	// @codeCoverageIgnoreStart
 	'api' => function () {
@@ -334,8 +316,13 @@ return [
 	},
 	// @codeCoverageIgnoreEnd
 	'toArray' => function () {
+		// $pagesCollection = $this->pagesCollection();
+
+		// dump($pagesCollection);
+		exit;
+
 		return [
-			'data'    => $this->data,
+			'data'    => $pagesCollection->items(),
 			'errors'  => $this->errors,
 			'options' => [
 				'add'      => $this->add,
@@ -352,7 +339,7 @@ return [
 				'size'     => $this->size,
 				'sortable' => $this->sortable
 			],
-			'pagination' => $this->pagination,
+			'pagination' => $pagesCollection->pagination(),
 		];
 	}
 ];

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -107,8 +107,8 @@ return [
 		'modelsPaginated' => function (): Pages {
 			return $this->collector()->paginated();
 		},
-		'collection' => function (): PagesCollection {
-			return $this->collection ??= new PagesCollection(
+		'component' => function (): PagesCollection {
+			return $this->component ??= new PagesCollection(
 				pages: $this->modelsPaginated(),
 				columns: $this->columns(),
 				empty: $this->empty(),
@@ -127,7 +127,7 @@ return [
 			return $this->models();
 		},
 		'data' => function (): array {
-			return $this->collection()->items();
+			return $this->component()->items();
 		},
 		'total' => function (): int {
 			return $this->models()->count();
@@ -204,7 +204,7 @@ return [
 			return true;
 		},
 		'pagination' => function () {
-			return $this->collection()->pagination();
+			return $this->component()->pagination();
 		},
 	],
 	'methods' => [
@@ -262,7 +262,7 @@ return [
 	},
 	// @codeCoverageIgnoreEnd
 	'toArray' => function () {
-		$props      = $this->collection()->props();
+		$props      = $this->component()->props();
 		$items      = $props['items'];
 		$pagination = $props['pagination'];
 

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -284,7 +284,7 @@ return [
 			return $blueprints;
 		},
 		'pagesCollection' => function () {
-			return new PagesCollection(
+			return $this->pagesCollection ??= new PagesCollection(
 				pages: $this->modelsPaginated(),
 				columns: $this->columns(),
 				empty: $this->empty(),
@@ -292,7 +292,6 @@ return [
 				image: $this->image(),
 				info: $this->info(),
 				layout: $this->layout(),
-				link: $this->link(),
 				sortable: $this->sortable(),
 				size: $this->size(),
 				text: $this->text(),
@@ -316,10 +315,7 @@ return [
 	},
 	// @codeCoverageIgnoreEnd
 	'toArray' => function () {
-		// $pagesCollection = $this->pagesCollection();
-
-		// dump($pagesCollection);
-		exit;
+		$pagesCollection = $this->pagesCollection();
 
 		return [
 			'data'    => $pagesCollection->items(),

--- a/src/Panel/Collector/FilesCollector.php
+++ b/src/Panel/Collector/FilesCollector.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Kirby\Panel\Collector;
+
+use Kirby\Cms\Files;
+use Kirby\Cms\Page;
+use Kirby\Cms\Pages;
+use Kirby\Cms\Site;
+use Kirby\Cms\User;
+use Kirby\Cms\Users;
+
+class FilesCollector extends ModelsCollector
+{
+	public function __construct(
+		protected Site|Page|User $parent,
+		protected bool $flip = false,
+		protected int|null $limit = null,
+		protected int $page = 1,
+		protected string|null $query = null,
+		protected string|null $search = null,
+		protected string|null $sortBy = null,
+		protected string|null $template = null,
+	) {
+	}
+
+	protected function collectByParent(): Files
+	{
+		return $this->parent->files();
+	}
+
+	protected function collectByQuery(): Files
+	{
+		return $this->parent->query($this->query, Files::class) ?? new Files([]);
+	}
+
+	protected function filter(Files|Pages|Users $models): Files
+	{
+		return $models->filter(function ($file) {
+			// remove all protected and hidden files
+			if ($file->isListable() === false) {
+				return false;
+			}
+
+			// filter by template
+			if ($this->template !== null && $file->template() !== $this->template) {
+				return false;
+			}
+
+			return true;
+		});
+	}
+
+	protected function sort(Files|Pages|Users $models): Files|Pages|Users
+	{
+		if ($this->sortBy === null) {
+			$models = $models->sorted();
+		}
+
+		return parent::sort($models);
+	}
+}

--- a/src/Panel/Collector/ModelsCollector.php
+++ b/src/Panel/Collector/ModelsCollector.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Kirby\Panel\Collector;
+
+use Kirby\Cms\Files;
+use Kirby\Cms\Page;
+use Kirby\Cms\Pages;
+use Kirby\Cms\Pagination;
+use Kirby\Cms\Site;
+use Kirby\Cms\User;
+use Kirby\Cms\Users;
+
+abstract class ModelsCollector
+{
+	protected Files|Pages|Users $all;
+	protected Files|Pages|Users $paginated;
+
+	public function __construct(
+		protected Site|Page|User $parent,
+		protected int|null $limit = null,
+		protected int $page = 1,
+		protected string|null $query = null,
+		protected string|null $template = null,
+		protected string|null $search = null,
+		protected string|null $sortBy = null,
+		protected bool $flip = false,
+	) {
+	}
+
+	public function all(): Files|Pages|Users
+	{
+		return $this->all ??= $this->collect();
+	}
+
+	public function collect(): Files|Pages|Users
+	{
+		if ($this->query !== null) {
+			$models = $this->collectByQuery();
+		} else {
+			$models = $this->collectByParent();
+		}
+
+		$models = $this->filter($models);
+		$models = $this->search($models);
+
+		if ($this->isSearching() === false) {
+			$models = $this->sort($models);
+		}
+
+		return $models;
+	}
+
+	abstract protected function collectByParent(): Files|Pages|Users;
+
+	abstract protected function collectByQuery(): Files|Pages|Users;
+
+	abstract protected function filter(Files|Pages|Users $models): Files|Pages|Users;
+
+	public function isSearching(): bool
+	{
+		return $this->search !== null && $this->search !== '';
+	}
+
+	public function paginated(): Files|Pages|Users
+	{
+		return $this->paginated ??= $this->all()->paginate([
+			'limit'  => $this->limit ?? 1000,
+			'page'   => $this->page,
+			'method' => 'none' // the page is manually provided
+		]);
+	}
+
+	public function pagination(): Pagination
+	{
+		return $this->paginated()->pagination();
+	}
+
+	protected function search(Files|Pages|Users $models): Files|Pages|Users
+	{
+		if ($this->isSearching() === true) {
+			return $models->search($this->search);
+		}
+
+		return $models;
+	}
+
+	protected function sort(Files|Pages|Users $models): Files|Pages|Users
+	{
+		if ($this->sortBy !== null) {
+			$models = $models->sort(...$models::sortArgs($this->sortBy));
+		}
+
+		if ($this->flip === true) {
+			$models = $models->flip();
+		}
+
+		return $models;
+	}
+}

--- a/src/Panel/Collector/PagesCollector.php
+++ b/src/Panel/Collector/PagesCollector.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Kirby\Panel\Collector;
+
+use Kirby\Cms\Files;
+use Kirby\Cms\Page;
+use Kirby\Cms\Pages;
+use Kirby\Cms\Site;
+use Kirby\Cms\User;
+use Kirby\Cms\Users;
+
+class PagesCollector extends ModelsCollector
+{
+	public function __construct(
+		protected Site|Page|User $parent,
+		protected int|null $limit = null,
+		protected int $page = 1,
+		protected string|null $query = null,
+		protected string|null $status = null,
+		protected array $templates = [],
+		protected array $templatesIgnore = [],
+		protected string|null $search = null,
+		protected string|null $sortBy = null,
+		protected bool $flip = false,
+	) {
+	}
+
+	protected function collectByParent(): Pages
+	{
+		return match ($this->status) {
+			'draft'     => $this->parent->drafts(),
+			'listed'    => $this->parent->children()->listed(),
+			'published' => $this->parent->children(),
+			'unlisted'  => $this->parent->children()->unlisted(),
+			default     => $this->parent->childrenAndDrafts()
+		};
+	}
+
+	protected function collectByQuery(): Pages
+	{
+		return $this->parent->query($this->query, Pages::class) ?? new Pages([]);
+	}
+
+	protected function filter(Files|Pages|Users $models): Pages
+	{
+		// filters pages that are protected and not in the templates list
+		// internal `filter()` method used instead of foreach loop that previously included `unset()`
+		// because `unset()` is updating the original data, `filter()` is just filtering
+		// also it has been tested that there is no performance difference
+		// even in 0.1 seconds on 100k virtual pages
+		return $models->filter(function (Page $model): bool {
+			// remove all protected and hidden pages
+			if ($model->isListable() === false) {
+				return false;
+			}
+
+			$intendedTemplate = $model->intendedTemplate()->name();
+
+			// filter by all set templates
+			if (
+				$this->templates &&
+				in_array($intendedTemplate, $this->templates, true) === false
+			) {
+				return false;
+			}
+
+			// exclude by all ignored templates
+			if (
+				$this->templatesIgnore &&
+				in_array($intendedTemplate, $this->templatesIgnore, true) === true
+			) {
+				return false;
+			}
+
+			return true;
+		});
+	}
+}

--- a/src/Panel/Collector/UsersCollector.php
+++ b/src/Panel/Collector/UsersCollector.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Kirby\Panel\Collector;
+
+use Kirby\Cms\App;
+use Kirby\Cms\Files;
+use Kirby\Cms\Pages;
+use Kirby\Cms\Users;
+
+class UsersCollector extends ModelsCollector
+{
+	public function __construct(
+		protected bool $flip = false,
+		protected int|null $limit = null,
+		protected int $page = 1,
+		protected string|null $query = null,
+		protected string|null $role = null,
+		protected string|null $search = null,
+		protected string|null $sortBy = null,
+	) {
+	}
+
+	protected function collectByParent(): Users
+	{
+		return App::instance()->users();
+	}
+
+	protected function collectByQuery(): Users
+	{
+		return $this->parent->query($this->query, Users::class) ?? new Users([]);
+	}
+
+	protected function filter(Files|Pages|Users $models): Users
+	{
+		if ($this->role !== null) {
+			$models = $models->role($this->role);
+		}
+
+		return $models;
+	}
+}

--- a/src/Panel/Collector/UsersCollector.php
+++ b/src/Panel/Collector/UsersCollector.php
@@ -27,7 +27,7 @@ class UsersCollector extends ModelsCollector
 
 	protected function collectByQuery(): Users
 	{
-		return $this->parent->query($this->query, Users::class) ?? new Users([]);
+		return App::instance()->site()->query($this->query, Users::class) ?? new Users([]);
 	}
 
 	protected function filter(Files|Pages|Users $models): Users

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -110,6 +110,11 @@ abstract class Model
 			return null;
 		}
 
+		// use the list layout images in tables
+		if ($layout === 'table') {
+			$layout = 'list';
+		}
+
 		// switched off from blueprint,
 		// only if not overwritten by $settings
 		$blueprint = $this->model->blueprint()->image();

--- a/src/Panel/Ui/Collection.php
+++ b/src/Panel/Ui/Collection.php
@@ -15,7 +15,7 @@ class Collection extends Items
 	public function __construct(
 		public array $columns = [],
 		public string $component = 'k-collection',
-		public array|null $empty = null,
+		public array|string|null $empty = null,
 		public string|null $help = null,
 		public array $items = [],
 		public string $layout = 'list',

--- a/src/Panel/Ui/Collection.php
+++ b/src/Panel/Ui/Collection.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+/**
+ * @package   Kirby Panel
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ */
+class Collection extends Items
+{
+	public function __construct(
+		public array $columns = [],
+		public string $component = 'k-collection',
+		public array|null $empty = null,
+		public string|null $help = null,
+		public array $items = [],
+		public string $layout = 'list',
+		public bool $link = true,
+		public array|bool $pagination = false,
+		public bool $selecting = false,
+		public bool $sortable = false,
+		public string $size = 'medium',
+		public string|null $theme = null,
+	) {
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'empty'      => $this->empty(),
+			'help'       => $this->help(),
+			'pagination' => $this->pagination(),
+		];
+	}
+}

--- a/src/Panel/Ui/FilesCollection.php
+++ b/src/Panel/Ui/FilesCollection.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+use Kirby\Cms\Files;
+use Kirby\Cms\ModelWithContent;
+
+/**
+ * @package   Kirby Panel
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ */
+class FilesCollection extends ModelsCollection
+{
+	public function __construct(
+		public Files $files,
+		public array $columns = [],
+		public string $component = 'k-collection',
+		public array|null $empty = null,
+		public string|null $help = null,
+		public array|null|bool $image = null,
+		public string|null $info = null,
+		public string $layout = 'list',
+		public array|bool $pagination = false,
+		public bool $selecting = false,
+		public bool $sortable = false,
+		public string $size = 'medium',
+		public string|null $text = '{{ file.filename }}',
+		public string|null $theme = null,
+	) {
+		$this->models = $files;
+	}
+
+	/**
+	 * @param \Kirby\Cms\File $model
+	 */
+	public function item(
+		ModelWithContent $model,
+		array|null|bool $image,
+		string|null $info,
+		string $layout,
+		string $text,
+	): array
+	{
+		$panel       = $model->panel();
+		$permissions = $model->permissions();
+
+		return [
+			'dragText'    => $panel->dragText(),
+			'extension'   => $model->extension(),
+			'filename'    => $model->filename(),
+			'id'          => $model->id(),
+			'image'       => $panel->image($image, $layout),
+			'info'        => $model->toSafeString($info ?? false),
+			'link'        => $panel->url(true),
+			'mime'        => $model->mime(),
+			'parent'      => $model->parent()->panel()->path(),
+			'permissions' => [
+				'delete' => $permissions->can('delete'),
+				'sort'   => $permissions->can('sort'),
+			],
+			'template'   => $model->template(),
+			'text'       => $model->toSafeString($text),
+			'url'        => $model->url(),
+		];
+	}
+}

--- a/src/Panel/Ui/FilesCollection.php
+++ b/src/Panel/Ui/FilesCollection.php
@@ -19,15 +19,17 @@ class FilesCollection extends ModelsCollection
 		public Files $files,
 		public array $columns = [],
 		public string $component = 'k-collection',
-		public array|null $empty = null,
+		public array|string|null $empty = null,
 		public string|null $help = null,
-		public array|null|bool $image = null,
+		public array|string|bool|null $image = null,
 		public string|null $info = null,
 		public string $layout = 'list',
+		public bool $link = true,
 		public array|bool $pagination = false,
+		public bool $rawValues = false,
 		public bool $selecting = false,
 		public bool $sortable = false,
-		public string $size = 'medium',
+		public string $size = 'auto',
 		public string|null $text = '{{ file.filename }}',
 		public string|null $theme = null,
 	) {
@@ -39,12 +41,11 @@ class FilesCollection extends ModelsCollection
 	 */
 	public function item(
 		ModelWithContent $model,
-		array|null|bool $image,
+		array|string|bool|null $image,
 		string|null $info,
 		string $layout,
 		string $text,
-	): array
-	{
+	): array {
 		$panel       = $model->panel();
 		$permissions = $model->permissions();
 

--- a/src/Panel/Ui/Items.php
+++ b/src/Panel/Ui/Items.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+/**
+ * @package   Kirby Panel
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ */
+class Items extends Component
+{
+	public function __construct(
+		public string $component = 'k-items',
+		public array $columns = [],
+		public array $fields = [],
+		public array $items = [],
+		public string $layout = 'list',
+		public bool $link = true,
+		public bool $selecting = false,
+		public bool $sortable = false,
+		public string $size = 'medium',
+		public string|null $theme = null,
+	) {
+	}
+
+	public function props(): array
+	{
+		return [
+			'columns'   => $this->columns(),
+			'fields'    => $this->fields(),
+			'items'     => $this->items(),
+			'layout'    => $this->layout(),
+			'link'      => $this->link(),
+			'selecting' => $this->selecting(),
+			'sortable'  => $this->sortable(),
+			'size'      => $this->size(),
+			'theme'     => $this->theme(),
+		];
+	}
+}

--- a/src/Panel/Ui/Items.php
+++ b/src/Panel/Ui/Items.php
@@ -15,7 +15,6 @@ class Items extends Component
 	public function __construct(
 		public string $component = 'k-items',
 		public array $columns = [],
-		public array $fields = [],
 		public array $items = [],
 		public string $layout = 'list',
 		public bool $link = true,
@@ -30,7 +29,6 @@ class Items extends Component
 	{
 		return [
 			'columns'   => $this->columns(),
-			'fields'    => $this->fields(),
 			'items'     => $this->items(),
 			'layout'    => $this->layout(),
 			'link'      => $this->link(),

--- a/src/Panel/Ui/ModelsCollection.php
+++ b/src/Panel/Ui/ModelsCollection.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Files;
+use Kirby\Cms\Pages;
+use Kirby\Cms\Users;
+use Kirby\Toolkit\I18n;
+
+/**
+ * @package   Kirby Panel
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ */
+abstract class ModelsCollection extends Collection
+{
+	public function __construct(
+		public Files|Pages|Users $models,
+		public array $columns = [],
+		public string $component = 'k-collection',
+		public array|null $empty = null,
+		public string|null $help = null,
+		public array|null|bool $image = null,
+		public string|null $info = null,
+		public string $layout = 'list',
+		public bool $link = true,
+		public array|bool $pagination = false,
+		public bool $selecting = false,
+		public bool $sortable = false,
+		public string $size = 'medium',
+		public string|null $text = '{{ model.title }}',
+		public string|null $theme = null,
+	) {
+	}
+
+	public function info(): string|null
+	{
+		return I18n::translate($this->info, $this->info);
+	}
+
+	abstract public function item(
+		ModelWithContent $model,
+		array|null|bool $image,
+		string|null $info,
+		string $layout,
+		string $text,
+	): array;
+
+	public function items(): array
+	{
+		$items = [];
+
+		$image  = $this->image();
+		$info   = $this->info();
+		$layout = $this->layout();
+		$text   = $this->text();
+
+		foreach ($this->models() as $model) {
+			$items[] = $this->item(
+				model: $model,
+				image: $image,
+				info: $info,
+				layout: $layout,
+				text: $text,
+			);
+		}
+
+		return $items;
+	}
+
+	public function models(): Files|Pages|Users
+	{
+		return $this->models;
+	}
+
+	public function pagination(): array|false
+	{
+		$pagination = $this->models()->pagination();
+
+		if ($pagination === null) {
+			return false;
+		}
+
+		return [
+			'limit'  => $pagination->limit(),
+			'offset' => $pagination->offset(),
+			'page'   => $pagination->page(),
+			'total'  => $pagination->total(),
+		];
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'pagination' => $this->pagination(),
+			'image'      => $this->image(),
+			'info'       => $this->info(),
+			'text'       => $this->text(),
+		];
+	}
+
+	public function text(): string
+	{
+		return I18n::translate($this->text, $this->text);
+	}
+}

--- a/src/Panel/Ui/ModelsCollection.php
+++ b/src/Panel/Ui/ModelsCollection.php
@@ -27,7 +27,6 @@ abstract class ModelsCollection extends Collection
 		public array|null|bool $image = null,
 		public string|null $info = null,
 		public string $layout = 'list',
-		public bool $link = true,
 		public array|bool $pagination = false,
 		public bool $selecting = false,
 		public bool $sortable = false,

--- a/src/Panel/Ui/ModelsCollection.php
+++ b/src/Panel/Ui/ModelsCollection.php
@@ -2,8 +2,8 @@
 
 namespace Kirby\Panel\Ui;
 
-use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Files;
+use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Pages;
 use Kirby\Cms\Users;
 use Kirby\Toolkit\I18n;
@@ -18,22 +18,34 @@ use Kirby\Toolkit\I18n;
  */
 abstract class ModelsCollection extends Collection
 {
+	protected ModelsTable $table;
+
 	public function __construct(
 		public Files|Pages|Users $models,
 		public array $columns = [],
 		public string $component = 'k-collection',
-		public array|null $empty = null,
+		public array|string|null $empty = null,
 		public string|null $help = null,
-		public array|null|bool $image = null,
+		public array|string|bool|null $image = null,
 		public string|null $info = null,
 		public string $layout = 'list',
 		public array|bool $pagination = false,
+		public bool $rawValues = false,
 		public bool $selecting = false,
 		public bool $sortable = false,
-		public string $size = 'medium',
+		public string $size = 'auto',
 		public string|null $text = '{{ model.title }}',
 		public string|null $theme = null,
 	) {
+	}
+
+	public function columns(): array
+	{
+		if ($this->layout !== 'table') {
+			return [];
+		}
+
+		return $this->table()->columns();
 	}
 
 	public function info(): string|null
@@ -43,7 +55,7 @@ abstract class ModelsCollection extends Collection
 
 	abstract public function item(
 		ModelWithContent $model,
-		array|null|bool $image,
+		array|string|bool|null $image,
 		string|null $info,
 		string $layout,
 		string $text,
@@ -57,6 +69,10 @@ abstract class ModelsCollection extends Collection
 		$info   = $this->info();
 		$layout = $this->layout();
 		$text   = $this->text();
+
+		if ($layout === 'table') {
+			return $this->table()->rows();
+		}
 
 		foreach ($this->models() as $model) {
 			$items[] = $this->item(
@@ -101,6 +117,18 @@ abstract class ModelsCollection extends Collection
 			'info'       => $this->info(),
 			'text'       => $this->text(),
 		];
+	}
+
+	public function table(): ModelsTable
+	{
+		return $this->table ??= new ModelsTable(
+			models: $this->models(),
+			columns: $this->columns,
+			text: $this->text,
+			image: $this->image,
+			info: $this->info,
+			rawValues: $this->rawValues
+		);
 	}
 
 	public function text(): string

--- a/src/Panel/Ui/ModelsTable.php
+++ b/src/Panel/Ui/ModelsTable.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+use Kirby\Cms\Blueprint;
+use Kirby\Cms\Files;
+use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Pages;
+use Kirby\Cms\Users;
+use Kirby\Form\Form;
+use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Str;
+
+class ModelsTable
+{
+	public function __construct(
+		public Files|Pages|Users $models,
+		public array $columns = [],
+		public string $component = 'k-table',
+		public array|bool|null $image = null,
+		public string|null $info = null,
+		public bool $rawValues = false,
+		public string|null $text = '{{ model.title }}',
+	) {
+	}
+
+	public function blueprint(): Blueprint|null
+	{
+		return $this->models->first()?->blueprint();
+	}
+
+	public function columns(): array
+	{
+		$columns = [];
+
+		if ($this->image !== false) {
+			$columns['image'] = $this->imageColumn();
+		}
+
+		if ($this->text) {
+			$columns['title'] = $this->titleColumn();
+		}
+
+		if ($this->info) {
+			$columns['info'] = $this->infoColumn();
+		}
+
+		foreach ($this->columns as $columnName => $column) {
+			if ($column === true) {
+				$column = [];
+			}
+
+			if ($column === false) {
+				continue;
+			}
+
+			// fallback for labels
+			$column['label'] ??= Str::ucfirst($columnName);
+
+			// make sure to translate labels
+			$column['label'] = I18n::translate($column['label'], $column['label']);
+
+			// keep the original column name as id
+			$column['id'] = $columnName;
+
+			// add the custom column to the array
+			// allowing to extend/overwrite existing columns
+			$columns[$columnName] = [
+				...$columns[$columnName] ?? [],
+				...$column
+			];
+		}
+
+		if ($this->rawValues === false) {
+			$columns = $this->injectColumnTypes($columns);
+		}
+
+		return $columns;
+	}
+
+	public function defaultCells(ModelWithContent $model, array $columns): array
+	{
+		$cells = [];
+
+		if ($this->image !== false) {
+			$cells['image'] = $this->imageCell($model);
+		}
+
+		if ($this->text) {
+			$cells['title'] = $this->titleCell($model);
+		}
+
+		if ($this->info) {
+			$cells['info'] = $this->infoCell($model);
+		}
+
+		$cells['link']        = $model->panel()->url(true);
+		$cells['permissions'] = $this->rowPermissions($model);
+
+		return $cells;
+	}
+
+	public function imageCell(ModelWithContent $model): array
+	{
+		return $model->panel()->image($this->image, 'table');
+	}
+
+	public function imageColumn(): array
+	{
+		return [
+			'label'  => ' ',
+			'mobile' => true,
+			'type'   => 'image',
+			'width'  => 'var(--table-row-height)'
+		];
+	}
+
+	public function infoCell(ModelWithContent $model): string
+	{
+		return $model->toString($this->info);
+	}
+
+	public function infoColumn(): array
+	{
+		return [
+			'label'  => I18n::translate('info'),
+			'mobile' => true,
+			'type'   => 'text'
+		];
+	}
+
+	public function injectColumnTypes(array $columns): array
+	{
+		$blueprint = $this->blueprint();
+
+		if ($blueprint === null) {
+			return $columns;
+		}
+
+		foreach ($columns as $columnName => $column) {
+			$columns[$columnName]['type'] ??= $blueprint->field($column['id'])['type'] ?? null;
+		}
+
+		return $columns;
+	}
+
+	public function props(): array
+	{
+		return [
+			'columns' => $this->columns(),
+			'rows'    => $this->rows(),
+		];
+	}
+
+	public function queryCell(ModelWithContent $model, string $query): mixed
+	{
+		return $model->toString($query);
+	}
+
+	public function rawCell(ModelWithContent $model, string $columnName, array $column): mixed
+	{
+		// if a column value query is defined, resolve the query
+		if (isset($column['value']) === true) {
+			return $this->queryCell($model, $column['value']);
+		}
+
+		return $model->content()->get($columnName)->value();
+	}
+
+	public function rawRow(ModelWithContent $model, array $columns): array
+	{
+		$row = [];
+
+		foreach ($columns as $columnName => $column) {
+			$row[$columnName] = $this->rawCell($model, $columnName, $column);
+		}
+
+		return $row;
+	}
+
+	public function row(ModelWithContent $model, array $columns): array
+	{
+		$row = [];
+
+		if ($this->rawValues === true) {
+			$row = $this->rawRow($model, $columns);
+		} else {
+			$row = $this->typedRow($model, $columns);
+		}
+
+		return [
+			...$row,
+			...$this->defaultCells($model, $columns)
+		];
+	}
+
+	public function rowPermissions(ModelWithContent $model): array
+	{
+		$permissions = $model->permissions();
+
+		return [
+			'delete' => $permissions->can('delete'),
+			'sort'   => $permissions->can('sort'),
+		];
+	}
+
+	public function rows(): array
+	{
+		$columns = $this->columns();
+		$rows    = [];
+
+		foreach ($this->models as $model) {
+			$rows[] = $this->row($model, $columns);
+		}
+
+		return $rows;
+	}
+
+	public function titleCell(ModelWithContent $model): array
+	{
+		return [
+			'text' => $model->toString($this->text),
+			'href' => $model->panel()->url(true)
+		];
+	}
+
+	public function titleColumn(): array
+	{
+		return [
+			'label' => I18n::translate('title'),
+			'mobile' => true,
+			'type'   => 'url',
+		];
+	}
+
+	public function typedCell(ModelWithContent $model, string $columnName, array $column, array $formValues): mixed
+	{
+		// if a column value query is defined, resolve the query
+		if (isset($column['value']) === true) {
+			return $this->queryCell($model, $column['value']);
+		}
+
+		return $formValues[$columnName] ?? null;
+	}
+
+	public function typedRow(ModelWithContent $model, array $columns): array
+	{
+		$form       = Form::for($model);
+		$formValues = $form->toFormValues();
+		$row        = [];
+
+		foreach ($columns as $columnName => $column) {
+			$row[$columnName] = $this->typedCell($model, $columnName, $column, $formValues);
+		}
+
+		return $row;
+	}
+}

--- a/src/Panel/Ui/PagesCollection.php
+++ b/src/Panel/Ui/PagesCollection.php
@@ -24,7 +24,6 @@ class PagesCollection extends ModelsCollection
 		public array|null|bool $image = null,
 		public string|null $info = null,
 		public string $layout = 'list',
-		public bool $link = true,
 		public array|bool $pagination = false,
 		public bool $selecting = false,
 		public bool $sortable = false,

--- a/src/Panel/Ui/PagesCollection.php
+++ b/src/Panel/Ui/PagesCollection.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Pages;
+
+/**
+ * @package   Kirby Panel
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ */
+class PagesCollection extends ModelsCollection
+{
+	public function __construct(
+		public Pages $pages,
+		public array $columns = [],
+		public string $component = 'k-collection',
+		public array|null $empty = null,
+		public string|null $help = null,
+		public array|null|bool $image = null,
+		public string|null $info = null,
+		public string $layout = 'list',
+		public bool $link = true,
+		public array|bool $pagination = false,
+		public bool $selecting = false,
+		public bool $sortable = false,
+		public string $size = 'medium',
+		public string|null $text = '{{ model.title }}',
+		public string|null $theme = null,
+	) {
+		$this->models = $pages;
+	}
+
+	/**
+	 * @param \Kirby\Cms\Page $model
+	 */
+	public function item(
+		ModelWithContent $model,
+		array|null $image,
+		string|null $info,
+		string $layout,
+		string $text,
+	): array
+	{
+		$panel       = $model->panel();
+		$permissions = $model->permissions();
+
+		return [
+			'dragText' => $panel->dragText(),
+			'id'       => $model->id(),
+			'image'    => $panel->image($image, $layout === 'table' ? 'list' : $layout),
+			'info'     => $model->toSafeString($info ?? false),
+			'link'     => $panel->url(true),
+			'parent'   => $model->parentId(),
+			'permissions' => [
+				'delete'       => $permissions->can('delete'),
+				'changeSlug'   => $permissions->can('changeSlug'),
+				'changeStatus' => $permissions->can('changeStatus'),
+				'changeTitle'  => $permissions->can('changeTitle'),
+				'sort'         => $permissions->can('sort'),
+			],
+			'status'     => $model->status(),
+			'template'   => $model->intendedTemplate()->name(),
+			'text'       => $model->toSafeString($text),
+		];
+	}
+}

--- a/src/Panel/Ui/PagesCollection.php
+++ b/src/Panel/Ui/PagesCollection.php
@@ -40,7 +40,7 @@ class PagesCollection extends ModelsCollection
 	 */
 	public function item(
 		ModelWithContent $model,
-		array|null $image,
+		array|null|bool $image,
 		string|null $info,
 		string $layout,
 		string $text,

--- a/src/Panel/Ui/PagesCollection.php
+++ b/src/Panel/Ui/PagesCollection.php
@@ -51,7 +51,7 @@ class PagesCollection extends ModelsCollection
 		return [
 			'dragText' => $panel->dragText(),
 			'id'       => $model->id(),
-			'image'    => $panel->image($image, $layout === 'table' ? 'list' : $layout),
+			'image'    => $panel->image($image, $layout),
 			'info'     => $model->toSafeString($info ?? false),
 			'link'     => $panel->url(true),
 			'parent'   => $model->parentId(),

--- a/src/Panel/Ui/PagesCollection.php
+++ b/src/Panel/Ui/PagesCollection.php
@@ -19,15 +19,17 @@ class PagesCollection extends ModelsCollection
 		public Pages $pages,
 		public array $columns = [],
 		public string $component = 'k-collection',
-		public array|null $empty = null,
+		public array|string|null $empty = null,
 		public string|null $help = null,
-		public array|null|bool $image = null,
+		public array|string|bool|null $image = null,
 		public string|null $info = null,
 		public string $layout = 'list',
+		public bool $link = true,
 		public array|bool $pagination = false,
+		public bool $rawValues = false,
 		public bool $selecting = false,
 		public bool $sortable = false,
-		public string $size = 'medium',
+		public string $size = 'auto',
 		public string|null $text = '{{ model.title }}',
 		public string|null $theme = null,
 	) {
@@ -39,12 +41,11 @@ class PagesCollection extends ModelsCollection
 	 */
 	public function item(
 		ModelWithContent $model,
-		array|null|bool $image,
+		array|string|bool|null $image,
 		string|null $info,
 		string $layout,
 		string $text,
-	): array
-	{
+	): array {
 		$panel       = $model->panel();
 		$permissions = $model->permissions();
 
@@ -66,5 +67,17 @@ class PagesCollection extends ModelsCollection
 			'template'   => $model->intendedTemplate()->name(),
 			'text'       => $model->toSafeString($text),
 		];
+	}
+
+	public function table(): PagesTable
+	{
+		return $this->table ??= new PagesTable(
+			models: $this->models(),
+			columns: $this->columns,
+			image: $this->image,
+			info: $this->info,
+			rawValues: $this->rawValues,
+			text: $this->text,
+		);
 	}
 }

--- a/src/Panel/Ui/PagesTable.php
+++ b/src/Panel/Ui/PagesTable.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Page;
+
+class PagesTable extends ModelsTable
+{
+	public function columns(): array
+	{
+		$columns = parent::columns();
+		$columns['flag'] = $this->flagColumn();
+
+		return $columns;
+	}
+
+	/**
+	 * @param Page $model
+	 */
+	public function defaultCells(ModelWithContent $model, array $columns): array
+	{
+		$cells = parent::defaultCells($model, $columns);
+		$cells['status'] = $model->status();
+
+		return $cells;
+	}
+
+	public function flagColumn(): array
+	{
+		return [
+			'label'  => ' ',
+			'mobile' => true,
+			'type'   => 'flag',
+			'width'  => 'var(--table-row-height)',
+		];
+	}
+
+	public function rowPermissions(ModelWithContent $model): array
+	{
+		$permissions = $model->permissions();
+
+		return [
+			'changeStatus' => $permissions->can('changeStatus'),
+			'delete'       => $permissions->can('delete'),
+			'sort'         => $permissions->can('sort'),
+		];
+	}
+}

--- a/src/Panel/Ui/UsersCollection.php
+++ b/src/Panel/Ui/UsersCollection.php
@@ -2,8 +2,8 @@
 
 namespace Kirby\Panel\Ui;
 
-use Kirby\Cms\Users;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Users;
 
 /**
  * @package   Kirby Panel

--- a/src/Panel/Ui/UsersCollection.php
+++ b/src/Panel/Ui/UsersCollection.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Kirby\Panel\Ui;
+
+use Kirby\Cms\Users;
+use Kirby\Cms\ModelWithContent;
+
+/**
+ * @package   Kirby Panel
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.1.0
+ */
+class UsersCollection extends ModelsCollection
+{
+	public function __construct(
+		public Users $users,
+		public array $columns = [],
+		public string $component = 'k-collection',
+		public array|string|null $empty = null,
+		public string|null $help = null,
+		public array|string|bool|null $image = null,
+		public string|null $info = '{{ user.role.title }}',
+		public string $layout = 'list',
+		public bool $link = true,
+		public array|bool $pagination = false,
+		public bool $rawValues = false,
+		public bool $selecting = false,
+		public bool $sortable = false,
+		public string $size = 'auto',
+		public string|null $text = '{{ user.username }}',
+		public string|null $theme = null,
+	) {
+		$this->models = $users;
+	}
+
+	/**
+	 * @param \Kirby\Cms\User $model
+	 */
+	public function item(
+		ModelWithContent $model,
+		array|string|bool|null $image,
+		string|null $info,
+		string $layout,
+		string $text,
+	): array {
+		$panel = $model->panel();
+
+		return [
+			'id'    => $model->id(),
+			'image' => $panel->image($image, $layout),
+			'info'  => $model->toSafeString($info ?? false),
+			'link'  => $panel->url(true),
+			'text'  => $model->toSafeString($text),
+		];
+	}
+}


### PR DESCRIPTION
This is a lab branch with a set of ideas to get rid of the files and pages sections and migrate them over to fields. But there are a lot of steps in between that are needed to refactor the code in a way that we can still keep the sections around. Here's a summary of the ideas that I had to tackle this. 

## Individual steps 

- [x] https://github.com/getkirby/kirby/pull/7433

## New UI Classes

New UI Classes help to create the correct props for our `<k-collection>` component, which we use to display pages, files and users. 

- `Kirby\Ui\ModelsCollection`
- `Kirby\Ui\PagesCollection`
- `Kirby\Ui\FilesCollection`
- `Kirby\Ui\UsersCollection`

Those classes take over a lot of the work that is normally be done in the pages and files section, but in a lot more controllable way. They should purely take care of creating the correct props. No additional logic should be solved here. 

Ideally, those classes are so universally usable, that each new backend route could later use them to create a list of models with the correct layout. 

The most complex part here is the table logic. I've outsourced it into two additional classes: 

- `Kirby\Ui\ModelsTable`
- `Kirby\Ui\PagesTable`

Again, those classes are here to mostly prepare all the needed props for the tables. They need a lot more logic though to fetch the values for the rows. It would maybe make sense to add another class one level below, which is purely just a Table UI Class without any or hardly any logic.

## New Collector classes

This is a brand new concept. I like it so far, but I'm not 100% sure about the naming yet. The idea is to outsource the complex data fetching logic that we need for pages, files and users in the Panel - including sorting, filtering and searching. 

Those classes can serve as data source for multiple use cases. Not just for sections. But right now they neatly take care of a huge chunk of the section logic. We can also write tests for this in a much more elegant way than we did for the sections. (still needs to be done) I really think that this separation between fetching data and displaying data is pretty useful. If you come up with a better name though, I'm totally up for it. 

## Next steps

The more logic we've separated from the sections' array config, the easier it will be to have new Field classes for them, but still keep the old array configuration around. I think there are a couple more parts that could be improved / outsourced: 

- Min/Max validation
- The `add` logic for pages
- The page status ('all', 'draft', 'published', 'listed', 'unlisted') could maybe become an Enum
- The `upload` logic in the files section

## Failing tests

There are only a few minor failing unit tests. I think we can debug this more easily as soon as the Table classes have their own unit tests. 









