### PR TITLE
fix: Remove media files when unpublishing page

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -865,6 +865,9 @@ trait PageActions
 			'template' => $this->intendedTemplate()->name(),
 		]);
 
+		// remove the media directory
+		Dir::remove($this->mediaRoot());
+
 		// actually do it on disk
 		if ($this->exists() === true) {
 			if (Dir::move($this->root(), $page->root()) !== true) {


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- No more orphaned media files when changing a page's status to draft
#6573

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion