### PR TITLE
refact!: Rename picker field methods to `::to*()`

### DIFF
--- a/config/fields/files.php
+++ b/config/fields/files.php
@@ -61,7 +61,7 @@ return [
 		},
 	],
 	'methods' => [
-		'fileResponse' => function ($file) {
+		'toFile' => function ($file) {
 			return $file->panel()->pickerData([
 				'image'  => $this->image,
 				'info'   => $this->info ?? false,
@@ -82,7 +82,7 @@ return [
 					$id !== null &&
 					($file = $this->kirby()->file($id, $this->model()))
 				) {
-					$files[] = $this->fileResponse($file);
+					$files[] = $this->toFile($file);
 				}
 			}
 

--- a/config/fields/pages.php
+++ b/config/fields/pages.php
@@ -53,7 +53,7 @@ return [
 		'default' => null
 	],
 	'methods' => [
-		'pageResponse' => function ($page) {
+		'toPage' => function ($page) {
 			return $page->panel()->pickerData([
 				'image'  => $this->image,
 				'info'   => $this->info,
@@ -71,7 +71,7 @@ return [
 				}
 
 				if ($id !== null && ($page = $kirby->page($id))) {
-					$pages[] = $this->pageResponse($page);
+					$pages[] = $this->toPage($page);
 				}
 			}
 

--- a/config/fields/users.php
+++ b/config/fields/users.php
@@ -43,7 +43,7 @@ return [
 				$user = $this->kirby()->user()
 			) {
 				return [
-					$this->userResponse($user)
+					$this->toUser($user)
 				];
 			}
 
@@ -51,7 +51,7 @@ return [
 		}
 	],
 	'methods' => [
-		'userResponse' => function ($user) {
+		'toUser' => function ($user) {
 			return $user->panel()->pickerData([
 				'info'   => $this->info,
 				'image'  => $this->image,
@@ -69,7 +69,7 @@ return [
 				}
 
 				if ($email !== null && ($user = $kirby->user($email))) {
-					$users[] = $this->userResponse($user);
+					$users[] = $this->toUser($user);
 				}
 			}
 


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- The field method `pageResponse()` of the pages field has been renamed to `toPage()`.
- The field method `fileResponse()` of the files field has been renamed to `toFile()`.
- The field method `userResponse()` of the users field has been renamed to `toUser()`.


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion