### PR TITLE
fix: Revert `buttons` prop for `k-field` for now

### DIFF
--- a/panel/src/components/Forms/Field.vue
+++ b/panel/src/components/Forms/Field.vue
@@ -27,15 +27,7 @@
 						{{ label }}
 					</k-label>
 				</slot>
-				<slot name="options">
-					<k-button-group
-						v-if="buttons"
-						:buttons="buttons"
-						size="xs"
-						variant="filled"
-						class="k-field-buttons"
-					/>
-				</slot>
+				<slot name="options" />
 				<slot name="counter">
 					<k-counter
 						v-if="counter"
@@ -63,7 +55,6 @@ import { disabled, help, id, label, name, required } from "@/mixins/props.js";
 export const props = {
 	mixins: [disabled, help, id, label, name, required],
 	props: {
-		buttons: Array,
 		counter: [Boolean, Object],
 		endpoints: Object,
 		input: [String, Number, Boolean],

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -3,7 +3,6 @@
 		v-bind="$props"
 		:class="['k-structure-field', $attrs.class]"
 		:style="$attrs.style"
-		:buttons="buttons"
 		@click.native.stop
 	>
 		<template v-if="hasFields && !disabled" #options>


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Fixes unreleased regression #7498 on `develop-minor` by revert adding the `buttons` prop to `k-field`.

An idea for the future could be to add the `buttons` prop but only for `k-field`, not in its exported `props`.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion