### PR TITLE
refact: Use list settings for table layout

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -94,10 +94,7 @@ return [
 					'extension' => $file->extension(),
 					'filename'  => $file->filename(),
 					'id'        => $file->id(),
-					'image'     => $panel->image(
-						$this->image,
-						$this->layout === 'table' ? 'list' : $this->layout
-					),
+					'image'     => $panel->image($this->image, $this->layout),
 					'info'      => $file->toSafeString($this->info ?? false),
 					'link'      => $panel->url(true),
 					'mime'      => $file->mime(),

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -122,10 +122,7 @@ return [
 				$item = [
 					'dragText'    => $panel->dragText(),
 					'id'          => $page->id(),
-					'image'       => $panel->image(
-						$this->image,
-						$this->layout === 'table' ? 'list' : $this->layout
-					),
+					'image'       => $panel->image($this->image, $this->layout),
 					'info'        => $page->toSafeString($this->info ?? false),
 					'link'        => $panel->url(true),
 					'parent'      => $page->parentId(),

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -269,6 +269,11 @@ class ModelTest extends TestCase
 		$this->assertStringContainsString('test-96x.jpg 96w', $image['srcset']);
 		$this->assertStringContainsString('test-192x.jpg 192w', $image['srcset']);
 
+		// table
+		$image = $panel->image('site.image', 'table');
+		$this->assertStringContainsString('test-38x.jpg 38w', $image['srcset']);
+		$this->assertStringContainsString('test-76x.jpg 76w', $image['srcset']);
+
 		// full options
 		$image = $panel->image([
 			'cover' => true,


### PR DESCRIPTION
## Description

This is just a simple enhancement for the `$panel->image()` method to always use the list settings for table layouts. 

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->

- Always use the `list` settings for table layouts in `Kirby\Panel\Model::image()`

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->

None

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion