### PR TITLE
fix: Optional model for `Panel\Ui\Stats`

### DIFF
--- a/src/Panel/Ui/Stats.php
+++ b/src/Panel/Ui/Stats.php
@@ -16,8 +16,8 @@ use Kirby\Exception\InvalidArgumentException;
 class Stats extends Component
 {
 	public function __construct(
-		public ModelWithContent $model,
 		public string $component = 'k-stats',
+		public ModelWithContent|null $model = null,
 		public array $reports = [],
 		public string $size = 'large',
 	) {
@@ -59,10 +59,15 @@ class Stats extends Component
 
 		foreach ($this->reports as $report) {
 			try {
-				$stat = Stat::from(
-					model: $this->model,
-					input: $report
-				);
+				if ($this->model === null) {
+					$stat = new Stat(...$report);
+				} else {
+					$stat = Stat::from(
+						model: $this->model,
+						input: $report
+					);
+				}
+
 			} catch (InvalidArgumentException) {
 				continue;
 			}

--- a/tests/Panel/Ui/StatTest.php
+++ b/tests/Panel/Ui/StatTest.php
@@ -75,6 +75,12 @@ class StatTest extends TestCase
 	public function testComponent(): void
 	{
 		$stat = new Stat(
+			label: 'Test Label',
+			value: 'Test Value'
+		);
+		$this->assertSame('k-stat', $stat->component());
+
+		$stat = new Stat(
 			model: $this->model,
 			label: 'Test Label',
 			value: 'Test Value'

--- a/tests/Panel/Ui/StatsTest.php
+++ b/tests/Panel/Ui/StatsTest.php
@@ -79,7 +79,6 @@ class StatsTest extends TestCase
 	public function testProps(): void
 	{
 		$stats = new Stats(
-			model: $this->model,
 			reports: [
 				[
 					'label' => 'test',
@@ -105,6 +104,30 @@ class StatsTest extends TestCase
 	}
 
 	public function testReports(): void
+	{
+		$stats = new Stats(
+			reports: [
+				[
+					'label' => 'test',
+					'value' => 'test',
+				],
+			],
+			size: 'medium'
+		);
+
+		$this->assertSame([
+			[
+				'icon'  => null,
+				'info'  => null,
+				'label' => 'test',
+				'link'  => null,
+				'theme' => null,
+				'value' => 'test',
+			],
+		], $stats->reports());
+	}
+
+	public function testReportsWithModel(): void
 	{
 		$stats = new Stats(
 			model: $this->model,


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Missed this in the other PR. Also `Stats` should work without a model, not just `Stat`.
Also added tests for both.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- Made model optional for `Kirby\Panel\Ui\Stats`


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion