### PR TITLE
fix: Merging Responder headers into Response

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -781,15 +781,7 @@ class App
 
 		// Responses
 		if ($input instanceof Response) {
-			$data = $input->toArray();
-
-			// inject headers from the global response configuration
-			// lazily (only if they are not already set);
-			// the case-insensitive nature of headers will be
-			// handled by PHP's `header()` function
-			$data['headers'] = [...$response->headers(), ...$data['headers']];
-
-			return new Response($data);
+			return $response->send($input);
 		}
 
 		// Pages

--- a/src/Cms/Responder.php
+++ b/src/Cms/Responder.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Mime;
+use Kirby\Http\Response as HttpResponse;
 use Kirby\Toolkit\Str;
 use Stringable;
 
@@ -337,8 +338,15 @@ class Responder implements Stringable
 	/**
 	 * Creates and returns the response object from the config
 	 */
-	public function send(string|null $body = null): Response
+	public function send(HttpResponse|string|null $body = null): HttpResponse
 	{
+		if ($body instanceof HttpResponse) {
+			// inject headers from the responser into the response
+			// (only if they are not already set);
+			$body->setHeaderFallbacks($this->headers());
+			return $body;
+		}
+
 		if ($body !== null) {
 			$this->body($body);
 		}

--- a/src/Cms/Responder.php
+++ b/src/Cms/Responder.php
@@ -341,7 +341,7 @@ class Responder implements Stringable
 	public function send(HttpResponse|string|null $body = null): HttpResponse
 	{
 		if ($body instanceof HttpResponse) {
-			// inject headers from the responser into the response
+			// inject headers from the responder into the response
 			// (only if they are not already set);
 			$body->setHeaderFallbacks($this->headers());
 			return $body;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -313,6 +313,19 @@ class Response implements Stringable
 	}
 
 	/**
+	 * Sets the provided headers in case they are not already set
+	 * @internal
+	 * @return $this
+	 */
+	public function setHeaderFallbacks(array $headers): static
+	{
+		// the case-insensitive nature of headers will be
+		// handled by PHP's `header()` functions
+		$this->headers = [...$headers, ...$this->headers];
+		return $this;
+	}
+
+	/**
 	 * Converts all relevant response attributes
 	 * to an associative array for debugging,
 	 * testing or whatever.

--- a/tests/Cms/ResponderTest.php
+++ b/tests/Cms/ResponderTest.php
@@ -5,6 +5,10 @@ namespace Kirby\Cms;
 use Kirby\Exception\InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 
+class TestResponse extends Response
+{
+}
+
 #[CoversClass(Responder::class)]
 class ResponderTest extends TestCase
 {
@@ -254,6 +258,38 @@ class ResponderTest extends TestCase
 		$this->assertTrue($responder->isPrivate(false, ['foo', 'bar']));
 		$this->assertFalse($responder->isPrivate(false, ['bar']));
 		$this->assertFalse($responder->isPrivate(false, []));
+	}
+
+	public function testSend(): void
+	{
+		$responder = new Responder();
+		$responder->header('a', 'b');
+		$response = $responder->send();
+		$this->assertInstanceOf(Response::class, $response);
+		$this->assertSame('', $response->body());
+		$this->assertSame(['a' => 'b'], $response->headers());
+	}
+
+	public function testSendWithBody(): void
+	{
+		$responder = new Responder();
+		$responder->header('a', 'b');
+		$response = $responder->send('foo');
+		$this->assertInstanceOf(Response::class, $response);
+		$this->assertSame('foo', $response->body());
+		$this->assertSame(['a' => 'b'], $response->headers());
+	}
+
+	public function testSendWithResponse(): void
+	{
+		$responder = new Responder();
+		$responder->header('a', 'b');
+		$response = new TestResponse([
+			'headers' => ['a' => 'c']
+		]);
+		$response = $responder->send($response);
+		$this->assertInstanceOf(TestResponse::class, $response);
+		$this->assertSame(['a' => 'c'], $response->headers());
 	}
 
 	public function testToArray(): void

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -338,6 +338,15 @@ class ResponseTest extends TestCase
 		$this->assertEquals(['Refresh' => '5; url=https://getkirby.com'], $response->headers());
 	}
 
+	public function testSetHeaderFallbacks(): void
+	{
+		$response = new Response([
+			'headers' => ['a' => 'b']
+		]);
+		$response->setHeaderFallbacks(['a' => 'z', 'c' => 'd']);
+		$this->assertEquals(['a' => 'b', 'c' => 'd'], $response->headers());
+	}
+
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState(false)]
 	public function testSend(): void


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Fixed a case where a subclass of `Kirby\Http\Response` would falsely converted to a `Kirby\Http\Response` object

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- Support passing a `Kirby\Http\Response` object to `Kirby\Cms\Responder::send()`


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion