### PR TITLE
refact!: Panel languages dropdown controller

### DIFF
--- a/config/areas/files/dropdowns.php
+++ b/config/areas/files/dropdowns.php
@@ -1,14 +1,9 @@
 <?php
 
 use Kirby\Cms\Find;
-use Kirby\Panel\Ui\Buttons\LanguagesDropdown;
 
 return [
 	'file' => function (string $parent, string $filename) {
 		return Find::file($parent, $filename)->panel()->dropdown();
-	},
-	'language' => function (string $parent, string $filename) {
-		$file = Find::file($parent, $filename);
-		return (new LanguagesDropdown($file))->options();
 	}
 ];

--- a/config/areas/site/buttons.php
+++ b/config/areas/site/buttons.php
@@ -3,7 +3,7 @@
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
-use Kirby\Panel\Ui\Buttons\LanguagesDropdown;
+use Kirby\Panel\Ui\Buttons\LanguagesButton;
 use Kirby\Panel\Ui\Buttons\OpenButton;
 use Kirby\Panel\Ui\Buttons\PageStatusButton;
 use Kirby\Panel\Ui\Buttons\PreviewButton;
@@ -64,8 +64,7 @@ return [
 	// as the  languages might be not loaded even in
 	// multilang mode when the `languages` option is deactivated
 	// (but content languages to switch between still can exist)
-	'languages' => fn (ModelWithContent $model) =>
-		new LanguagesDropdown($model),
+	'languages' => fn (ModelWithContent $model) => new LanguagesButton($model),
 
 	// file buttons
 	...require __DIR__ . '/../files/buttons.php'

--- a/config/areas/site/dropdowns.php
+++ b/config/areas/site/dropdowns.php
@@ -1,8 +1,7 @@
 <?php
 
-use Kirby\Cms\App;
 use Kirby\Cms\Find;
-use Kirby\Panel\Ui\Buttons\LanguagesDropdown;
+use Kirby\Panel\Controller\Dropdown\LanguagesDropdownController;
 
 $files = require __DIR__ . '/../files/dropdowns.php';
 
@@ -15,10 +14,7 @@ return [
 	],
 	'page.languages' => [
 		'pattern' => 'pages/(:any)/languages',
-		'options' => function (string $path) {
-			$page = Find::page($path);
-			return (new LanguagesDropdown($page))->options();
-		}
+		'options' => LanguagesDropdownController::class
 	],
 	'page.file' => [
 		'pattern' => '(pages/.*?)/files/(:any)',
@@ -26,14 +22,12 @@ return [
 	],
 	'page.file.languages' => [
 		'pattern' => '(pages/.*?)/files/(:any)/languages',
-		'options' => $files['language']
+		'options' => LanguagesDropdownController::class
 	],
 	'site.languages' => [
 		'pattern' => 'site/languages',
-		'options' => function () {
-			$site = App::instance()->site();
-			return (new LanguagesDropdown($site))->options();
-		}
+		'options' => LanguagesDropdownController::class
+
 	],
 	'site.file' => [
 		'pattern' => '(site)/files/(:any)',
@@ -41,6 +35,6 @@ return [
 	],
 	'site.file.languages' => [
 		'pattern' => '(site)/files/(:any)/languages',
-		'options' => $files['language']
+		'options' => LanguagesDropdownController::class
 	]
 ];

--- a/config/areas/site/dropdowns.php
+++ b/config/areas/site/dropdowns.php
@@ -13,7 +13,7 @@ return [
 		}
 	],
 	'page.languages' => [
-		'pattern' => 'pages/(:any)/languages',
+		'pattern' => '(pages/.*?)/languages',
 		'options' => LanguagesDropdownController::class
 	],
 	'page.file' => [
@@ -25,7 +25,7 @@ return [
 		'options' => LanguagesDropdownController::class
 	],
 	'site.languages' => [
-		'pattern' => 'site/languages',
+		'pattern' => '(site)/languages',
 		'options' => LanguagesDropdownController::class
 
 	],

--- a/config/areas/users/dropdowns.php
+++ b/config/areas/users/dropdowns.php
@@ -12,7 +12,7 @@ return [
 			Find::user($id)->panel()->dropdown()
 	],
 	'user.languages' => [
-		'pattern' => 'users/(:any)/languages',
+		'pattern' => '(users/.*?)/languages',
 		'options' => LanguagesDropdownController::class
 	],
 	'user.file' => [

--- a/config/areas/users/dropdowns.php
+++ b/config/areas/users/dropdowns.php
@@ -1,7 +1,7 @@
 <?php
 
 use Kirby\Cms\Find;
-use Kirby\Panel\Ui\Buttons\LanguagesDropdown;
+use Kirby\Panel\Controller\Dropdown\LanguagesDropdownController;
 
 $files = require __DIR__ . '/../files/dropdowns.php';
 
@@ -13,10 +13,7 @@ return [
 	],
 	'user.languages' => [
 		'pattern' => 'users/(:any)/languages',
-		'options' => function (string $id) {
-			$user = Find::user($id);
-			return (new LanguagesDropdown($user))->options();
-		}
+		'options' => LanguagesDropdownController::class
 	],
 	'user.file' => [
 		'pattern' => '(users/.*?)/files/(:any)',
@@ -24,6 +21,6 @@ return [
 	],
 	'user.file.languages' => [
 		'pattern' => '(users/.*?)/files/(:any)/languages',
-		'options' => $files['language']
+		'options' => LanguagesDropdownController::class
 	]
 ];

--- a/src/Panel/Controller/Dropdown/LanguagesDropdownController.php
+++ b/src/Panel/Controller/Dropdown/LanguagesDropdownController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Kirby\Panel\Controller\Dropdown;
+
+use Kirby\Cms\App;
+use Kirby\Cms\Find;
+use Kirby\Cms\Language;
+use Kirby\Cms\ModelWithContent;
+use Kirby\Content\Version;
+use Kirby\Panel\Controller\DropdownController;
+
+/**
+ * @package   Kirby Panel
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ * @unstable
+ */
+class LanguagesDropdownController extends DropdownController
+{
+	protected Version $changes;
+
+	public function __construct(
+		public ModelWithContent $model
+	) {
+		parent::__construct();
+		$this->changes = $this->model->version('changes');
+	}
+
+	public static function factory(
+		string|null $parent = null,
+		string|null $filename = null
+	): static {
+		if ($parent !== null && $filename !== null) {
+			return new static(model: Find::file($parent, $filename));
+		}
+
+		if ($parent !== null) {
+			return new static(model: Find::page($parent));
+		}
+
+		return new static(model: App::instance()->site());
+	}
+
+	/**
+	 * Options are used in the Fiber dropdown routes
+	 */
+	public function load(): array
+	{
+		$languages = $this->kirby->languages();
+		$options   = [];
+
+		if ($this->kirby->multilang() === false) {
+			return $options;
+		}
+
+		// add the primary/default language first
+		if ($default = $languages->default()) {
+			$options[] = $this->option($default);
+			$options[] = '-';
+			$languages = $languages->not($default);
+		}
+
+		// add all secondary languages after the separator
+		foreach ($languages as $language) {
+			$options[] = $this->option($language);
+		}
+
+		return $options;
+	}
+
+	public function option(Language $language): array
+	{
+		return [
+			'text'    => $language->name(),
+			'code'    => $language->code(),
+			'current' => $language->code() === $this->kirby->language()?->code(),
+			'default' => $language->isDefault(),
+			'changes' => $this->changes->exists($language),
+			'lock'    => $this->changes->isLocked('*')
+		];
+	}
+}

--- a/src/Panel/Controller/Dropdown/LanguagesDropdownController.php
+++ b/src/Panel/Controller/Dropdown/LanguagesDropdownController.php
@@ -38,7 +38,7 @@ class LanguagesDropdownController extends DropdownController
 		}
 
 		if ($parent !== null) {
-			return new static(model: Find::page($parent));
+			return new static(model: Find::parent($parent));
 		}
 
 		return new static(model: App::instance()->site());

--- a/src/Panel/Ui/Buttons/LanguagesButton.php
+++ b/src/Panel/Ui/Buttons/LanguagesButton.php
@@ -3,7 +3,6 @@
 namespace Kirby\Panel\Ui\Buttons;
 
 use Kirby\Cms\App;
-use Kirby\Cms\Language;
 use Kirby\Cms\Languages;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Toolkit\Str;
@@ -19,7 +18,7 @@ use Kirby\Toolkit\Str;
  * @since     5.0.0
  * @unstable
  */
-class LanguagesDropdown extends ViewButton
+class LanguagesButton extends ViewButton
 {
 	protected App $kirby;
 
@@ -57,47 +56,6 @@ class LanguagesDropdown extends ViewButton
 		}
 
 		return false;
-	}
-
-	public function option(Language $language): array
-	{
-		$changes = $this->model->version('changes');
-
-		return [
-			'text'    => $language->name(),
-			'code'    => $language->code(),
-			'current' => $language->code() === $this->kirby->language()?->code(),
-			'default' => $language->isDefault(),
-			'changes' => $changes->exists($language),
-			'lock'    => $changes->isLocked('*')
-		];
-	}
-
-	/**
-	 * Options are used in the Panel dropdown routes
-	 */
-	public function options(): array
-	{
-		$languages = $this->kirby->languages();
-		$options   = [];
-
-		if ($this->kirby->multilang() === false) {
-			return $options;
-		}
-
-		// add the primary/default language first
-		if ($default = $languages->default()) {
-			$options[] = $this->option($default);
-			$options[] = '-';
-			$languages = $languages->not($default);
-		}
-
-		// add all secondary languages after the separator
-		foreach ($languages as $language) {
-			$options[] = $this->option($language);
-		}
-
-		return $options;
 	}
 
 	public function props(): array

--- a/tests/Panel/Areas/AccountDropdownsTest.php
+++ b/tests/Panel/Areas/AccountDropdownsTest.php
@@ -52,23 +52,4 @@ class AccountDropdownsTest extends AreaTestCase
 		$this->assertSame('/account/delete', $delete['dialog']);
 		$this->assertSame('Delete your account', $delete['text']);
 	}
-
-	public function testAccountLanguageDropdown(): void
-	{
-		$this->app([
-			'languages' => [
-				'en' => [
-					'code' => 'en',
-					'name' => 'English',
-				],
-				'de' => [
-					'code' => 'de',
-					'name' => 'Deutsch',
-				]
-			]
-		]);
-
-		$this->login();
-		$this->assertLanguageDropdown('account/languages');
-	}
 }

--- a/tests/Panel/Areas/AreaTestCase.php
+++ b/tests/Panel/Areas/AreaTestCase.php
@@ -68,15 +68,6 @@ abstract class AreaTestCase extends TestCase
 		$this->assertSame('k-form-dialog', $dialog['component']);
 	}
 
-	protected function assertLanguageDropdown(string $path): void
-	{
-		$options = $this->dropdown($path)['options'];
-
-		$this->assertSame('English', $options[0]['text']);
-		$this->assertSame('-', $options[1]);
-		$this->assertSame('Deutsch', $options[2]['text']);
-	}
-
 	protected function assertRedirect(
 		string $source,
 		string $dest = '/',

--- a/tests/Panel/Areas/FileDropdownsTest.php
+++ b/tests/Panel/Areas/FileDropdownsTest.php
@@ -182,32 +182,4 @@ class FileDropdownsTest extends AreaTestCase
 		$this->assertSame('/users/test/files/test.jpg/delete', $options[5]['dialog']);
 		$this->assertSame('Delete', $options[5]['text']);
 	}
-
-	public function testFileLanguageDropdownForAccountFile(): void
-	{
-		$this->createUserFile();
-		$this->login();
-		$this->assertLanguageDropdown('account/files/test.jpg/languages');
-	}
-
-	public function testFileLanguageDropdownForPageFile(): void
-	{
-		$this->createPageFile();
-		$this->login();
-		$this->assertLanguageDropdown('pages/test/files/test.jpg/languages');
-	}
-
-	public function testFileLanguageDropdownForSiteFile(): void
-	{
-		$this->createSiteFile();
-		$this->login();
-		$this->assertLanguageDropdown('site/files/test.jpg/languages');
-	}
-
-	public function testFileLanguageDropdownForUserFile(): void
-	{
-		$this->createUserFile();
-		$this->login();
-		$this->assertLanguageDropdown('users/test/files/test.jpg/languages');
-	}
 }

--- a/tests/Panel/Areas/SiteDropdownsTest.php
+++ b/tests/Panel/Areas/SiteDropdownsTest.php
@@ -97,47 +97,4 @@ class SiteDropdownsTest extends AreaTestCase
 		$this->assertSame('_blank', $preview['target']);
 		$this->assertSame('Open', $preview['text']);
 	}
-
-	public function testPageLanguageDropdown(): void
-	{
-		$this->app([
-			'site' => [
-				'children' => [
-					['slug' => 'test']
-				]
-			],
-			'languages' => [
-				'en' => [
-					'code' => 'en',
-					'name' => 'English',
-				],
-				'de' => [
-					'code' => 'de',
-					'name' => 'Deutsch',
-				]
-			]
-		]);
-
-		$this->login();
-		$this->assertLanguageDropdown('pages/test/languages');
-	}
-
-	public function testSiteLanguageDropdown(): void
-	{
-		$this->app([
-			'languages' => [
-				'en' => [
-					'code' => 'en',
-					'name' => 'English',
-				],
-				'de' => [
-					'code' => 'de',
-					'name' => 'Deutsch',
-				]
-			]
-		]);
-
-		$this->login();
-		$this->assertLanguageDropdown('site/languages');
-	}
 }

--- a/tests/Panel/Areas/UserDropdownsTest.php
+++ b/tests/Panel/Areas/UserDropdownsTest.php
@@ -52,23 +52,4 @@ class UserDropdownsTest extends AreaTestCase
 		$this->assertSame('/users/editor/delete', $delete['dialog']);
 		$this->assertSame('Delete this user', $delete['text']);
 	}
-
-	public function testUserLanguageDropdown(): void
-	{
-		$this->app([
-			'languages' => [
-				'en' => [
-					'code' => 'en',
-					'name' => 'English',
-				],
-				'de' => [
-					'code' => 'de',
-					'name' => 'Deutsch',
-				]
-			]
-		]);
-
-		$this->login();
-		$this->assertLanguageDropdown('users/editor/languages');
-	}
 }

--- a/tests/Panel/Controller/Dropdown/LanguagesDropdownControllerTest.php
+++ b/tests/Panel/Controller/Dropdown/LanguagesDropdownControllerTest.php
@@ -82,7 +82,7 @@ class LanguagesDropdownControllerTest extends TestCase
 
 		$app->impersonate('kirby');
 
-		$dropdown = LanguagesDropdownController::factory('test');
+		$dropdown = LanguagesDropdownController::factory('pages/test');
 		$this->assertInstanceOf(LanguagesDropdownController::class, $dropdown);
 		$this->assertSame($app->page('test'), $dropdown->model);
 	}
@@ -91,9 +91,30 @@ class LanguagesDropdownControllerTest extends TestCase
 	{
 		$app = new App();
 		$app->impersonate('kirby');
+		$dropdown = LanguagesDropdownController::factory('site');
+		$this->assertInstanceOf(LanguagesDropdownController::class, $dropdown);
+		$this->assertSame($app->site(), $dropdown->model);
+
 		$dropdown = LanguagesDropdownController::factory();
 		$this->assertInstanceOf(LanguagesDropdownController::class, $dropdown);
 		$this->assertSame($app->site(), $dropdown->model);
+	}
+
+	public function testFactoryForUser(): void
+	{
+		$app = new App([
+			'users' => [
+				[
+					'id' => 'test'
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$dropdown = LanguagesDropdownController::factory('users/test');
+		$this->assertInstanceOf(LanguagesDropdownController::class, $dropdown);
+		$this->assertSame($app->user('test'), $dropdown->model);
 	}
 
 	public function testLoadSingleLang(): void

--- a/tests/Panel/Controller/Dropdown/LanguagesDropdownControllerTest.php
+++ b/tests/Panel/Controller/Dropdown/LanguagesDropdownControllerTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Kirby\Panel\Controller\Dropdown;
+
+use Kirby\Cms\App;
+use Kirby\Cms\Language;
+use Kirby\Cms\Page;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(LanguagesDropdownController::class)]
+class LanguagesDropdownControllerTest extends TestCase
+{
+	public function testFactoryForPageFile(): void
+	{
+		$app = new App([
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'test',
+						'files' => [
+							['filename' => 'test.jpg']
+						]
+					]
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$dropdown = LanguagesDropdownController::factory('pages/test', 'test.jpg');
+		$this->assertInstanceOf(LanguagesDropdownController::class, $dropdown);
+		$this->assertSame($app->file('test/test.jpg'), $dropdown->model);
+	}
+
+	public function testFactoryForSiteFile(): void
+	{
+		$app = new App([
+			'site' => [
+				'files' => [
+					['filename' => 'test.jpg']
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$dropdown = LanguagesDropdownController::factory('', 'test.jpg');
+		$this->assertInstanceOf(LanguagesDropdownController::class, $dropdown);
+		$this->assertSame($app->file('test.jpg'), $dropdown->model);
+	}
+
+	public function testFactoryForUserFile(): void
+	{
+		$app = new App([
+			'users' => [
+				[
+					'id'    => 'test',
+					'files' => [
+						['filename' => 'test.jpg']
+					]
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$dropdown = LanguagesDropdownController::factory('users/test', 'test.jpg');
+		$this->assertInstanceOf(LanguagesDropdownController::class, $dropdown);
+		$this->assertSame($app->user('test')->file('test.jpg'), $dropdown->model);
+	}
+
+	public function testFactoryForPage(): void
+	{
+		$app = new App([
+			'site' => [
+				'children' => [
+					['slug' => 'test']
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$dropdown = LanguagesDropdownController::factory('test');
+		$this->assertInstanceOf(LanguagesDropdownController::class, $dropdown);
+		$this->assertSame($app->page('test'), $dropdown->model);
+	}
+
+	public function testFactoryForSite(): void
+	{
+		$app = new App();
+		$app->impersonate('kirby');
+		$dropdown = LanguagesDropdownController::factory();
+		$this->assertInstanceOf(LanguagesDropdownController::class, $dropdown);
+		$this->assertSame($app->site(), $dropdown->model);
+	}
+
+	public function testLoadSingleLang(): void
+	{
+		$page     = new Page(['slug' => 'test']);
+		$dropdown = new LanguagesDropdownController($page);
+		$this->assertSame([], $dropdown->load());
+	}
+
+	public function testLoadMultiLang(): void
+	{
+		new App([
+			'options' => [
+				'languages' => true
+			],
+			'languages' => [
+				'en' => [
+					'code'    => 'en',
+					'default' => true,
+					'name'    => 'English'
+				],
+				'de' => [
+					'code'    => 'de',
+					'default' => false,
+					'name'    => 'Deutsch'
+				]
+			]
+		]);
+
+		$page     = new Page(['slug' => 'test']);
+		$dropdown = new LanguagesDropdownController($page);
+		$this->assertSame([
+			[
+				'text'    => 'English',
+				'code'    => 'en',
+				'current' => true,
+				'default' => true,
+				'changes' => false,
+				'lock'    => false
+			],
+			'-',
+			[
+				'text'    => 'Deutsch',
+				'code'    => 'de',
+				'current' => false,
+				'default' => false,
+				'changes' => false,
+				'lock'    => false
+			]
+		], $dropdown->load());
+	}
+
+	public function testOption(): void
+	{
+		$page     = new Page(['slug' => 'test']);
+		$dropdown = new LanguagesDropdownController($page);
+		$language = new Language(['name' => 'Deutsch', 'code' => 'de']);
+		$this->assertSame([
+			'text'    => 'Deutsch',
+			'code'    => 'de',
+			'current' => false,
+			'default' => false,
+			'changes' => false,
+			'lock'    => false
+		], $dropdown->option($language));
+	}
+}

--- a/tests/Panel/Ui/Buttons/LanguagesButtonTest.php
+++ b/tests/Panel/Ui/Buttons/LanguagesButtonTest.php
@@ -2,13 +2,12 @@
 
 namespace Kirby\Panel\Ui\Buttons;
 
-use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\Panel\Areas\AreaTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
-#[CoversClass(LanguagesDropdown::class)]
-class LanguagesDropdownTest extends AreaTestCase
+#[CoversClass(LanguagesButton::class)]
+class LanguagesButtonTest extends AreaTestCase
 {
 	public function testHasDiff(): void
 	{
@@ -16,7 +15,7 @@ class LanguagesDropdownTest extends AreaTestCase
 		$this->installLanguages();
 
 		$page = new Page(['slug' => 'test']);
-		$button = new LanguagesDropdown($page);
+		$button = new LanguagesButton($page);
 
 		// no changes
 		$this->assertFalse($button->hasDiff());
@@ -32,60 +31,10 @@ class LanguagesDropdownTest extends AreaTestCase
 		$this->assertTrue($button->hasDiff());
 	}
 
-	public function testOption(): void
-	{
-		$page     = new Page(['slug' => 'test']);
-		$button   = new LanguagesDropdown($page);
-		$language = new Language(['name' => 'Deutsch', 'code' => 'de']);
-		$this->assertSame([
-			'text'    => 'Deutsch',
-			'code'    => 'de',
-			'current' => false,
-			'default' => false,
-			'changes' => false,
-			'lock'    => false
-		], $button->option($language));
-	}
-
-	public function testOptionsSingleLang(): void
-	{
-		$page   = new Page(['slug' => 'test']);
-		$button = new LanguagesDropdown($page);
-		$this->assertSame([], $button->options());
-	}
-
-	public function testOptionsMultiLang(): void
-	{
-		$this->enableMultilang();
-		$this->installLanguages();
-
-		$page   = new Page(['slug' => 'test']);
-		$button = new LanguagesDropdown($page);
-		$this->assertSame([
-			[
-				'text'    => 'English',
-				'code'    => 'en',
-				'current' => true,
-				'default' => true,
-				'changes' => false,
-				'lock'    => false
-			],
-			'-',
-			[
-				'text'    => 'Deutsch',
-				'code'    => 'de',
-				'current' => false,
-				'default' => false,
-				'changes' => false,
-				'lock'    => false
-			]
-		], $button->options());
-	}
-
 	public function testProps(): void
 	{
 		$page   = new Page(['slug' => 'test']);
-		$button = new LanguagesDropdown($page);
+		$button = new LanguagesButton($page);
 		$props  = $button->props();
 		$this->assertFalse($props['hasDiff']);
 	}
@@ -93,7 +42,7 @@ class LanguagesDropdownTest extends AreaTestCase
 	public function testRenderDefault(): void
 	{
 		$page   = new Page(['slug' => 'test']);
-		$button = new LanguagesDropdown($page);
+		$button = new LanguagesButton($page);
 		$this->assertNull($button->render());
 	}
 
@@ -111,7 +60,7 @@ class LanguagesDropdownTest extends AreaTestCase
 		]);
 
 		$page   = new Page(['slug' => 'test']);
-		$button = new LanguagesDropdown($page);
+		$button = new LanguagesButton($page);
 		$this->assertNull($button->render());
 	}
 
@@ -121,7 +70,7 @@ class LanguagesDropdownTest extends AreaTestCase
 		$this->installLanguages();
 
 		$page   = new Page(['slug' => 'test']);
-		$button = new LanguagesDropdown($page);
+		$button = new LanguagesButton($page);
 		$this->assertSame('k-languages-dropdown', $button->component);
 		$this->assertSame('k-languages-dropdown', $button->class);
 		$this->assertSame('translate', $button->icon);


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

- [x] https://github.com/getkirby/kirby/pull/7422


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- New `Kirby\Panel\Controller\Dropdown\LanguagesDropdownController` class to handle the options for the content languages dropdown

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- Renamed `Kirby\Panel\Ui\Buttons\LanguagesDropdown` to `Kirby\Panel\Ui\Buttons\LanguagesButton`
- Removed `::option()` and `::options()` methods from `Kirby\Panel\Ui\Buttons\LanguagesButton`. Use `Kirby\Panel\Controller\Dropdown\LanguagesDropdownController` instead.


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion