### PR TITLE
feat: `Uuid::toUrl()` + `PageUuid/FileUuid::toPermalink()`

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -210,7 +210,7 @@ return [
 				Uuid::is($tag->value, 'page') === true ||
 				Uuid::is($tag->value, 'file') === true
 			) {
-				$tag->value = Uuid::for($tag->value)?->modelUrl();
+				$tag->value = Uuid::for($tag->value)?->toUrl();
 			}
 
 			// if url is empty, throw exception or link to the error page

--- a/config/tags.php
+++ b/config/tags.php
@@ -210,7 +210,7 @@ return [
 				Uuid::is($tag->value, 'page') === true ||
 				Uuid::is($tag->value, 'file') === true
 			) {
-				$tag->value = Uuid::for($tag->value)->model()?->url();
+				$tag->value = Uuid::for($tag->value)?->modelUrl();
 			}
 
 			// if url is empty, throw exception or link to the error page

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -514,7 +514,7 @@ class File extends ModelWithContent
 	 */
 	public function permalink(): string|null
 	{
-		return $this->uuid()?->url();
+		return $this->uuid()?->toPermalink();
 	}
 
 	/**

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -31,6 +31,7 @@ use Kirby\Toolkit\Str;
  * @license   https://getkirby.com/license
  *
  * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Files>
+ * @method \Kirby\Uuid\FileUuid uuid()
  */
 class File extends ModelWithContent
 {

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -872,7 +872,7 @@ class Page extends ModelWithContent
 	 */
 	public function permalink(): string|null
 	{
-		return $this->uuid()?->url();
+		return $this->uuid()?->toPermalink();
 	}
 
 	/**

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -30,6 +30,7 @@ use Throwable;
  * @license   https://getkirby.com/license
  *
  * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Pages>
+ * @method \Kirby\Uuid\PageUuid uuid()
  */
 class Page extends ModelWithContent
 {

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -20,6 +20,8 @@ use Kirby\Toolkit\A;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @method \Kirby\Uuid\SiteUuid uuid()
  */
 class Site extends ModelWithContent
 {

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -26,6 +26,7 @@ use SensitiveParameter;
  * @license   https://getkirby.com/license
  *
  * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Users>
+ * @method \Kirby\Uuid\UserUuid uuid()
  */
 class User extends ModelWithContent
 {

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -255,7 +255,7 @@ class Uri implements Stringable
 
 	public function hasFragment(): bool
 	{
-		return empty($this->fragment) === false;
+		return $this->fragment !== null && $this->fragment !== '';
 	}
 
 	public function hasPath(): bool
@@ -308,6 +308,15 @@ class Uri implements Stringable
 	public function isAbsolute(): bool
 	{
 		return empty($this->host) === false;
+	}
+
+	/**
+	 * Returns the fragment after the hash
+	 * @since 5.1.0
+	 */
+	public function fragment(): string|null
+	{
+		return $this->fragment;
 	}
 
 	/**
@@ -479,8 +488,8 @@ class Uri implements Stringable
 		$url .= $path;
 		$url .= $this->query->toString(true);
 
-		if (empty($this->fragment) === false) {
-			$url .= '#' . $this->fragment;
+		if ($this->hasFragment() === true) {
+			$url .= '#' . $this->fragment();
 		}
 
 		return $url;

--- a/src/Uuid/FileUuid.php
+++ b/src/Uuid/FileUuid.php
@@ -88,7 +88,7 @@ class FileUuid extends ModelUuid
 	/**
 	 * Returns permalink url
 	 */
-	public function url(): string
+	public function toPermalink(): string
 	{
 		// make sure UUID is cached because the permalink
 		// route only looks up UUIDs from cache
@@ -97,5 +97,13 @@ class FileUuid extends ModelUuid
 		}
 
 		return App::instance()->url() . '/@/' . static::TYPE . '/' . $this->id();
+	}
+
+	/**
+	 * @deprecated 5.1.0 Use `::toPermalink()` instead
+	 */
+	public function url(): string
+	{
+		return $this->toPermalink();
 	}
 }

--- a/src/Uuid/PageUuid.php
+++ b/src/Uuid/PageUuid.php
@@ -58,7 +58,7 @@ class PageUuid extends ModelUuid
 	/**
 	 * Returns permalink url
 	 */
-	public function url(): string
+	public function toPermalink(): string
 	{
 		// make sure UUID is cached because the permalink
 		// route only looks up UUIDs from cache
@@ -74,5 +74,13 @@ class PageUuid extends ModelUuid
 		}
 
 		return $url . '/@/' . static::TYPE . '/' . $this->id();
+	}
+
+	/**
+	 * @deprecated 5.1.0 Use `::toPermalink()` instead
+	 */
+	public function url(): string
+	{
+		return $this->toPermalink();
 	}
 }

--- a/src/Uuid/Uuid.php
+++ b/src/Uuid/Uuid.php
@@ -374,6 +374,32 @@ abstract class Uuid implements Stringable
 	}
 
 	/**
+	 * Returns the URL of the model, including the query and fragment
+	 * @since 5.1.0
+	 */
+	public function modelUrl(): string|null
+	{
+		$model = $this->model();
+
+		if ($model === null) {
+			return null;
+		}
+
+		if (method_exists($model, 'url') === false) {
+			return null;
+		}
+
+		$url  = $model->url();
+		$url .= $this->uri->query->toString(true);
+
+		if ($this->uri->hasFragment() === true) {
+			$url .= '#' . $this->uri->fragment();
+		}
+
+		return $url;
+	}
+
+	/**
 	 * Feeds the UUID into the cache
 	 */
 	public function populate(bool $force = false): bool

--- a/src/Uuid/Uuid.php
+++ b/src/Uuid/Uuid.php
@@ -374,32 +374,6 @@ abstract class Uuid implements Stringable
 	}
 
 	/**
-	 * Returns the URL of the model, including the query and fragment
-	 * @since 5.1.0
-	 */
-	public function modelUrl(): string|null
-	{
-		$model = $this->model();
-
-		if ($model === null) {
-			return null;
-		}
-
-		if (method_exists($model, 'url') === false) {
-			return null;
-		}
-
-		$url  = $model->url();
-		$url .= $this->uri->query->toString(true);
-
-		if ($this->uri->hasFragment() === true) {
-			$url .= '#' . $this->uri->fragment();
-		}
-
-		return $url;
-	}
-
-	/**
 	 * Feeds the UUID into the cache
 	 */
 	public function populate(bool $force = false): bool
@@ -433,6 +407,32 @@ abstract class Uuid implements Stringable
 		$this->populate();
 
 		return $this->uri->toString();
+	}
+
+	/**
+	 * Returns the URL of the model, including the query and fragment
+	 * @since 5.1.0
+	 */
+	public function toUrl(): string|null
+	{
+		$model = $this->model();
+
+		if ($model === null) {
+			return null;
+		}
+
+		if (method_exists($model, 'url') === false) {
+			return null;
+		}
+
+		$url  = $model->url();
+		$url .= $this->uri->query->toString(true);
+
+		if ($this->uri->hasFragment() === true) {
+			$url .= '#' . $this->uri->fragment();
+		}
+
+		return $url;
 	}
 
 	/**

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -116,6 +116,15 @@ class UriTest extends TestCase
 		$this->assertSame('/a/b/ktest.loc', $uri->toString());
 	}
 
+	public function testFragment(): void
+	{
+		$uri = new Uri('https://getkirby.com#top');
+		$this->assertSame('top', $uri->fragment());
+
+		$uri = new Uri('https://getkirby.com');
+		$this->assertNull($uri->fragment());
+	}
+
 	public function testValidScheme(): void
 	{
 		$url = new Uri();

--- a/tests/Uuid/FileUuidTest.php
+++ b/tests/Uuid/FileUuidTest.php
@@ -82,10 +82,11 @@ class FileUuidTest extends TestCase
 		$this->assertSame('my-file', ModelUuid::retrieveId($file));
 	}
 
-	public function testUrl(): void
+	public function testToPermalink(): void
 	{
 		$file = $this->app->file('page-a/test.pdf');
 		$url  = 'https://getkirby.com/@/file/my-file';
+		$this->assertSame($url, $file->uuid()->toPermalink());
 		$this->assertSame($url, $file->uuid()->url());
 	}
 

--- a/tests/Uuid/PageUuidTest.php
+++ b/tests/Uuid/PageUuidTest.php
@@ -82,10 +82,11 @@ class PageUuidTest extends TestCase
 		$this->assertSame('my-page', ModelUuid::retrieveId($page));
 	}
 
-	public function testUrl(): void
+	public function testToPermalink(): void
 	{
 		$page = $this->app->page('page-a');
 		$url  = 'https://getkirby.com/@/page/my-page';
+		$this->assertSame($url, $page->uuid()->toPermalink());
 		$this->assertSame($url, $page->uuid()->url());
 	}
 

--- a/tests/Uuid/PermalinksTest.php
+++ b/tests/Uuid/PermalinksTest.php
@@ -34,7 +34,7 @@ class PermalinksTest extends TestCase
 		$uuid->clear();
 		$response = $app->call('/@/page/my-id');
 		$this->assertFalse($response);
-		$uuid->url();
+		$uuid->toPermalink();
 		$response = $app->call('/@/page/my-id')->send();
 		$this->assertSame(302, $response->code());
 		$this->assertSame('https://getkirby.com/a', $response->header('Location'));

--- a/tests/Uuid/UuidTest.php
+++ b/tests/Uuid/UuidTest.php
@@ -371,6 +371,26 @@ class UuidTest extends TestCase
 		Uuid::for('page://something')->model();
 	}
 
+	public function testModelUrl(): void
+	{
+		$uuid = Uuid::for('page://my-page');
+		$this->assertSame('https://getkirby.com/page-a', $uuid->modelUrl());
+
+		$uuid = Uuid::for('page://my-page?foo=bar');
+		$this->assertSame('https://getkirby.com/page-a?foo=bar', $uuid->modelUrl());
+
+		$uuid = Uuid::for('page://my-page#fragment');
+		$this->assertSame('https://getkirby.com/page-a#fragment', $uuid->modelUrl());
+
+		$uuid = Uuid::for('page://does-not-exist');
+		$this->assertNull($uuid->modelUrl());
+
+		$uuid = Uuid::for('file://my-id');
+		$this->assertNull($uuid->modelUrl());
+
+
+	}
+
 	public function testPopulateGenerate(): void
 	{
 		$page = $this->app->page('page-b');

--- a/tests/Uuid/UuidTest.php
+++ b/tests/Uuid/UuidTest.php
@@ -371,26 +371,6 @@ class UuidTest extends TestCase
 		Uuid::for('page://something')->model();
 	}
 
-	public function testModelUrl(): void
-	{
-		$uuid = Uuid::for('page://my-page');
-		$this->assertSame('https://getkirby.com/page-a', $uuid->modelUrl());
-
-		$uuid = Uuid::for('page://my-page?foo=bar');
-		$this->assertSame('https://getkirby.com/page-a?foo=bar', $uuid->modelUrl());
-
-		$uuid = Uuid::for('page://my-page#fragment');
-		$this->assertSame('https://getkirby.com/page-a#fragment', $uuid->modelUrl());
-
-		$uuid = Uuid::for('page://does-not-exist');
-		$this->assertNull($uuid->modelUrl());
-
-		$uuid = Uuid::for('file://my-id');
-		$this->assertNull($uuid->modelUrl());
-
-
-	}
-
 	public function testPopulateGenerate(): void
 	{
 		$page = $this->app->page('page-b');
@@ -418,6 +398,24 @@ class UuidTest extends TestCase
 		$this->assertIsString($id = $uuid->toString());
 		$this->assertSame($id, (string)$uuid);
 		$this->assertSame(Str::after($id, '://'), $this->app->page('page-b')->content()->get('uuid')->value());
+	}
+
+	public function testToUrl(): void
+	{
+		$uuid = Uuid::for('page://my-page');
+		$this->assertSame('https://getkirby.com/page-a', $uuid->toUrl());
+
+		$uuid = Uuid::for('page://my-page?foo=bar');
+		$this->assertSame('https://getkirby.com/page-a?foo=bar', $uuid->toUrl());
+
+		$uuid = Uuid::for('page://my-page#fragment');
+		$this->assertSame('https://getkirby.com/page-a#fragment', $uuid->toUrl());
+
+		$uuid = Uuid::for('page://does-not-exist');
+		$this->assertNull($uuid->toUrl());
+
+		$uuid = Uuid::for('file://my-id');
+		$this->assertNull($uuid->toUrl());
 	}
 
 	public function testValue(): void


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- New `Uuid::toUrl()` method that returns the model's absolute URL and includes query and/or fragment that was included in the UUID uri
- Better IDE support for the return type of `Page::uuid()`, `Site::uuid()`, `File::uuid()` and `User::uuid()`

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Support query and fragments in `link` KirbyTag when using a UUID 
#7477

### Deprecated
- The `::url()` method of `PageUuid` and `FileUUid` has been renamed to `::toPermalink()` and will be removed in a future release.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion