### PR TITLE
fix: Only redirect to valid URLs after Panel login

### DIFF
--- a/src/Panel/Home.php
+++ b/src/Panel/Home.php
@@ -118,13 +118,21 @@ class Home
 					return false;
 				}
 
-				// if auth is not required the redirect is allowed
-				if ($auth === false) {
-					return true;
+				// check the firewall, if auth is required
+				if (
+					$auth !== false &&
+					Panel::hasAccess($user, $areaId) === false
+				) {
+					return false;
 				}
 
-				// check the firewall
-				return Panel::hasAccess($user, $areaId);
+				// check if the route yields a valid result
+				$result = $route->action()->call(
+					$route,
+					...$route->arguments()
+				);
+
+				return $result !== false;
 			});
 		} catch (Throwable) {
 			return false;

--- a/tests/Panel/HomeTest.php
+++ b/tests/Panel/HomeTest.php
@@ -179,6 +179,11 @@ class HomeTest extends TestCase
 			],
 			'users' => [
 				['email' => 'test@getkirby.com', 'role' => 'admin']
+			],
+			'options' => [
+				'api' => [
+					'allowImpersonation' => true
+				]
 			]
 		]);
 
@@ -220,6 +225,11 @@ class HomeTest extends TestCase
 			],
 			'users' => [
 				['email' => 'test@getkirby.com', 'role' => 'editor']
+			],
+			'options' => [
+				'api' => [
+					'allowImpersonation' => true
+				]
 			]
 		]);
 
@@ -229,6 +239,28 @@ class HomeTest extends TestCase
 		$this->assertFalse(Home::hasAccess($user, 'pages/test'));
 		$this->assertTrue(Home::hasAccess($user, 'users/test@getkirby.com'));
 		$this->assertTrue(Home::hasAccess($user, 'account'));
+	}
+
+	public function testHasAccessWithInvalidPath(): void
+	{
+		$this->app = $this->app->clone([
+			'site' => [
+				'children' => [
+					['slug' => 'test']
+				]
+			],
+			'users' => [
+				['email' => 'test@getkirby.com', 'role' => 'admin']
+			],
+			'options' => [
+				'api' => [
+					'allowImpersonation' => true
+				]
+			]
+		]);
+
+		$user = $this->app->impersonate('test@getkirby.com');
+		$this->assertFalse(Home::hasAccess($user, 'pages/foo+bar'));
 	}
 
 	public function testHasValidDomain(): void


### PR DESCRIPTION
## Description

### How to test
- Log out of the Panel
- Try access https://sandbox.test/panel/pages/foo+bar
- Being redirected to login
- Log in
- Being redirected to site view with this PR; before this PR error dialog


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->
### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Panel will not redirect anymore to non-existing Panel views if these were attempted to access prior to login
#6682

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion