### PR TITLE
fix: Page create ignore all core fields

### DIFF
--- a/src/Panel/Controller/Dialog/PageCreateDialogController.php
+++ b/src/Panel/Controller/Dialog/PageCreateDialogController.php
@@ -159,13 +159,14 @@ class PageCreateDialogController extends DialogController
 	 */
 	public function customFields(): array
 	{
-		$custom    = [];
-		$ignore    = ['title', 'slug', 'parent', 'template', 'uuid'];
-		$blueprint = $this->blueprint();
-		$fields    = $blueprint->fields();
+		$custom = [];
+		$fields = $this->blueprint()->fields();
+		$ignore = [...array_keys($this->coreFields()), 'title', 'slug'];
 
-		foreach ($blueprint->create()['fields'] ?? [] as $name) {
-			if (!$field = ($fields[$name] ?? null)) {
+		foreach ($this->blueprint()->create()['fields'] ?? [] as $name) {
+			$field = $fields[$name] ?? null;
+
+			if ($field === null) {
 				throw new InvalidArgumentException(
 					message: 'Unknown field  "' . $name . '" in create dialog'
 				);


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

This PR uses all fields that the `::coreFields()` method defines and ignores them instead of a separately defined list of fields.


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion