### PR TITLE
refact!: Make Symfony default YAML handler

### DIFF
--- a/src/Data/Yaml.php
+++ b/src/Data/Yaml.php
@@ -22,8 +22,8 @@ class Yaml extends Handler
 	public static function encode($data): string
 	{
 		return match (static::handler()) {
-			'symfony' => YamlSymfony::encode($data),
-			default   => YamlSpyc::encode($data),
+			'spyc'  => YamlSpyc::encode($data),
+			default => YamlSymfony::encode($data),
 		};
 	}
 
@@ -47,17 +47,16 @@ class Yaml extends Handler
 		}
 
 		return match (static::handler()) {
-			'symfony' => YamlSymfony::decode($string),
-			default   => YamlSpyc::decode($string)
+			'spyc'  => YamlSpyc::decode($string),
+			default => YamlSymfony::decode($string),
 		};
 	}
 
 	/**
-	 * Returns which YAML parser (`spyc` or `symfony`)
-	 * is configured to be used
+	 * Returns YAML parser configured to be used
 	 */
-	public static function handler(): string
+	public static function handler(): string|null
 	{
-		return App::instance(null, true)?->option('yaml.handler') ?? 'spyc';
+		return App::instance(null, true)?->option('yaml.handler');
 	}
 }

--- a/src/Data/YamlSpyc.php
+++ b/src/Data/YamlSpyc.php
@@ -8,11 +8,12 @@ use Spyc;
 /**
  * Simple Wrapper around the Spyc YAML class
  *
- * @package   Kirby Data
- * @author    Bastian Allgeier <bastian@getkirby.com>
- * @link      https://getkirby.com
- * @copyright Bastian Allgeier
- * @license   https://opensource.org/licenses/MIT
+ * @package    Kirby Data
+ * @author     Bastian Allgeier <bastian@getkirby.com>
+ * @link       https://getkirby.com
+ * @copyright  Bastian Allgeier
+ * @license    https://opensource.org/licenses/MIT
+ * @deprecated 6.0.0 Use `Kirby\Data\YamlSymfony` instead
  */
 class YamlSpyc
 {

--- a/tests/Data/YamlTest.php
+++ b/tests/Data/YamlTest.php
@@ -27,8 +27,8 @@ class YamlTest extends TestCase
 		$result = Yaml::decode($data);
 		$this->assertSame($array, $result);
 
-		$this->assertSame('', Yaml::encode([]));
-		$this->assertSame([], Yaml::decode(''));
+		$this->assertSame('[]', Yaml::encode([]));
+		$this->assertSame([], Yaml::decode('[]'));
 
 		$this->assertSame([], Yaml::decode(null));
 		$this->assertSame(['this is' => 'an array'], Yaml::decode(['this is' => 'an array']));
@@ -77,7 +77,7 @@ class YamlTest extends TestCase
 	public function testEncodeNodeTypes(): void
 	{
 		$data = Yaml::encode(['test' => '']);
-		$this->assertSame('test: ""' . PHP_EOL, $data);
+		$this->assertSame('test: \'\'' . PHP_EOL, $data);
 
 		$data = Yaml::encode(['test' => null]);
 		$this->assertSame('test: null' . PHP_EOL, $data);
@@ -95,6 +95,6 @@ class YamlTest extends TestCase
 		$this->assertSame('test: string' . PHP_EOL, $data);
 
 		$data = Yaml::encode(['test' => '"string"']);
-		$this->assertSame('test: "string"' . PHP_EOL, $data);
+		$this->assertSame('test: \'"string"\'' . PHP_EOL, $data);
 	}
 }

--- a/tests/Option/OptionsQueryTest.php
+++ b/tests/Option/OptionsQueryTest.php
@@ -127,8 +127,7 @@ class OptionsQueryTest extends TestCase
 -
   name: foo
 -
-  name: bar
-				'
+  name: bar'
 			]
 		]);
 


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ☠️ Deprecated
<!-- 
e.g. Deprecate method X. Use method Y instead.
-->
- The Spyc YAML handler has been deprecated and will be removed in a future release.

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- Changed the default YAML handler to Symfony YAML which sometimes enforces a stricter syntax than our previous Spyc handler. You can switch back to Spyc with the config option `'yaml.handler' => 'spyc'`


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion