### PR TITLE
fix: Disable field previews in sections

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -190,6 +190,7 @@ return [
 				'batch'    => $this->batch,
 				'columns'  => $this->columnsWithTypes(),
 				'empty'    => $this->empty,
+				'fields'   => (object)$this->fields(),
 				'headline' => $this->headline,
 				'help'     => $this->help,
 				'layout'   => $this->layout,

--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -2,6 +2,7 @@
 
 use Kirby\Cms\ModelWithContent;
 use Kirby\Form\Form;
+use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
 
@@ -112,16 +113,8 @@ return [
 
 			// add the type to the columns for the table layout
 			if ($this->layout === 'table') {
-				$blueprint = $this->models->first()?->blueprint();
-
-				if ($blueprint === null) {
-					return $columns;
-				}
-
-				foreach ($columns as $columnName => $column) {
-					if ($id = $column['id'] ?? null) {
-						$columns[$columnName]['type'] ??= $blueprint->field($id)['type'] ?? null;
-					}
+				foreach ($this->fields() as $columnName => $field) {
+					$columns[$columnName]['type'] ??= $field['type'] ?? null;
 				}
 			}
 
@@ -173,6 +166,33 @@ return [
 			}
 
 			return $item;
-		}
+		},
+		'fields' => function () {
+			if (isset($this->fields)) {
+				return $this->fields;
+			}
+
+			$blueprint = $this->models->first()?->blueprint();
+
+			if ($blueprint === null) {
+				return [];
+			}
+
+			$this->fields = [];
+
+			foreach ($this->columns as $columnName => $column) {
+				if ($id = $column['id'] ?? null) {
+					if ($field = $blueprint->field($id)) {
+						$this->fields[$columnName] = [
+							...$field,
+							'disabled' => true
+						];
+					}
+				}
+			}
+
+			return $this->fields;
+
+		},
 	],
 ];

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -2,7 +2,6 @@
 
 use Kirby\Cms\Blueprint;
 use Kirby\Cms\Page;
-use Kirby\Cms\Pages;
 use Kirby\Cms\Site;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Panel\Collector\PagesCollector;
@@ -272,6 +271,7 @@ return [
 				'batch'    => $this->batch,
 				'columns'  => $this->columnsWithTypes(),
 				'empty'    => $this->empty,
+				'fields'   => (object)$this->fields(),
 				'headline' => $this->headline,
 				'help'     => $this->help,
 				'layout'   => $this->layout,


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

We already expected to receive `fields` in `ModelsSection.vue`. However, it was never passed. This PR starts passing them and setting on all fields `disabled: true`. This also solves editable field previews (e.g. toggle) that would not update the content nevertheless. The toggle preview now also shows texts from the blueprint.

It makes the `layout` mixin not less complex, rather more, but I don't think we can solve this with this PR. And I think it would be good to fix the bug.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- Toggle field preview shows defined texts from blueprint in pages and files sections

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Editable field previews are disabled in  pages and files sections (instead of intractable but non-functional)
#6582


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion