### PR TITLE
refact: Use model items classes in more places

### DIFF
--- a/src/Panel/Controller/Search.php
+++ b/src/Panel/Controller/Search.php
@@ -3,7 +3,9 @@
 namespace Kirby\Panel\Controller;
 
 use Kirby\Cms\App;
-use Kirby\Toolkit\Escape;
+use Kirby\Panel\Ui\Item\FileItem;
+use Kirby\Panel\Ui\Item\PageItem;
+use Kirby\Panel\Ui\Item\UserItem;
 
 /**
  * The Search controller takes care of the logic
@@ -40,13 +42,7 @@ class Search
 		}
 
 		return [
-			'results' => $files->values(fn ($file) => [
-				'image' => $file->panel()->image(),
-				'text'  => Escape::html($file->filename()),
-				'link'  => $file->panel()->url(true),
-				'info'  => Escape::html($file->id()),
-				'uuid'  => $file->uuid()->toString(),
-			]),
+			'results'    => $files->values(fn ($file) => (new FileItem(file: $file, info: '{{ file.id }}'))->props()),
 			'pagination' => $files->pagination()?->toArray()
 		];
 	}
@@ -67,13 +63,7 @@ class Search
 		}
 
 		return [
-			'results' => $pages->values(fn ($page) => [
-				'image' => $page->panel()->image(),
-				'text' => Escape::html($page->title()->value()),
-				'link' => $page->panel()->url(true),
-				'info' => Escape::html($page->id()),
-				'uuid' => $page->uuid()?->toString(),
-			]),
+			'results'    => $pages->values(fn ($page) => (new PageItem(page: $page, info: '{{ page.id }}'))->props()),
 			'pagination' => $pages->pagination()?->toArray()
 		];
 	}
@@ -91,13 +81,7 @@ class Search
 		}
 
 		return [
-			'results' => $users->values(fn ($user) => [
-				'image' => $user->panel()->image(),
-				'text'  => Escape::html($user->username()),
-				'link'  => $user->panel()->url(true),
-				'info'  => Escape::html($user->role()->title()),
-				'uuid'  => $user->uuid()->toString(),
-			]),
+			'results'    => $users->values(fn ($user) => (new UserItem(user: $user))->props()),
 			'pagination' => $users->pagination()?->toArray()
 		];
 	}

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -7,6 +7,7 @@ use Kirby\Cms\ModelWithContent;
 use Kirby\Filesystem\Asset;
 use Kirby\Panel\Ui\Buttons\ViewButtons;
 use Kirby\Panel\Ui\FilePreview;
+use Kirby\Panel\Ui\Item\FileItem;
 use Kirby\Toolkit\I18n;
 use Throwable;
 
@@ -359,8 +360,9 @@ class File extends Model
 	 */
 	public function pickerData(array $params = []): array
 	{
-		$name = $this->model->filename();
-		$id   = $this->model->id();
+		$name     = $this->model->filename();
+		$id       = $this->model->id();
+		$absolute = false;
 
 		if (empty($params['model']) === false) {
 			$parent   = $this->model->parent();
@@ -374,13 +376,19 @@ class File extends Model
 			};
 		}
 
-		$params['text'] ??= '{{ file.filename }}';
+		$item = new FileItem(
+			file: $this->model,
+			dragTextIsAbsolute: $absolute,
+			image: $params['image'] ?? null,
+			info: $params['info'] ?? null,
+			layout: $params['layout'] ?? null,
+			text: $params['text'] ?? null,
+		);
 
 		return [
-			...parent::pickerData($params),
-			'dragText' => $this->dragText('auto', absolute: $absolute ?? false),
-			'filename' => $name,
-			'id'	   => $id,
+			...$item->props(),
+			'id'       => $id,
+			'sortable' => true,
 			'type'     => $this->model->type(),
 			'url'      => $this->model->url()
 		];

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -9,6 +9,7 @@ use Kirby\Cms\ModelWithContent;
 use Kirby\Filesystem\Asset;
 use Kirby\Form\Fields;
 use Kirby\Http\Uri;
+use Kirby\Panel\Ui\Item\ModelItem;
 use Kirby\Toolkit\A;
 
 /**
@@ -338,17 +339,18 @@ abstract class Model
 	 */
 	public function pickerData(array $params = []): array
 	{
+		$item = new ModelItem(
+			model: $this->model,
+			image: $params['image'] ?? null,
+			info: $params['info'] ?? null,
+			layout: $params['layout'] ?? null,
+			text: $params['text'] ?? null,
+		);
+
 		return [
-			'id'       => $this->model->id(),
-			'image'    => $this->image(
-				$params['image'] ?? [],
-				$params['layout'] ?? 'list'
-			),
-			'info'     => $this->model->toSafeString($params['info'] ?? false),
-			'link'     => $this->url(true),
+			...$item->props(),
 			'sortable' => true,
-			'text'     => $this->model->toSafeString($params['text'] ?? false),
-			'uuid'     => $this->model->uuid()?->toString()
+			'url'      => $this->url(true)
 		];
 	}
 

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -6,6 +6,7 @@ use Kirby\Cms\File as CmsFile;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Filesystem\Asset;
 use Kirby\Panel\Ui\Buttons\ViewButtons;
+use Kirby\Panel\Ui\Item\PageItem;
 use Kirby\Toolkit\I18n;
 
 /**
@@ -254,12 +255,18 @@ class Page extends Model
 	 */
 	public function pickerData(array $params = []): array
 	{
-		$params['text'] ??= '{{ page.title }}';
+		$item = new PageItem(
+			page: $this->model,
+			image: $params['image'] ?? null,
+			info: $params['info'] ?? null,
+			layout: $params['layout'] ?? null,
+			text: $params['text'] ?? null,
+		);
 
 		return [
-			...parent::pickerData($params),
-			'dragText'    => $this->dragText(),
+			...$item->props(),
 			'hasChildren' => $this->model->hasChildren(),
+			'sortable'    => true,
 			'url'         => $this->model->url()
 		];
 	}

--- a/src/Panel/Ui/Item/FileItem.php
+++ b/src/Panel/Ui/Item/FileItem.php
@@ -31,15 +31,15 @@ class FileItem extends ModelItem
 		protected bool $dragTextIsAbsolute = false,
 		string|array|false|null $image = [],
 		string|null $info = null,
-		string $layout = 'list',
-		string $text = '{{ file.filename }}',
+		string|null $layout = null,
+		string|null $text = null,
 	) {
 		parent::__construct(
 			model: $file,
 			image: $image,
 			info: $info,
 			layout: $layout,
-			text: $text,
+			text: $text ?? '{{ file.filename }}',
 		);
 	}
 

--- a/src/Panel/Ui/Item/ModelItem.php
+++ b/src/Panel/Ui/Item/ModelItem.php
@@ -16,17 +16,22 @@ use Kirby\Panel\Ui\Component;
  */
 class ModelItem extends Component
 {
+	protected string $layout;
 	protected Panel $panel;
+	protected string $text;
 
 	public function __construct(
 		protected ModelWithContent $model,
 		protected string|array|false|null $image = [],
 		protected string|null $info = null,
-		protected string $layout = 'list',
-		protected string $text = '{{ model.title }}',
+		string|null $layout = null,
+		string|null $text = null,
 	) {
 		parent::__construct(component: 'k-item');
-		$this->panel = $this->model->panel();
+
+		$this->layout = $layout ?? 'list';
+		$this->panel  = $this->model->panel();
+		$this->text   = $text ?? '{{ model.title }}';
 	}
 
 	protected function info(): string|null

--- a/src/Panel/Ui/Item/PageItem.php
+++ b/src/Panel/Ui/Item/PageItem.php
@@ -30,15 +30,15 @@ class PageItem extends ModelItem
 		Page $page,
 		string|array|false|null $image = [],
 		string|null $info = null,
-		string $layout = 'list',
-		string $text = '{{ page.title }}',
+		string|null $layout = null,
+		string|null $text = null,
 	) {
 		parent::__construct(
 			model: $page,
 			image: $image,
 			info: $info,
 			layout: $layout,
-			text: $text,
+			text: $text ?? '{{ page.title }}',
 		);
 	}
 

--- a/src/Panel/Ui/Item/UserItem.php
+++ b/src/Panel/Ui/Item/UserItem.php
@@ -24,15 +24,15 @@ class UserItem extends ModelItem
 		User $user,
 		string|array|false|null $image = [],
 		string|null $info = '{{ user.role.title }}',
-		string $layout = 'list',
-		string $text = '{{ user.username }}',
+		string|null $layout = null,
+		string|null $text = null,
 	) {
 		parent::__construct(
 			model: $user,
 			image: $image,
 			info: $info,
 			layout: $layout,
-			text: $text,
+			text: $text ?? '{{ user.username }}',
 		);
 	}
 

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -8,6 +8,7 @@ use Kirby\Cms\Translation;
 use Kirby\Cms\Url;
 use Kirby\Filesystem\Asset;
 use Kirby\Panel\Ui\Buttons\ViewButtons;
+use Kirby\Panel\Ui\Item\UserItem;
 use Kirby\Toolkit\I18n;
 
 /**
@@ -200,11 +201,19 @@ class User extends Model
 	 */
 	public function pickerData(array $params = []): array
 	{
-		$params['text'] ??= '{{ user.username }}';
+		$item = new UserItem(
+			user: $this->model,
+			image: $params['image'] ?? null,
+			info: $params['info'] ?? null,
+			layout: $params['layout'] ?? null,
+			text: $params['text'] ?? null,
+		);
 
 		return [
-			...parent::pickerData($params),
+			...$item->props(),
 			'email'    => $this->model->email(),
+			'sortable' => true,
+			'url'      => $this->model->url(),
 			'username' => $this->model->username(),
 		];
 	}

--- a/tests/Form/Field/PagesFieldTest.php
+++ b/tests/Form/Field/PagesFieldTest.php
@@ -218,11 +218,21 @@ class PagesFieldTest extends TestCase
 			],
 			'info' => '',
 			'link' => '/pages/test',
-			'sortable' => true,
+			'permissions' => [
+				'changeSlug' => true,
+				'changeStatus' => true,
+				'changeTitle' => true,
+				'delete' => true,
+				'sort' => false,
+			],
 			'text' => 'Test Title',
 			'uuid' => 'page://my-test-uuid',
 			'dragText' => '(link: page://my-test-uuid text: Test Title)',
+			'parent' => null,
+			'status' => 'unlisted',
+			'template' => 'default',
 			'hasChildren' => false,
+			'sortable' => true,
 			'url' => '/test',
 		], $api['data'][0]);
 		$this->assertSame('a', $api['data'][1]['id']);

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -434,6 +434,32 @@ class ModelTest extends TestCase
 		$this->assertInstanceOf(ModelSite::class, $panel->model());
 	}
 
+	public function testPickerData(): void
+	{
+		$panel = $this->panel();
+		$data = $panel->pickerData();
+
+		$this->assertSame([
+			'id' => null,
+			'image' => [
+				'back' => 'pattern',
+				'color' => 'gray-500',
+				'cover' => false,
+				'icon' => 'page',
+			],
+			'info' => '',
+			'link' => '/site',
+			'permissions' => [
+				'changeTitle' => false,
+				'update' => false,
+			],
+			'text' => '',
+			'uuid' => 'site://',
+			'sortable' => true,
+			'url' => '/custom',
+		], $data);
+	}
+
 	public function testProps(): void
 	{
 		$site = [


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- Use new Model Item classes in `::pickerData()` methods and in the `Kirby\Panel\Controller\Search` controller to clean up all places where such item props are created. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion