### PR TITLE
fix: guess audio mime type for webm extension

### DIFF
--- a/src/Filesystem/Mime.php
+++ b/src/Filesystem/Mime.php
@@ -100,7 +100,7 @@ class Mime
 		'tiff'  => 'image/tiff',
 		'wav'   => 'audio/x-wav',
 		'wbxml' => 'application/wbxml',
-		'webm'  => ['video/webm', 'audio/webm],
+		'webm'  => ['video/webm', 'audio/webm'],
 		'webp'  => 'image/webp',
 		'word'  => ['application/msword', 'application/octet-stream'],
 		'xhtml' => 'application/xhtml+xml',

--- a/src/Filesystem/Mime.php
+++ b/src/Filesystem/Mime.php
@@ -100,7 +100,7 @@ class Mime
 		'tiff'  => 'image/tiff',
 		'wav'   => 'audio/x-wav',
 		'wbxml' => 'application/wbxml',
-		'webm'  => 'video/webm',
+		'webm'  => ['video/webm', 'audio/webm],
 		'webp'  => 'image/webp',
 		'word'  => ['application/msword', 'application/octet-stream'],
 		'xhtml' => 'application/xhtml+xml',


### PR DESCRIPTION
## Description

Currently all `.webm` files are inferred to be video files. However, `.webm` is both an [audio AND a video format](https://www.webmproject.org/docs/container/). In fact it's the default format for most browsers when recording audio-only input via the [MediaRecorder API](https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder).

When I define my file template like this:

```
title: Audioaufnahme

accept: audio/webm, audio/ogg, audio/mpeg, audio/wav
fields:
  title:
    label: Titel
    type: text
  created:
    label: Erstellt am
    type: date
    display: DD.MM.YYYY
    time: true
    disabled: true
    step:
      size: 1
      unit: second
```

I cannot upload an audio file with `.webm` ending, as Kirby will always complain about the wrong mime type, because it infers `video/webm` from the `.webm` file extension.
