### PR TITLE
fix: Support `dialog` + `drawer` in `Ui\Stat`

### DIFF
--- a/panel/src/components/Layout/Stat.vue
+++ b/panel/src/components/Layout/Stat.vue
@@ -20,13 +20,24 @@
 export default {
 	props: {
 		/**
-		 * Label text of the stat (2nd line)
+		 * Function to be called when clicked
 		 */
-		label: String,
+		click: Function,
 		/**
-		 * Main text of the stat (1st line)
+		 * Dialog endpoint or options to be passed to `this.$panel.dialog.open()`.
+		 * Use instead of `link` or `drawer`.
 		 */
-		value: String,
+		dialog: {
+			type: [String, Object]
+		},
+		/**
+		 * Drawer endpoint or options to be passed to `this.$panel.drawer.open()`.
+		 * Use instead of `link` or `dialog`.
+		 * @since 5.1.0
+		 */
+		drawer: {
+			type: [String, Object]
+		},
 		/**
 		 * Additional icon for the stat
 		 * @since 4.0.0
@@ -37,21 +48,22 @@ export default {
 		 */
 		info: String,
 		/**
+		 * Label text of the stat (2nd line)
+		 */
+		label: String,
+		/**
+		 * Absolute or relative URL.
+		 * Use instead of `dialog` or `drawer`.
+		 */
+		link: String,
+		/**
 		 * @values "negative", "positive", "warning", "info"
 		 */
 		theme: String,
-		/** Absolute or relative URL */
-		link: String,
 		/**
-		 * Function to be called when clicked
+		 * Main text of the stat (1st line)
 		 */
-		click: Function,
-		/**
-		 * Dialog endpoint or options to be passed to `this.$dialog`
-		 */
-		dialog: {
-			type: [String, Object]
-		}
+		value: String
 	},
 	computed: {
 		component() {
@@ -71,7 +83,11 @@ export default {
 			}
 
 			if (this.dialog) {
-				return () => this.$dialog(this.dialog);
+				return () => this.$panel.dialog.open(this.dialog);
+			}
+
+			if (this.drawer) {
+				return () => this.$panel.drawer.open(this.drawer);
 			}
 
 			return null;

--- a/src/Panel/Ui/Stat.php
+++ b/src/Panel/Ui/Stat.php
@@ -20,12 +20,28 @@ class Stat extends Component
 		public array|string $label,
 		public array|string $value,
 		public string $component = 'k-stat',
+		public array|string|null $dialog = null,
+		public array|string|null $drawer = null,
 		public string|null $icon = null,
 		public array|string|null $info = null,
 		public array|string|null $link = null,
 		public ModelWithContent|null $model = null,
 		public string|null $theme = null,
 	) {
+	}
+
+	public function dialog(): string|null
+	{
+		return $this->stringTemplate(
+			$this->i18n($this->dialog)
+		);
+	}
+
+	public function drawer(): string|null
+	{
+		return $this->stringTemplate(
+			$this->i18n($this->drawer)
+		);
 	}
 
 	/**
@@ -81,12 +97,14 @@ class Stat extends Component
 	public function props(): array
 	{
 		return [
-			'icon'  => $this->icon(),
-			'info'  => $this->info(),
-			'label' => $this->label(),
-			'link'  => $this->link(),
-			'theme' => $this->theme(),
-			'value' => $this->value(),
+			'dialog' => $this->dialog(),
+			'drawer' => $this->drawer(),
+			'icon'   => $this->icon(),
+			'info'   => $this->info(),
+			'label'  => $this->label(),
+			'link'   => $this->link(),
+			'theme'  => $this->theme(),
+			'value'  => $this->value(),
 		];
 	}
 

--- a/tests/Cms/Sections/StatsSectionTest.php
+++ b/tests/Cms/Sections/StatsSectionTest.php
@@ -17,20 +17,24 @@ class MockPageForStatsSection extends Page
 	{
 		return [
 			[
-				'icon'  => 'heart',
-				'info'  => 'Info A',
-				'label' => 'A',
-				'link'  => 'https://getkirby.com',
-				'theme' => null,
-				'value' => 'Value A',
+				'dialog' => null,
+				'drawer' => null,
+				'icon'   => 'heart',
+				'info'   => 'Info A',
+				'label'  => 'A',
+				'link'   => 'https://getkirby.com',
+				'theme'  => null,
+				'value'  => 'Value A',
 			],
 			[
-				'icon'  => null,
-				'info'  => null,
-				'label' => 'B',
-				'link'  => null,
-				'theme' => null,
-				'value' => 'Value B',
+				'dialog' => null,
+				'drawer' => null,
+				'icon'   => null,
+				'info'   => null,
+				'label'  => 'B',
+				'link'   => null,
+				'theme'  => null,
+				'value'  => 'Value B',
 			]
 		];
 	}

--- a/tests/Panel/Ui/StatTest.php
+++ b/tests/Panel/Ui/StatTest.php
@@ -106,6 +106,26 @@ class StatTest extends TestCase
 		$this->assertSame('k-stat-test', $stat->component());
 	}
 
+	public function testDialog(): void
+	{
+		$this->assertProp(
+			prop: 'dialog',
+			nullable: true,
+			translatable: true,
+			queryable: true
+		);
+	}
+
+	public function testDrawer(): void
+	{
+		$this->assertProp(
+			prop: 'drawer',
+			nullable: true,
+			translatable: true,
+			queryable: true
+		);
+	}
+
 	public function testFrom(): void
 	{
 		// from array with model

--- a/tests/Panel/Ui/StatsTest.php
+++ b/tests/Panel/Ui/StatsTest.php
@@ -50,12 +50,14 @@ class StatsTest extends TestCase
 
 		$this->assertSame([
 			[
-				'icon'  => null,
-				'info'  => null,
-				'label' => 'test',
-				'link'  => null,
-				'theme' => null,
-				'value' => 'test',
+				'dialog' => null,
+				'drawer' => null,
+				'icon'   => null,
+				'info'   => null,
+				'label'  => 'test',
+				'link'   => null,
+				'theme'  => null,
+				'value'  => 'test',
 			],
 		], $stats->reports());
 	}
@@ -91,12 +93,14 @@ class StatsTest extends TestCase
 		$this->assertSame([
 			'reports' => [
 				[
-					'icon'  => null,
-					'info'  => null,
-					'label' => 'test',
-					'link'  => null,
-					'theme' => null,
-					'value' => 'test',
+					'dialog' => null,
+					'drawer' => null,
+					'icon'   => null,
+					'info'   => null,
+					'label'  => 'test',
+					'link'   => null,
+					'theme'  => null,
+					'value'  => 'test',
 				],
 			],
 			'size' => 'large',
@@ -117,12 +121,14 @@ class StatsTest extends TestCase
 
 		$this->assertSame([
 			[
-				'icon'  => null,
-				'info'  => null,
-				'label' => 'test',
-				'link'  => null,
-				'theme' => null,
-				'value' => 'test',
+				'dialog' => null,
+				'drawer' => null,
+				'icon'   => null,
+				'info'   => null,
+				'label'  => 'test',
+				'link'   => null,
+				'theme'  => null,
+				'value'  => 'test',
 			],
 		], $stats->reports());
 	}
@@ -141,12 +147,14 @@ class StatsTest extends TestCase
 
 		$this->assertSame([
 			[
-				'icon'  => null,
-				'info'  => null,
-				'label' => 'test',
-				'link'  => null,
-				'theme' => null,
-				'value' => 'test',
+				'dialog' => null,
+				'drawer' => null,
+				'icon'   => null,
+				'info'   => null,
+				'label'  => 'test',
+				'link'   => null,
+				'theme'  => null,
+				'value'  => 'test',
 			],
 		], $stats->reports());
 	}
@@ -166,12 +174,14 @@ class StatsTest extends TestCase
 
 		$this->assertSame([
 			[
-				'icon'  => null,
-				'info'  => null,
-				'label' => 'test',
-				'link'  => null,
-				'theme' => null,
-				'value' => 'test',
+				'dialog' => null,
+				'drawer' => null,
+				'icon'   => null,
+				'info'   => null,
+				'label'  => 'test',
+				'link'   => null,
+				'theme'  => null,
+				'value'  => 'test',
 			],
 		], $stats->reports());
 	}


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Just adding missing support for `dialog` or `drawer` instead of `link` to the unreleased `Kirby\Panel\Ui\Stat` class.

## Changelog

### Enhancements
- Stats (`stats` field and section as well as the `k-stats`/`k-stat` components) now support passing a `drawer` instead of a link or dialog