### PR TITLE
fix: Support `Stat` in `Stats::reports()`

### DIFF
--- a/src/Panel/Ui/Stat.php
+++ b/src/Panel/Ui/Stat.php
@@ -32,20 +32,22 @@ class Stat extends Component
 	 * @psalm-suppress TooFewArguments
 	 */
 	public static function from(
-		ModelWithContent $model,
-		array|string $input
+		array|string $input,
+		ModelWithContent|null $model = null,
 	): static {
-		if (is_string($input) === true) {
-			$input = $model->query($input);
+		if ($model !== null) {
+			if (is_string($input) === true) {
+				$input = $model->query($input);
 
-			if (is_array($input) === false) {
-				throw new InvalidArgumentException(
-					message: 'Invalid data from stat query. The query must return an array.'
-				);
+				if (is_array($input) === false) {
+					throw new InvalidArgumentException(
+						message: 'Invalid data from stat query. The query must return an array.'
+					);
+				}
 			}
-		}
 
-		$input['model'] = $model;
+			$input['model'] = $model;
+		}
 
 		return new static(...$input);
 	}

--- a/src/Panel/Ui/Stats.php
+++ b/src/Panel/Ui/Stats.php
@@ -57,19 +57,17 @@ class Stats extends Component
 	{
 		$reports = [];
 
-		foreach ($this->reports as $report) {
-			try {
-				if ($this->model === null) {
-					$stat = new Stat(...$report);
-				} else {
+		foreach ($this->reports as $stat) {
+			// if not already a Stat object, convert it
+			if ($stat instanceof Stat === false) {
+				try {
 					$stat = Stat::from(
-						model: $this->model,
-						input: $report
+						input: $stat,
+						model: $this->model
 					);
+				} catch (InvalidArgumentException) {
+					continue;
 				}
-
-			} catch (InvalidArgumentException) {
-				continue;
 			}
 
 			$reports[] = $stat->props();

--- a/tests/Panel/Ui/StatTest.php
+++ b/tests/Panel/Ui/StatTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel\Ui;
 
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -14,7 +15,15 @@ class StatTest extends TestCase
 
 	public function setUp(): void
 	{
-		$this->model = new Page(['slug' => 'test']);
+		$this->model = new class (['slug' => 'test']) extends Page {
+			public function report(): array
+			{
+				return [
+					'label' => 'Test Query Label',
+					'value' => 'Test Query Value',
+				];
+			}
+		};
 	}
 
 	public function assertProp(
@@ -95,6 +104,59 @@ class StatTest extends TestCase
 		);
 
 		$this->assertSame('k-stat-test', $stat->component());
+	}
+
+	public function testFrom(): void
+	{
+		// from array with model
+		$stat = Stat::from(
+			input: [
+				'label' => 'Test Label',
+				'value' => 'Test Value',
+			],
+			model: $this->model
+		);
+
+		$this->assertInstanceOf(Stat::class, $stat);
+		$this->assertSame('Test Label', $stat->label());
+		$this->assertSame('Test Value', $stat->value());
+		$this->assertSame($this->model, $stat->model);
+
+
+		// from array without model
+		$stat = Stat::from(
+			input: [
+				'label' => 'Test Label',
+				'value' => 'Test Value',
+			],
+			model: null
+		);
+
+		$this->assertInstanceOf(Stat::class, $stat);
+		$this->assertSame('Test Label', $stat->label());
+		$this->assertSame('Test Value', $stat->value());
+		$this->assertNull($stat->model);
+
+		// from query
+		$stat = Stat::from(
+			input: 'page.report',
+			model: $this->model
+		);
+
+		$this->assertInstanceOf(Stat::class, $stat);
+		$this->assertSame('Test Query Label', $stat->label());
+		$this->assertSame('Test Query Value', $stat->value());
+	}
+
+	public function testFromWithInvalidInput(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid data from stat query. The query must return an array.');
+
+		Stat::from(
+			input: 'invalid',
+			model: $this->model
+		);
 	}
 
 	public function testIcon(): void

--- a/tests/Panel/Ui/StatsTest.php
+++ b/tests/Panel/Ui/StatsTest.php
@@ -127,6 +127,30 @@ class StatsTest extends TestCase
 		], $stats->reports());
 	}
 
+	public function testReportsWithStatObject(): void
+	{
+		$stats = new Stats(
+			reports: [
+				new Stat(
+					label: 'test',
+					value: 'test',
+				),
+			],
+			size: 'medium'
+		);
+
+		$this->assertSame([
+			[
+				'icon'  => null,
+				'info'  => null,
+				'label' => 'test',
+				'link'  => null,
+				'theme' => null,
+				'value' => 'test',
+			],
+		], $stats->reports());
+	}
+
 	public function testReportsWithModel(): void
 	{
 		$stats = new Stats(


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

No changelog as this just fixes a part of a yet unreleased code.
- Allow `Stat::from()` to be called without model
- Support existing `Stat` objects in `Stats::reports()`
- Adds unit tests for `Stat::from()`

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion