### PR TITLE
Add collapse/expand all for Field-Blocks in Blocks Menu

### DIFF
--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -158,9 +158,6 @@ export default {
 
 			return "k-block-type-default";
 		},
-		isCollapsable() {
-			return this.fieldset.preview === "fields";
-		},
 		isDisabled() {
 			return this.disabled === true || this.fieldset.disabled === true;
 		},
@@ -250,14 +247,10 @@ export default {
 			this.$panel.drawer.close(this.id);
 		},
 		collapse() {
-			if (this.isCollapsable) {
-				this.$refs.editor?.collapse();
-			}
+			this.$refs.editor?.collapse?.();
 		},
 		expand() {
-			if (this.isCollapsable) {
-				this.$refs.editor?.expand();
-			}
+			this.$refs.editor?.expand?.();
 		},
 		focus() {
 			if (typeof this.$refs.editor?.focus === "function") {

--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -266,7 +266,6 @@ export default {
 				this.$refs.container?.focus();
 			}
 		},
-
 		goTo(block) {
 			if (block) {
 				block.$refs.container?.focus();

--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -265,6 +265,12 @@ export default {
 				block.open(null, true);
 			}
 		},
+		isCollapsible() {
+			if (this.$refs.editor) {
+				return typeof this.$refs.editor.collapse === "function";
+			}
+			return false;
+		},
 		isSplitable() {
 			if (this.isFull === true) {
 				return false;

--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -158,6 +158,9 @@ export default {
 
 			return "k-block-type-default";
 		},
+		isCollapsable() {
+			return this.fieldset.preview === "fields";
+		},
 		isDisabled() {
 			return this.disabled === true || this.fieldset.disabled === true;
 		},
@@ -246,6 +249,16 @@ export default {
 		close() {
 			this.$panel.drawer.close(this.id);
 		},
+		collapse() {
+			if (this.isCollapsable) {
+				this.$refs.editor?.collapse();
+			}
+		},
+		expand() {
+			if (this.isCollapsable) {
+				this.$refs.editor?.expand();
+			}
+		},
 		focus() {
 			if (typeof this.$refs.editor?.focus === "function") {
 				this.$refs.editor.focus();
@@ -253,6 +266,7 @@ export default {
 				this.$refs.container?.focus();
 			}
 		},
+
 		goTo(block) {
 			if (block) {
 				block.$refs.container?.focus();

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -103,6 +103,7 @@ export default {
 	data() {
 		return {
 			blocks: this.value ?? [],
+			isCollapsible: false,
 			isEditing: false,
 			isMultiSelectKey: false,
 			selected: []
@@ -150,8 +151,17 @@ export default {
 		}
 	},
 	watch: {
-		value() {
-			this.blocks = this.value;
+		value: {
+			handler() {
+				this.blocks = this.value;
+				this.checkCollapsibility();
+			},
+			immediate: true
+		},
+		isCollapsible: {
+			handler(newVal) {
+				this.$emit("collapsible-change", newVal);
+			}
 		}
 	},
 	mounted() {
@@ -185,6 +195,12 @@ export default {
 
 			await this.$nextTick();
 			this.focusOrOpen(block);
+		},
+		async checkCollapsibility() {
+			await this.$nextTick();
+			this.isCollapsible = this.blocks.some((block) => {
+				return this.ref(block).isCollapsible();
+			});
 		},
 		choose(index) {
 			if (this.$helper.object.length(this.fieldsets) === 1) {

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -94,7 +94,7 @@ export const props = {
 			default: () => []
 		}
 	},
-	emits: ["input"]
+	emits: ["input", "collapsible-change"]
 };
 
 export default {

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -226,6 +226,15 @@ export default {
 				}
 			});
 		},
+		collapse(block) {
+			const ref = this.ref(block);
+			ref?.collapse();
+		},
+		collapseAll() {
+			for (const block of this.blocks) {
+				this.collapse(block);
+			}
+		},
 		copy(e) {
 			// don't copy when there are no blocks yet
 			if (this.blocks.length === 0) {
@@ -336,6 +345,15 @@ export default {
 			};
 			this.blocks.splice(index + 1, 0, copy);
 			this.save();
+		},
+		expand(block) {
+			const ref = this.ref(block);
+			ref?.expand();
+		},
+		expandAll() {
+			for (const block of this.blocks) {
+				this.expand(block);
+			}
 		},
 		fieldset(block) {
 			return (

--- a/panel/src/components/Forms/Blocks/Types/Fields.vue
+++ b/panel/src/components/Forms/Blocks/Types/Fields.vue
@@ -72,6 +72,14 @@ export default {
 		toggle() {
 			this.collapsed = !this.collapsed;
 			this.state(this.collapsed);
+		},
+		collapse() {
+			this.collapsed = true;
+			this.state(this.collapsed);
+		},
+		expand() {
+			this.collapsed = false;
+			this.state(this.collapsed);
 		}
 	}
 };

--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -75,7 +75,7 @@ export default {
 			return this.max && this.value.length >= this.max;
 		},
 		isCollapsable() {
-			var hasPreviewFields = false;
+			let hasPreviewFields = false;
 			this.value.forEach((item) => {
 				if (this.fieldsets[item.type]?.preview === "fields") {
 					hasPreviewFields = true;

--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -37,6 +37,7 @@
 				@close="opened = $event"
 				@open="opened = $event"
 				@input="$emit('input', $event)"
+				@collapsible-change="onCollapsibleChange"
 			/>
 		</k-input-validator>
 
@@ -61,7 +62,8 @@ export default {
 	inheritAttrs: false,
 	data() {
 		return {
-			opened: []
+			opened: [],
+			isCollapsible: false
 		};
 	},
 	computed: {
@@ -74,12 +76,6 @@ export default {
 		isFull() {
 			return this.max && this.value.length >= this.max;
 		},
-		isCollapsable() {
-			return this.value.some(
-				(item) => this.fieldsets[item.type]?.preview === "fields"
-			);
-		},
-
 		options() {
 			return [
 				{
@@ -94,7 +90,7 @@ export default {
 					icon: "download",
 					text: this.$t("paste")
 				},
-				...(this.isCollapsable
+				...(this.isCollapsible
 					? [
 							"-",
 							{
@@ -124,6 +120,9 @@ export default {
 	methods: {
 		focus() {
 			this.$refs.blocks.focus();
+		},
+		onCollapsibleChange(value) {
+			this.isCollapsible = value;
 		}
 	}
 };

--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -74,6 +74,9 @@ export default {
 		isFull() {
 			return this.max && this.value.length >= this.max;
 		},
+		isCollapsable() {
+			return Object.values(this.fieldsets).some(fieldset => fieldset.preview === "fields");
+		},
 		options() {
 			return [
 				{
@@ -88,6 +91,21 @@ export default {
 					icon: "download",
 					text: this.$t("paste")
 				},
+				...(this.isCollapsable ? [
+					"-",
+					{
+						click: () => this.$refs.blocks.collapseAll(),
+						disabled: this.isEmpty,
+						icon: "collapse",
+						text: this.$t("collapse.all")
+					},
+					{
+						click: () => this.$refs.blocks.expandAll(),
+						disabled: this.isEmpty,
+						icon: "expand",
+						text: this.$t("expand.all")
+					},
+					]: [])				,
 				"-",
 				{
 					click: () => this.$refs.blocks.removeAll(),

--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -75,10 +75,15 @@ export default {
 			return this.max && this.value.length >= this.max;
 		},
 		isCollapsable() {
-			return Object.values(this.fieldsets).some(
-				(fieldset) => fieldset.preview === "fields"
-			);
+			var hasPreviewFields = false;
+			this.value.forEach((item) => {
+				if (this.fieldsets[item.type]?.preview === "fields") {
+					hasPreviewFields = true;
+				}
+			});
+			return hasPreviewFields;
 		},
+
 		options() {
 			return [
 				{

--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -75,13 +75,9 @@ export default {
 			return this.max && this.value.length >= this.max;
 		},
 		isCollapsable() {
-			let hasPreviewFields = false;
-			this.value.forEach((item) => {
-				if (this.fieldsets[item.type]?.preview === "fields") {
-					hasPreviewFields = true;
-				}
-			});
-			return hasPreviewFields;
+			return this.value.some(
+				(item) => this.fieldsets[item.type]?.preview === "fields"
+			);
 		},
 
 		options() {

--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -75,7 +75,9 @@ export default {
 			return this.max && this.value.length >= this.max;
 		},
 		isCollapsable() {
-			return Object.values(this.fieldsets).some(fieldset => fieldset.preview === "fields");
+			return Object.values(this.fieldsets).some(
+				(fieldset) => fieldset.preview === "fields"
+			);
 		},
 		options() {
 			return [
@@ -91,21 +93,23 @@ export default {
 					icon: "download",
 					text: this.$t("paste")
 				},
-				...(this.isCollapsable ? [
-					"-",
-					{
-						click: () => this.$refs.blocks.collapseAll(),
-						disabled: this.isEmpty,
-						icon: "collapse",
-						text: this.$t("collapse.all")
-					},
-					{
-						click: () => this.$refs.blocks.expandAll(),
-						disabled: this.isEmpty,
-						icon: "expand",
-						text: this.$t("expand.all")
-					},
-					]: [])				,
+				...(this.isCollapsable
+					? [
+							"-",
+							{
+								click: () => this.$refs.blocks.collapseAll(),
+								disabled: this.isEmpty,
+								icon: "collapse",
+								text: this.$t("collapse.all")
+							},
+							{
+								click: () => this.$refs.blocks.expandAll(),
+								disabled: this.isEmpty,
+								icon: "expand",
+								text: this.$t("expand.all")
+							}
+						]
+					: []),
 				"-",
 				{
 					click: () => this.$refs.blocks.removeAll(),


### PR DESCRIPTION
## Description

This PR adds two new buttons to the `blocks` menu of the panel to allow editors to expand or collapse all blocks with `preview: fields` at once.
The goal is to improve usability for content-heavy pages by reducing repetitive clicks and making it faster to manage large sets of blocks. The feature should be fully backwards-compatible and does not affect other block types, so the buttons wont show in the menu, if not at least one field-block is in the fieldsets. No need for config or field params atm.

https://github.com/user-attachments/assets/ef1887e6-d2da-4ca9-92fd-9f8e3bb018cd


## Changelog

### 🎉 Features

* Added "Expand all" and "Collapse all" buttons to the `blocks` menu,  for blocks with `preview: fields`.
* Buttons use already existing Translations and Kirby Icons
* Buttons wont show, if not at least 1 block with preview: fields is in the fieldsets
* Buttons are disabled, if blocks is empty
 
### ✨ Enhancements

* Improves workflow for editors managing large sets of block content.

## Docs

* Include a screenshot or short GIF to demonstrate the feature.

### For review team

* [ ] Add lab and/or sandbox examples (wherever helpful)
* [ ] Add changes & docs to release notes draft in Notion

