### PR TITLE
Improve kirby issue 7305 fix

### DIFF
--- a/panel/src/components/Forms/Input/WriterInput.vue
+++ b/panel/src/components/Forms/Input/WriterInput.vue
@@ -93,7 +93,7 @@ export const props = {
 		},
 		nodes: {
 			type: [Array, Boolean],
-			default: () => ["heading", "bulletList", "orderedList"]
+			default: () => ["paragraph", "heading", "bulletList", "orderedList"]
 		},
 		paste: {
 			type: Function,
@@ -143,6 +143,11 @@ export default {
 				marks:
 					Array.isArray(this.marks) || this.marks === false
 						? this.marks
+						: undefined,
+				// if custom set of nodes is enabled, use as toolbar default as well
+				nodes:
+					Array.isArray(this.nodes) || this.nodes === false
+						? this.nodes
 						: undefined,
 				...this.toolbar,
 				editor: this.editor


### PR DESCRIPTION
## Description
This PR addresses the issue where the Writer field toolbar would incorrectly display a paragraph button even when `nodes: false` and `marks: false` were set, as reported in [#7305](https://github.com/getkirby/kirby/issues/7305).

The root cause was that the `WriterInput.vue` component was not passing its `nodes` prop to the `Toolbar.vue` component. The toolbar component has a default `nodes: true`, leading to the paragraph button always appearing.

This solution is a cleaner approach compared to the previous attempt in [#7310](https://github.com/getkirby/kirby/pull/7310). It leverages existing toolbar logic by:
1.  Including "paragraph" in the default `nodes` array in `WriterInput.vue`.
2.  Ensuring the `nodes` prop from `WriterInput.vue` is correctly passed to the toolbar via `toolbarOptions`, mirroring how the `marks` prop is handled.

This allows the toolbar to correctly hide when `nodes: false` and `marks: false` are configured, and provides full control over which node buttons are displayed based on the field's `nodes` option.

## Changelog

### 🐛 Bug fixes
- Fixed an issue where the Writer field toolbar would incorrectly display a paragraph button even when `nodes: false` and `marks: false` were set. See issue [#7305](https://github.com/getkirby/kirby/issues/7305).

### ✨ Enhancements
- The `nodes` configuration from the Writer field is now correctly passed to the toolbar, allowing for full control over displayed node buttons.

## Docs
N/A

### For review team
- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion

---

[Open in Web](https://cursor.com/agents?id=bc-e55d34f2-626b-4057-8dd8-c2e1a2b47113) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e55d34f2-626b-4057-8dd8-c2e1a2b47113) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)