### PR TITLE
feat: `Uuid::is()` to support multiple schemes

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -421,10 +421,7 @@ return [
 		// support UUIDs
 		if (
 			$path !== null &&
-			(
-				Uuid::is($path, 'page') === true ||
-				Uuid::is($path, 'file') === true
-			)
+			Uuid::is($path, ['page', 'file']) === true
 		) {
 			$model = Uuid::for($path)->model();
 

--- a/config/tags.php
+++ b/config/tags.php
@@ -206,10 +206,7 @@ return [
 
 			// if value is a UUID, resolve to page/file model
 			// and use the URL as value
-			if (
-				Uuid::is($tag->value, 'page') === true ||
-				Uuid::is($tag->value, 'file') === true
-			) {
+			if (Uuid::is($tag->value, ['page', 'file']) === true) {
 				$tag->value = Uuid::for($tag->value)?->toUrl();
 			}
 

--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -638,7 +638,7 @@ V::$validators = [
 	/**
 	 * Checks for a valid Uuid, optionally for specific model type
 	 */
-	'uuid' => function (string $value, string|null $type = null): bool {
+	'uuid' => function (string $value, string|array|null $type = null): bool {
 		return Uuid::is($value, $type);
 	}
 ];

--- a/src/Uuid/HasUuids.php
+++ b/src/Uuid/HasUuids.php
@@ -19,7 +19,7 @@ trait HasUuids
 	 */
 	protected function findByUuid(
 		string $uuid,
-		string|null $scheme = null
+		string|array|null $scheme = null
 	): Identifiable|null {
 		// handle UUID shortcuts with a leading @
 		if ($scheme !== null && str_starts_with($uuid, '@') === true) {

--- a/src/Uuid/Uuid.php
+++ b/src/Uuid/Uuid.php
@@ -13,6 +13,7 @@ use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
+use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
 use Stringable;
 
@@ -282,14 +283,16 @@ abstract class Uuid implements Stringable
 	 */
 	final public static function is(
 		string $string,
-		string|null $type = null
+		string|array|null $type = null
 	): bool {
 		// always return false when UUIDs have been disabled
 		if (Uuids::enabled() === false) {
 			return false;
 		}
 
-		$type  ??= implode('|', Uri::$schemes);
+		// use all available schemes by default
+		$type  ??= Uri::$schemes;
+		$type    = implode('|', A::wrap($type));
 		$pattern = sprintf('!^(%s)://(.*)!', $type);
 
 		if (preg_match($pattern, $string, $matches) !== 1) {

--- a/tests/Uuid/UuidTest.php
+++ b/tests/Uuid/UuidTest.php
@@ -264,6 +264,7 @@ class UuidTest extends TestCase
 
 	public function testIs(): void
 	{
+		// correct UUIDs
 		$this->assertTrue(Uuid::is('site://'));
 		$this->assertTrue(Uuid::is('page://something'));
 		$this->assertTrue(Uuid::is('user://something'));
@@ -278,7 +279,10 @@ class UuidTest extends TestCase
 		$this->assertTrue(Uuid::is('page://something', 'page'));
 		$this->assertTrue(Uuid::is('user://something', 'user'));
 		$this->assertTrue(Uuid::is('file://something', 'file'));
+		$this->assertTrue(Uuid::is('page://something', ['page', 'file']));
+		$this->assertTrue(Uuid::is('file://something', ['page', 'file']));
 
+		// invalid UUIDs
 		$this->assertFalse(Uuid::is('page://'));
 		$this->assertFalse(Uuid::is('file://'));
 		$this->assertFalse(Uuid::is('user://'));
@@ -294,6 +298,8 @@ class UuidTest extends TestCase
 		$this->assertFalse(Uuid::is('foo://something'));
 		$this->assertFalse(Uuid::is('page//something'));
 		$this->assertFalse(Uuid::is('page//something', 'page'));
+		$this->assertFalse(Uuid::is('file://something', ['page']));
+		$this->assertFalse(Uuid::is('file://something', ['page', 'user']));
 		$this->assertFalse(Uuid::is('not a page://something'));
 	}
 


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- `Kirby\Uuid\Uuid::is()` now accepts an array of multiple types to test against

### For review team
<!--
We will take care of the following before merging the PR.
-->

Code coverage of the actual `Uuid` class changes is in place.

- [x] Add changes & docs to release notes draft in Notion