### PR TITLE
fix: Update toolbar sticky selector for focus states

### DIFF
--- a/panel/src/components/Forms/Toolbar/Toolbar.vue
+++ b/panel/src/components/Forms/Toolbar/Toolbar.vue
@@ -134,7 +134,7 @@ export default {
 	--toolbar-text: var(--color-gray-400);
 	--toolbar-border: var(--panel-color-back);
 }
-.k-toolbar:not([data-inline="true"]):has(~ :focus-within) {
+.k-toolbar:not([data-inline="true"]):has(~ :focus-within, :focus) {
 	position: sticky;
 	top: var(--header-sticky-offset);
 	inset-inline: 0;


### PR DESCRIPTION
I've applied my solution that I've mentioned [in here](https://github.com/getkirby/kirby/issues/7364#issuecomment-3075833987).

Modified the CSS selector to make the toolbar sticky when any following sibling or itself is focused.

## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Clicking a button in the Writer toolbar has no effect when it is sticky at the top. #7364

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion