### PR TITLE
fix: Use current for `$model::save()`

### DIFF
--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -462,7 +462,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 		// update the clone
 		$clone->version()->save(
 			$data ?? [],
-			$languageCode ?? 'default',
+			$languageCode ?? 'current',
 			$overwrite
 		);
 


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- `ModelWithContent::save()` now consistently uses the current language, not default language, if not provided explicitly
#7487

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion