### PR TITLE
fix: Pass missing input prop in complex fields 

### DIFF
--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -1,6 +1,7 @@
 <template>
 	<k-field
 		v-bind="$props"
+		:input="id"
 		:class="['k-blocks-field', $attrs.class]"
 		:style="$attrs.style"
 	>
@@ -28,7 +29,7 @@
 		</template>
 
 		<k-input-validator
-			v-bind="{ min, max, required }"
+			v-bind="{ id, min, max, required }"
 			:value="JSON.stringify(value)"
 		>
 			<k-blocks

--- a/panel/src/components/Forms/Field/EntriesField.vue
+++ b/panel/src/components/Forms/Field/EntriesField.vue
@@ -1,6 +1,7 @@
 <template>
 	<k-field
 		v-bind="$props"
+		:input="id"
 		:class="['k-entries-field', $attrs.class]"
 		:style="$attrs.style"
 		@click.native.stop
@@ -30,7 +31,7 @@
 		</template>
 
 		<k-input-validator
-			v-bind="{ min, max, required }"
+			v-bind="{ id, min, max, required }"
 			:value="JSON.stringify(entries)"
 		>
 			<!-- Empty State -->

--- a/panel/src/components/Forms/Field/LayoutField.vue
+++ b/panel/src/components/Forms/Field/LayoutField.vue
@@ -1,6 +1,7 @@
 <template>
 	<k-field
 		v-bind="$props"
+		:input="id"
 		:class="['k-layout-field', $attrs.class]"
 		:style="$attrs.style"
 	>
@@ -26,7 +27,7 @@
 		</template>
 
 		<k-input-validator
-			v-bind="{ min, max, required }"
+			v-bind="{ id, min, max, required }"
 			:value="JSON.stringify(value)"
 		>
 			<k-layouts

--- a/panel/src/components/Forms/Field/ModelsField.vue
+++ b/panel/src/components/Forms/Field/ModelsField.vue
@@ -1,6 +1,7 @@
 <template>
 	<k-field
 		v-bind="$props"
+		:input="id"
 		:class="['k-models-field', `k-${$options.type}-field`, $attrs.class]"
 		:style="$attrs.style"
 	>
@@ -17,7 +18,7 @@
 
 		<k-dropzone :disabled="!hasDropzone" @drop="drop">
 			<k-input-validator
-				v-bind="{ min, max, required }"
+				v-bind="{ id, min, max, required }"
 				:value="JSON.stringify(value)"
 			>
 				<k-collection

--- a/panel/src/components/Forms/Field/ObjectField.vue
+++ b/panel/src/components/Forms/Field/ObjectField.vue
@@ -1,9 +1,10 @@
 <template>
-	<k-field v-bind="$props" class="k-object-field">
+	<k-field v-bind="$props" :input="id" class="k-object-field">
 		<!-- Remove button -->
 		<template v-if="!disabled && hasFields" #options>
 			<k-button
 				v-if="isEmpty"
+				:id="id"
 				icon="add"
 				size="xs"
 				variant="filled"

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -2,6 +2,7 @@
 	<k-field
 		v-bind="$props"
 		:class="['k-structure-field', $attrs.class]"
+		:input="id"
 		:style="$attrs.style"
 		:buttons="buttons"
 		@click.native.stop
@@ -57,7 +58,7 @@
 		</template>
 
 		<k-input-validator
-			v-bind="{ min, max, required }"
+			v-bind="{ id, min, max, required }"
 			:value="JSON.stringify(items)"
 		>
 			<template v-if="hasFields">

--- a/panel/src/components/Forms/Input/Validator.js
+++ b/panel/src/components/Forms/Input/Validator.js
@@ -25,6 +25,11 @@ export default class InputValidator extends HTMLElement {
 
 	connectedCallback() {
 		this.tabIndex = 0;
+
+		// pass-through the id attribute
+		this.input.setAttribute("id", this.getAttribute("id"));
+		this.removeAttribute("id");
+
 		this.validate();
 	}
 
@@ -38,6 +43,14 @@ export default class InputValidator extends HTMLElement {
 
 	has(value) {
 		return this.entries.includes(value);
+	}
+
+	get input() {
+		return (
+			this.querySelector(this.getAttribute("anchor")) ??
+			this.querySelector("input, textarea, select, button") ??
+			this.querySelector(":scope > *")
+		);
 	}
 
 	get isEmpty() {
@@ -57,10 +70,6 @@ export default class InputValidator extends HTMLElement {
 	}
 
 	validate() {
-		const anchor =
-			this.querySelector(this.getAttribute("anchor")) ??
-			this.querySelector("input, textarea, select, button") ??
-			this.querySelector(":scope > *");
 		const max = parseInt(this.getAttribute("max"));
 		const min = parseInt(this.getAttribute("min"));
 
@@ -72,19 +81,19 @@ export default class InputValidator extends HTMLElement {
 			this.internals.setValidity(
 				{ valueMissing: true },
 				window.panel.$t("error.validation.required"),
-				anchor
+				this.input
 			);
 		} else if (this.hasAttribute("min") && this.entries.length < min) {
 			this.internals.setValidity(
 				{ rangeUnderflow: true },
 				window.panel.$t("error.validation.min", { min }),
-				anchor
+				this.input
 			);
 		} else if (this.hasAttribute("max") && this.entries.length > max) {
 			this.internals.setValidity(
 				{ rangeOverflow: true },
 				window.panel.$t("error.validation.max", { max }),
-				anchor
+				this.input
 			);
 		} else {
 			this.internals.setValidity({});


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Fixes unreleased regression on `develop-minor`: As `k-label` now hides the asterisk when no `input` is specified, it became apparent that some fields are not passing any `input` to `k-label`.

This PR passes `input` for those missing fields. To do that it also adds `id` attribute support to `k-input-validator`.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion