### PR TITLE
feat: Add support for refresh-based redirects in Panel

### DIFF
--- a/config/areas/login.php
+++ b/config/areas/login.php
@@ -36,7 +36,7 @@ return function ($kirby) {
 					 * be used to redirect to that view again
 					 */
 					$kirby->session()->set('panel.path', $path);
-					Panel::go('login');
+					Panel::go(url: 'login', refresh: 0);
 				}
 			]
 		]

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -275,6 +275,23 @@ class Response implements Stringable
 	}
 
 	/**
+	 * Creates a refresh response, which will
+	 * send the visitor to the given location
+	 * after the specified number of seconds.
+	 *
+	 * @since 5.0.3
+	 */
+	public static function refresh(string $location = '/', int $code = 302, int $refresh = 0): static
+	{
+		return new static([
+			'code'    => $code,
+			'headers' => [
+				'Refresh' => $refresh . '; url=' . Url::unIdn($location)
+			]
+		]);
+	}
+
+	/**
 	 * Sends all registered headers and
 	 * returns the response body
 	 */

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -181,9 +181,9 @@ class Panel
 	 * @throws \Kirby\Panel\Redirect
 	 * @codeCoverageIgnore
 	 */
-	public static function go(string|null $url = null, int $code = 302): void
+	public static function go(string|null $url = null, int $code = 302, int|false $refresh = false): void
 	{
-		throw new Redirect(static::url($url), $code);
+		throw new Redirect(static::url($url), $code, $refresh);
 	}
 
 	/**

--- a/src/Panel/Redirect.php
+++ b/src/Panel/Redirect.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel;
 
 use Exception;
+use Throwable;
 
 /**
  * The Redirect exception can be thrown in all Fiber
@@ -18,6 +19,15 @@ use Exception;
  */
 class Redirect extends Exception
 {
+	public function __construct(
+		string $location,
+		int $code = 302,
+		protected int|false $refresh = false,
+		Throwable|null $previous = null
+	) {
+		parent::__construct($location, $code, $previous);
+	}
+
 	/**
 	 * Returns the HTTP code for the redirect
 	 */
@@ -38,5 +48,13 @@ class Redirect extends Exception
 	public function location(): string
 	{
 		return $this->getMessage();
+	}
+
+	/**
+	 * Returns the refresh time in seconds
+	 */
+	public function refresh(): int|false
+	{
+		return $this->refresh;
 	}
 }

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -315,6 +315,11 @@ class View
 	{
 		// handle redirects
 		if ($data instanceof Redirect) {
+			// if the redirect is a refresh, return a refresh response
+			if ($data->refresh() !== false) {
+				return Response::refresh($data->location(), $data->code(), $data->refresh());
+			}
+
 			return Response::redirect($data->location(), $data->code());
 		}
 

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -322,6 +322,30 @@ class ResponseTest extends TestCase
 		$this->assertEquals(['Location' => '/'], $response->headers()); // cannot use strict assertion (Uri object)
 	}
 
+	public function testRefresh(): void
+	{
+		$response = Response::refresh();
+		$this->assertSame('', $response->body());
+		$this->assertSame(302, $response->code());
+		$this->assertEquals(['Refresh' => '0; url=/'], $response->headers());
+	}
+
+	public function testRefreshWithLocation(): void
+	{
+		$response = Response::refresh('https://getkirby.com');
+		$this->assertSame('', $response->body());
+		$this->assertSame(302, $response->code());
+		$this->assertEquals(['Refresh' => '0; url=https://getkirby.com'], $response->headers());
+	}
+
+	public function testRefreshWithTime(): void
+	{
+		$response = Response::refresh('https://getkirby.com', 302, 5);
+		$this->assertSame('', $response->body());
+		$this->assertSame(302, $response->code());
+		$this->assertEquals(['Refresh' => '5; url=https://getkirby.com'], $response->headers());
+	}
+
 	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled

--- a/tests/Panel/Areas/AreaTestCase.php
+++ b/tests/Panel/Areas/AreaTestCase.php
@@ -84,7 +84,13 @@ abstract class AreaTestCase extends TestCase
 		int $code = 302
 	): void {
 		$response = $this->response($source);
-		$location = $response->header('Location');
+
+		if ($refresh = $response->header('Refresh')) {
+			preg_match('/url=(.+)/', $refresh, $matches);
+			$location = $matches[1] ?? null;
+		}
+
+		$location ??= $response->header('Location');
 
 		$this->assertInstanceOf(Response::class, $response);
 		$this->assertSame($code, $response->code());

--- a/tests/Panel/PanelTest.php
+++ b/tests/Panel/PanelTest.php
@@ -271,7 +271,7 @@ class PanelTest extends TestCase
 	/**
 	 * @covers ::go
 	 */
-	public function testGo()
+	public function testGo(): void
 	{
 		$thrown = false;
 		try {
@@ -280,6 +280,21 @@ class PanelTest extends TestCase
 			$thrown = true;
 			$this->assertSame('/panel/test', $r->getMessage());
 			$this->assertSame(302, $r->getCode());
+			$this->assertFalse($r->refresh());
+		}
+		$this->assertTrue($thrown);
+	}
+
+	public function testGoRefresh(): void
+	{
+		$thrown = false;
+		try {
+			Panel::go('test', 302, 5);
+		} catch (Redirect $r) {
+			$thrown = true;
+			$this->assertSame('/panel/test', $r->getMessage());
+			$this->assertSame(302, $r->getCode());
+			$this->assertSame(5, $r->refresh());
 		}
 		$this->assertTrue($thrown);
 	}

--- a/tests/Panel/RedirectTest.php
+++ b/tests/Panel/RedirectTest.php
@@ -35,4 +35,12 @@ class RedirectTest extends TestCase
 		$redirect = new Redirect('https://getkirby.com');
 		$this->assertSame('https://getkirby.com', $redirect->location());
 	}
+
+	public function testRefresh(): void
+	{
+		$redirect = new Redirect('https://getkirby.com', 302, 5);
+		$this->assertSame('https://getkirby.com', $redirect->location());
+		$this->assertSame(302, $redirect->code());
+		$this->assertSame(5, $redirect->refresh());
+	}
 }

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -596,6 +596,26 @@ class ViewTest extends TestCase
 		$this->assertSame('https://getkirby.com', $response->header('Location'));
 	}
 
+	public function testResponseFromRedirectRefresh(): void
+	{
+		// fake json request for easier assertions
+		$this->app = $this->app->clone([
+			'request' => [
+				'query' => [
+					'_json' => true,
+				]
+			]
+		]);
+
+		$redirect = new Redirect('https://getkirby.com', refresh: 5);
+		$response = View::response($redirect);
+
+		$this->assertInstanceOf(Response::class, $response);
+
+		$this->assertSame(302, $response->code());
+		$this->assertSame('5; url=https://getkirby.com', $response->header('Refresh'));
+	}
+
 	/**
 	 * @covers ::response
 	 */


### PR DESCRIPTION
## Description

Introduces the ability to perform refresh-based redirects by extending the `Panel::go()` and `Redirect` classes to accept a refresh parameter. The View class now returns a refresh response when appropriate and `Response::refresh` has been added to generate the correct HTTP headers. Updates login area config to use the new refresh redirect.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
- Add support for refresh-based redirects in Panel
- New `Response::refresh()` method added

### 🐛 Bug fixes
- Invalid CSRF token error when logging in after panel session expired #7274


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion