### PR TITLE
feat: New Panel Collector classes

### DIFF
--- a/src/Panel/Collector/FilesCollector.php
+++ b/src/Panel/Collector/FilesCollector.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Kirby\Panel\Collector;
+
+use Kirby\Cms\Files;
+use Kirby\Cms\Page;
+use Kirby\Cms\Pages;
+use Kirby\Cms\Site;
+use Kirby\Cms\User;
+use Kirby\Cms\Users;
+
+/**
+ * @package   Kirby Panel
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class FilesCollector extends ModelsCollector
+{
+	public function __construct(
+		protected bool $flip = false,
+		protected int|null $limit = null,
+		protected int $page = 1,
+		protected Site|Page|User|null $parent = null,
+		protected string|null $query = null,
+		protected string|null $search = null,
+		protected string|null $sortBy = null,
+		protected string|null $template = null,
+	) {
+	}
+
+	protected function collect(): Files
+	{
+		return $this->parent()->files()->sorted();
+	}
+
+	protected function collectByQuery(): Files
+	{
+		return $this->parent()->query($this->query, Files::class) ?? new Files([]);
+	}
+
+	protected function filter(Files|Pages|Users $models): Files
+	{
+		return $models->filter(function ($file) {
+			// remove all protected and hidden files
+			if ($file->isListable() === false) {
+				return false;
+			}
+
+			// filter by template
+			if ($this->template !== null && $file->template() !== $this->template) {
+				return false;
+			}
+
+			return true;
+		});
+	}
+}

--- a/src/Panel/Collector/ModelsCollector.php
+++ b/src/Panel/Collector/ModelsCollector.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Kirby\Panel\Collector;
+
+use Kirby\Cms\App;
+use Kirby\Cms\Files;
+use Kirby\Cms\Page;
+use Kirby\Cms\Pages;
+use Kirby\Cms\Pagination;
+use Kirby\Cms\Site;
+use Kirby\Cms\User;
+use Kirby\Cms\Users;
+
+/**
+ * @package   Kirby Panel
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+abstract class ModelsCollector
+{
+	protected Files|Pages|Users $models;
+	protected Files|Pages|Users $paginated;
+
+	public function __construct(
+		protected int|null $limit = null,
+		protected int $page = 1,
+		protected Site|Page|User|null $parent = null,
+		protected string|null $query = null,
+		protected string|null $search = null,
+		protected string|null $sortBy = null,
+		protected bool $flip = false,
+	) {
+	}
+
+	abstract protected function collect(): Files|Pages|Users;
+	abstract protected function collectByQuery(): Files|Pages|Users;
+	abstract protected function filter(Files|Pages|Users $models): Files|Pages|Users;
+
+	protected function flip(Files|Pages|Users $models): Files|Pages|Users
+	{
+		return $models->flip();
+	}
+
+	public function isFlipping(): bool
+	{
+		if ($this->isSearching() === true) {
+			return false;
+		}
+
+		return $this->flip === true;
+	}
+
+	public function isQuerying(): bool
+	{
+		return $this->query !== null;
+	}
+
+	public function isSearching(): bool
+	{
+		return $this->search !== null && trim($this->search) !== '';
+	}
+
+	public function isSorting(): bool
+	{
+		if ($this->isSearching() === true) {
+			return false;
+		}
+
+		return $this->sortBy !== null;
+	}
+
+	public function models(bool $paginated = false): Files|Pages|Users
+	{
+		if ($paginated === true) {
+			return $this->paginated ??= $this->models()->paginate([
+				'limit'  => $this->limit ?? 1000,
+				'page'   => $this->page,
+				'method' => 'none' // the page is manually provided
+			]);
+		}
+
+		if (isset($this->models) === true) {
+			return $this->models;
+		}
+
+		if ($this->isQuerying() === true) {
+			$models = $this->collectByQuery();
+		} else {
+			$models = $this->collect();
+		}
+
+		$models = $this->filter($models);
+
+		if ($this->isSearching() === true) {
+			$models = $this->search($models);
+		}
+
+		if ($this->isSorting() === true) {
+			$models = $this->sort($models);
+		}
+
+		if ($this->isFlipping() === true) {
+			$models = $this->flip($models);
+		}
+
+		return $this->models ??= $models;
+	}
+
+	public function pagination(): Pagination
+	{
+		return $this->models(paginated: true)->pagination();
+	}
+
+	protected function parent(): Site|Page|User
+	{
+		return $this->parent ?? App::instance()->site();
+	}
+
+	protected function search(Files|Pages|Users $models): Files|Pages|Users
+	{
+		return $models->search($this->search);
+	}
+
+	protected function sort(Files|Pages|Users $models): Files|Pages|Users
+	{
+		return $models->sort(...$models::sortArgs($this->sortBy));
+	}
+}

--- a/src/Panel/Collector/PagesCollector.php
+++ b/src/Panel/Collector/PagesCollector.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Kirby\Panel\Collector;
+
+use Kirby\Cms\Files;
+use Kirby\Cms\Page;
+use Kirby\Cms\Pages;
+use Kirby\Cms\Site;
+use Kirby\Cms\User;
+use Kirby\Cms\Users;
+
+/**
+ * @package   Kirby Panel
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class PagesCollector extends ModelsCollector
+{
+	public function __construct(
+		protected int|null $limit = null,
+		protected int $page = 1,
+		protected Site|Page|User|null $parent = null,
+		protected string|null $query = null,
+		protected string|null $status = null,
+		protected array $templates = [],
+		protected array $templatesIgnore = [],
+		protected string|null $search = null,
+		protected string|null $sortBy = null,
+		protected bool $flip = false,
+	) {
+	}
+
+	protected function collect(): Pages
+	{
+		return match ($this->status) {
+			'draft'     => $this->parent()->drafts(),
+			'listed'    => $this->parent()->children()->listed(),
+			'published' => $this->parent()->children(),
+			'unlisted'  => $this->parent()->children()->unlisted(),
+			default     => $this->parent()->childrenAndDrafts()
+		};
+	}
+
+	protected function collectByQuery(): Pages
+	{
+		return $this->parent()->query($this->query, Pages::class) ?? new Pages([]);
+	}
+
+	protected function filter(Files|Pages|Users $models): Pages
+	{
+		// filters pages that are protected and not in the templates list
+		// internal `filter()` method used instead of foreach loop that previously included `unset()`
+		// because `unset()` is updating the original data, `filter()` is just filtering
+		// also it has been tested that there is no performance difference
+		// even in 0.1 seconds on 100k virtual pages
+		return $models->filter(function (Page $model): bool {
+			// remove all protected and hidden pages
+			if ($model->isListable() === false) {
+				return false;
+			}
+
+			$intendedTemplate = $model->intendedTemplate()->name();
+
+			// filter by all set templates
+			if (
+				$this->templates &&
+				in_array($intendedTemplate, $this->templates, true) === false
+			) {
+				return false;
+			}
+
+			// exclude by all ignored templates
+			if (
+				$this->templatesIgnore &&
+				in_array($intendedTemplate, $this->templatesIgnore, true) === true
+			) {
+				return false;
+			}
+
+			return true;
+		});
+	}
+}

--- a/src/Panel/Collector/UsersCollector.php
+++ b/src/Panel/Collector/UsersCollector.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Kirby\Panel\Collector;
+
+use Kirby\Cms\App;
+use Kirby\Cms\Files;
+use Kirby\Cms\Page;
+use Kirby\Cms\Pages;
+use Kirby\Cms\Site;
+use Kirby\Cms\User;
+use Kirby\Cms\Users;
+
+/**
+ * @package   Kirby Panel
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class UsersCollector extends ModelsCollector
+{
+	public function __construct(
+		protected bool $flip = false,
+		protected int|null $limit = null,
+		protected int $page = 1,
+		protected Site|Page|User|null $parent = null,
+		protected string|null $query = null,
+		protected string|null $role = null,
+		protected string|null $search = null,
+		protected string|null $sortBy = null,
+	) {
+	}
+
+	protected function collect(): Users
+	{
+		return App::instance()->users();
+	}
+
+	protected function collectByQuery(): Users
+	{
+		return $this->parent()->query($this->query, Users::class) ?? new Users([]);
+	}
+
+	protected function filter(Files|Pages|Users $models): Users
+	{
+		$user = App::instance()->user();
+
+		if ($user === null) {
+			return new Users([]);
+		}
+
+		if ($user->role()->permissions()->for('access', 'users') === false) {
+			return new Users([]);
+		}
+
+		if ($this->role !== null) {
+			$models = $models->role($this->role);
+		}
+
+		return $models;
+	}
+}

--- a/tests/Panel/Collector/FilesCollectorTest.php
+++ b/tests/Panel/Collector/FilesCollectorTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Kirby\Panel\Collector;
+
+use Kirby\Cms\Files;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(FilesCollector::class)]
+class FilesCollectorTest extends TestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Collector.FilesCollector';
+
+	public function setUpFiles()
+	{
+		$this->app = $this->app->clone([
+			'site' => [
+				'files' => [
+					[
+						'filename' => 'image-a.jpg',
+						'template' => 'default',
+					],
+					[
+						'filename' => 'image-b.jpg',
+						'template' => 'hero',
+					],
+					[
+						'filename' => 'image-c.jpg',
+						'template' => 'hero',
+					],
+				]
+			]
+		]);
+	}
+
+	public function testCollect(): void
+	{
+		$this->setUpFiles();
+		$this->app->impersonate('kirby');
+		$this->assertCollect(FilesCollector::class, ['image-a.jpg', 'image-b.jpg', 'image-c.jpg']);
+	}
+
+	public function testCollectByQuery(): void
+	{
+		$this->setUpFiles();
+		$this->app->impersonate('kirby');
+		$this->assertCollectByQuery(FilesCollector::class, 'site.files.template("hero")', ['image-b.jpg', 'image-c.jpg']);
+	}
+
+	public function testCollectSorted(): void
+	{
+		$this->setUpFiles();
+		$this->app->impersonate('kirby');
+
+		$this->app->site()->files()->find('image-c.jpg')->changeSort(1);
+		$this->app->site()->files()->find('image-a.jpg')->changeSort(2);
+		$this->app->site()->files()->find('image-b.jpg')->changeSort(3);
+
+		$this->assertCollect(FilesCollector::class, ['image-c.jpg', 'image-a.jpg', 'image-b.jpg']);
+	}
+
+	public function testCollectUnauthenticated(): void
+	{
+		$this->setUpFiles();
+		$this->assertCollectUnauthenticated(FilesCollector::class);
+	}
+
+	public function testFilterByTemplates(): void
+	{
+		$this->setUpFiles();
+		$this->app->impersonate('kirby');
+
+		$collector = new FilesCollector(
+			template: 'hero'
+		);
+
+		$this->assertModelsInCollector($collector, ['image-b.jpg', 'image-c.jpg'], );
+	}
+
+	public function testFlip(): void
+	{
+		$this->setUpFiles();
+		$this->app->impersonate('kirby');
+
+		$this->assertFlip(FilesCollector::class, ['image-c.jpg', 'image-b.jpg', 'image-a.jpg']);
+	}
+
+	public function testIsFlipping(): void
+	{
+		$this->assertIsFlipping(FilesCollector::class);
+	}
+
+	public function testIsQuerying(): void
+	{
+		$this->assertIsQuerying(FilesCollector::class);
+	}
+
+	public function testIsSearching(): void
+	{
+		$this->assertIsSearching(FilesCollector::class);
+	}
+
+	public function testIsSorting(): void
+	{
+		$this->assertIsSorting(FilesCollector::class);
+	}
+
+	public function testModels(): void
+	{
+		$this->assertModels(FilesCollector::class, Files::class);
+	}
+
+	public function testPagination(): void
+	{
+		$this->setUpFiles();
+		$this->app->impersonate('kirby');
+		$this->assertPagination(FilesCollector::class);
+	}
+
+	public function testSearch(): void
+	{
+		$this->setUpFiles();
+		$this->app->impersonate('kirby');
+		$this->app->site()->files()->find('image-c.jpg')->update([
+			'alt' => 'Searchword'
+		]);
+
+		$this->assertSearch(FilesCollector::class, 'Searchword', ['image-c.jpg']);
+	}
+
+	public function testSearchAndFlip(): void
+	{
+		$this->setUpFiles();
+		$this->app->impersonate('kirby');
+
+		$this->app->site()->files()->find('image-b.jpg')->update([
+			'alt' => 'Searchword'
+		]);
+
+		$this->app->site()->files()->find('image-c.jpg')->update([
+			'alt' => 'Searchword'
+		]);
+
+		// flipping should be ignored for the search
+		$this->assertSearchAndFlip(FilesCollector::class, 'Searchword', ['image-b.jpg', 'image-c.jpg']);
+	}
+
+	public function testSearchAndSortBy(): void
+	{
+		$this->setUpFiles();
+		$this->app->impersonate('kirby');
+
+		$this->app->site()->files()->find('image-b.jpg')->update([
+			'alt' => 'Searchword'
+		]);
+
+		$this->app->site()->files()->find('image-c.jpg')->update([
+			'alt' => 'Searchword'
+		]);
+
+		// the sorting should be ignored for the search
+		$this->assertSearchAndSortBy(FilesCollector::class, 'Searchword', 'filename desc', ['image-b.jpg', 'image-c.jpg']);
+	}
+
+	public function testSortBy(): void
+	{
+		$this->setUpFiles();
+		$this->app->impersonate('kirby');
+		$this->assertSortBy(FilesCollector::class, 'filename desc', ['image-c.jpg', 'image-b.jpg', 'image-a.jpg']);
+	}
+}

--- a/tests/Panel/Collector/ModelsCollectorTest.php
+++ b/tests/Panel/Collector/ModelsCollectorTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Kirby\Panel\Collector;
+
+use Kirby\Cms\Files;
+use Kirby\Cms\Page;
+use Kirby\Cms\Pages;
+use Kirby\Cms\Site;
+use Kirby\Cms\User;
+use Kirby\Cms\Users;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+class ModelsCollectorMock extends ModelsCollector
+{
+	protected function collect(): Files|Pages|Users
+	{
+		return Pages::factory([
+			[
+				'slug' => 'a',
+			],
+			[
+				'slug' => 'b',
+			],
+			[
+				'slug' => 'c',
+				'content' => [
+					'text' => 'Searchword',
+				]
+			],
+		]);
+	}
+
+	protected function collectByQuery(): Files|Pages|Users
+	{
+		return $this->collect()->not('c');
+	}
+
+	protected function filter(Files|Pages|Users $models): Files|Pages|Users
+	{
+		return $models;
+	}
+
+	public function parentModel(): Site|Page|User
+	{
+		return $this->parent();
+	}
+}
+
+#[CoversClass(ModelsCollector::class)]
+class ModelsCollectorTest extends TestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Collector.ModelsCollector';
+
+	public function testFlip(): void
+	{
+		$this->assertFlip(ModelsCollectorMock::class, ['c', 'b', 'a']);
+	}
+
+	public function testCollectByQuery(): void
+	{
+		$this->assertCollectByQuery(ModelsCollectorMock::class, 'test', ['a', 'b']);
+	}
+
+	public function testIsFlipping(): void
+	{
+		$this->assertIsFlipping(ModelsCollectorMock::class);
+	}
+
+	public function testIsQuerying(): void
+	{
+		$this->assertIsQuerying(ModelsCollectorMock::class);
+	}
+
+	public function testIsSearching(): void
+	{
+		$this->assertIsSearching(ModelsCollectorMock::class);
+	}
+
+	public function testIsSorting(): void
+	{
+		$this->assertIsSorting(ModelsCollectorMock::class);
+	}
+
+	public function testModels(): void
+	{
+		$this->assertModels(ModelsCollectorMock::class, Pages::class);
+	}
+
+	public function testParent(): void
+	{
+		$collector = new ModelsCollectorMock();
+
+		$this->assertInstanceOf(Site::class, $collector->parentModel());
+
+		$collector = new ModelsCollectorMock(parent: new Page(['slug' => 'test']));
+
+		$this->assertInstanceOf(Page::class, $collector->parentModel());
+	}
+
+	public function testPagination(): void
+	{
+		$this->assertPagination(ModelsCollectorMock::class);
+	}
+
+	public function testSearch(): void
+	{
+		$this->assertSearch(ModelsCollectorMock::class, 'Searchword', ['c']);
+	}
+
+	public function testSortBy(): void
+	{
+		$this->assertSortBy(ModelsCollectorMock::class, 'slug desc', ['c', 'b', 'a']);
+	}
+}

--- a/tests/Panel/Collector/PagesCollectorTest.php
+++ b/tests/Panel/Collector/PagesCollectorTest.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Kirby\Panel\Collector;
+
+use Kirby\Cms\Pages;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(PagesCollector::class)]
+class PagesCollectorTest extends TestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Collector.PagesCollector';
+
+	public function setUpPages()
+	{
+		$this->app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'a',
+						'template' => 'default',
+					],
+					[
+						'slug'     => 'b',
+						'template' => 'article',
+					],
+					[
+						'slug'     => 'c',
+						'template' => 'article',
+					],
+				]
+			]
+		]);
+	}
+
+	public function testCollect(): void
+	{
+		$this->setUpPages();
+		$this->app->impersonate('kirby');
+		$this->assertCollect(PagesCollector::class, ['a', 'b', 'c']);
+	}
+
+	public function testCollectByStatus(): void
+	{
+		$this->app = $this->app->clone([
+			'site' => [
+				'children' => [
+					['slug' => 'b', 'num' => 1],
+					['slug' => 'c'],
+				],
+				'drafts' => [
+					['slug' => 'a'],
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		// all
+		$collector = new PagesCollector();
+
+		$this->assertModelsInCollector($collector, ['b', 'c', 'a'], );
+
+		// listed
+		$collector = new PagesCollector(
+			status: 'listed'
+		);
+
+		$this->assertModelsInCollector($collector, ['b'], );
+
+		// unlisted
+		$collector = new PagesCollector(
+			status: 'unlisted'
+		);
+
+		$this->assertModelsInCollector($collector, ['c'], );
+
+		// published
+		$collector = new PagesCollector(
+			status: 'published'
+		);
+
+		$this->assertModelsInCollector($collector, ['b', 'c'], );
+
+		// drafts
+		$collector = new PagesCollector(
+			status: 'draft'
+		);
+
+		$this->assertModelsInCollector($collector, ['a'], );
+	}
+
+	public function testCollectByQuery(): void
+	{
+		$this->setUpPages();
+		$this->app->impersonate('kirby');
+		$this->assertCollectByQuery(PagesCollector::class, 'site.children.filterBy("intendedTemplate", "article")', ['b', 'c']);
+	}
+
+	public function testCollectUnauthenticated(): void
+	{
+		$this->setUpPages();
+		$this->assertCollectUnauthenticated(PagesCollector::class);
+	}
+
+	public function testFilterByTemplates(): void
+	{
+		$this->setUpPages();
+		$this->app->impersonate('kirby');
+
+		$collector = new PagesCollector(
+			templates: ['article']
+		);
+
+		$this->assertModelsInCollector($collector, ['b', 'c'], );
+	}
+
+	public function testFilterByTemplatesIgnore(): void
+	{
+		$this->setUpPages();
+		$this->app->impersonate('kirby');
+
+		$collector = new PagesCollector(
+			templatesIgnore: ['article']
+		);
+
+		$this->assertModelsInCollector($collector, ['a'], );
+	}
+
+	public function testFlip(): void
+	{
+		$this->setUpPages();
+		$this->app->impersonate('kirby');
+
+		$this->assertFlip(PagesCollector::class, ['c', 'b', 'a']);
+	}
+
+	public function testIsFlipping(): void
+	{
+		$this->assertIsFlipping(PagesCollector::class);
+	}
+
+	public function testIsQuerying(): void
+	{
+		$this->assertIsQuerying(PagesCollector::class);
+	}
+
+	public function testIsSearching(): void
+	{
+		$this->assertIsSearching(PagesCollector::class);
+	}
+
+	public function testIsSorting(): void
+	{
+		$this->assertIsSorting(PagesCollector::class);
+	}
+
+	public function testModels(): void
+	{
+		$this->assertModels(PagesCollector::class, Pages::class);
+	}
+
+	public function testPagination(): void
+	{
+		$this->setUpPages();
+		$this->app->impersonate('kirby');
+		$this->assertPagination(PagesCollector::class);
+	}
+
+	public function testSearch(): void
+	{
+		$this->setUpPages();
+		$this->app->impersonate('kirby');
+		$this->app->site()->children()->find('c')->update([
+			'title' => 'Searchword'
+		]);
+
+		$this->assertSearch(PagesCollector::class, 'Searchword', ['c']);
+	}
+
+	public function testSearchAndFlip(): void
+	{
+		$this->setUpPages();
+		$this->app->impersonate('kirby');
+
+		$this->app->site()->children()->find('b')->update([
+			'title' => 'Searchword'
+		]);
+
+		$this->app->site()->children()->find('c')->update([
+			'title' => 'Searchword'
+		]);
+
+		// flipping should be ignored for the search
+		$this->assertSearchAndFlip(PagesCollector::class, 'Searchword', ['b', 'c']);
+	}
+
+	public function testSearchAndSortBy(): void
+	{
+		$this->setUpPages();
+		$this->app->impersonate('kirby');
+
+		$this->app->site()->children()->find('b')->update([
+			'title' => 'Searchword'
+		]);
+
+		$this->app->site()->children()->find('c')->update([
+			'title' => 'Searchword'
+		]);
+
+		// the sorting should be ignored for the search
+		$this->assertSearchAndSortBy(PagesCollector::class, 'Searchword', 'slug desc', ['b', 'c']);
+	}
+
+	public function testSortBy(): void
+	{
+		$this->setUpPages();
+		$this->app->impersonate('kirby');
+		$this->assertSortBy(PagesCollector::class, 'slug desc', ['c', 'b', 'a']);
+	}
+}

--- a/tests/Panel/Collector/TestCase.php
+++ b/tests/Panel/Collector/TestCase.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Kirby\Panel\Collector;
+
+use Kirby\Cms\App;
+use Kirby\Cms\Pagination;
+use Kirby\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Collector.ModelsCollector';
+
+	public function setUp(): void
+	{
+		parent::setUpTmp();
+
+		$this->app = new App([
+			'roots' => [
+				'index' => static::TMP,
+			]
+		]);
+	}
+
+	public function tearDown(): void
+	{
+		parent::tearDownTmp();
+	}
+
+	public function assertCollect(string $collectorClass, array $expectedKeys): void
+	{
+		$collector = new $collectorClass();
+		$this->assertModelsInCollector($collector, $expectedKeys);
+	}
+
+	public function assertCollectByQuery(string $collectorClass, string $query, array $expectedKeys): void
+	{
+		$collector = new $collectorClass(
+			query: $query
+		);
+
+		$this->assertModelsInCollector($collector, $expectedKeys);
+	}
+
+	public function assertCollectUnauthenticated(string $collectorClass): void
+	{
+		$collector = new $collectorClass();
+		$this->assertModelsInCollector($collector, []);
+	}
+
+	public function assertFlip(string $collectorClass, array $expectedKeys): void
+	{
+		$collector = new $collectorClass(
+			flip: true
+		);
+
+		$this->assertModelsInCollector($collector, $expectedKeys);
+	}
+
+	public function assertIsFlipping(string $collectorClass): void
+	{
+		$collector = new $collectorClass();
+
+		$this->assertFalse($collector->isFlipping());
+
+		$collector = new $collectorClass(
+			flip: true
+		);
+
+		$this->assertTrue($collector->isFlipping());
+
+		// the collector is not flipping when the search is active
+		$collector = new $collectorClass(
+			flip: true,
+			search: 'test'
+		);
+
+		$this->assertFalse($collector->isFlipping());
+	}
+
+	public function assertIsQuerying(string $collectorClass): void
+	{
+		$collector = new $collectorClass();
+
+		$this->assertFalse($collector->isQuerying());
+
+		$collector = new $collectorClass(
+			query: 'site.children'
+		);
+
+		$this->assertTrue($collector->isQuerying());
+	}
+
+	public function assertIsSearching(string $collectorClass): void
+	{
+		$collector = new $collectorClass();
+
+		$this->assertFalse($collector->isSearching());
+
+		$collector = new $collectorClass(
+			search: ''
+		);
+
+		$this->assertFalse($collector->isSearching());
+
+		$collector = new $collectorClass(
+			search: ' '
+		);
+
+		$this->assertFalse($collector->isSearching());
+
+		$collector = new $collectorClass(
+			search: 'test'
+		);
+
+		$this->assertTrue($collector->isSearching());
+	}
+
+	public function assertIsSorting(string $collectorClass): void
+	{
+		$collector = new $collectorClass();
+
+		$this->assertFalse($collector->isSorting());
+
+		$collector = new $collectorClass(
+			sortBy: 'title desc'
+		);
+
+		$this->assertTrue($collector->isSorting());
+
+		// the collector is not sorting when the search is active
+		$collector = new $collectorClass(
+			sortBy: 'title desc',
+			search: 'test'
+		);
+
+		$this->assertFalse($collector->isSorting());
+	}
+
+	public function assertModels(string $collectorClass, string $collectionClass): void
+	{
+		$collector = new $collectorClass();
+
+		$this->assertInstanceOf($collectionClass, $collector->models());
+	}
+
+	public function assertModelsInCollector(ModelsCollector $collector, array $expectedKeys): void
+	{
+		$this->assertSame($expectedKeys, $collector->models()->keys());
+	}
+
+	public function assertPagination(string $collectorClass): void
+	{
+		$collector = new $collectorClass();
+		$this->assertInstanceOf(Pagination::class, $collector->pagination());
+		$this->assertCount(3, $collector->models());
+
+		// paginate
+		$collector = new $collectorClass(
+			page: 2,
+			limit: 1
+		);
+
+		$this->assertSame(3, $collector->pagination()->total());
+		$this->assertSame(2, $collector->pagination()->page());
+		$this->assertSame(1, $collector->pagination()->limit());
+	}
+
+	public function assertSearch(string $collectorClass, string $search, array $expectedKeys): void
+	{
+		$collector = new $collectorClass(
+			search: $search
+		);
+
+		$this->assertModelsInCollector($collector, $expectedKeys);
+	}
+
+	public function assertSearchAndFlip(string $collectorClass, string $search, array $expectedKeys): void
+	{
+		$collector = new $collectorClass(
+			flip: true,
+			search: $search,
+		);
+
+		$this->assertModelsInCollector($collector, $expectedKeys);
+	}
+
+	public function assertSearchAndSortBy(string $collectorClass, string $search, string $sortBy, array $expectedKeys): void
+	{
+		$collector = new $collectorClass(
+			search: $search,
+			sortBy: $sortBy
+		);
+
+		$this->assertModelsInCollector($collector, $expectedKeys);
+	}
+
+	public function assertSortBy(string $collectorClass, string $sortBy, array $expectedKeys): void
+	{
+		$collector = new $collectorClass(
+			sortBy: $sortBy
+		);
+
+		$this->assertModelsInCollector($collector, $expectedKeys);
+	}
+}

--- a/tests/Panel/Collector/UsersCollectorTest.php
+++ b/tests/Panel/Collector/UsersCollectorTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Kirby\Panel\Collector;
+
+use Kirby\Cms\Users;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(UsersCollector::class)]
+class UsersCollectorTest extends TestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Collector.UsersCollector';
+
+	public function setUpUsers()
+	{
+		$this->app = $this->app->clone([
+			'roles' => [
+				[
+					'name' => 'admin'
+				],
+				[
+					'name' => 'editor'
+				],
+			],
+			'users' => [
+				[
+					'id'    => 'a',
+					'email' => 'a@getkirby.com',
+					'role'  => 'admin',
+				],
+				[
+					'id'    => 'b',
+					'email' => 'b@getkirby.com',
+					'role'  => 'editor',
+				],
+				[
+					'id'    => 'c',
+					'email' => 'c@getkirby.com',
+					'role'  => 'editor',
+				],
+			]
+		]);
+	}
+
+	public function testCollect(): void
+	{
+		$this->setUpUsers();
+		$this->app->impersonate('kirby');
+		$this->assertCollect(UsersCollector::class, ['a', 'b', 'c']);
+	}
+
+	public function testCollectByQuery(): void
+	{
+		$this->setUpUsers();
+		$this->app->impersonate('kirby');
+		$this->assertCollectByQuery(UsersCollector::class, 'kirby.users.role("editor")', ['b', 'c']);
+	}
+
+	public function testCollectUnauthenticated(): void
+	{
+		$this->setUpUsers();
+		$this->assertCollectUnauthenticated(UsersCollector::class);
+	}
+
+	public function testCollectWithoutAccess(): void
+	{
+		$this->setUpUsers();
+		$this->app->impersonate('nobody');
+		$this->assertCollectUnauthenticated(UsersCollector::class);
+	}
+
+	public function testFilterByRole(): void
+	{
+		$this->setUpUsers();
+		$this->app->impersonate('kirby');
+
+		$collector = new UsersCollector(
+			role: 'editor'
+		);
+
+		$this->assertModelsInCollector($collector, ['b', 'c'], );
+	}
+
+	public function testFlip(): void
+	{
+		$this->setUpUsers();
+		$this->app->impersonate('kirby');
+
+		$this->assertFlip(UsersCollector::class, ['c', 'b', 'a']);
+	}
+
+	public function testIsFlipping(): void
+	{
+		$this->assertIsFlipping(UsersCollector::class);
+	}
+
+	public function testIsQuerying(): void
+	{
+		$this->assertIsQuerying(UsersCollector::class);
+	}
+
+	public function testIsSearching(): void
+	{
+		$this->assertIsSearching(UsersCollector::class);
+	}
+
+	public function testIsSorting(): void
+	{
+		$this->assertIsSorting(UsersCollector::class);
+	}
+
+	public function testModels(): void
+	{
+		$this->assertModels(UsersCollector::class, Users::class);
+	}
+
+	public function testPagination(): void
+	{
+		$this->setUpUsers();
+		$this->app->impersonate('kirby');
+		$this->assertPagination(UsersCollector::class);
+	}
+
+	public function testSearch(): void
+	{
+		$this->setUpUsers();
+		$this->app->impersonate('kirby');
+		$this->app->users()->find('c@getkirby.com')->update([
+			'text' => 'Searchword'
+		]);
+
+		$this->assertSearch(UsersCollector::class, 'Searchword', ['c']);
+	}
+
+	public function testSearchAndFlip(): void
+	{
+		$this->setUpUsers();
+		$this->app->impersonate('kirby');
+
+		$this->app->users()->find('b@getkirby.com')->update([
+			'title' => 'Searchword'
+		]);
+
+		$this->app->users()->find('c@getkirby.com')->update([
+			'title' => 'Searchword'
+		]);
+
+		// flipping should be ignored for the search
+		$this->assertSearchAndFlip(UsersCollector::class, 'Searchword', ['b', 'c']);
+	}
+
+	public function testSearchAndSortBy(): void
+	{
+		$this->setUpUsers();
+		$this->app->impersonate('kirby');
+
+		$this->app->users()->find('b@getkirby.com')->update([
+			'title' => 'Searchword'
+		]);
+
+		$this->app->users()->find('c@getkirby.com')->update([
+			'title' => 'Searchword'
+		]);
+
+		// the sorting should be ignored for the search
+		$this->assertSearchAndSortBy(UsersCollector::class, 'Searchword', 'email desc', ['b', 'c']);
+	}
+
+	public function testSortBy(): void
+	{
+		$this->setUpUsers();
+		$this->app->impersonate('kirby');
+		$this->assertSortBy(UsersCollector::class, 'email desc', ['c', 'b', 'a']);
+	}
+}


### PR DESCRIPTION
## Description

The new Panel Collector classes help us to collect pages, files and users for our sections and files. They take care of sorting, searching, filtering and more. For more details about the upcoming refactoring steps, check out https://github.com/getkirby/kirby/pull/7419

The classes are not yet used anywhere in our code. This is planned for the next PR. This PR is all about getting a clean state for each class and their tests.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->

- New `Kirby\Panel\Collector\PagesCollector` class
- New `Kirby\Panel\Collector\FilesCollector` class
- New `Kirby\Panel\Collector\UsersCollector` class

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion