### PR TITLE
fix: Stable tooltip width for range input

### DIFF
--- a/panel/src/components/Forms/Input/RangeInput.vue
+++ b/panel/src/components/Forms/Input/RangeInput.vue
@@ -24,7 +24,12 @@
 			<span v-if="tooltip.before" class="k-range-input-tooltip-before">{{
 				tooltip.before
 			}}</span>
-			<span class="k-range-input-tooltip-text">{{ label }}</span>
+			<span
+				:style="`--digits: ${maxLength}ch`"
+				class="k-range-input-tooltip-text"
+			>
+				{{ label }}
+			</span>
 			<span v-if="tooltip.after" class="k-range-input-tooltip-after">{{
 				tooltip.after
 			}}</span>
@@ -96,6 +101,9 @@ export default {
 			return this.required || this.value || this.value === 0
 				? this.format(this.position)
 				: "–";
+		},
+		maxLength() {
+			return Math.floor(Math.abs(this.max)).toString().length;
 		},
 		position() {
 			return this.value || this.value === 0
@@ -192,6 +200,11 @@ export default {
 }
 .k-range-input-tooltip > * {
 	padding: var(--spacing-1);
+}
+.k-range-input-tooltip-text {
+	font-family: var(--font-mono);
+	width: calc(var(--digits) + var(--spacing-1) * 2);
+	text-align: center;
 }
 
 .k-range-input[data-disabled="true"] {


### PR DESCRIPTION

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Range input: Tooltip keeps a stable width based on the `max` value
#7417


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion