### PR TITLE
fix: Hide Writer toolbar dropdown for only 1 node

### DIFF
--- a/panel/src/components/Forms/Writer/Toolbar.vue
+++ b/panel/src/components/Forms/Writer/Toolbar.vue
@@ -168,14 +168,14 @@ export default {
 		 * @returns {Boolean}
 		 */
 		hasDropdownEntries() {
-			return this.$helper.object.length(this.dropdownEntries) > 0;
+			return this.$helper.object.length(this.dropdownEntries) > 1;
 		},
 		/**
 		 * Whether there are any inline buttons to show in the toolbar
 		 * @returns {Boolean}
 		 */
 		hasInlineEntries() {
-			return this.$helper.object.length(this.inlineEntries) > 1;
+			return this.$helper.object.length(this.inlineEntries) > 0;
 		},
 		/**
 		 * All inline entries that are available and requested


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

When only one node available, the writer content should be fully that node and we can hide the dropdown.

When only one mark available, it could still be relevant to show it as the content could still exist, e.g. of unbolded and bolded text.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Writer field: Hide nodes dropdown when only one node available
#7305

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion