### PR TITLE
refact!: Move more logic to `picker` field mixin

### DIFF
--- a/config/fields/files.php
+++ b/config/fields/files.php
@@ -1,8 +1,6 @@
 <?php
 
 use Kirby\Cms\ModelWithContent;
-use Kirby\Data\Data;
-use Kirby\Toolkit\A;
 
 return [
 	'mixins' => [
@@ -54,39 +52,15 @@ return [
 			return $this->query ?? $this->parentModel::CLASS_ALIAS . '.files';
 		},
 		'default' => function () {
-			return $this->toFiles($this->default);
+			return $this->toFormValues($this->default);
 		},
 		'value' => function () {
-			return $this->toFiles($this->value);
+			return $this->toFormValues($this->value);
 		},
 	],
 	'methods' => [
-		'fileResponse' => function ($file) {
-			return $file->panel()->pickerData([
-				'image'  => $this->image,
-				'info'   => $this->info ?? false,
-				'layout' => $this->layout,
-				'model'  => $this->model(),
-				'text'   => $this->text,
-			]);
-		},
-		'toFiles' => function ($value = null) {
-			$files = [];
-
-			foreach (Data::decode($value, 'yaml') as $id) {
-				if (is_array($id) === true) {
-					$id = $id['uuid'] ?? $id['id'] ?? null;
-				}
-
-				if (
-					$id !== null &&
-					($file = $this->kirby()->file($id, $this->model()))
-				) {
-					$files[] = $this->fileResponse($file);
-				}
-			}
-
-			return $files;
+		'toModel' => function (string $id) {
+			return $this->kirby()->file($id, $this->model());
 		}
 	],
 	'api' => function () {
@@ -132,7 +106,7 @@ return [
 		];
 	},
 	'save' => function ($value = null) {
-		return A::pluck($value, $this->store);
+		return $this->toStoredValues($value);
 	},
 	'validations' => [
 		'max',

--- a/config/fields/mixins/picker.php
+++ b/config/fields/mixins/picker.php
@@ -98,6 +98,21 @@ return [
 		'getIdFromArray' => function (array $array) {
 			return $array['uuid'] ?? $array['id'] ?? null;
 		},
+		'toFormValues' => function ($value = null) {
+			$items = [];
+
+			foreach (Data::decode($value, 'yaml') as $id) {
+				if (is_array($id) === true) {
+					$id = $this->getIdFromArray($id);
+				}
+
+				if ($id !== null && ($model = $this->toModel($id))) {
+					$items[] = $this->toItem($model);
+				}
+			}
+
+			return $items;
+		},
 		'toItem' => function (ModelWithContent $model) {
 			return $model->panel()->pickerData([
 				'image'  => $this->image,
@@ -115,21 +130,6 @@ return [
 		},
 		'toModel' => function (string $id) {
 			throw new Exception(message: 'toModel() is not implemented on ' . $this->type() . ' field');
-		},
-		'toFormValues' => function ($value = null) {
-			$items = [];
-
-			foreach (Data::decode($value, 'yaml') as $id) {
-				if (is_array($id) === true) {
-					$id = $this->getIdFromArray($id);
-				}
-
-				if ($id !== null && ($model = $this->toModel($id))) {
-					$items[] = $this->toItem($model);
-				}
-			}
-
-			return $items;
 		},
 		'toStoredValues' => function ($value = null) {
 			return A::map(

--- a/config/fields/mixins/picker.php
+++ b/config/fields/mixins/picker.php
@@ -1,5 +1,9 @@
 <?php
 
+use Kirby\Cms\ModelWithContent;
+use Kirby\Data\Data;
+use Kirby\Exception\Exception;
+use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
 use Kirby\Uuid\Uuids;
@@ -90,4 +94,48 @@ return [
 			return $text;
 		},
 	],
+	'methods' => [
+		'getIdFromArray' => function (array $array) {
+			return $array['uuid'] ?? $array['id'] ?? null;
+		},
+		'toItem' => function (ModelWithContent $model) {
+			return $model->panel()->pickerData([
+				'image'  => $this->image,
+				'info'   => $this->info ?? false,
+				'layout' => $this->layout,
+				'model'  => $this->model(),
+				'text'   => $this->text,
+			]);
+		},
+		'toItems' => function (array $models) {
+			return A::map(
+				$models,
+				fn ($model) => $this->toItem($model)
+			);
+		},
+		'toModel' => function (string $id) {
+			throw new Exception(message: 'toModel() is not implemented on ' . $this->type() . ' field');
+		},
+		'toFormValues' => function ($value = null) {
+			$items = [];
+
+			foreach (Data::decode($value, 'yaml') as $id) {
+				if (is_array($id) === true) {
+					$id = $this->getIdFromArray($id);
+				}
+
+				if ($id !== null && ($model = $this->toModel($id))) {
+					$items[] = $this->toItem($model);
+				}
+			}
+
+			return $items;
+		},
+		'toStoredValues' => function ($value = null) {
+			return A::map(
+				$value ?? [],
+				fn (array $item) => $item[$this->store]
+			);
+		},
+	]
 ];

--- a/config/fields/pages.php
+++ b/config/fields/pages.php
@@ -1,7 +1,5 @@
 <?php
 
-use Kirby\Cms\App;
-use Kirby\Data\Data;
 use Kirby\Toolkit\A;
 
 return [
@@ -25,7 +23,7 @@ return [
 		 * Default selected page(s) when a new page/file/user is created
 		 */
 		'default' => function ($default = null) {
-			return $this->toPages($default);
+			return $this->toFormValues($default);
 		},
 
 		/**
@@ -43,7 +41,7 @@ return [
 		},
 
 		'value' => function ($value = null) {
-			return $this->toPages($value);
+			return $this->toFormValues($value);
 		},
 	],
 	'computed' => [
@@ -53,29 +51,8 @@ return [
 		'default' => null
 	],
 	'methods' => [
-		'pageResponse' => function ($page) {
-			return $page->panel()->pickerData([
-				'image'  => $this->image,
-				'info'   => $this->info,
-				'layout' => $this->layout,
-				'text'   => $this->text,
-			]);
-		},
-		'toPages' => function ($value = null) {
-			$pages = [];
-			$kirby = App::instance();
-
-			foreach (Data::decode($value, 'yaml') as $id) {
-				if (is_array($id) === true) {
-					$id =  $id['uuid'] ?? $id['id'] ?? null;
-				}
-
-				if ($id !== null && ($page = $kirby->page($id))) {
-					$pages[] = $this->pageResponse($page);
-				}
-			}
-
-			return $pages;
+		'toModel' => function (string $id) {
+			return $this->kirby()->page($id);
 		}
 	],
 	'api' => function () {
@@ -102,7 +79,7 @@ return [
 		];
 	},
 	'save' => function ($value = null) {
-		return A::pluck($value, $this->store);
+		return $this->toStoredValues($value);
 	},
 	'validations' => [
 		'max',

--- a/config/fields/users.php
+++ b/config/fields/users.php
@@ -1,7 +1,5 @@
 <?php
 
-use Kirby\Cms\App;
-use Kirby\Data\Data;
 use Kirby\Toolkit\A;
 
 return [
@@ -29,7 +27,7 @@ return [
 		},
 
 		'value' => function ($value = null) {
-			return $this->toUsers($value);
+			return $this->toFormValues($value);
 		},
 	],
 	'computed' => [
@@ -42,38 +40,18 @@ return [
 				$this->default === true &&
 				$user = $this->kirby()->user()
 			) {
-				return [
-					$this->userResponse($user)
-				];
+				return [$this->toItem($user)];
 			}
 
-			return $this->toUsers($this->default);
+			return $this->toFormValues($this->default);
 		}
 	],
 	'methods' => [
-		'userResponse' => function ($user) {
-			return $user->panel()->pickerData([
-				'info'   => $this->info,
-				'image'  => $this->image,
-				'layout' => $this->layout,
-				'text'   => $this->text,
-			]);
+		'getIdFromArray' => function (array $array) {
+			return $array['uuid'] ?? $array['id'] ?? $array['email'] ?? null;
 		},
-		'toUsers' => function ($value = null): array {
-			$users = [];
-			$kirby = App::instance();
-
-			foreach (Data::decode($value, 'yaml') as $id) {
-				if (is_array($id) === true) {
-					$id =  $id['uuid'] ?? $id['id'] ?? $id['email'] ?? null;
-				}
-
-				if ($id !== null && ($user = $kirby->user($id))) {
-					$users[] = $this->userResponse($user);
-				}
-			}
-
-			return $users;
+		'toModel' => function (string $id) {
+			return $this->kirby()->user($id);
 		}
 	],
 	'api' => function () {
@@ -98,7 +76,7 @@ return [
 		];
 	},
 	'save' => function ($value = null) {
-		return A::pluck($value, $this->store);
+		return $this->toStoredValues($value);
 	},
 	'validations' => [
 		'max',

--- a/tests/Form/Field/FilesFieldTest.php
+++ b/tests/Form/Field/FilesFieldTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Form\Field;
 
 use Kirby\Cms\App;
+use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Cms\User;
@@ -325,5 +326,16 @@ class FilesFieldTest extends TestCase
 		]);
 
 		$this->assertSame('id', $field->store());
+	}
+
+	public function testToModel(): void
+	{
+		$field = $this->field('files', [
+			'model' => new Page(['slug' => 'test']),
+		]);
+
+		$model = $field->toModel('test/a.jpg');
+		$this->assertInstanceOf(File::class, $model);
+		$this->assertSame('test/a.jpg', $model->id());
 	}
 }

--- a/tests/Form/Field/Mixins/PickerMixinTest.php
+++ b/tests/Form/Field/Mixins/PickerMixinTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Exception;
+use Kirby\Cms\App;
+use Kirby\Cms\Page;
+use Kirby\Form\Field;
+
+class PickerMixinTest extends TestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Form.Fields.PickerMixin';
+
+	protected Field $field;
+
+	public function setUp(): void
+	{
+		$kirby = new App([
+			'roots' => [
+				'index' => static::TMP
+			]
+		]);
+
+		Field::$types = [
+			'test' => [
+				'mixins' => ['picker']
+			]
+		];
+
+		$kirby->impersonate('kirby');
+
+		$this->field = $this->field('test', [
+			'model' => new Page(['slug' => 'test']),
+		]);
+	}
+
+	public function tearDown(): void
+	{
+		App::destroy();
+	}
+
+	public function testGetIdFromArray(): void
+	{
+		$this->assertSame('page://aa', $this->field->getIdFromArray([
+			'id'    => 'a/aa',
+			'uuid'  => 'page://aa'
+		]));
+
+		$this->assertSame('a/aa', $this->field->getIdFromArray([
+			'id'    => 'a/aa'
+		]));
+
+		$this->assertNull($this->field->getIdFromArray([]));
+	}
+
+	public function testToItem(): void
+	{
+		$item = $this->field->toItem(new Page([
+			'slug'    => 'test',
+			'content' => [
+				'title' => 'Test Title'
+			]
+		]));
+
+		$this->assertIsArray($item);
+		$this->assertArrayHasKey('image', $item);
+		$this->assertSame('test', $item['id']);
+		$this->assertSame('Test Title', $item['text']);
+	}
+
+	public function testToItems(): void
+	{
+		$items = $this->field->toItems([
+			new Page(['slug' => 'test']),
+			new Page(['slug' => 'test2'])
+		]);
+
+		$this->assertIsArray($items);
+		$this->assertCount(2, $items);
+		$this->assertArrayHasKey('image', $items[0]);
+		$this->assertArrayHasKey('id', $items[0]);
+		$this->assertArrayHasKey('text', $items[0]);
+	}
+
+	public function testToModel(): void
+	{
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('toModel() is not implemented on test field');
+		$this->field->toModel('a/aa');
+	}
+
+	public function testToStoredValues(): void
+	{
+		$values = $this->field->toStoredValues([
+			['uuid' => 'page://aa'],
+			['uuid' => 'page://bb']
+		]);
+
+		$this->assertSame(['page://aa', 'page://bb'], $values);
+	}
+}

--- a/tests/Form/Field/PagesFieldTest.php
+++ b/tests/Form/Field/PagesFieldTest.php
@@ -240,4 +240,15 @@ class PagesFieldTest extends TestCase
 		$this->assertSame('b', $api['data'][2]['id']);
 		$this->assertSame('c', $api['data'][3]['id']);
 	}
+
+	public function testToModel(): void
+	{
+		$field = $this->field('pages', [
+			'model' => new Page(['slug' => 'test']),
+		]);
+
+		$model = $field->toModel('a/aa');
+		$this->assertInstanceOf(Page::class, $model);
+		$this->assertSame('a/aa', $model->id());
+	}
 }

--- a/tests/Form/Field/UsersFieldTest.php
+++ b/tests/Form/Field/UsersFieldTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Form\Field;
 
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
+use Kirby\Cms\User;
 
 class UsersFieldTest extends TestCase
 {
@@ -98,26 +99,28 @@ class UsersFieldTest extends TestCase
 		$this->assertSame([], $field->default());
 	}
 
-	public function testValue(): void
+	public function testGetIdFromArray(): void
 	{
 		$field = $this->field('users', [
 			'model' => new Page(['slug' => 'test']),
-			'value' => [
-				'leonardo@getkirby.com', // exists
-				'raphael@getkirby.com', // exists
-				'homer@getkirby.com'  // does not exist
-			]
 		]);
 
-		$value = $field->value();
-		$ids   = array_column($value, 'email');
+		$this->assertSame('user://leonardo', $field->getIdFromArray([
+			'email' => 'leonardo@getkirby.com',
+			'id'    => 'leonardo',
+			'uuid'  => 'user://leonardo'
+		]));
 
-		$expected = [
-			'leonardo@getkirby.com',
-			'raphael@getkirby.com'
-		];
+		$this->assertSame('leonardo', $field->getIdFromArray([
+			'email' => 'leonardo@getkirby.com',
+			'id'    => 'leonardo'
+		]));
 
-		$this->assertSame($expected, $ids);
+		$this->assertSame('leonardo@getkirby.com', $field->getIdFromArray([
+			'email' => 'leonardo@getkirby.com'
+		]));
+
+		$this->assertNull($field->getIdFromArray([]));
 	}
 
 	public function testMin(): void
@@ -240,5 +243,38 @@ class UsersFieldTest extends TestCase
 		$this->assertSame('leonardo@getkirby.com', $api['data'][1]['email']);
 		$this->assertSame('michelangelo@getkirby.com', $api['data'][2]['email']);
 		$this->assertSame('raphael@getkirby.com', $api['data'][3]['email']);
+	}
+
+	public function testToModel(): void
+	{
+		$field = $this->field('users', [
+			'model' => new Page(['slug' => 'test']),
+		]);
+
+		$model = $field->toModel('leonardo@getkirby.com');
+		$this->assertInstanceOf(User::class, $model);
+		$this->assertSame('leonardo@getkirby.com', $model->email());
+	}
+
+	public function testValue(): void
+	{
+		$field = $this->field('users', [
+			'model' => new Page(['slug' => 'test']),
+			'value' => [
+				'leonardo@getkirby.com', // exists
+				'raphael@getkirby.com', // exists
+				'homer@getkirby.com'  // does not exist
+			]
+		]);
+
+		$value = $field->value();
+		$ids   = array_column($value, 'email');
+
+		$expected = [
+			'leonardo@getkirby.com',
+			'raphael@getkirby.com'
+		];
+
+		$this->assertSame($expected, $ids);
 	}
 }


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Based on the current construction of the `Form\Field` class, I think we cannot properly test the `save` field method.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- `picker` field mixin provides more centralized logic, e.g. `toItem`, `toItems`, `toFormValues`, `toStoredValues` methods

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- Files field: `fileResponse` and `toFiles` methods have been removed. Use `toItem` and `toFormValues` instead.
- Pages field: `pageResponse` and `toFiles` methods have been removed. Use `toItem` and `toFormValues` instead.
- Users field: `userResponse` and `toFiles` methods have been removed. Use `toItem` and `toFormValues` instead.


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion