### PR TITLE
feat: `Toolkit\HasI18n` trait

### DIFF
--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -3,7 +3,7 @@
 namespace Kirby\Form;
 
 use Kirby\Cms\HasSiblings;
-use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\HasI18n;
 
 /**
  * Abstract field class to be used instead
@@ -20,6 +20,7 @@ use Kirby\Toolkit\I18n;
  */
 abstract class FieldClass
 {
+	use HasI18n;
 	use HasSiblings;
 	use Mixin\After;
 	use Mixin\Api;
@@ -96,11 +97,6 @@ abstract class FieldClass
 	public function drawers(): array
 	{
 		return [];
-	}
-
-	protected function i18n(string|array|null $param = null): string|null
-	{
-		return empty($param) === false ? I18n::translate($param, $param) : null;
 	}
 
 	public function id(): string

--- a/src/Panel/Area.php
+++ b/src/Panel/Area.php
@@ -9,7 +9,7 @@ use Kirby\Panel\Routes\DropdownRoutes;
 use Kirby\Panel\Routes\RequestRoutes;
 use Kirby\Panel\Routes\SearchRoutes;
 use Kirby\Panel\Routes\ViewRoutes;
-use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\HasI18n;
 
 /**
  * @package   Kirby Panel
@@ -21,6 +21,8 @@ use Kirby\Toolkit\I18n;
  */
 class Area
 {
+	use HasI18n;
+
 	public function __construct(
 		protected string $id,
 		protected array $breadcrumb = [],
@@ -53,22 +55,6 @@ class Area
 	public function breadcrumbLabel(): string
 	{
 		return $this->i18n($this->breadcrumbLabel ?? $this->label());
-	}
-
-	/**
-	 * Translator for breadcrumbLabel, label & title
-	 */
-	protected function i18n(Closure|array|string|null $value): string|null
-	{
-		if ($value instanceof Closure) {
-			$value = $value();
-		}
-
-		if ($value === null) {
-			return null;
-		}
-
-		return I18n::translate($value, $value);
 	}
 
 	/**

--- a/src/Panel/Controller/Controller.php
+++ b/src/Panel/Controller/Controller.php
@@ -5,7 +5,7 @@ namespace Kirby\Panel\Controller;
 use Kirby\Cms\App;
 use Kirby\Cms\Site;
 use Kirby\Http\Request;
-use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\HasI18n;
 
 /**
  * @package   Kirby Panel
@@ -20,6 +20,8 @@ use Kirby\Toolkit\I18n;
  */
 abstract class Controller
 {
+	use HasI18n;
+
 	protected App $kirby;
 	protected Request $request;
 	protected Site $site;
@@ -29,22 +31,6 @@ abstract class Controller
 		$this->kirby   = App::instance();
 		$this->request = $this->kirby->request();
 		$this->site    = $this->kirby->site();
-	}
-
-	protected function i18n(
-		string|array|null $key,
-		array|null $data = null
-	): string|null {
-
-		if ($key === null) {
-			return null;
-		}
-
-		if ($data === null) {
-			return I18n::translate($key, $key);
-		}
-
-		return I18n::template($key, $data);
 	}
 
 	abstract public function load(): mixed;

--- a/src/Panel/Controller/Controller.php
+++ b/src/Panel/Controller/Controller.php
@@ -5,6 +5,7 @@ namespace Kirby\Panel\Controller;
 use Kirby\Cms\App;
 use Kirby\Cms\Site;
 use Kirby\Http\Request;
+use Kirby\Toolkit\I18n;
 
 /**
  * @package   Kirby Panel
@@ -28,6 +29,22 @@ abstract class Controller
 		$this->kirby   = App::instance();
 		$this->request = $this->kirby->request();
 		$this->site    = $this->kirby->site();
+	}
+
+	protected function i18n(
+		string|array|null $key,
+		array|null $data = null
+	): string|null {
+
+		if ($key === null) {
+			return null;
+		}
+
+		if ($data === null) {
+			return I18n::translate($key, $key);
+		}
+
+		return I18n::template($key, $data);
 	}
 
 	abstract public function load(): mixed;

--- a/src/Panel/Controller/Dialog/FileChangeNameDialogController.php
+++ b/src/Panel/Controller/Dialog/FileChangeNameDialogController.php
@@ -4,7 +4,6 @@ namespace Kirby\Panel\Controller\Dialog;
 
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for changing the name of a file
@@ -24,7 +23,7 @@ class FileChangeNameDialogController extends FileDialogController
 		return new FormDialog(
 			fields: [
 				'name' => [
-					'label'     => I18n::translate('name'),
+					'label'     => $this->i18n('name'),
 					'type'      => 'slug',
 					'required'  => true,
 					'icon'      => 'title',
@@ -33,7 +32,7 @@ class FileChangeNameDialogController extends FileDialogController
 					'preselect' => true
 				]
 			],
-			submitButton: I18n::translate('rename'),
+			submitButton: $this->i18n('rename'),
 			value: [
 				'name' => $this->file->name(),
 			]

--- a/src/Panel/Controller/Dialog/FileChangeSortDialogController.php
+++ b/src/Panel/Controller/Dialog/FileChangeSortDialogController.php
@@ -5,7 +5,6 @@ namespace Kirby\Panel\Controller\Dialog;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for changing the sorting number of a file
@@ -26,7 +25,7 @@ class FileChangeSortDialogController extends FileDialogController
 			fields: [
 				'position' => Field::filePosition($this->file)
 			],
-			submitButton: I18n::translate('change'),
+			submitButton: $this->i18n('change'),
 			value: [
 				'position' => $this->file->sort()->isEmpty() ?
 					$this->file->siblings(false)->count() + 1 :

--- a/src/Panel/Controller/Dialog/FileChangeTemplateDialogController.php
+++ b/src/Panel/Controller/Dialog/FileChangeTemplateDialogController.php
@@ -5,7 +5,6 @@ namespace Kirby\Panel\Controller\Dialog;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for changing the template of a file
@@ -29,14 +28,14 @@ class FileChangeTemplateDialogController extends FileDialogController
 				'warning' => [
 					'type'  => 'info',
 					'theme' => 'notice',
-					'text'  => I18n::translate('file.changeTemplate.notice')
+					'text'  => $this->i18n('file.changeTemplate.notice')
 				],
 				'template' => Field::template($blueprints, [
 					'required' => true
 				])
 			],
 			submitButton: [
-				'text' => I18n::translate('change'),
+				'text' => $this->i18n('change'),
 				'theme' => 'notice'
 			],
 			value: [

--- a/src/Panel/Controller/Dialog/FileDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/FileDeleteDialogController.php
@@ -5,7 +5,6 @@ namespace Kirby\Panel\Controller\Dialog;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
 use Kirby\Toolkit\Escape;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for deleting a file
@@ -23,7 +22,7 @@ class FileDeleteDialogController extends FileDialogController
 	public function load(): Dialog
 	{
 		return new RemoveDialog(
-			text: I18n::template('file.delete.confirm', [
+			text: $this->i18n('file.delete.confirm', [
 				'filename' => Escape::html($this->file->filename())
 			])
 		);

--- a/src/Panel/Controller/Dialog/LanguageDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/LanguageDeleteDialogController.php
@@ -8,7 +8,6 @@ use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
 use Kirby\Toolkit\Escape;
-use Kirby\Toolkit\I18n;
 
 /**
  * Dialog controller for deleting a language
@@ -36,7 +35,7 @@ class LanguageDeleteDialogController extends DialogController
 	public function load(): Dialog
 	{
 		return new RemoveDialog(
-			text: I18n::template('language.delete.confirm', [
+			text: $this->i18n('language.delete.confirm', [
 				'name' => Escape::html($this->language->name())
 			])
 		);

--- a/src/Panel/Controller/Dialog/LanguageFormDialogController.php
+++ b/src/Panel/Controller/Dialog/LanguageFormDialogController.php
@@ -8,7 +8,6 @@ use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
 use Kirby\Toolkit\A;
-use Kirby\Toolkit\I18n;
 
 /**
  * Dialog controller for creating a new language
@@ -43,13 +42,13 @@ class LanguageFormDialogController extends DialogController
 		return [
 			'name' => [
 				'counter'  => false,
-				'label'    => I18n::translate('language.name'),
+				'label'    => $this->i18n('language.name'),
 				'type'     => 'text',
 				'required' => true,
 				'icon'     => 'title'
 			],
 			'code' => [
-				'label'    => I18n::translate('language.code'),
+				'label'    => $this->i18n('language.code'),
 				'type'     => 'text',
 				// the code of an existing language cannot be changed
 				'disabled' => $this->language !== null,
@@ -59,18 +58,18 @@ class LanguageFormDialogController extends DialogController
 				'width'    => '1/2'
 			],
 			'direction' => [
-				'label'    => I18n::translate('language.direction'),
+				'label'    => $this->i18n('language.direction'),
 				'type'     => 'select',
 				'required' => true,
 				'empty'    => false,
 				'options'  => [
 					[
 						'value' => 'ltr',
-						'text' => I18n::translate('language.direction.ltr')
+						'text' => $this->i18n('language.direction.ltr')
 					],
 					[
 						'value' => 'rtl',
-						'text' => I18n::translate('language.direction.rtl')
+						'text' => $this->i18n('language.direction.rtl')
 					]
 				],
 				'width'    => '1/2'
@@ -81,8 +80,8 @@ class LanguageFormDialogController extends DialogController
 			// we display a warning box instead.
 			'locale' => [
 				'counter' => false,
-				'label'   => I18n::translate('language.locale'),
-				'text'    => I18n::translate('language.locale.warning'),
+				'label'   => $this->i18n('language.locale'),
+				'text'    => $this->i18n('language.locale.warning'),
 				'type'    => is_array($this->locale()) ? 'info' : 'text',
 			],
 		];
@@ -93,7 +92,7 @@ class LanguageFormDialogController extends DialogController
 		return new FormDialog(
 			component: 'k-language-dialog',
 			fields: $this->fields(),
-			submitButton: I18n::translate(
+			submitButton: $this->i18n(
 				$this->language ? 'save' : 'language.create'
 			),
 			value: $this->value()

--- a/src/Panel/Controller/Dialog/LanguageVariableDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/LanguageVariableDeleteDialogController.php
@@ -9,7 +9,6 @@ use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
 use Kirby\Toolkit\Escape;
-use Kirby\Toolkit\I18n;
 
 /**
  * Dialog controller for deleting a language variable
@@ -43,7 +42,7 @@ class LanguageVariableDeleteDialogController extends DialogController
 	public function load(): Dialog
 	{
 		return new RemoveDialog(
-			text: I18n::template('language.variable.delete.confirm', [
+			text: $this->i18n('language.variable.delete.confirm', [
 				'key' => Escape::html($this->variable->key())
 			])
 		);

--- a/src/Panel/Controller/Dialog/LanguageVariableFormDialogController.php
+++ b/src/Panel/Controller/Dialog/LanguageVariableFormDialogController.php
@@ -9,7 +9,6 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Dialog controller for creating a new language variable
@@ -54,29 +53,29 @@ class LanguageVariableFormDialogController extends DialogController
 			'key' => [
 				'counter'  => false,
 				'icon'     => null,
-				'label'    => I18n::translate('language.variable.key'),
+				'label'    => $this->i18n('language.variable.key'),
 				'type'     => 'text',
 				// the key field cannot be changed
 				'disabled' => $this->variable !== null
 			],
 			'multiple' => [
-				'label'   => I18n::translate('language.variable.multiple'),
-				'text'    => I18n::translate('language.variable.multiple.text'),
-				'help'    => I18n::translate('language.variable.multiple.help'),
+				'label'   => $this->i18n('language.variable.multiple'),
+				'text'    => $this->i18n('language.variable.multiple.text'),
+				'help'    => $this->i18n('language.variable.multiple.help'),
 				'type'    => $this->variable ? 'hidden' : 'toggle'
 			],
 			'value' => [
 				'buttons'   => false,
 				'counter'   => false,
-				'label'     => I18n::translate('language.variable.value'),
+				'label'     => $this->i18n('language.variable.value'),
 				'type'      => 'textarea',
 				'when'      => ['multiple' => false],
 				'autofocus' => $this->hasMultipleValues() === false
 			],
 			'entries' => [
 				'field'     => ['type' => 'text'],
-				'label'     => I18n::translate('language.variable.entries'),
-				'help'      => I18n::translate('language.variable.entries.help'),
+				'label'     => $this->i18n('language.variable.entries'),
+				'help'      => $this->i18n('language.variable.entries.help'),
 				'type'      => 'entries',
 				'min'       => 1,
 				'when'      => ['multiple' => true],

--- a/src/Panel/Controller/Dialog/PageChangeSortDialogController.php
+++ b/src/Panel/Controller/Dialog/PageChangeSortDialogController.php
@@ -6,7 +6,6 @@ use Kirby\Exception\PermissionException;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for changing the sorting position of a page
@@ -34,7 +33,7 @@ class PageChangeSortDialogController extends PageDialogController
 			fields: [
 				'position' => Field::pagePosition($this->page),
 			],
-			submitButton: I18n::translate('change'),
+			submitButton: $this->i18n('change'),
 			value: [
 				'position' => $this->page->panel()->position()
 			]

--- a/src/Panel/Controller/Dialog/PageChangeStatusDialogController.php
+++ b/src/Panel/Controller/Dialog/PageChangeStatusDialogController.php
@@ -6,7 +6,6 @@ use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\ErrorDialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for changing the status of a page
@@ -36,7 +35,7 @@ class PageChangeStatusDialogController extends PageDialogController
 
 		$fields = [
 			'status' => [
-				'label'    => I18n::translate('page.changeStatus.select'),
+				'label'    => $this->i18n('page.changeStatus.select'),
 				'type'     => 'radio',
 				'required' => true,
 				'options'  => $states
@@ -61,7 +60,7 @@ class PageChangeStatusDialogController extends PageDialogController
 			// errors and the draft cannot be published
 			if (count($errors) > 0) {
 				return new ErrorDialog(
-					message: I18n::translate('error.page.changeStatus.incomplete'),
+					message: $this->i18n('error.page.changeStatus.incomplete'),
 					details: $errors,
 				);
 			}
@@ -69,7 +68,7 @@ class PageChangeStatusDialogController extends PageDialogController
 
 		return new FormDialog(
 			fields: $this->fields(),
-			submitButton: I18n::translate('change'),
+			submitButton: $this->i18n('change'),
 			value: [
 				'status'   => $this->page->status(),
 				'position' => $this->position()

--- a/src/Panel/Controller/Dialog/PageChangeTemplateDialogController.php
+++ b/src/Panel/Controller/Dialog/PageChangeTemplateDialogController.php
@@ -6,7 +6,6 @@ use Kirby\Exception\Exception;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for changing the template of a page
@@ -37,14 +36,14 @@ class PageChangeTemplateDialogController extends PageDialogController
 				'notice' => [
 					'type'  => 'info',
 					'theme' => 'notice',
-					'text'  => I18n::translate('page.changeTemplate.notice')
+					'text'  => $this->i18n('page.changeTemplate.notice')
 				],
 				'template' => Field::template($blueprints, [
 					'required' => true
 				])
 			],
 			submitButton: [
-				'text'  => I18n::translate('change'),
+				'text'  => $this->i18n('change'),
 				'theme' => 'notice'
 			],
 			value: [

--- a/src/Panel/Controller/Dialog/PageChangeTitleDialogController.php
+++ b/src/Panel/Controller/Dialog/PageChangeTitleDialogController.php
@@ -5,7 +5,7 @@ namespace Kirby\Panel\Controller\Dialog;
 use Kirby\Cms\PageRules;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
-use Kirby\Panel\Ui\DialogsFormDialog;
+use Kirby\Panel\Ui\Dialog\FormDialog;
 use Kirby\Toolkit\Str;
 
 /**

--- a/src/Panel/Controller/Dialog/PageChangeTitleDialogController.php
+++ b/src/Panel/Controller/Dialog/PageChangeTitleDialogController.php
@@ -5,8 +5,7 @@ namespace Kirby\Panel\Controller\Dialog;
 use Kirby\Cms\PageRules;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
-use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
+use Kirby\Panel\Ui\DialogsFormDialog;
 use Kirby\Toolkit\Str;
 
 /**
@@ -40,12 +39,12 @@ class PageChangeTitleDialogController extends PageDialogController
 					'path'      => $this->path(),
 					'disabled'  => $permissions->can('changeSlug') === false,
 					'wizard'    => [
-						'text'  => I18n::translate('page.changeSlug.fromTitle'),
+						'text'  => $this->i18n('page.changeSlug.fromTitle'),
 						'field' => 'title'
 					]
 				])
 			],
-			submitButton: I18n::translate('change'),
+			submitButton: $this->i18n('change'),
 			value: [
 				'title' => $this->page->title()->value(),
 				'slug'  => $this->page->slug(),

--- a/src/Panel/Controller/Dialog/PageCreateDialogController.php
+++ b/src/Panel/Controller/Dialog/PageCreateDialogController.php
@@ -19,7 +19,6 @@ use Kirby\Panel\Panel;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
 use Kirby\Toolkit\A;
-use Kirby\Toolkit\I18n;
 use Kirby\Uuid\Uuid;
 use Kirby\Uuid\Uuids;
 
@@ -124,7 +123,7 @@ class PageCreateDialogController extends DialogController
 			$label = $title['label'] ?? 'title';
 			$fields['title'] = Field::title([
 				...$title ?? [],
-				'label'     => I18n::translate($label, $label),
+				'label'     => $this->i18n($label),
 				'required'  => true,
 				'preselect' => true
 			]);
@@ -239,7 +238,7 @@ class PageCreateDialogController extends DialogController
 
 		$status   = $this->blueprint()->create()['status'] ?? 'draft';
 		$status   = $this->blueprint()->status()[$status]['label'] ?? null;
-		$status ??= I18n::translate('page.status.' . $status);
+		$status ??= $this->i18n('page.status.' . $status);
 
 		$fields  = $this->fields();
 		$visible = array_filter(
@@ -259,9 +258,7 @@ class PageCreateDialogController extends DialogController
 			component: 'k-page-create-dialog',
 			blueprints: $blueprints,
 			fields: $fields,
-			submitButton: I18n::template('page.create', [
-				'status' => $status
-			]),
+			submitButton: $this->i18n('page.create', ['status' => $status]),
 			template: $this->template,
 			value: $this->value()
 		);

--- a/src/Panel/Controller/Dialog/PageDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/PageDeleteDialogController.php
@@ -7,7 +7,6 @@ use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
 use Kirby\Toolkit\Escape;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for deleting a page
@@ -24,7 +23,7 @@ class PageDeleteDialogController extends PageDialogController
 {
 	public function load(): Dialog
 	{
-		$text = I18n::template('page.delete.confirm', [
+		$text = $this->i18n('page.delete.confirm', [
 			'title' => Escape::html($this->page->title()->value())
 		]);
 
@@ -37,17 +36,17 @@ class PageDeleteDialogController extends PageDialogController
 				'info' => [
 					'type'  => 'info',
 					'theme' => 'negative',
-					'text'  => I18n::translate('page.delete.confirm.subpages')
+					'text'  => $this->i18n('page.delete.confirm.subpages')
 				],
 				'check' => [
-					'label'   => I18n::translate('page.delete.confirm.title'),
+					'label'   => $this->i18n('page.delete.confirm.title'),
 					'type'    => 'text',
 					'counter' => false
 				]
 			],
 			size: 'medium',
 			submitButton: [
-				'text'  => I18n::translate('delete'),
+				'text'  => $this->i18n('delete'),
 				'theme' => 'negative'
 			],
 			text: $text

--- a/src/Panel/Controller/Dialog/PageDuplicateDialogController.php
+++ b/src/Panel/Controller/Dialog/PageDuplicateDialogController.php
@@ -6,7 +6,6 @@ use Kirby\Cms\Url;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for duplicating a page
@@ -36,7 +35,7 @@ class PageDuplicateDialogController extends PageDialogController
 				'required' => true,
 				'path'     => $this->path(),
 				'wizard'   => [
-					'text'  => I18n::translate('page.changeSlug.fromTitle'),
+					'text'  => $this->i18n('page.changeSlug.fromTitle'),
 					'field' => 'title'
 				]
 			])
@@ -44,7 +43,7 @@ class PageDuplicateDialogController extends PageDialogController
 
 		if ($this->page->hasFiles() === true) {
 			$fields['files'] = [
-				'label' => I18n::translate('page.duplicate.files'),
+				'label' => $this->i18n('page.duplicate.files'),
 				'type'  => 'toggle',
 				'width' => $width
 			];
@@ -52,7 +51,7 @@ class PageDuplicateDialogController extends PageDialogController
 
 		if ($this->page->hasChildren() === true) {
 			$fields['children'] = [
-				'label' => I18n::translate('page.duplicate.pages'),
+				'label' => $this->i18n('page.duplicate.pages'),
 				'type'  => 'toggle',
 				'width' => $width
 			];
@@ -65,7 +64,7 @@ class PageDuplicateDialogController extends PageDialogController
 	{
 		return new FormDialog(
 			fields: $this->fields(),
-			submitButton: I18n::translate('duplicate'),
+			submitButton: $this->i18n('duplicate'),
 			value: [
 				'children' => false,
 				'files'    => false,
@@ -91,7 +90,7 @@ class PageDuplicateDialogController extends PageDialogController
 
 	protected function slugAppendix(): string
 	{
-		return Url::slug(I18n::translate('page.duplicate.appendix'));
+		return Url::slug($this->i18n('page.duplicate.appendix'));
 	}
 
 	public function submit(): array
@@ -129,7 +128,7 @@ class PageDuplicateDialogController extends PageDialogController
 
 	public function title(): string
 	{
-		$appendix = I18n::translate('page.duplicate.appendix');
+		$appendix = $this->i18n('page.duplicate.appendix');
 		$title    = $this->page->title() . ' ' . $appendix;
 
 		if ($count = $this->suffixCount()) {

--- a/src/Panel/Controller/Dialog/SiteChangeTitleDialogController.php
+++ b/src/Panel/Controller/Dialog/SiteChangeTitleDialogController.php
@@ -6,7 +6,6 @@ use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog to change the title of the site
@@ -30,7 +29,7 @@ class SiteChangeTitleDialogController extends DialogController
 					'preselect' => true
 				])
 			],
-			submitButton: I18n::translate('rename'),
+			submitButton: $this->i18n('rename'),
 			value: [
 				'title' => $this->site->title()->value(),
 			]

--- a/src/Panel/Controller/Dialog/SystemLicenseActivateDialogController.php
+++ b/src/Panel/Controller/Dialog/SystemLicenseActivateDialogController.php
@@ -6,7 +6,6 @@ use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Dialog to activate/register the site with a license
@@ -28,18 +27,18 @@ class SystemLicenseActivateDialogController extends DialogController
 
 		return [
 			'domain' => [
-				'label' => I18n::translate('license.activate.label'),
+				'label' => $this->i18n('license.activate.label'),
 				'type'  => 'info',
 				'theme' => $local ? 'warning' : 'info',
-				'text'  => I18n::template('license.activate.' . ($local ? 'local' : 'domain'), ['host' => $system->indexUrl()])
+				'text'  => $this->i18n('license.activate.' . ($local ? 'local' : 'domain'), ['host' => $system->indexUrl()])
 			],
 			'license' => [
-				'label'       => I18n::translate('license.code.label'),
+				'label'       => $this->i18n('license.code.label'),
 				'type'        => 'text',
 				'required'    => true,
 				'counter'     => false,
 				'placeholder' => 'K-',
-				'help'        => I18n::translate('license.code.help') . ' ' . '<a href="https://getkirby.com/buy" target="_blank">' . I18n::translate('license.buy') . ' &rarr;</a>'
+				'help'        => $this->i18n('license.code.help') . ' ' . '<a href="https://getkirby.com/buy" target="_blank">' . $this->i18n('license.buy') . ' &rarr;</a>'
 			],
 			'email' => Field::email(['required' => true])
 		];
@@ -51,7 +50,7 @@ class SystemLicenseActivateDialogController extends DialogController
 			fields: $this->fields(),
 			submitButton: [
 				'icon'  => 'key',
-				'text'  => I18n::translate('activate'),
+				'text'  => $this->i18n('activate'),
 				'theme' => 'love',
 			],
 			value: [
@@ -73,7 +72,7 @@ class SystemLicenseActivateDialogController extends DialogController
 
 		return [
 			'event'   => 'system.register',
-			'message' => I18n::translate('license.success')
+			'message' => $this->i18n('license.success')
 		];
 	}
 }

--- a/src/Panel/Controller/Dialog/SystemLicenseDialogController.php
+++ b/src/Panel/Controller/Dialog/SystemLicenseDialogController.php
@@ -6,7 +6,6 @@ use Kirby\Cms\License;
 use Kirby\Exception\LogicException;
 use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Ui\Dialog;
-use Kirby\Toolkit\I18n;
 
 /**
  *  Dialog to display (and potentially renew) the license
@@ -56,7 +55,7 @@ class SystemLicenseDialogController extends DialogController
 			cancelButton: $this->isRenewable(),
 			submitButton: $this->isRenewable() ? [
 				'icon'  => 'refresh',
-				'text'  => I18n::translate('renew'),
+				'text'  => $this->i18n('renew'),
 				'theme' => 'love',
 			] : false,
 			license: $this->license()
@@ -81,7 +80,7 @@ class SystemLicenseDialogController extends DialogController
 		if ($response['status'] === 'complete') {
 			return [
 				'event'   => 'system.renew',
-				'message' => I18n::translate('license.success')
+				'message' => $this->i18n('license.success')
 			];
 		}
 

--- a/src/Panel/Controller/Dialog/SystemLicenseRemoveDialogController.php
+++ b/src/Panel/Controller/Dialog/SystemLicenseRemoveDialogController.php
@@ -5,7 +5,6 @@ namespace Kirby\Panel\Controller\Dialog;
 use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Dialog to remove the site's license
@@ -23,11 +22,11 @@ class SystemLicenseRemoveDialogController extends DialogController
 	public function load(): Dialog
 	{
 		return new RemoveDialog(
-			text: I18n::translate('license.remove.text'),
+			text: $this->i18n('license.remove.text'),
 			size: 'medium',
 			submitButton: [
 				'icon'  => 'trash',
-				'text'  => I18n::translate('remove'),
+				'text'  => $this->i18n('remove'),
 				'theme' => 'negative',
 			]
 		);

--- a/src/Panel/Controller/Dialog/UserChangeEmailDialogController.php
+++ b/src/Panel/Controller/Dialog/UserChangeEmailDialogController.php
@@ -4,7 +4,6 @@ namespace Kirby\Panel\Controller\Dialog;
 
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for changing the email of a user
@@ -24,13 +23,13 @@ class UserChangeEmailDialogController extends UserDialogController
 		return new FormDialog(
 			fields: [
 				'email' => [
-					'label'     => I18n::translate('email'),
+					'label'     => $this->i18n('email'),
 					'required'  => true,
 					'type'      => 'email',
 					'preselect' => true
 				]
 			],
-			submitButton: I18n::translate('change'),
+			submitButton: $this->i18n('change'),
 			value: [
 				'email' => $this->user->email()
 			]

--- a/src/Panel/Controller/Dialog/UserChangeLanguageDialogController.php
+++ b/src/Panel/Controller/Dialog/UserChangeLanguageDialogController.php
@@ -5,7 +5,6 @@ namespace Kirby\Panel\Controller\Dialog;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for changing the language of a user
@@ -26,7 +25,7 @@ class UserChangeLanguageDialogController extends UserDialogController
 			fields: [
 				'translation' => Field::translation(['required' => true])
 			],
-			submitButton: I18n::translate('change'),
+			submitButton: $this->i18n('change'),
 			value: [
 				'translation' => $this->user->language()
 			]

--- a/src/Panel/Controller/Dialog/UserChangeNameDialogController.php
+++ b/src/Panel/Controller/Dialog/UserChangeNameDialogController.php
@@ -5,7 +5,6 @@ namespace Kirby\Panel\Controller\Dialog;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for changing the name of a user
@@ -28,7 +27,7 @@ class UserChangeNameDialogController extends UserDialogController
 					'preselect' => true
 				])
 			],
-			submitButton: I18n::translate('rename'),
+			submitButton: $this->i18n('rename'),
 			value: [
 				'name' => $this->user->name()->value()
 			]

--- a/src/Panel/Controller/Dialog/UserChangePasswordDialogController.php
+++ b/src/Panel/Controller/Dialog/UserChangePasswordDialogController.php
@@ -8,7 +8,6 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for changing the password of a user
@@ -28,19 +27,19 @@ class UserChangePasswordDialogController extends UserDialogController
 		return new FormDialog(
 			fields: [
 				'currentPassword' => Field::password([
-					'label'        => I18n::translate('user.changePassword.current'),
+					'label'        => $this->i18n('user.changePassword.current'),
 					'autocomplete' => 'current-password'
 				]),
 				'password' => Field::password([
-					'label'        => I18n::translate('user.changePassword.new'),
+					'label'        => $this->i18n('user.changePassword.new'),
 					'autocomplete' => 'new-password'
 				]),
 				'passwordConfirmation' => Field::password([
-					'label'        => I18n::translate('user.changePassword.new.confirm'),
+					'label'        => $this->i18n('user.changePassword.new.confirm'),
 					'autocomplete' => 'new-password'
 				])
 			],
-			submitButton: I18n::translate('change')
+			submitButton: $this->i18n('change')
 		);
 	}
 

--- a/src/Panel/Controller/Dialog/UserChangeRoleDialogController.php
+++ b/src/Panel/Controller/Dialog/UserChangeRoleDialogController.php
@@ -5,7 +5,6 @@ namespace Kirby\Panel\Controller\Dialog;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for changing the role of a user
@@ -27,12 +26,12 @@ class UserChangeRoleDialogController extends UserDialogController
 				'role' => Field::role(
 					roles: $this->user->roles(),
 					props: [
-						'label'    => I18n::translate('user.changeRole.select'),
+						'label'    => $this->i18n('user.changeRole.select'),
 						'required' => true,
 					]
 				)
 			],
-			submitButton: I18n::translate('user.changeRole'),
+			submitButton: $this->i18n('user.changeRole'),
 			value: [
 				'role' => $this->user->role()->name()
 			]

--- a/src/Panel/Controller/Dialog/UserCreateDialogController.php
+++ b/src/Panel/Controller/Dialog/UserCreateDialogController.php
@@ -6,7 +6,6 @@ use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for changing the email of a user
@@ -51,7 +50,7 @@ class UserCreateDialogController extends DialogController
 				]),
 				'role' => $roles
 			],
-			submitButton: I18n::translate('create'),
+			submitButton: $this->i18n('create'),
 			value: [
 				'name'        => '',
 				'email'       => '',

--- a/src/Panel/Controller/Dialog/UserDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/UserDeleteDialogController.php
@@ -5,7 +5,6 @@ namespace Kirby\Panel\Controller\Dialog;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
 use Kirby\Toolkit\Escape;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog for deleting a user
@@ -25,7 +24,7 @@ class UserDeleteDialogController extends UserDialogController
 		$i18nPrefix = $this->user->isLoggedIn() ? 'account' : 'user';
 
 		return new RemoveDialog(
-			text: I18n::template($i18nPrefix . '.delete.confirm', [
+			text: $this->i18n($i18nPrefix . '.delete.confirm', [
 				'email' => Escape::html($this->user->email())
 			])
 		);

--- a/src/Panel/Controller/Dialog/UserTotpDisableDialogController.php
+++ b/src/Panel/Controller/Dialog/UserTotpDisableDialogController.php
@@ -10,7 +10,6 @@ use Kirby\Exception\PermissionException;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
 use Kirby\Toolkit\Escape;
-use Kirby\Toolkit\I18n;
 
 /**
  * Controls the Panel dialog to disable TOTP auth for a user
@@ -33,7 +32,7 @@ class UserTotpDisableDialogController extends UserDialogController
 	{
 		$currentUser = $this->kirby->user();
 		$submitBtn   = [
-			'text'  => I18n::translate('disable'),
+			'text'  => $this->i18n('disable'),
 			'icon'  => 'protected',
 			'theme' => 'negative'
 		];
@@ -47,7 +46,7 @@ class UserTotpDisableDialogController extends UserDialogController
 			$name = $this->user->name()->or($this->user->email());
 
 			return new FormDialog(
-				text: I18n::template('login.totp.disable.admin', [
+				text: $this->i18n('login.totp.disable.admin', [
 					'user' => Escape::html($name)
 				]),
 				submitButton: $submitBtn,
@@ -61,8 +60,8 @@ class UserTotpDisableDialogController extends UserDialogController
 					'type'     => 'password',
 					'required' => true,
 					'counter'  => false,
-					'label'    => I18n::translate('login.totp.disable.label'),
-					'help'     => I18n::translate('login.totp.disable.help'),
+					'label'    => $this->i18n('login.totp.disable.label'),
+					'help'     => $this->i18n('login.totp.disable.help'),
 				]
 			],
 			submitButton: $submitBtn
@@ -89,7 +88,7 @@ class UserTotpDisableDialogController extends UserDialogController
 			$this->user->changeTotp(null);
 
 			return [
-				'message' => I18n::translate('login.totp.disable.success')
+				'message' => $this->i18n('login.totp.disable.success')
 			];
 		} catch (InvalidArgumentException $e) {
 			// Catch and re-throw exception so that any

--- a/src/Panel/Controller/Dialog/UserTotpEnableDialogController.php
+++ b/src/Panel/Controller/Dialog/UserTotpEnableDialogController.php
@@ -7,7 +7,6 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Image\QrCode;
 use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Ui\Dialog;
-use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Totp;
 
 /**
@@ -79,7 +78,7 @@ class UserTotpEnableDialogController extends DialogController
 		$this->user->changeTotp($secret);
 
 		return [
-			'message' => I18n::translate('login.totp.enable.success')
+			'message' => $this->i18n('login.totp.enable.success')
 		];
 	}
 

--- a/src/Panel/Controller/Dropdown/FileSettingsDropdownController.php
+++ b/src/Panel/Controller/Dropdown/FileSettingsDropdownController.php
@@ -4,7 +4,6 @@ namespace Kirby\Panel\Controller\Dropdown;
 
 use Kirby\Cms\Find;
 use Kirby\Cms\ModelWithContent;
-use Kirby\Toolkit\I18n;
 
 /**
  * @package   Kirby Panel
@@ -46,7 +45,7 @@ class FileSettingsDropdownController extends ModelSettingsDropdownController
 				'link'   => $this->model->previewUrl(),
 				'target' => '_blank',
 				'icon'   => 'open',
-				'text'   => I18n::translate('open')
+				'text'   => $this->i18n('open')
 			];
 			$options[] = '-';
 		}
@@ -54,7 +53,7 @@ class FileSettingsDropdownController extends ModelSettingsDropdownController
 		$options[] = [
 			'dialog'   => $url . '/changeName',
 			'icon'     => 'title',
-			'text'     => I18n::translate('rename'),
+			'text'     => $this->i18n('rename'),
 			'disabled' => $this->isDisabledOption('changeName')
 		];
 
@@ -62,7 +61,7 @@ class FileSettingsDropdownController extends ModelSettingsDropdownController
 			$options[] = [
 				'dialog'   => $url . '/changeSort',
 				'icon'     => 'sort',
-				'text'     => I18n::translate('file.sort'),
+				'text'     => $this->i18n('file.sort'),
 				'disabled' => $this->isDisabledOption('sort')
 			];
 		}
@@ -70,7 +69,7 @@ class FileSettingsDropdownController extends ModelSettingsDropdownController
 		$options[] = [
 			'dialog'   => $url . '/changeTemplate',
 			'icon'     => 'template',
-			'text'     => I18n::translate('file.changeTemplate'),
+			'text'     => $this->i18n('file.changeTemplate'),
 			'disabled' => $this->isDisabledOption('changeTemplate')
 		];
 
@@ -79,7 +78,7 @@ class FileSettingsDropdownController extends ModelSettingsDropdownController
 		$options[] = [
 			'click'    => 'replace',
 			'icon'     => 'upload',
-			'text'     => I18n::translate('replace'),
+			'text'     => $this->i18n('replace'),
 			'disabled' => $this->isDisabledOption('replace')
 		];
 
@@ -87,7 +86,7 @@ class FileSettingsDropdownController extends ModelSettingsDropdownController
 		$options[] = [
 			'dialog'   => $url . '/delete',
 			'icon'     => 'trash',
-			'text'     => I18n::translate('delete'),
+			'text'     => $this->i18n('delete'),
 			'disabled' => $this->isDisabledOption('delete')
 		];
 

--- a/src/Panel/Controller/Dropdown/PageSettingsDropdownController.php
+++ b/src/Panel/Controller/Dropdown/PageSettingsDropdownController.php
@@ -4,7 +4,6 @@ namespace Kirby\Panel\Controller\Dropdown;
 
 use Kirby\Cms\Find;
 use Kirby\Cms\ModelWithContent;
-use Kirby\Toolkit\I18n;
 
 /**
  * @package   Kirby Panel
@@ -46,14 +45,14 @@ class PageSettingsDropdownController extends ModelSettingsDropdownController
 				'link'     => $this->model->previewUrl(),
 				'target'   => '_blank',
 				'icon'     => 'open',
-				'text'     => I18n::translate('open'),
+				'text'     => $this->i18n('open'),
 				'disabled' => $isPreviewDisabled = $this->isDisabledOption('preview')
 			];
 
 			$options['preview'] = [
 				'icon'     => 'window',
 				'link'     => $url . '/preview/compare',
-				'text'     => I18n::translate('preview'),
+				'text'     => $this->i18n('preview'),
 				'disabled' => $isPreviewDisabled
 			];
 
@@ -66,7 +65,7 @@ class PageSettingsDropdownController extends ModelSettingsDropdownController
 				'query' => ['select' => 'title']
 			],
 			'icon'     => 'title',
-			'text'     => I18n::translate('rename'),
+			'text'     => $this->i18n('rename'),
 			'disabled' => $this->isDisabledOption('changeTitle')
 		];
 
@@ -76,14 +75,14 @@ class PageSettingsDropdownController extends ModelSettingsDropdownController
 				'query' => ['select' => 'slug']
 			],
 			'icon'     => 'url',
-			'text'     => I18n::translate('page.changeSlug'),
+			'text'     => $this->i18n('page.changeSlug'),
 			'disabled' => $this->isDisabledOption('changeSlug')
 		];
 
 		$options['changeStatus'] = [
 			'dialog'   => $url . '/changeStatus',
 			'icon'     => 'preview',
-			'text'     => I18n::translate('page.changeStatus'),
+			'text'     => $this->i18n('page.changeStatus'),
 			'disabled' => $this->isDisabledOption('changeStatus')
 		];
 
@@ -92,14 +91,14 @@ class PageSettingsDropdownController extends ModelSettingsDropdownController
 		$options['changeSort'] = [
 			'dialog'   => $url . '/changeSort',
 			'icon'     => 'sort',
-			'text'     => I18n::translate('page.sort'),
+			'text'     => $this->i18n('page.sort'),
 			'disabled' => $siblings->count() === 0 || $this->isDisabledOption('sort')
 		];
 
 		$options['changeTemplate'] = [
 			'dialog'   => $url . '/changeTemplate',
 			'icon'     => 'template',
-			'text'     => I18n::translate('page.changeTemplate'),
+			'text'     => $this->i18n('page.changeTemplate'),
 			'disabled' => $this->isDisabledOption('changeTemplate')
 		];
 
@@ -108,14 +107,14 @@ class PageSettingsDropdownController extends ModelSettingsDropdownController
 		$options['move'] = [
 			'dialog'   => $url . '/move',
 			'icon'     => 'parent',
-			'text'     => I18n::translate('page.move'),
+			'text'     => $this->i18n('page.move'),
 			'disabled' => $this->isDisabledOption('move')
 		];
 
 		$options['duplicate'] = [
 			'dialog'   => $url . '/duplicate',
 			'icon'     => 'copy',
-			'text'     => I18n::translate('duplicate'),
+			'text'     => $this->i18n('duplicate'),
 			'disabled' => $this->isDisabledOption('duplicate')
 		];
 
@@ -124,7 +123,7 @@ class PageSettingsDropdownController extends ModelSettingsDropdownController
 		$options['delete'] = [
 			'dialog'   => $url . '/delete',
 			'icon'     => 'trash',
-			'text'     => I18n::translate('delete'),
+			'text'     => $this->i18n('delete'),
 			'disabled' => $this->isDisabledOption('delete')
 		];
 

--- a/src/Panel/Controller/Dropdown/UserSettingsDropdownController.php
+++ b/src/Panel/Controller/Dropdown/UserSettingsDropdownController.php
@@ -4,7 +4,6 @@ namespace Kirby\Panel\Controller\Dropdown;
 
 use Kirby\Cms\Find;
 use Kirby\Cms\ModelWithContent;
-use Kirby\Toolkit\I18n;
 
 /**
  * @package   Kirby Panel
@@ -45,7 +44,7 @@ class UserSettingsDropdownController extends ModelSettingsDropdownController
 		$options[] = [
 			'dialog'   => $url . '/changeName',
 			'icon'     => 'title',
-			'text'     => I18n::translate($i18nPrefix . '.changeName'),
+			'text'     => $this->i18n($i18nPrefix . '.changeName'),
 			'disabled' => $this->isDisabledOption('changeName')
 		];
 
@@ -54,21 +53,21 @@ class UserSettingsDropdownController extends ModelSettingsDropdownController
 		$options[] = [
 			'dialog'   => $url . '/changeEmail',
 			'icon'     => 'email',
-			'text'     => I18n::translate('user.changeEmail'),
+			'text'     => $this->i18n('user.changeEmail'),
 			'disabled' => $this->isDisabledOption('changeEmail')
 		];
 
 		$options[] = [
 			'dialog'   => $url . '/changeRole',
 			'icon'     => 'bolt',
-			'text'     => I18n::translate('user.changeRole'),
+			'text'     => $this->i18n('user.changeRole'),
 			'disabled' => $this->isDisabledOption('changeRole') || $this->model->roles()->count() < 2
 		];
 
 		$options[] = [
 			'dialog'   => $url . '/changeLanguage',
 			'icon'     => 'translate',
-			'text'     => I18n::translate('user.changeLanguage'),
+			'text'     => $this->i18n('user.changeLanguage'),
 			'disabled' => $this->isDisabledOption('changeLanguage')
 		];
 
@@ -77,7 +76,7 @@ class UserSettingsDropdownController extends ModelSettingsDropdownController
 		$options[] = [
 			'dialog'   => $url . '/changePassword',
 			'icon'     => 'key',
-			'text'     => I18n::translate('user.changePassword'),
+			'text'     => $this->i18n('user.changePassword'),
 			'disabled' => $this->isDisabledOption('changePassword')
 		];
 
@@ -85,7 +84,7 @@ class UserSettingsDropdownController extends ModelSettingsDropdownController
 			$options[] = [
 				'dialog'   => $url . '/totp/enable',
 				'icon'     => 'qr-code',
-				'text'     => I18n::translate('login.totp.enable.option')
+				'text'     => $this->i18n('login.totp.enable.option')
 			];
 		}
 
@@ -93,7 +92,7 @@ class UserSettingsDropdownController extends ModelSettingsDropdownController
 			$options[] = [
 				'dialog'   => $url . '/totp/disable',
 				'icon'     => 'qr-code',
-				'text'     => I18n::translate('login.totp.disable.option')
+				'text'     => $this->i18n('login.totp.disable.option')
 			];
 		}
 
@@ -102,7 +101,7 @@ class UserSettingsDropdownController extends ModelSettingsDropdownController
 		$options[] = [
 			'dialog'   => $url . '/delete',
 			'icon'     => 'trash',
-			'text'     => I18n::translate($i18nPrefix . '.delete'),
+			'text'     => $this->i18n($i18nPrefix . '.delete'),
 			'disabled' => $this->isDisabledOption('delete')
 		];
 

--- a/src/Panel/Controller/Request/PageTreeRequestController.php
+++ b/src/Panel/Controller/Request/PageTreeRequestController.php
@@ -6,7 +6,6 @@ use Kirby\Cms\Find;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Panel\Controller\RequestController;
-use Kirby\Toolkit\I18n;
 
 /**
  * Returns children for the parent as entries
@@ -60,7 +59,7 @@ class PageTreeRequestController extends RequestController
 			'id'          => $id,
 			'open'        => false,
 			'label'       => match (true) {
-				$entry instanceof Site => I18n::translate('view.site'),
+				$entry instanceof Site => $this->i18n('view.site'),
 				default                => $entry->title()->value()
 			},
 			'url'         => $url,

--- a/src/Panel/Ui/Component.php
+++ b/src/Panel/Ui/Component.php
@@ -3,7 +3,7 @@
 namespace Kirby\Panel\Ui;
 
 use Kirby\Exception\LogicException;
-use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\HasI18n;
 use Kirby\Toolkit\Str;
 
 /**
@@ -19,6 +19,8 @@ use Kirby\Toolkit\Str;
  */
 abstract class Component
 {
+	use HasI18n;
+
 	protected string $key;
 	public array $attrs = [];
 
@@ -54,15 +56,6 @@ abstract class Component
 		// setter
 		$this->$name = $args[0];
 		return $this;
-	}
-
-	/**
-	 * Translates a key to a string
-	 * @since 6.0.0
-	 */
-	protected function i18n(string|array|null $key): string|null
-	{
-		return $key !== null ? I18n::translate($key, $key) : null;
 	}
 
 	/**

--- a/src/Toolkit/HasI18n.php
+++ b/src/Toolkit/HasI18n.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Kirby\Toolkit;
+
+use Closure;
+
+/**
+ * Adds a i18n helper method to the class
+ *
+ * @package   Kirby Toolkit
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+trait HasI18n
+{
+	/**
+	 * Translates a key or template string
+	 */
+	protected function i18n(
+		Closure|string|array|null $key,
+		array|null $data = null
+	): string|null {
+
+		if ($key instanceof Closure) {
+			$key = $key();
+		}
+
+		if ($key === null) {
+			return null;
+		}
+
+		if ($data === null) {
+			return I18n::translate($key, $key);
+		}
+
+		return I18n::template($key, $data);
+	}
+}

--- a/tests/Toolkit/HasI18nTest.php
+++ b/tests/Toolkit/HasI18nTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kirby\Toolkit;
+
+use Kirby\TestCase;
+
+class HasI18nTest extends TestCase
+{
+	protected function object(): object
+	{
+		return new class () {
+			use HasI18n;
+
+			public function translate($key, $data = null)
+			{
+				return $this->i18n($key, $data);
+			}
+		};
+	}
+
+	public function testI18n(): void
+	{
+		$class = $this->object();
+
+		$this->assertNull($class->translate(null));
+		$this->assertSame('Hello', $class->translate('Hello'));
+		$this->assertSame('Hello', $class->translate(fn () => 'Hello'));
+		$this->assertSame('Hello', $class->translate(['Hello']));
+		$this->assertSame('Hello', $class->translate(['Hello', 'World']));
+
+		$this->assertSame('Copy all', $class->translate('copy.all'));
+		$this->assertSame('3 copied!', $class->translate('copy.success.multiple', ['count' => 3]));
+	}
+}


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### Enhancements
- New `Kirby\Toolkit\Has18n` trait that adds a `::i18n()` helper method to the class which can be used to translate and/or template i18n strings

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- Replaced `I18n::` calls in panel controllers with `Kirby\Toolkit\HasI18n::i18n()` helper


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion