### PR TITLE
refact!: Rename to `k-dropdown`, drop `align` prop

### DIFF
--- a/panel/lab/components/buttons/5_groups/index.vue
+++ b/panel/lab/components/buttons/5_groups/index.vue
@@ -39,12 +39,12 @@
 					icon="dots"
 					@click="$refs.dropdown.toggle()"
 				/>
-				<k-dropdown-content ref="dropdown" align-x="end">
+				<k-dropdown ref="dropdown" align-x="end">
 					<k-dropdown-item icon="edit">Edit</k-dropdown-item>
 					<k-dropdown-item icon="copy">Duplicate</k-dropdown-item>
 					<hr />
 					<k-dropdown-item icon="trash">Delete</k-dropdown-item>
-				</k-dropdown-content>
+				</k-dropdown>
 			</k-button-group>
 		</k-lab-example>
 		<k-lab-example :flex="true" label="layout: collapsed and themed">
@@ -69,12 +69,12 @@
 						icon="dots"
 						@click="$refs.dropdown.toggle()"
 					/>
-					<k-dropdown-content ref="dropdown" align-x="end">
+					<k-dropdown ref="dropdown" align-x="end">
 						<k-dropdown-item icon="edit">Edit</k-dropdown-item>
 						<k-dropdown-item icon="copy">Duplicate</k-dropdown-item>
 						<hr />
 						<k-dropdown-item icon="trash">Delete</k-dropdown-item>
-					</k-dropdown-content>
+					</k-dropdown>
 				</k-button-group>
 			</k-bar>
 		</k-lab-example>

--- a/panel/lab/components/dropdowns/1_themes/index.vue
+++ b/panel/lab/components/dropdowns/1_themes/index.vue
@@ -8,7 +8,7 @@
 			>
 				Dropdown
 			</k-button>
-			<k-dropdown-content ref="dropdownA" :options="options" />
+			<k-dropdown ref="dropdownA" :options="options" />
 		</k-lab-example>
 		<k-lab-example :flex="true" label="light">
 			<k-button
@@ -18,7 +18,7 @@
 			>
 				Dropdown
 			</k-button>
-			<k-dropdown-content ref="dropdownB" :options="options" theme="light" />
+			<k-dropdown ref="dropdownB" :options="options" theme="light" />
 		</k-lab-example>
 	</k-lab-examples>
 </template>

--- a/panel/lab/components/dropdowns/2_alignment/index.vue
+++ b/panel/lab/components/dropdowns/2_alignment/index.vue
@@ -9,7 +9,7 @@
 						variant="filled"
 						@click="$refs.dropdown.toggle()"
 					/>
-					<k-dropdown-content
+					<k-dropdown
 						ref="dropdown"
 						:options="options"
 						:align-x="x"
@@ -42,7 +42,7 @@ export default {
 	data() {
 		return {
 			x: "start",
-			y: "start",
+			y: "start"
 		};
 	},
 	computed: {
@@ -50,47 +50,47 @@ export default {
 			return [
 				{
 					text: "start (default)",
-					value: "start",
+					value: "start"
 				},
 				{
 					text: "center",
-					value: "center",
+					value: "center"
 				},
 				{
 					text: "end",
-					value: "end",
-				},
+					value: "end"
+				}
 			];
 		},
 		yOptions() {
 			return [
 				{
 					text: "top",
-					value: "top",
+					value: "top"
 				},
 				{
 					text: "bottom",
-					value: "bottom",
-				},
+					value: "bottom"
+				}
 			];
 		},
 		options() {
 			return [
 				{
 					text: "Edit",
-					icon: "edit",
+					icon: "edit"
 				},
 				{
 					text: "Duplicate",
-					icon: "copy",
+					icon: "copy"
 				},
 				"-",
 				{
 					text: "Delete",
-					icon: "trash",
-				},
+					icon: "trash"
+				}
 			];
-		},
-	},
+		}
+	}
 };
 </script>

--- a/panel/lab/components/dropdowns/index.php
+++ b/panel/lab/components/dropdowns/index.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-	'docs' => 'k-dropdown-content',
+	'docs' => 'k-dropdown',
 ];

--- a/panel/src/components/Drawers/Drawer.vue
+++ b/panel/src/components/Drawers/Drawer.vue
@@ -23,7 +23,7 @@
 								class="k-drawer-option"
 								@click="$refs['dropdown-' + index][0].toggle()"
 							/>
-							<k-dropdown-content
+							<k-dropdown
 								:ref="'dropdown-' + index"
 								:key="'dropdown-' + index"
 								:options="option.dropdown"

--- a/panel/src/components/Dropdowns/Dropdown.vue
+++ b/panel/src/components/Dropdowns/Dropdown.vue
@@ -2,18 +2,18 @@
 	<dialog
 		v-if="isOpen"
 		ref="dropdown"
-		:data-align-x="axis.x"
-		:data-align-y="axis.y"
+		:data-align-x="align.x"
+		:data-align-y="align.y"
 		:data-theme="theme"
 		:style="{
 			top: position.y + 'px',
 			left: position.x + 'px'
 		}"
-		class="k-dropdown-content"
+		class="k-dropdown k-dropdown-content"
 		@close="onClose"
 		@click="onClick"
 	>
-		<k-navigate ref="navigate" :disabled="navigate === false" axis="y">
+		<k-navigate ref="navigate" :disabled="navigate === false" align="y">
 			<!-- @slot Content of the dropdown which overrides passed `options` prop -->
 			<slot v-bind="{ items }">
 				<template v-for="(option, index) in items">
@@ -41,19 +41,10 @@
 let OpenDropdown = null;
 
 /**
- * Dropdowns are constructed with two elements: `<k-dropdown-content>` holds any content shown when opening the dropdown: any number of `<k-dropdown-item>` elements or any other HTML; typically a `<k-button>` then is used to call the `toggle()` method on `<k-dropdown-content>`.
- *
- * @todo rename to `k-dropdown` in v6 (with alias to old name)
+ * Dropdowns are constructed with two elements: `<k-dropdown>` holds any content shown when opening the dropdown: any number of `<k-dropdown-item>` elements or any other HTML; typically a `<k-button>` then is used to call the `toggle()` method on `<k-dropdown>`.
  */
 export default {
 	props: {
-		/**
-		 * @deprecated 4.0.0 Use `align-x` instead
-		 * @todo rename `axis` data to `align` when removed
-		 */
-		align: {
-			type: String
-		},
 		/**
 		 * Default horizontal alignment of the dropdown
 		 * @since 4.0.0
@@ -111,7 +102,7 @@ export default {
 	],
 	data() {
 		return {
-			axis: {
+			align: {
 				x: this.alignX,
 				y: this.alignY
 			},
@@ -123,13 +114,6 @@ export default {
 			items: [],
 			opener: null
 		};
-	},
-	mounted() {
-		if (this.align) {
-			window.panel.deprecated(
-				"<k-dropdown-content>: `align` prop will be removed in a future version. Use the `alignX` prop instead."
-			);
-		}
 	},
 	methods: {
 		/**
@@ -248,23 +232,23 @@ export default {
 		async setPosition() {
 			// reset to the alignment defaults
 			// before running position calculation
-			this.axis = {
+			this.align = {
 				x: this.alignX ?? this.align,
 				y: this.alignY
 			};
 
-			if (this.axis.x === "right") {
-				this.axis.x = "end";
-			} else if (this.axis.x === "left") {
-				this.axis.x = "start";
+			if (this.align.x === "right") {
+				this.align.x = "end";
+			} else if (this.align.x === "left") {
+				this.align.x = "start";
 			}
 
-			// flip x axis for RTL languages
+			// flip x align for RTL languages
 			if (this.$panel.direction === "rtl") {
-				if (this.axis.x === "start") {
-					this.axis.x = "end";
-				} else if (this.axis.x === "end") {
-					this.axis.x = "start";
+				if (this.align.x === "start") {
+					this.align.x = "end";
+				} else if (this.align.x === "end") {
+					this.align.x = "start";
 				}
 			}
 
@@ -295,35 +279,35 @@ export default {
 
 			// Horizontal: check if dropdown is outside of viewport
 			// and adapt alignment if necessary
-			if (this.axis.x === "end") {
+			if (this.align.x === "end") {
 				if (opener.left - rect.width < safeSpace) {
-					this.axis.x = "start";
+					this.align.x = "start";
 				}
 			} else if (
 				opener.left + rect.width > window.innerWidth - safeSpace &&
 				rect.width + safeSpace < rect.left
 			) {
-				this.axis.x = "end";
+				this.align.x = "end";
 			}
 
-			if (this.axis.x === "start") {
+			if (this.align.x === "start") {
 				this.position.x = this.position.x - opener.width;
 			}
 
 			// Vertical: check if dropdown is outside of viewport
 			// and adapt alignment if necessary
-			if (this.axis.y === "top") {
+			if (this.align.y === "top") {
 				if (rect.height + safeSpace > rect.top) {
-					this.axis.y = "bottom";
+					this.align.y = "bottom";
 				}
 			} else if (
 				opener.top + rect.height > window.innerHeight - safeSpace &&
 				rect.height + safeSpace < rect.top
 			) {
-				this.axis.y = "top";
+				this.align.y = "top";
 			}
 
-			if (this.axis.y === "top") {
+			if (this.align.y === "top") {
 				this.position.y = this.position.y - opener.height;
 			}
 		},
@@ -352,7 +336,7 @@ export default {
 	--dropdown-shadow: var(--shadow-xl);
 }
 
-.k-dropdown-content {
+.k-dropdown {
 	--dropdown-x: 0;
 	--dropdown-y: 0;
 	position: absolute;
@@ -368,27 +352,27 @@ export default {
 	text-align: start;
 	transform: translate(var(--dropdown-x), var(--dropdown-y));
 }
-.k-dropdown-content::backdrop {
+.k-dropdown::backdrop {
 	background: none;
 }
 
-.k-dropdown-content[data-align-x="end"] {
+.k-dropdown[data-align-x="end"] {
 	--dropdown-x: -100%;
 }
-.k-dropdown-content[data-align-x="center"] {
+.k-dropdown[data-align-x="center"] {
 	--dropdown-x: -50%;
 }
-.k-dropdown-content[data-align-y="top"] {
+.k-dropdown[data-align-y="top"] {
 	--dropdown-y: -100%;
 }
 
-.k-dropdown-content hr {
+.k-dropdown hr {
 	margin: 0.5rem 0;
 	height: 1px;
 	background: var(--dropdown-color-hr);
 }
 
-.k-dropdown-content[data-theme="light"] {
+.k-dropdown[data-theme="light"] {
 	--dropdown-color-bg: var(--color-white);
 	--dropdown-color-current: var(--color-blue-800);
 	--dropdown-color-hr: var(--color-gray-250);

--- a/panel/src/components/Dropdowns/DropdownItem.vue
+++ b/panel/src/components/Dropdowns/DropdownItem.vue
@@ -13,7 +13,7 @@
 
 <script>
 /**
- * Item to be used within `<k-dropdown-content>`
+ * Item to be used within `<k-dropdown>`
  * @example <k-dropdown-item>Option A</k-dropdown-item>
  * @unstable
  */

--- a/panel/src/components/Dropdowns/OptionsDropdown.vue
+++ b/panel/src/components/Dropdowns/OptionsDropdown.vue
@@ -32,7 +32,7 @@
 			class="k-options-dropdown-toggle"
 			@click="$refs.options.toggle()"
 		/>
-		<k-dropdown-content
+		<k-dropdown
 			ref="options"
 			:align-x="align"
 			:options="options"

--- a/panel/src/components/Dropdowns/PicklistDropdown.vue
+++ b/panel/src/components/Dropdowns/PicklistDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-	<k-dropdown-content
+	<k-dropdown
 		ref="dropdown"
 		align-x="start"
 		:disabled="disabled"
@@ -14,7 +14,7 @@
 			@input="input"
 			@escape="$refs.dropdown.close()"
 		/>
-	</k-dropdown-content>
+	</k-dropdown>
 </template>
 
 <script>

--- a/panel/src/components/Dropdowns/index.js
+++ b/panel/src/components/Dropdowns/index.js
@@ -1,4 +1,4 @@
-import DropdownContent from "./DropdownContent.vue";
+import Dropdown from "./Dropdown.vue";
 import DropdownItem from "./DropdownItem.vue";
 
 import OptionsDropdown from "./OptionsDropdown.vue";
@@ -6,10 +6,13 @@ import PicklistDropdown from "./PicklistDropdown.vue";
 
 export default {
 	install(app) {
-		app.component("k-dropdown-content", DropdownContent);
+		app.component("k-dropdown", Dropdown);
 		app.component("k-dropdown-item", DropdownItem);
 
 		app.component("k-options-dropdown", OptionsDropdown);
 		app.component("k-picklist-dropdown", PicklistDropdown);
+
+		// @deprecated
+		app.component("k-dropdown-content", Dropdown);
 	}
 };

--- a/panel/src/components/Forms/Blocks/BlockOptions.vue
+++ b/panel/src/components/Forms/Blocks/BlockOptions.vue
@@ -205,7 +205,7 @@ export default {
 .k-block-options > .k-button:not(:last-of-type) {
 	border-inline-end: 1px solid var(--toolbar-border);
 }
-.k-block-options .k-dropdown-content {
+.k-block-options .k-dropdown {
 	margin-top: 0.5rem;
 }
 </style>

--- a/panel/src/components/Forms/Blocks/Elements/BlockBackgroundDropdown.vue
+++ b/panel/src/components/Forms/Blocks/Elements/BlockBackgroundDropdown.vue
@@ -8,7 +8,7 @@
 		>
 			<k-color-frame :color="valueAdapted" ratio="1/1" />
 		</k-button>
-		<k-dropdown-content
+		<k-dropdown
 			ref="dropdown"
 			align-x="end"
 			:options="[

--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -23,7 +23,7 @@
 					size="xs"
 					@click="$refs.options.toggle()"
 				/>
-				<k-dropdown-content ref="options" :options="options" align-x="end" />
+				<k-dropdown ref="options" :options="options" align-x="end" />
 			</k-button-group>
 		</template>
 

--- a/panel/src/components/Forms/Field/ColorField.vue
+++ b/panel/src/components/Forms/Field/ColorField.vue
@@ -26,7 +26,7 @@
 					>
 						<k-color-frame :color="value" />
 					</button>
-					<k-dropdown-content ref="picker" class="k-color-field-picker">
+					<k-dropdown ref="picker" class="k-color-field-picker">
 						<k-colorpicker-input
 							ref="color"
 							v-bind="$props"
@@ -34,7 +34,7 @@
 							@input="$emit('input', $event)"
 							@click.stop
 						/>
-					</k-dropdown-content>
+					</k-dropdown>
 				</template>
 				<k-color-frame v-else :color="value" />
 			</template>

--- a/panel/src/components/Forms/Field/DateField.vue
+++ b/panel/src/components/Forms/Field/DateField.vue
@@ -22,14 +22,14 @@
 						class="k-input-icon-button"
 						@click="$refs.calendar.toggle()"
 					/>
-					<k-dropdown-content ref="calendar" align-x="end">
+					<k-dropdown ref="calendar" align-x="end">
 						<k-calendar
 							:value="iso.date"
 							:min="min"
 							:max="max"
 							@input="onDateInput"
 						/>
-					</k-dropdown-content>
+					</k-dropdown>
 				</template>
 			</k-input>
 
@@ -55,13 +55,13 @@
 						class="k-input-icon-button"
 						@click="$refs.times.toggle()"
 					/>
-					<k-dropdown-content ref="times" align-x="end">
+					<k-dropdown ref="times" align-x="end">
 						<k-timeoptions-input
 							:display="time.display"
 							:value="value"
 							@input="onTimesInput"
 						/>
-					</k-dropdown-content>
+					</k-dropdown>
 				</template>
 			</k-input>
 		</div>

--- a/panel/src/components/Forms/Field/EntriesField.vue
+++ b/panel/src/components/Forms/Field/EntriesField.vue
@@ -25,7 +25,7 @@
 					size="xs"
 					@click="$refs.options.toggle()"
 				/>
-				<k-dropdown-content ref="options" :options="options" align-x="end" />
+				<k-dropdown ref="options" :options="options" align-x="end" />
 			</k-button-group>
 		</template>
 

--- a/panel/src/components/Forms/Field/LayoutField.vue
+++ b/panel/src/components/Forms/Field/LayoutField.vue
@@ -21,7 +21,7 @@
 					size="xs"
 					@click="$refs.options.toggle()"
 				/>
-				<k-dropdown-content ref="options" :options="options" align-x="end" />
+				<k-dropdown ref="options" :options="options" align-x="end" />
 			</k-button-group>
 		</template>
 

--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -20,7 +20,7 @@
 				>
 					{{ currentType.label }}
 				</k-button>
-				<k-dropdown-content ref="types" :options="activeTypesOptions" />
+				<k-dropdown ref="types" :options="activeTypesOptions" />
 
 				<!-- Input -->
 				<div

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -33,7 +33,7 @@
 						variant="filled"
 						@click="$refs.options.toggle()"
 					/>
-					<k-dropdown-content
+					<k-dropdown
 						ref="options"
 						:options="[
 							{

--- a/panel/src/components/Forms/Field/TimeField.vue
+++ b/panel/src/components/Forms/Field/TimeField.vue
@@ -19,13 +19,13 @@
 					class="k-input-icon-button"
 					@click="$refs.times.toggle()"
 				/>
-				<k-dropdown-content ref="times" align-x="end">
+				<k-dropdown ref="times" align-x="end">
 					<k-timeoptions-input
 						:display="display"
 						:value="value"
 						@input="select"
 					/>
-				</k-dropdown-content>
+				</k-dropdown>
 			</template>
 		</k-input>
 	</k-field>

--- a/panel/src/components/Forms/FormControls.vue
+++ b/panel/src/components/Forms/FormControls.vue
@@ -12,11 +12,7 @@
 			variant="filled"
 			:size="size"
 		/>
-		<k-dropdown-content
-			ref="dropdown"
-			align-x="end"
-			class="k-form-controls-dropdown"
-		>
+		<k-dropdown ref="dropdown" align-x="end" class="k-form-controls-dropdown">
 			<p v-if="isLocked">
 				{{ $t("form.locked") }}
 			</p>
@@ -46,7 +42,7 @@
 					{{ $t("form.preview") }}
 				</k-dropdown-item>
 			</template>
-		</k-dropdown-content>
+		</k-dropdown>
 	</k-button-group>
 </template>
 

--- a/panel/src/components/Forms/Layouts/Layout.vue
+++ b/panel/src/components/Forms/Layouts/Layout.vue
@@ -40,7 +40,7 @@
 				icon="angle-down"
 				@click="$refs.options.toggle()"
 			/>
-			<k-dropdown-content ref="options" :options="options" align-x="end" />
+			<k-dropdown ref="options" :options="options" align-x="end" />
 			<k-sort-handle />
 		</nav>
 	</section>

--- a/panel/src/components/Forms/Toolbar/Toolbar.vue
+++ b/panel/src/components/Forms/Toolbar/Toolbar.vue
@@ -19,7 +19,7 @@
 						: button.click?.($event)
 				"
 			/>
-			<k-dropdown-content
+			<k-dropdown
 				v-if="(button.when ?? true) && button.dropdown?.length"
 				:key="index + '-dropdown'"
 				:ref="index + '-dropdown'"

--- a/panel/src/components/Layout/Tabs.vue
+++ b/panel/src/components/Layout/Tabs.vue
@@ -20,7 +20,7 @@
 				variant="dimmed"
 				@click.stop="$refs.more.toggle()"
 			/>
-			<k-dropdown-content
+			<k-dropdown
 				ref="more"
 				:options="dropdown"
 				align-x="end"

--- a/panel/src/components/Navigation/Breadcrumb.vue
+++ b/panel/src/components/Navigation/Breadcrumb.vue
@@ -2,7 +2,7 @@
 	<nav :aria-label="label" class="k-breadcrumb">
 		<div v-if="crumbs.length > 1" class="k-breadcrumb-dropdown">
 			<k-button icon="home" @click="$refs.dropdown.toggle()" />
-			<k-dropdown-content ref="dropdown" :options="dropdown" />
+			<k-dropdown ref="dropdown" :options="dropdown" />
 		</div>
 
 		<ol>
@@ -104,7 +104,7 @@ export default {
 .k-breadcrumb-dropdown {
 	display: grid;
 }
-.k-breadcrumb-dropdown .k-dropdown-content {
+.k-breadcrumb-dropdown .k-dropdown {
 	width: 15rem;
 }
 

--- a/panel/src/components/Navigation/Pagination.vue
+++ b/panel/src/components/Navigation/Pagination.vue
@@ -28,7 +28,7 @@
 				@click="$refs.dropdown.toggle()"
 			/>
 
-			<k-dropdown-content
+			<k-dropdown
 				ref="dropdown"
 				align-x="end"
 				class="k-pagination-selector"
@@ -51,7 +51,7 @@
 					</label>
 					<k-button type="submit" icon="check" />
 				</form>
-			</k-dropdown-content>
+			</k-dropdown>
 		</template>
 
 		<!-- next -->

--- a/panel/src/components/Navigation/SearchBar.vue
+++ b/panel/src/components/Navigation/SearchBar.vue
@@ -11,7 +11,7 @@
 					class="k-search-bar-types"
 					@click="$refs.types.toggle()"
 				/>
-				<k-dropdown-content ref="types" :options="typesDropdown" />
+				<k-dropdown ref="types" :options="typesDropdown" />
 			</template>
 
 			<!-- Input -->

--- a/panel/src/components/View/Buttons/Button.vue
+++ b/panel/src/components/View/Buttons/Button.vue
@@ -5,7 +5,7 @@
 			:dropdown="dropdown || hasDropdown"
 			@click="onClick"
 		/>
-		<k-dropdown-content
+		<k-dropdown
 			v-if="hasDropdown"
 			ref="dropdown"
 			:options="Array.isArray(options) ? options : $dropdown(options)"

--- a/panel/src/components/View/Buttons/LanguagesDropdown.vue
+++ b/panel/src/components/View/Buttons/LanguagesDropdown.vue
@@ -6,11 +6,7 @@
 			:dropdown="true"
 			@click="$refs.dropdown.toggle()"
 		/>
-		<k-dropdown-content
-			ref="dropdown"
-			:options="$dropdown(options)"
-			align-x="end"
-		>
+		<k-dropdown ref="dropdown" :options="$dropdown(options)" align-x="end">
 			<template #item="{ item: language, index }">
 				<k-button
 					:key="'item-' + index"
@@ -36,7 +32,7 @@
 					</span>
 				</k-button>
 			</template>
-		</k-dropdown-content>
+		</k-dropdown>
 	</div>
 </template>
 

--- a/panel/src/components/Views/Files/FilePreviewFrame.vue
+++ b/panel/src/components/Views/Files/FilePreviewFrame.vue
@@ -10,7 +10,7 @@
 					class="k-file-preview-frame-dropdown-toggle"
 					@click="$refs.dropdown.toggle()"
 				/>
-				<k-dropdown-content
+				<k-dropdown
 					ref="dropdown"
 					:options="options"
 					theme="light"

--- a/panel/src/components/Views/Preview/PreviewView.vue
+++ b/panel/src/components/Views/Preview/PreviewView.vue
@@ -19,9 +19,9 @@
 				>
 					{{ title }}
 				</k-button>
-				<k-dropdown-content ref="tree" theme="dark" class="k-preview-view-tree">
+				<k-dropdown ref="tree" theme="dark" class="k-preview-view-tree">
 					<k-page-tree :current="id" @click.stop @select="navigate" />
-				</k-dropdown-content>
+				</k-dropdown>
 			</k-button-group>
 
 			<k-button-group>

--- a/panel/src/components/Views/System/TableUpdateStatusCell.vue
+++ b/panel/src/components/Views/System/TableUpdateStatusCell.vue
@@ -18,7 +18,7 @@
 				variant="filled"
 				@click.stop="$refs.dropdown.toggle()"
 			/>
-			<k-dropdown-content ref="dropdown" align-x="end">
+			<k-dropdown ref="dropdown" align-x="end">
 				<dl class="k-plugin-info">
 					<dt>{{ $t("plugin") }}</dt>
 					<dd>{{ value.pluginName }}</dd>
@@ -35,7 +35,7 @@
 						{{ $t("versionInformation") }}
 					</k-button>
 				</template>
-			</k-dropdown-content>
+			</k-dropdown>
 		</template>
 	</div>
 </template>

--- a/panel/src/components/Views/Users/UserAvatar.vue
+++ b/panel/src/components/Views/Users/UserAvatar.vue
@@ -7,7 +7,7 @@
 	>
 		<template v-if="avatar">
 			<k-image-frame :cover="true" :src="avatar" />
-			<k-dropdown-content
+			<k-dropdown
 				ref="dropdown"
 				:options="[
 					{


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- `k-dropdown-content` has been renamed to `k-dropdown`. The `align` prop has been removed. Use `align-x` instead.


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion