### PR TITLE
refact: Site dialogs as controllers

### DIFF
--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -8,6 +8,7 @@ use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\PermissionException;
 use Kirby\Panel\Controller\Dialog\ChangesDialogController;
+use Kirby\Panel\Controller\Dialog\SiteChangeTitleDialogController;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialogs\PageCreateDialog;
 use Kirby\Toolkit\Escape;
@@ -533,31 +534,7 @@ return [
 
 	'site.changeTitle' => [
 		'pattern' => 'site/changeTitle',
-		'load' => function () {
-			return [
-				'component' => 'k-form-dialog',
-				'props' => [
-					'fields' => [
-						'title' => Field::title([
-							'required'  => true,
-							'preselect' => true
-						])
-					],
-					'submitButton' => I18n::translate('rename'),
-					'value' => [
-						'title' => App::instance()->site()->title()->value()
-					]
-				]
-			];
-		},
-		'submit' => function () {
-			$kirby = App::instance();
-			$kirby->site()->changeTitle($kirby->request()->get('title'));
-
-			return [
-				'event' => 'site.changeTitle',
-			];
-		}
+		'action'  => SiteChangeTitleDialogController::class,
 	],
 
 	'site.fields' => [

--- a/src/Panel/Controller/Dialog/SiteChangeTitleDialogController.php
+++ b/src/Panel/Controller/Dialog/SiteChangeTitleDialogController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Kirby\Panel\Controller\Dialog;
+
+use Kirby\Panel\Controller\DialogController;
+use Kirby\Panel\Field;
+use Kirby\Panel\Ui\Dialog;
+use Kirby\Panel\Ui\Dialogs\FormDialog;
+use Kirby\Toolkit\I18n;
+
+/**
+ * Controls the Panel dialog to change the title of the site
+ *
+ * @package   Kirby Panel
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ * @unstable
+ */
+class SiteChangeTitleDialogController extends DialogController
+{
+	public function load(): Dialog
+	{
+		return new FormDialog(
+			fields: [
+				'title' => Field::title([
+					'required'  => true,
+					'preselect' => true
+				])
+			],
+			submitButton: I18n::translate('rename'),
+			value: [
+				'title' => $this->site->title()->value(),
+			]
+		);
+	}
+
+	public function submit(): array
+	{
+		$title      = $this->request->get('title');
+		$this->site = $this->site->changeTitle($title);
+
+		return [
+			'event' => 'site.changeTitle'
+		];
+	}
+}

--- a/tests/Panel/Controller/Dialog/SiteChangeTitleDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/SiteChangeTitleDialogControllerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Kirby\Panel\Controller\Dialog;
+
+use Kirby\Panel\TestCase;
+use Kirby\Panel\Ui\Dialogs\FormDialog;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(SiteChangeTitleDialogController::class)]
+class SiteChangeTitleDialogControllerTest extends TestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Panel.Controller.Dialog.SiteChangeTitleDialogController';
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->app = $this->app->clone([
+			'site' => [
+				'content' => [
+					'title' => 'My Site'
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+	}
+
+	public function testLoad(): void
+	{
+		$controller = new SiteChangeTitleDialogController();
+		$dialog     = $controller->load();
+
+		$this->assertInstanceOf(FormDialog::class, $dialog);
+
+		$props = $dialog->props();
+		$this->assertArrayHasKey('title', $props['fields']);
+		$this->assertSame('My Site', $props['value']['title']);
+	}
+
+	public function testSubmit(): void
+	{
+		$this->app = $this->app->clone([
+			'request' => [
+				'query' => [
+					'title' => 'My Other Site',
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		$controller = new SiteChangeTitleDialogController();
+		$this->assertSame('My Site', $this->app->site()->title()->value());
+
+		$response = $controller->submit();
+		$this->assertSame('My Other Site', $this->app->site()->title()->value());
+		$this->assertSame('site.changeTitle', $response['event']);
+	}
+}


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- Refactored all site dialogs as dialog controllers

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion