### PR TITLE
refact: Throw for no closure in `Field::dialogs()`

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -224,14 +224,17 @@ class Field extends Component
 	 */
 	public function dialogs(): array
 	{
-		if (
-			isset($this->options['dialogs']) === true &&
-			$this->options['dialogs'] instanceof Closure
-		) {
+		if (isset($this->options['dialogs']) === false) {
+			return [];
+		}
+
+		if ($this->options['dialogs'] instanceof Closure) {
 			return $this->options['dialogs']->call($this);
 		}
 
-		return [];
+		throw new InvalidArgumentException(
+			message: 'Dialogs of field "' . $this->name() . '" must be define as a closure'
+		);
 	}
 
 	/**
@@ -239,14 +242,17 @@ class Field extends Component
 	 */
 	public function drawers(): array
 	{
-		if (
-			isset($this->options['drawers']) === true &&
-			$this->options['drawers'] instanceof Closure
-		) {
+		if (isset($this->options['drawers']) === false) {
+			return [];
+		}
+
+		if ($this->options['drawers'] instanceof Closure) {
 			return $this->options['drawers']->call($this);
 		}
 
-		return [];
+		throw new InvalidArgumentException(
+			message: 'Drawers of field "' . $this->name() . '" must be define as a closure'
+		);
 	}
 
 	/**

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -233,7 +233,7 @@ class Field extends Component
 		}
 
 		throw new InvalidArgumentException(
-			message: 'Dialogs of field "' . $this->name() . '" must be define as a closure'
+			message: 'Dialogs of field "' . $this->name() . '" must be defined as a closure'
 		);
 	}
 
@@ -251,7 +251,7 @@ class Field extends Component
 		}
 
 		throw new InvalidArgumentException(
-			message: 'Drawers of field "' . $this->name() . '" must be define as a closure'
+			message: 'Drawers of field "' . $this->name() . '" must be defined as a closure'
 		);
 	}
 

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -238,81 +238,94 @@ class FieldTest extends TestCase
 
 	public function testDialogs(): void
 	{
-		// no defined as default
-		Field::$types = [
-			'test' => []
-		];
-
-		$model = new Page(['slug' => 'test']);
-
-		$field = new Field('test', [
-			'model' => $model,
-		]);
-
-		$this->assertSame([], $field->dialogs());
-
-		// test dialogs
+		$model  = new Page(['slug' => 'test']);
 		$routes = [
 			[
 				'pattern' => 'foo',
-				'load'    => function () {
-				},
-				'submit'  => function () {
-				}
+				'load'    => function () {},
+				'submit'  => function () {}
 			]
 		];
 
-		// return routes
+		// return routes via Closure
 		Field::$types = [
 			'test' => [
 				'dialogs' => fn () => $routes
 			]
 		];
 
-		$field = new Field('test', [
-			'model' => $model,
-		]);
-
+		$field = new Field('test', ['model' => $model]);
 		$this->assertSame($routes, $field->dialogs());
-	}
 
-	public function testDrawers(): void
-	{
-		// no defined as default
+		// none defined
 		Field::$types = [
 			'test' => []
 		];
 
-		$model = new Page(['slug' => 'test']);
-		$field = new Field('test', [
-			'model' => $model,
-		]);
+		$field = new Field('test', ['model' => $model]);
+		$this->assertSame([], $field->dialogs());
+	}
 
-		$this->assertSame([], $field->drawers());
+	public function testDialogsInvalid(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Dialogs of field "test" must be define as a closure');
 
-		// test drawers
-		$routes = [
-			[
-				'pattern' => 'foo',
-				'load'    => function () {
-				},
-				'submit'  => function () {
-				}
+		Field::$types = [
+			'test' => [
+				'dialogs' => 'foo'
 			]
 		];
 
-		// return routes
+		$model = new Page(['slug' => 'test']);
+		$field = new Field('test', ['model' => $model]);
+		$field->dialogs();
+	}
+
+	public function testDrawers(): void
+	{
+		$model  = new Page(['slug' => 'test']);
+		$routes = [
+			[
+				'pattern' => 'foo',
+				'load'    => function () {},
+				'submit'  => function () {}
+			]
+		];
+
+		// return routes via Closure
 		Field::$types = [
 			'test' => [
 				'drawers' => fn () => $routes
 			]
 		];
 
-		$field = new Field('test', [
-			'model' => $model,
-		]);
-
+		$field = new Field('test', ['model' => $model]);
 		$this->assertSame($routes, $field->drawers());
+
+		// none defined
+		Field::$types = [
+			'test' => []
+		];
+
+		$field = new Field('test', ['model' => $model]);
+		$this->assertSame([], $field->drawers());
+	}
+
+	public function testDrawersInvalid(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Drawers of field "test" must be define as a closure');
+
+		Field::$types = [
+			'test' => [
+				'drawers' => 'foo'
+			]
+		];
+
+		$model = new Page(['slug' => 'test']);
+		$field = new Field('test', ['model' => $model]);
+		$field->drawers();
 	}
 
 	public function testErrors(): void

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -269,7 +269,7 @@ class FieldTest extends TestCase
 	public function testDialogsInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Dialogs of field "test" must be define as a closure');
+		$this->expectExceptionMessage('Dialogs of field "test" must be defined as a closure');
 
 		Field::$types = [
 			'test' => [
@@ -315,7 +315,7 @@ class FieldTest extends TestCase
 	public function testDrawersInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Drawers of field "test" must be define as a closure');
+		$this->expectExceptionMessage('Drawers of field "test" must be defined as a closure');
 
 		Field::$types = [
 			'test' => [


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- Exception is thrown when trying to register field dialogs or drawers without a closure


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion