### PR TITLE
fix: add "audio/wav" mime type

### DIFF
--- a/src/Filesystem/Mime.php
+++ b/src/Filesystem/Mime.php
@@ -98,7 +98,7 @@ class Mime
 		'tgz'   => ['application/x-tar', 'application/x-gzip-compressed'],
 		'tif'   => 'image/tiff',
 		'tiff'  => 'image/tiff',
-		'wav'   => ['audio/wav', 'audio/x-wav'],
+		'wav'   => ['audio/wav', 'audio/x-wav', 'audio/vnd.wave', 'audio/wave'],
 		'wbxml' => 'application/wbxml',
 		'webm'  => 'video/webm',
 		'webp'  => 'image/webp',

--- a/src/Filesystem/Mime.php
+++ b/src/Filesystem/Mime.php
@@ -98,7 +98,7 @@ class Mime
 		'tgz'   => ['application/x-tar', 'application/x-gzip-compressed'],
 		'tif'   => 'image/tiff',
 		'tiff'  => 'image/tiff',
-		'wav'   => ['audio/x-wav', 'audio/wav'],
+		'wav'   => ['audio/wav', 'audio/x-wav'],
 		'wbxml' => 'application/wbxml',
 		'webm'  => 'video/webm',
 		'webp'  => 'image/webp',

--- a/src/Filesystem/Mime.php
+++ b/src/Filesystem/Mime.php
@@ -98,7 +98,7 @@ class Mime
 		'tgz'   => ['application/x-tar', 'application/x-gzip-compressed'],
 		'tif'   => 'image/tiff',
 		'tiff'  => 'image/tiff',
-		'wav'   => 'audio/x-wav',
+		'wav'   => ['audio/x-wav', 'audio/wav'],
 		'wbxml' => 'application/wbxml',
 		'webm'  => 'video/webm',
 		'webp'  => 'image/webp',


### PR DESCRIPTION
## Description
`.wav` files come with either one of two mime types: Either `audio/wav` or `audio/x-wav`. The first one (which seems to be more popular) was missing.
