### PR TITLE
refact: Migrate TOTP dialogs to dialog controllers

### DIFF
--- a/config/areas/account/dialogs.php
+++ b/config/areas/account/dialogs.php
@@ -1,6 +1,6 @@
 <?php
 
-use Kirby\Panel\Ui\Dialogs\UserTotpEnableDialog;
+use Kirby\Panel\Controller\Dialog\UserTotpEnableDialogController;
 
 $dialogs = require __DIR__ . '/../users/dialogs.php';
 
@@ -55,8 +55,7 @@ return [
 	],
 	'account.totp.enable' => [
 		'pattern' => '(account)/totp/enable',
-		'load'    => fn () => (new UserTotpEnableDialog())->load(),
-		'submit'  => fn () => (new UserTotpEnableDialog())->submit()
+		'action'  => UserTotpEnableDialogController::class
 	],
 	'account.totp.disable' => [
 		'pattern' => '(account)/totp/disable',

--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -5,9 +5,8 @@ use Kirby\Cms\Find;
 use Kirby\Cms\UserRules;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Panel\Controller\Dialog\UserTotpDisableDialogController;
 use Kirby\Panel\Field;
-use Kirby\Panel\Panel;
-use Kirby\Panel\Ui\Dialogs\UserTotpDisableDialog;
 use Kirby\Toolkit\Escape;
 use Kirby\Toolkit\I18n;
 
@@ -348,7 +347,6 @@ return [
 
 	'user.totp.disable' => [
 		'pattern' => 'users/(:any)/totp/disable',
-		'load'    => fn (string $id) => (new UserTotpDisableDialog($id))->load(),
-		'submit'  => fn (string $id) => (new UserTotpDisableDialog($id))->submit()
+		'action'  => UserTotpDisableDialogController::class
 	],
 ];

--- a/src/Panel/Controller/Dialog/UserTotpEnableDialogController.php
+++ b/src/Panel/Controller/Dialog/UserTotpEnableDialogController.php
@@ -1,48 +1,43 @@
 <?php
 
-namespace Kirby\Panel\Ui\Dialogs;
+namespace Kirby\Panel\Controller\Dialog;
 
-use Kirby\Cms\App;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Image\QrCode;
+use Kirby\Panel\Controller\DialogController;
+use Kirby\Panel\Ui\Dialog;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Totp;
 
 /**
  * Manages the Panel dialog to enable TOTP auth for the current user
- * @since 4.0.0
  *
  * @package   Kirby Panel
  * @author    Nico Hoffmann <nico@getkirby.com>
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ * @since     6.0.0
  */
-class UserTotpEnableDialog
+class UserTotpEnableDialogController extends DialogController
 {
-	public App $kirby;
 	public Totp $totp;
 	public User $user;
 
 	public function __construct()
 	{
-		$this->kirby = App::instance();
+		parent::__construct();
 		$this->user  = $this->kirby->user();
 	}
 
-	/**
-	 * Returns the Panel dialog state when opening the dialog
-	 */
-	public function load(): array
+	public function load(): Dialog
 	{
-		return [
-			'component' => 'k-totp-dialog',
-			'props' => [
-				'qr'    => $this->qr()->toSvg(size: '100%'),
-				'value' => ['secret' => $this->secret()]
-			]
-		];
+		return new Dialog(
+			component: 'k-totp-dialog',
+			qr: $this->qr()->toSvg(size: '100%'),
+			value: ['secret' => $this->secret()]
+		);
 	}
 
 	/**
@@ -66,8 +61,8 @@ class UserTotpEnableDialog
 	 */
 	public function submit(): array
 	{
-		$secret  = $this->kirby->request()->get('secret');
-		$confirm = $this->kirby->request()->get('confirm');
+		$secret  = $this->request->get('secret');
+		$confirm = $this->request->get('confirm');
 
 		if ($confirm === null) {
 			throw new InvalidArgumentException(


### PR DESCRIPTION
## Description

- [x] https://github.com/getkirby/kirby/pull/7443

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- Refactored `Kirby\Panel\Ui\Dialogs\ UserTotpEnableDialog ` as `Kirby\Panel\Controller\Dialog\ UserTotpEnableDialogController ` and `Kirby\Panel\Ui\Dialogs\UserTotpDisableDialog ` as `Kirby\Panel\Controller\Dialog\UserTotpDisableDialogController`.

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- Removed `Kirby\Panel\Ui\Dialogs\UserTotpEnableDialog `. Use `Kirby\Panel\Controller\Dialog\UserTotpEnableDialogController` instead
- Removed `Kirby\Panel\Ui\Dialogs\UserTotpDisableDialog `. Use `Kirby\Panel\Controller\Dialog\UserTotpDisableDialogController` instead

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion