### PR TITLE
feat: Allow UI component in `JsonResponse::from()`

### DIFF
--- a/src/Panel/Response/JsonResponse.php
+++ b/src/Panel/Response/JsonResponse.php
@@ -7,6 +7,7 @@ use Kirby\Exception\Exception;
 use Kirby\Http\Response;
 use Kirby\Panel\Area;
 use Kirby\Panel\Redirect;
+use Kirby\Panel\Ui\Component;
 use Throwable;
 
 /**
@@ -102,6 +103,11 @@ class JsonResponse extends Response
 			return new static([
 				'redirect' => $data->location(),
 			]);
+		}
+
+		// handle UI components
+		if ($data instanceof Component) {
+			return static::from($data->render());
 		}
 
 		// interpret strings as errors

--- a/tests/Panel/Response/JsonResponseTest.php
+++ b/tests/Panel/Response/JsonResponseTest.php
@@ -7,6 +7,7 @@ use Kirby\Data\Json;
 use Kirby\Exception\Exception as KirbyException;
 use Kirby\Panel\Redirect;
 use Kirby\Panel\TestCase;
+use Kirby\Panel\Ui\Button;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(JsonResponse::class)]
@@ -112,6 +113,14 @@ class JsonResponseTest extends TestCase
 		$output = JsonResponse::from($input);
 
 		$this->assertSame('Error message', $output->data()['error']);
+	}
+
+	public function testFromUiComponent(): void
+	{
+		$input  = new Button('k-my-button');
+		$output = JsonResponse::from($input);
+
+		$this->assertSame('k-my-button', $output->data()['component']);
 	}
 
 	public function testFromString(): void


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- Resolve a Panel UI component object in `JsonResponse::from()` but calling its `::render()` method. This allows us to return UI component instances from a Panel controller's `::load()` method.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion