### PR TITLE
feat: `k-item` skeleton theme

### DIFF
--- a/panel/lab/components/item/4_skeletons/index.vue
+++ b/panel/lab/components/item/4_skeletons/index.vue
@@ -1,0 +1,13 @@
+<template>
+	<k-lab-examples>
+		<k-lab-example label="List item">
+			<k-item :image="{ icon: 'loader' }" layout="list" theme="skeleton" />
+		</k-lab-example>
+		<k-lab-example label="Cardlet item">
+			<k-item :image="{ icon: 'loader' }" layout="cardlets" theme="skeleton" />
+		</k-lab-example>
+		<k-lab-example label="Card item">
+			<k-item :image="{ icon: 'loader' }" layout="cards" theme="skeleton" />
+		</k-lab-example>
+	</k-lab-examples>
+</template>

--- a/panel/src/components/Collection/Item.vue
+++ b/panel/src/components/Collection/Item.vue
@@ -172,6 +172,8 @@ export default {
 	--item-button-height: var(--height-md);
 	--item-button-width: var(--height-md);
 	--item-color-back: light-dark(var(--color-white), var(--color-gray-850));
+	--item-color-icon: light-dark(var(--color-gray-800), var(--color-gray-400));
+	--item-color-image: light-dark(var(--color-gray-300), var(--color-gray-950));
 	--item-height: auto;
 	--item-height-cardlet: calc(var(--height-md) * 3);
 	--item-shadow: var(--shadow-sm);
@@ -187,10 +189,6 @@ export default {
 }
 .k-item:has(a:focus) {
 	outline: 2px solid var(--color-focus);
-}
-
-.k-item .k-icon-frame {
-	--back: var(--color-gray-300);
 }
 
 .k-item-content {
@@ -351,14 +349,6 @@ export default {
 	margin-top: 0.125em;
 }
 
-/** Theme: disabled */
-.k-item[data-theme="disabled"] {
-	background: transparent;
-	box-shadow: none;
-	outline: 1px solid var(--color-border);
-	outline-offset: -1px;
-}
-
 /** Selectable state */
 .k-item[data-selecting="true"][data-selectable="true"] {
 	cursor: pointer;
@@ -374,5 +364,25 @@ export default {
 .k-item[data-selectable="true"]:has(.k-item-options-checkbox input:checked) {
 	--item-color-back: light-dark(var(--color-blue-250), var(--color-blue-800));
 	--item-shadow: 0 1px 3px 0 rgba(0 0 0 / 0.25), 0 1px 2px 0 rgba(0 0 0 / 0.05);
+}
+
+/** Theme: disabled */
+.k-item[data-theme="disabled"] {
+	background: transparent;
+	box-shadow: none;
+	outline: 1px solid var(--color-border);
+	outline-offset: -1px;
+}
+
+/** Theme: skeleton */
+.k-item[data-theme="skeleton"] {
+	--item-color-icon: light-dark(var(--color-gray-500), var(--color-gray-650));
+	--item-color-image: light-dark(var(--color-gray-250), var(--color-gray-800));
+}
+.k-item[data-theme="skeleton"] .k-item-content {
+	opacity: 0.4;
+}
+.k-item[data-theme="skeleton"] .k-item-options {
+	visibility: hidden;
 }
 </style>

--- a/panel/src/components/Collection/Item.vue
+++ b/panel/src/components/Collection/Item.vue
@@ -33,10 +33,10 @@
 					:to="link"
 				>
 					<!-- eslint-disable-next-line vue/no-v-html -->
-					<span v-html="text ?? '–'" />
+					<span v-html="text ?? '&nbsp;'" />
 				</k-link>
 				<!-- eslint-disable-next-line vue/no-v-html -->
-				<span v-else v-html="text ?? '–'" />
+				<span v-else v-html="text ?? '&nbsp;'" />
 			</h3>
 			<!-- eslint-disable-next-line vue/no-v-html -->
 			<p v-if="info" :title="title(info)" class="k-item-info" v-html="info" />
@@ -379,9 +379,7 @@ export default {
 	--item-color-icon: light-dark(var(--color-gray-500), var(--color-gray-650));
 	--item-color-image: light-dark(var(--color-gray-250), var(--color-gray-800));
 }
-.k-item[data-theme="skeleton"] .k-item-content {
-	opacity: 0.4;
-}
+
 .k-item[data-theme="skeleton"] .k-item-options {
 	visibility: hidden;
 }

--- a/panel/src/components/Collection/ItemImage.vue
+++ b/panel/src/components/Collection/ItemImage.vue
@@ -37,7 +37,7 @@ export default {
 	computed: {
 		attrs() {
 			return {
-				back: this.image.back ?? "gray-500",
+				back: this.image.back,
 				cover: true,
 				...this.image,
 				ratio: this.layout === "list" ? "auto" : this.image.ratio,
@@ -67,3 +67,10 @@ export default {
 	}
 };
 </script>
+
+<style>
+.k-item-image {
+	--back: var(--item-color-image);
+	--icon-color: var(--item-color-icon);
+}
+</style>


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

The idea is to have an `k-item` theme that can be used while an item is still being loaded as placeholder.

I don't think this is necessarily the best design, but I could not come up with something better and am counting a little bit on @bastianallgeier to maybe have a better idea how it should look like.

Lab: https://sandbox.test/panel/lab/components/item/4_skeletons

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
-`sekeleton` theme for `k-item`

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion