### PR TITLE
fix: Use null as default for input prop

### DIFF
--- a/panel/src/components/Forms/Field.vue
+++ b/panel/src/components/Forms/Field.vue
@@ -57,7 +57,10 @@ export const props = {
 	props: {
 		counter: [Boolean, Object],
 		endpoints: Object,
-		input: [String, Number, Boolean],
+		input: {
+			type: [String, Number, Boolean],
+			default: null
+		},
 		translate: Boolean,
 		type: String
 	}


### PR DESCRIPTION
## Description 

This PR is replacing https://github.com/getkirby/kirby/pull/7508

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes

- Use `null` as default for the Field input prop to avoid an unintended removal of the required asterisk in the label #7506

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion