### PR TITLE
refact: `Panel\Ui\Stat` optional `$model` property

### DIFF
--- a/src/Panel/Ui/Stat.php
+++ b/src/Panel/Ui/Stat.php
@@ -17,13 +17,13 @@ use Kirby\Toolkit\I18n;
 class Stat extends Component
 {
 	public function __construct(
-		public ModelWithContent $model,
 		public array|string $label,
 		public array|string $value,
 		public string $component = 'k-stat',
 		public string|null $icon = null,
 		public array|string|null $info = null,
 		public array|string|null $link = null,
+		public ModelWithContent|null $model = null,
 		public string|null $theme = null,
 	) {
 	}
@@ -90,6 +90,10 @@ class Stat extends Component
 
 	protected function stringTemplate(string|null $string = null): string|null
 	{
+		if ($this->model === null) {
+			return $string;
+		}
+
 		if ($string !== null) {
 			return $this->model->toString($string);
 		}


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

@bastianallgeier I think the component would be more useful if a model isn't required. IMO it's only required when one wants to use the query functionality, but as UI element, a stat could also be used completely without that smart logic but by providing the final values directly.