### PR TITLE
fix: Stucture field `_id` handling

### DIFF
--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -198,9 +198,6 @@ return [
 				)
 				->toStoredValues();
 
-			// remove frontend helper id
-			unset($row['_id']);
-
 			$data[] = $row;
 		}
 

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -517,7 +517,12 @@ export default {
 		 * @param {array} values
 		 */
 		save(values = this.items) {
-			this.$emit("input", values);
+			this.$emit(
+				"input",
+				// strip _id from values
+				// eslint-disable-next-line no-unused-vars
+				values.map(({ _id, ...value }) => value)
+			);
 		},
 		/**
 		 * Sort items according to `sortBy` prop


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

This seems to be a feasible quick fix for #7491: Adding `_id` in the structure field will trigger the form controls every time when included in the emitted value as it will always be different to what's coming from the backend. This PR strips `_id` again before emitting the structure field value.

In the larger picture, I think our handling of `_id` here is a bit weird: I was first thinking "but StructureObject does already have an ID" - but then realized that in the structure field handling itself the `Structure`\`StructureObject` classes aren't involved at all. I think we should change this for a future refactoring of the field:
- Parse the content value as yaml
- Pass it to the structure classes
- Retrieve the data (including its UUID) from the classes and pass it to the frontend
- Only for newly added rows, add a UUID in the frontend


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Structure field does not trigger the form controls for no reason 
#7491



### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion