### PR TITLE
Fix input field stripping last character

### DIFF
--- a/panel/src/helpers/string.slug.test.js
+++ b/panel/src/helpers/string.slug.test.js
@@ -71,8 +71,18 @@ describe.concurrent("$helper.string.slug()", () => {
 	});
 
 	it("should produces safe filenames", () => {
-		const result = slug("-what a view@2x.png_", [], "a-z0-9@._-");
-		expect(result).toBe("what-a-view@2x.png");
+		const result = slug("-what a_view@2x.png-", [], "a-z0-9@._-");
+		expect(result).toBe("what-a_view@2x.png");
+	});
+
+	it("should handle underscores with custom allow", () => {
+		const result = slug("test_slug_with_underscores", [], "_");
+		expect(result).toBe("test_slug_with_underscores");
+	});
+
+	it("should handle mixed characters with underscore allow", () => {
+		const result = slug("hello world_test", [], "_");
+		expect(result).toBe("hello-world_test");
 	});
 
 	it("should return empty string when no param sent", () => {


### PR DESCRIPTION
## Description
This PR resolves the issue where slug fields with custom `allow` characters (e.g., `_`) become unusable due to premature character stripping, as reported in #7309. A previous attempt in #7312 introduced this regression.

The solution involves a two-pronged approach:
1.  **Refining the `slug` helper function**: Improved the logic for building allowed character sets, handling language rules, and robust trimming of leading/trailing separators and non-allowed characters.
2.  **Overhauling the `SlugInput` component**: Eliminated problematic dual state management and introduced debouncing (300ms) for slugification. This ensures that characters are not stripped while the user is actively typing, providing a smoother user experience while still applying the slugification rules after a brief pause.

This fixes the usability of slug fields with custom allowed characters, particularly underscores, and prevents the "last character stripped too quickly" problem.

## Changelog 

### ✨ Enhancements
- Improved slug generation logic in the `slug` helper to better handle custom allowed characters and trimming.
- Enhanced `SlugInput` component for a smoother typing experience by debouncing slugification, preventing premature character stripping.

### 🐛 Bug fixes
- Fixed slug fields becoming unusable when `allow` option is used (e.g., `allow: _`), resolving #7309.

## Docs
No specific documentation changes are required for this fix, as it resolves an internal behavior issue.

### For review team
- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion

---

[Open in Web](https://cursor.com/agents?id=bc-2f83bbd5-e1a6-4d03-9de5-ee9dc30607e5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2f83bbd5-e1a6-4d03-9de5-ee9dc30607e5) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)