### PR TITLE
refact!: Remove `model` prop from model views

### DIFF
--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -12,7 +12,6 @@ export default {
 		lock: {
 			type: [Boolean, Object]
 		},
-		model: Object,
 		next: Object,
 		prev: Object,
 		permissions: {

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -332,37 +332,16 @@ class File extends Model
 	 */
 	public function props(): array
 	{
-		$props = parent::props();
-		$file  = $this->model;
-
-		// Additional model information
-		// @deprecated Use the top-level props instead
-		$model = [
-			'dimensions' => $file->dimensions()->toArray(),
-			'extension'  => $file->extension(),
-			'filename'   => $file->filename(),
-			'link'       => $props['link'],
-			'mime'       => $file->mime(),
-			'niceSize'   => $file->niceSize(),
-			'id'         => $props['id'],
-			'parent'     => $file->parent()->panel()->path(),
-			'template'   => $file->template(),
-			'type'       => $file->type(),
-			'url'        => $file->url(),
-			'uuid'       => $props['uuid'],
-		];
-
 		return [
-			...$props,
+			...parent::props(),
 			...$this->prevNext(),
 			'blueprint' => $this->model->template() ?? 'default',
-			'extension' => $model['extension'],
-			'filename'  => $model['filename'],
-			'mime'      => $model['mime'],
-			'model'     => $model,
+			'extension' => $this->model->extension(),
+			'filename'  => $this->model->filename(),
+			'mime'      => $this->model->mime(),
 			'preview'   => FilePreview::factory($this->model)->render(),
-			'type'      => $model['type'],
-			'url'       => $model['url'],
+			'type'      => $this->model->type(),
+			'url'       => $this->model->url(),
 		];
 	}
 

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -242,26 +242,11 @@ class Page extends Model
 	 */
 	public function props(): array
 	{
-		$props = parent::props();
-
-		// Additional model information
-		// @deprecated Use the top-level props instead
-		$model = [
-			'id'         => $props['id'],
-			'link'       => $props['link'],
-			'parent'     => $this->model->parentModel()->panel()->url(true),
-			'previewUrl' => $this->model->previewUrl(),
-			'status'     => $this->model->status(),
-			'title'      => $this->model->title()->toString(),
-			'uuid'       => $props['uuid'],
-		];
-
 		return [
-			...$props,
+			...parent::props(),
 			...$this->prevNext(),
-			'blueprint'  => $this->model->intendedTemplate()->name(),
-			'model'      => $model,
-			'title'      => $model['title'],
+			'blueprint' => $this->model->intendedTemplate()->name(),
+			'title'     => $this->model->title()->toString(),
 		];
 	}
 
@@ -273,8 +258,8 @@ class Page extends Model
 		return [
 			'breadcrumb' => $this->model->panel()->breadcrumb(),
 			'component'  => 'k-page-view',
-			'props'      => $props = $this->props(),
-			'title'      => $props['title'],
+			'props'      => $this->props(),
+			'title'      => $this->model->title()->toString()
 		];
 	}
 }

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -75,21 +75,11 @@ class Site extends Model
 	{
 		$props = parent::props();
 
-		// Additional model information
-		// @deprecated Use the top-level props instead
-		$model = [
-			'link'       => $props['link'],
-			'previewUrl' => $this->model->previewUrl(),
-			'title'      => $this->model->title()->toString(),
-			'uuid'       => $props['uuid'],
-		];
-
 		return [
 			...$props,
 			'blueprint'   => 'site',
 			'id'          => '/',
-			'model'       => $model,
-			'title'       => $model['title'],
+			'title'       => $this->model->title()->toString(),
 			'permissions' => [
 				...$props['permissions'],
 				'preview' => $this->model->homePage()?->permissions()->can('preview') === true,

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -157,40 +157,22 @@ class User extends Model
 	 */
 	public function props(): array
 	{
-		$props       = parent::props();
-		$user        = $this->model;
 		$permissions = $this->options();
-
-		// Additional model information
-		// @deprecated Use the top-level props instead
-		$model = [
-			'account'  => $user->isLoggedIn(),
-			'avatar'   => $user->avatar()?->url(),
-			'email'    => $user->email(),
-			'id'       => $props['id'],
-			'language' => $this->translation()->name(),
-			'link'     => $props['link'],
-			'name'     => $user->name()->toString(),
-			'role'     => $user->role()->title(),
-			'username' => $user->username(),
-			'uuid'     => $props['uuid'],
-		];
 
 		return [
 			...parent::props(),
 			...$this->prevNext(),
-			'avatar'            => $model['avatar'],
+			'avatar'            => $this->model->avatar()?->url(),
 			'blueprint'         => $this->model->role()->name(),
 			'canChangeEmail'    => $permissions['changeEmail'],
 			'canChangeLanguage' => $permissions['changeLanguage'],
 			'canChangeName'     => $permissions['changeName'],
 			'canChangeRole'     => $this->model->roles()->count() > 1,
-			'email'             => $model['email'],
-			'language'          => $model['language'],
-			'model'             => $model,
-			'name'              => $model['name'],
-			'role'              => $model['role'],
-			'username'          => $model['username'],
+			'email'             => $this->model->email(),
+			'language'          => $this->translation()->name(),
+			'name'              => $this->model->name()->toString(),
+			'role'              => $this->model->role()->title(),
+			'username'          => $this->model->username(),
 		];
 	}
 

--- a/tests/Panel/Areas/AccountTest.php
+++ b/tests/Panel/Areas/AccountTest.php
@@ -23,7 +23,7 @@ class AccountTest extends AreaTestCase
 		$view = $this->view('account');
 		$this->assertSame('account', $view['id']);
 		$this->assertSame('k-account-view', $view['component']);
-		$this->assertSame('test@getkirby.com', $view['props']['model']['email']);
+		$this->assertSame('test@getkirby.com', $view['props']['email']);
 	}
 
 	public function testAccountFiles(): void

--- a/tests/Panel/Areas/SiteTest.php
+++ b/tests/Panel/Areas/SiteTest.php
@@ -34,7 +34,6 @@ class SiteTest extends AreaTestCase
 
 		$view  = $this->view('pages/test');
 		$props = $view['props'];
-		$model = $props['model'];
 
 		$this->assertSame('default', $props['blueprint']);
 		$this->assertSame([
@@ -48,15 +47,10 @@ class SiteTest extends AreaTestCase
 		], $props['lock']);
 		$this->assertArrayNotHasKey('tab', $props);
 		$this->assertSame([], $props['tabs']);
-
 		$this->assertSame('Test', $props['versions']['latest']['title']);
 		$this->assertSame('Test', $props['versions']['changes']['title']);
-
-		// model
-		$this->assertSame('test', $model['id']);
-		$this->assertSame('draft', $model['status']);
-		$this->assertSame('Test', $model['title']);
-
+		$this->assertSame('test', $props['id']);
+		$this->assertSame('Test', $props['title']);
 		$this->assertNull($props['next']);
 		$this->assertNull($props['prev']);
 	}
@@ -94,7 +88,6 @@ class SiteTest extends AreaTestCase
 
 		$view  = $this->view('pages/test/files/test.jpg');
 		$props = $view['props'];
-		$model = $props['model'];
 
 		$this->assertSame('image', $props['blueprint']);
 		$this->assertSame([
@@ -112,13 +105,11 @@ class SiteTest extends AreaTestCase
 		$this->assertSame([], $props['versions']['latest']);
 
 		// model
-		$this->assertSame('jpg', $model['extension']);
-		$this->assertSame('test.jpg', $model['filename']);
-		$this->assertSame('test/test.jpg', $model['id']);
-		$this->assertSame('image/jpeg', $model['mime']);
-		$this->assertSame('0 KB', $model['niceSize']);
-		$this->assertSame('pages/test', $model['parent']);
-		$this->assertSame('image', $model['type']);
+		$this->assertSame('jpg', $props['extension']);
+		$this->assertSame('test.jpg', $props['filename']);
+		$this->assertSame('test/test.jpg', $props['id']);
+		$this->assertSame('image/jpeg', $props['mime']);
+		$this->assertSame('image', $props['type']);
 
 		$this->assertNull($props['next']);
 		$this->assertNull($props['prev']);
@@ -176,9 +167,8 @@ class SiteTest extends AreaTestCase
 		$this->assertSame('k-site-view', $view['component']);
 
 		$this->assertSame('site', $props['blueprint']);
-		$this->assertSame('/site', $props['model']['link']);
-		$this->assertSame('/', $props['model']['previewUrl']);
-		$this->assertSame('', $props['model']['title']);
+		$this->assertSame('/site', $props['link']);
+		$this->assertSame('', $props['title']);
 	}
 
 	public function testSiteFile(): void
@@ -198,7 +188,6 @@ class SiteTest extends AreaTestCase
 
 		$view  = $this->view('site/files/test.jpg');
 		$props = $view['props'];
-		$model = $props['model'];
 
 		$this->assertSame('image', $props['blueprint']);
 		$this->assertSame([
@@ -216,13 +205,11 @@ class SiteTest extends AreaTestCase
 		// model
 		$this->assertSame([], $props['versions']['changes']);
 		$this->assertSame([], $props['versions']['latest']);
-		$this->assertSame('jpg', $model['extension']);
-		$this->assertSame('test.jpg', $model['filename']);
-		$this->assertSame('test.jpg', $model['id']);
-		$this->assertSame('image/jpeg', $model['mime']);
-		$this->assertSame('0 KB', $model['niceSize']);
-		$this->assertSame('site', $model['parent']);
-		$this->assertSame('image', $model['type']);
+		$this->assertSame('jpg', $props['extension']);
+		$this->assertSame('test.jpg', $props['filename']);
+		$this->assertSame('test.jpg', $props['id']);
+		$this->assertSame('image/jpeg', $props['mime']);
+		$this->assertSame('image', $props['type']);
 
 		$this->assertNull($props['next']);
 		$this->assertNull($props['prev']);

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -721,17 +721,12 @@ class FileTest extends TestCase
 	{
 		$props = $this->panel()->props();
 
-		$this->assertArrayHasKey('model', $props);
-		$this->assertArrayHasKey('dimensions', $props['model']);
-		$this->assertArrayHasKey('extension', $props['model']);
-		$this->assertArrayHasKey('filename', $props['model']);
-		$this->assertArrayHasKey('id', $props['model']);
-		$this->assertArrayHasKey('mime', $props['model']);
-		$this->assertArrayHasKey('niceSize', $props['model']);
-		$this->assertArrayHasKey('parent', $props['model']);
-		$this->assertArrayHasKey('url', $props['model']);
-		$this->assertArrayHasKey('template', $props['model']);
-		$this->assertArrayHasKey('type', $props['model']);
+		$this->assertArrayHasKey('extension', $props);
+		$this->assertArrayHasKey('filename', $props);
+		$this->assertArrayHasKey('id', $props);
+		$this->assertArrayHasKey('mime', $props);
+		$this->assertArrayHasKey('url', $props);
+		$this->assertArrayHasKey('type', $props);
 		$this->assertArrayHasKey('preview', $props);
 
 		// inherited props

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -459,12 +459,8 @@ class PageTest extends TestCase
 		$panel = new Page($page);
 		$props = $panel->props();
 
-		$this->assertArrayHasKey('model', $props);
-		$this->assertArrayHasKey('id', $props['model']);
-		$this->assertArrayHasKey('parent', $props['model']);
-		$this->assertArrayHasKey('previewUrl', $props['model']);
-		$this->assertArrayHasKey('status', $props['model']);
-		$this->assertArrayHasKey('title', $props['model']);
+		$this->assertArrayHasKey('id', $props);
+		$this->assertArrayHasKey('title', $props);
 
 		// inherited props
 		$this->assertArrayHasKey('blueprint', $props);

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -103,9 +103,7 @@ class SiteTest extends TestCase
 	{
 		$props = $this->panel()->props();
 
-		$this->assertArrayHasKey('model', $props);
-		$this->assertArrayHasKey('previewUrl', $props['model']);
-		$this->assertArrayHasKey('title', $props['model']);
+		$this->assertArrayHasKey('title', $props);
 
 		// inherited props
 		$this->assertArrayHasKey('blueprint', $props);

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -294,14 +294,13 @@ class UserTest extends TestCase
 		$panel = new User($user);
 		$props = $panel->props();
 
-		$this->assertArrayHasKey('model', $props);
-		$this->assertArrayHasKey('avatar', $props['model']);
-		$this->assertArrayHasKey('email', $props['model']);
-		$this->assertArrayHasKey('id', $props['model']);
-		$this->assertArrayHasKey('language', $props['model']);
-		$this->assertArrayHasKey('name', $props['model']);
-		$this->assertArrayHasKey('role', $props['model']);
-		$this->assertArrayHasKey('username', $props['model']);
+		$this->assertArrayHasKey('avatar', $props);
+		$this->assertArrayHasKey('email', $props);
+		$this->assertArrayHasKey('id', $props);
+		$this->assertArrayHasKey('language', $props);
+		$this->assertArrayHasKey('name', $props);
+		$this->assertArrayHasKey('role', $props);
+		$this->assertArrayHasKey('username', $props);
 
 		// inherited props
 		$this->assertArrayHasKey('blueprint', $props);


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

It would help a lot with the view controllers and UI classes if we can loose those redundant nested data inside the `model` prop.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- Removed derprevcatd `model` prop from model views. Use the top-level props instead.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion