### PR TITLE
fix: Ensure temporary page models use memory storage and UUIDs

### DIFF
--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -287,6 +287,7 @@ return [
 				slug: $request->get('slug'),
 				template: $request->get('template'),
 				title: $request->get('title'),
+				uuid: $request->get('uuid'),
 				viewId: $request->get('view'),
 			);
 
@@ -300,6 +301,7 @@ return [
 				slug: $request->get('slug'),
 				template: $request->get('template'),
 				title: $request->get('title'),
+				uuid: $request->get('uuid'),
 				viewId: $request->get('view'),
 			);
 

--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -142,6 +142,13 @@ class PageCreateDialog
 			]);
 		}
 
+		// pass uuid field to the dialog if uuids are enabled
+		// to use the same uuid and prevent generating a new one
+		// when the page is created
+		if (Uuids::enabled() === true) {
+			$fields['uuid'] = Field::hidden();
+		}
+
 		return [
 			...$fields,
 			'parent'   => Field::hidden(),

--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -37,6 +37,7 @@ class PageCreateDialog
 	protected string|null $slug;
 	protected string|null $template;
 	protected string|null $title;
+	protected string|null $uuid;
 	protected Page|Site|User|File $view;
 	protected string|null $viewId;
 
@@ -72,6 +73,7 @@ class PageCreateDialog
 		// optional
 		string|null $slug = null,
 		string|null $title = null,
+		string|null $uuid = null,
 	) {
 		$this->parentId  = $parentId ?? 'site';
 		$this->parent    = Find::parent($this->parentId);
@@ -79,6 +81,7 @@ class PageCreateDialog
 		$this->slug      = $slug;
 		$this->template  = $template;
 		$this->title     = $title;
+		$this->uuid      = $uuid;
 		$this->viewId    = $viewId;
 		$this->view      = Find::parent($this->viewId ?? $this->parentId);
 	}
@@ -164,7 +167,7 @@ class PageCreateDialog
 	public function customFields(): array
 	{
 		$custom    = [];
-		$ignore    = ['title', 'slug', 'parent', 'template'];
+		$ignore    = ['title', 'slug', 'parent', 'template', 'uuid'];
 		$blueprint = $this->blueprint();
 		$fields    = $blueprint->fields();
 
@@ -280,7 +283,7 @@ class PageCreateDialog
 		// and added to content right away
 		if (Uuids::enabled() === true) {
 			$props['content'] = [
-				'uuid' => Uuid::generate()
+				'uuid' => $this->uuid = Uuid::generate()
 			];
 		}
 
@@ -325,9 +328,14 @@ class PageCreateDialog
 	{
 		$input['title'] ??= $this->title ?? '';
 		$input['slug']  ??= $this->slug  ?? '';
+		$input['uuid']  ??= $this->uuid  ?? null;
 
 		$input   = $this->resolveFieldTemplates($input);
 		$content = ['title' => trim($input['title'])];
+
+		if ($uuid = $input['uuid'] ?? null) {
+			$content['uuid'] = $uuid;
+		}
 
 		foreach ($this->customFields() as $name => $field) {
 			$content[$name] = $input[$name] ?? null;
@@ -408,6 +416,7 @@ class PageCreateDialog
 			'slug'     => $this->slug ?? '',
 			'template' => $this->template,
 			'title'    => $this->title ?? '',
+			'uuid'     => $this->uuid,
 			'view'     => $this->viewId,
 		];
 

--- a/tests/Panel/PageCreateDialogTest.php
+++ b/tests/Panel/PageCreateDialogTest.php
@@ -33,6 +33,7 @@ class PageCreateDialogTest extends AreaTestCase
 		$this->assertCount(7, $fields);
 		$this->assertSame('Title', $fields['title']['label']);
 		$this->assertSame('/', $fields['slug']['path']);
+		$this->assertTrue($fields['uuid']['hidden']);
 	}
 
 	public function testCoreFieldsUuidDisabled(): void

--- a/tests/Panel/PageCreateDialogTest.php
+++ b/tests/Panel/PageCreateDialogTest.php
@@ -2,8 +2,11 @@
 
 namespace Kirby\Panel;
 
+use Kirby\Cms\Page;
+use Kirby\Content\MemoryStorage;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Panel\Areas\AreaTestCase;
+use Kirby\Uuid\PageUuid;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(PageCreateDialog::class)]
@@ -119,6 +122,9 @@ class PageCreateDialogTest extends AreaTestCase
 	public function testSanitize(): void
 	{
 		$this->app([
+			'options' => [
+				'content.uuid' => false
+			],
 			'blueprints' => [
 				'pages/test' => [
 					'create' => [
@@ -295,5 +301,82 @@ class PageCreateDialogTest extends AreaTestCase
 			'view'     => null,
 			'foo'      => 'bar'
 		], $value);
+	}
+
+	public function testModel(): void
+	{
+		$this->app([
+			'blueprints' => [
+				'pages/test' => [
+					'create' => [
+						'fields' => ['foo', 'bar']
+					],
+					'fields' => [
+						'foo' => [
+							'type'     => 'text',
+							'required' => true
+						],
+						'bar' => [
+							'type'     => 'text',
+							'required' => true,
+							'default'  => 'bar'
+						]
+					]
+				]
+			]
+		]);
+
+		$dialog = new PageCreateDialog(
+			null,
+			null,
+			'test',
+			null
+		);
+
+		$model = $dialog->model();
+
+		$this->assertInstanceOf(Page::class, $model);
+		$this->assertInstanceOf(MemoryStorage::class, $model->storage());
+		$this->assertInstanceOf(PageUuid::class, $model->uuid());
+	}
+
+	public function testModelUuidDisabled(): void
+	{
+		$this->app([
+			'options' => [
+				'content.uuid' => false
+			],
+			'blueprints' => [
+				'pages/test' => [
+					'create' => [
+						'fields' => ['foo', 'bar']
+					],
+					'fields' => [
+						'foo' => [
+							'type'     => 'text',
+							'required' => true
+						],
+						'bar' => [
+							'type'     => 'text',
+							'required' => true,
+							'default'  => 'bar'
+						]
+					]
+				]
+			]
+		]);
+
+		$dialog = new PageCreateDialog(
+			null,
+			null,
+			'test',
+			null
+		);
+
+		$model = $dialog->model();
+
+		$this->assertInstanceOf(Page::class, $model);
+		$this->assertInstanceOf(MemoryStorage::class, $model->storage());
+		$this->assertNull($model->uuid());
 	}
 }

--- a/tests/Panel/PageCreateDialogTest.php
+++ b/tests/Panel/PageCreateDialogTest.php
@@ -178,7 +178,8 @@ class PageCreateDialogTest extends AreaTestCase
 		$input = $dialog->sanitize([
 			'slug'  => 'foo',
 			'title' => 'Foo',
-			'foo'   => 'bar'
+			'foo'   => 'bar',
+			'uuid'  => 'test-uuid'
 		]);
 
 		$this->assertSame([
@@ -186,6 +187,7 @@ class PageCreateDialogTest extends AreaTestCase
 				'foo'   => 'bar',
 				'bar'   => 'bar',
 				'title' => 'Foo',
+				'uuid'  => 'test-uuid',
 			],
 			'slug'     => 'foo',
 			'template' => 'test',

--- a/tests/Panel/PageCreateDialogTest.php
+++ b/tests/Panel/PageCreateDialogTest.php
@@ -320,6 +320,7 @@ class PageCreateDialogTest extends AreaTestCase
 			'slug'     => '',
 			'template' => 'test',
 			'title'    => '',
+			'uuid'     => null,
 			'view'     => null,
 			'foo'      => 'bar'
 		], $value);

--- a/tests/Panel/PageCreateDialogTest.php
+++ b/tests/Panel/PageCreateDialogTest.php
@@ -30,6 +30,28 @@ class PageCreateDialogTest extends AreaTestCase
 
 		$fields = $dialog->coreFields();
 
+		$this->assertCount(7, $fields);
+		$this->assertSame('Title', $fields['title']['label']);
+		$this->assertSame('/', $fields['slug']['path']);
+	}
+
+	public function testCoreFieldsUuidDisabled(): void
+	{
+		$this->app([
+			'options' => [
+				'content.uuid' => false
+			]
+		]);
+
+		$dialog = new PageCreateDialog(
+			null,
+			null,
+			'test',
+			null
+		);
+
+		$fields = $dialog->coreFields();
+
 		$this->assertCount(6, $fields);
 		$this->assertSame('Title', $fields['title']['label']);
 		$this->assertSame('/', $fields['slug']['path']);


### PR DESCRIPTION
## Description

AFAIK content uuid is generated when the page is created (`PageActions::create`). Uuid is not generated when a new page object is created with the `Page::factory()` method. Therefore, I solved the problem by generating and sending the uuid when the page is factory-generated.

Furthermore, following @distantnative suggestion, we ensured that this temporary model is never written to disk using `MemoryStorage`.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- UUID for new page is the same as the latest page UUID #7405

### 🚨 Breaking changes

AFAIK none.

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion