### PR TITLE
fix: Panel view state do not replace with `null`

### DIFF
--- a/src/Panel/State.php
+++ b/src/Panel/State.php
@@ -350,8 +350,8 @@ class State
 
 		$view = array_replace_recursive(
 			$defaults,
-			$this->area?->view() ?? [],
-			$this->view
+			array_filter($this->area?->view() ?? [], fn ($x) => $x !== null),
+			array_filter($this->view, fn ($x) => $x !== null)
 		);
 
 		// make sure that views and dialogs are gone


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

I am not sure if this is the right solution, but here is the problem:
If we have a key in `$this->view` that is `null` by default, it will overwrite the defaults/area data. Most times this isn't intended, because `null` here just means no actual value has been provided. This PR would fix this.

However, it also then removes the possibility to actually unset an existing value by setting the key to `null`. Alternatively though, we would have to wrap every `View::render()` call with the filter function.

What do you think?