### PR TITLE
refact: Use `json_validate` for `V::json()`

### DIFF
--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -448,13 +448,11 @@ V::$validators = [
 	 * Checks for valid json
 	 */
 	'json' => function ($value): bool {
-		if (!is_string($value) || $value === '') {
+		if (is_string($value) === false) {
 			return false;
 		}
 
-		json_decode($value);
-
-		return json_last_error() === JSON_ERROR_NONE;
+		return json_validate($value);
 	},
 
 	/**


### PR DESCRIPTION
Code coverage is wrong. `VTest::testJson()` exists.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
-  Use `json_validate` for `V::json()`

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion