### PR TITLE
fix: Abort previous Panel view requests

### DIFF
--- a/panel/src/panel/dialog.test.js
+++ b/panel/src/panel/dialog.test.js
@@ -11,6 +11,7 @@ describe.concurrent("panel.dialog", () => {
 		const panel = Panel.create();
 		const dialog = Dialog(panel);
 		const state = {
+			abortController: null,
 			component: null,
 			isLoading: false,
 			legacy: false,

--- a/panel/src/panel/drawer.test.js
+++ b/panel/src/panel/drawer.test.js
@@ -12,6 +12,7 @@ describe.concurrent("panel.drawer", () => {
 		const drawer = Drawer(panel);
 
 		const state = {
+			abortController: null,
 			component: null,
 			id: null,
 			isLoading: false,

--- a/panel/src/panel/dropdown.test.js
+++ b/panel/src/panel/dropdown.test.js
@@ -12,6 +12,7 @@ describe.concurrent("panel.dropdown", () => {
 		const dropdown = Dropdown(panel);
 
 		const state = {
+			abortController: null,
 			component: null,
 			isLoading: false,
 			on: {},

--- a/panel/src/panel/feature.js
+++ b/panel/src/panel/feature.js
@@ -8,6 +8,8 @@ import State from "./state.js";
  */
 export const defaults = () => {
 	return {
+		// request abort controller
+		abortController: null,
 		// the feature component
 		component: null,
 		// loading state
@@ -80,6 +82,11 @@ export default (panel, key, defaults) => {
 			if (options.silent !== true) {
 				this.isLoading = true;
 			}
+
+			// create a new abort controller
+			// and add to the options
+			this.abortController = new AbortController();
+			options.signal = this.abortController.signal;
 
 			// the global open method is used to make sure
 			// that a response can also trigger other features.

--- a/panel/src/panel/modal.test.js
+++ b/panel/src/panel/modal.test.js
@@ -15,6 +15,7 @@ describe.concurrent("panel/modal.js", () => {
 		const modal = Modal(panel, "test", defaults());
 
 		const state = {
+			abortController: null,
 			component: null,
 			isLoading: false,
 			on: {},

--- a/panel/src/panel/panel.js
+++ b/panel/src/panel/panel.js
@@ -171,6 +171,10 @@ export default {
 	 * @param {Boolean} openNotification
 	 */
 	error(error, openNotification = true) {
+		if (error.name === "AbortError") {
+			return;
+		}
+
 		if (this.debug === true) {
 			console.error(error);
 		}

--- a/panel/src/panel/view.js
+++ b/panel/src/panel/view.js
@@ -24,6 +24,21 @@ export default (panel) => {
 		...parent,
 
 		/**
+		 * Load a view from the server and
+		 * cancel any previous request
+		 *
+		 * @param {String|URL} url
+		 * @param {Object|Function} options
+		 * @returns {Object} Returns the current state
+		 */
+		async load(url, options = {}) {
+			// cancel any previous request
+			this.abortController?.abort();
+
+			return parent.load.call(this, url, options);
+		},
+
+		/**
 		 * Setting the active view state
 		 * will also change the document title
 		 * and the browser URL

--- a/panel/src/panel/view.test.js
+++ b/panel/src/panel/view.test.js
@@ -28,6 +28,7 @@ describe.concurrent("panel.view", () => {
 		const view = View(Panel());
 
 		const state = {
+			abortController: null,
 			breadcrumb: [],
 			breadcrumbLabel: null,
 			component: null,


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

I tried to catch the abort request error right in the view code, but only could manage to silence it in the error handler.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Subsequent Panel view request cancel out ongoing (slow) previous view request to ensure navigation always lands at the latest requested view
#6536


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion