### PR TITLE
fix: Use specific `get` method for `panel.feature`

### DIFF
--- a/panel/src/panel/feature.js
+++ b/panel/src/panel/feature.js
@@ -52,6 +52,28 @@ export default (panel, key, defaults) => {
 		...listeners(),
 
 		/**
+		 * Sends a get request to the backend route for
+		 * this Feature
+		 * @since 5.1.0
+		 *
+		 * @param {Object} value
+		 * @param {Object} options
+		 */
+		async get(url, options = {}) {
+			this.isLoading = true;
+
+			try {
+				return await panel.get(url, options);
+			} catch (error) {
+				panel.error(error);
+			} finally {
+				this.isLoading = false;
+			}
+
+			return false;
+		},
+
+		/**
 		 * Loads a feature from the server
 		 * and opens it afterwards
 		 *
@@ -189,9 +211,9 @@ export default (panel, key, defaults) => {
 		 * Reloads the properties for the feature
 		 */
 		async refresh(options = {}) {
-			options.url = options.url ?? this.url();
+			options.url ??= this.url();
 
-			const response = await panel.get(options.url, options);
+			const response = await this.get(options.url, options);
 			const state = response["$" + this.key()];
 
 			// the state cannot be updated


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Refreshing a dialog or drawer should trigger its `isLoading` state. For this, we need a custom `get` method inside `feature.js` - same as we have a custom `post` method.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Show loading spinner during dialog and drawer refreshes

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion