### PR TITLE
refact!: `ViewButtons` with direct object support

### DIFF
--- a/src/Panel/Ui/Buttons/ViewButtons.php
+++ b/src/Panel/Ui/Buttons/ViewButtons.php
@@ -21,9 +21,9 @@ use Kirby\Panel\Model;
 class ViewButtons
 {
 	public function __construct(
-		public readonly string $view,
-		public readonly ModelWithContent|Language|null $model = null,
 		public array|false|null $buttons = null,
+		public readonly string|null $view = null,
+		public readonly ModelWithContent|Language|null $model = null,
 		public array $data = []
 	) {
 		// if no specific buttons are passed,
@@ -69,16 +69,22 @@ class ViewButtons
 		$buttons = [];
 
 		foreach ($this->buttons ?? [] as $name => $button) {
-			$buttons[] = ViewButton::factory(
-				button: $button,
-				name: $name,
-				view: $this->view,
-				model: $this->model,
-				data: $this->data
-			)?->render();
+			if ($button instanceof ViewButton === false) {
+				$button = ViewButton::factory(
+					button: $button,
+					name: $name,
+					view: $this->view,
+					model: $this->model,
+					data: $this->data
+				);
+			}
+
+			if ($button !== null) {
+				$buttons[] = $button->render();
+			}
 		}
 
-		return array_values(array_filter($buttons));
+		return array_values($buttons);
 	}
 
 	/**

--- a/tests/Panel/Ui/Buttons/ViewButtonsTest.php
+++ b/tests/Panel/Ui/Buttons/ViewButtonsTest.php
@@ -33,34 +33,44 @@ class ViewButtonsTest extends AreaTestCase
 	public function testConstruct(): void
 	{
 		// no buttons
-		$buttons = new ViewButtons('test', buttons: []);
+		$buttons = new ViewButtons([]);
 		$this->assertCount(0, $buttons->buttons);
 
-		// passed directly
-		$buttons = new ViewButtons('test', buttons: ['a', 'b']);
+		// passed directly as array
+		$buttons = new ViewButtons(['a', 'b']);
+		$this->assertCount(2, $buttons->buttons);
+
+		$buttons = new ViewButtons(['a', 'b'], view: 'test');
+		$this->assertCount(2, $buttons->buttons);
+
+		// passed directly as ViewButton
+		$buttons = new ViewButtons([
+			new ViewButton(text: 'Button A'),
+			new ViewButton(text: 'Button B'),
+		]);
 		$this->assertCount(2, $buttons->buttons);
 
 		// from options
-		$buttons = new ViewButtons('test');
+		$buttons = new ViewButtons(view: 'test');
 		$this->assertCount(4, $buttons->buttons);
 	}
 
 	public function testBind(): void
 	{
-		$buttons = new ViewButtons('foo');
+		$buttons = new ViewButtons();
 		$this->assertSame([], $buttons->data);
 
-		$buttons = new ViewButtons('foo', data: ['foo' => 'bar']);
+		$buttons = new ViewButtons(data: ['foo' => 'bar']);
 		$this->assertSame(['foo' => 'bar'], $buttons->data);
 
-		$buttons = new ViewButtons('foo', data: ['foo' => 'bar']);
+		$buttons = new ViewButtons(data: ['foo' => 'bar']);
 		$buttons->bind(['homer' => 'simpson']);
 		$this->assertSame(['foo' => 'bar', 'homer' => 'simpson'], $buttons->data);
 	}
 
 	public function testDefaults(): void
 	{
-		$buttons = new ViewButtons('foo');
+		$buttons = new ViewButtons();
 		$this->assertCount(0, $buttons->buttons ?? []);
 
 		$buttons->defaults('a', 'b');
@@ -69,7 +79,7 @@ class ViewButtonsTest extends AreaTestCase
 
 	public function testRender(): void
 	{
-		$buttons = new ViewButtons('test', buttons: ['a', 'y']);
+		$buttons = new ViewButtons(buttons: ['a', 'y'], view: 'test');
 		$result  = $buttons->render();
 
 		$this->assertCount(2, $result);
@@ -79,7 +89,7 @@ class ViewButtonsTest extends AreaTestCase
 
 	public function testRenderFromConfig(): void
 	{
-		$buttons = new ViewButtons('test');
+		$buttons = new ViewButtons(view: 'test');
 		$result  = $buttons->render();
 
 		$this->assertCount(3, $result);
@@ -88,9 +98,22 @@ class ViewButtonsTest extends AreaTestCase
 		$this->assertSame('result-c', $result[2]['component']);
 	}
 
+	public function testRenderWithViewButtonObjects(): void
+	{
+		$buttons = new ViewButtons([
+			new ViewButton(text: 'Button A'),
+			new ViewButton(text: 'Button B'),
+		]);
+
+		$result = $buttons->render();
+		$this->assertCount(2, $result);
+		$this->assertSame('Button A', $result[0]['props']['text']);
+		$this->assertSame('Button B', $result[1]['props']['text']);
+	}
+
 	public function testRenderNoButtons(): void
 	{
-		$buttons = new ViewButtons('test', buttons: false);
+		$buttons = new ViewButtons(buttons: false);
 		$this->assertSame([], $buttons->render());
 	}
 


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Some improvements for the `Kirby\Panel\Ui\Buttons\ViewButtons` class:
- Changed the argument order to have `$buttons` first so that passing an array of already existing view button objects becomes more natural/the default use case as with many other collection-like classes.
- Made `$view` argument optional as it is not needed when `$buttons` are passed.
- Support for already initialized view button objects in `::render()`


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- `Kirby\Panel\Ui\Buttons\ViewButtons` now supports passing an array of `Kirby\Panel\Ui\Buttons\ViewButton` objects

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- The argument for the `Kirby\Panel\Ui\Buttons\ViewButtons` constructor has changed.


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion