### PR TITLE
refact!: Split `Uuid::for()` and `Uuid::from()`

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -421,9 +421,12 @@ return [
 		// support UUIDs
 		if (
 			$path !== null &&
-			Uuid::is($path, ['page', 'file']) === true
+			$uuid = Uuid::from($path, ['page', 'file'])
 		) {
-			$model = Uuid::for($path)->model();
+			/**
+			 * @var \Kirby\Cms\Page|\Kirby\Cms\File|null $model
+			 */
+			$model = $uuid->model();
 
 			if ($model === null) {
 				throw new NotFoundException(

--- a/config/components.php
+++ b/config/components.php
@@ -421,12 +421,12 @@ return [
 		// support UUIDs
 		if (
 			$path !== null &&
-			$uuid = Uuid::from($path, ['page', 'file'])
+			Uuid::is($path, ['page', 'file']) === true
 		) {
 			/**
 			 * @var \Kirby\Cms\Page|\Kirby\Cms\File|null $model
 			 */
-			$model = $uuid->model();
+			$model = Uuid::from($path)?->model();
 
 			if ($model === null) {
 				throw new NotFoundException(

--- a/config/tags.php
+++ b/config/tags.php
@@ -206,8 +206,8 @@ return [
 
 			// if value is a UUID, resolve to page/file model
 			// and use the URL as value
-			if (Uuid::is($tag->value, ['page', 'file']) === true) {
-				$tag->value = Uuid::for($tag->value)?->toUrl();
+			if ($uuid = Uuid::from($tag->value, ['page', 'file'])) {
+				$tag->value = $uuid->toUrl();
 			}
 
 			// if url is empty, throw exception or link to the error page

--- a/config/tags.php
+++ b/config/tags.php
@@ -206,8 +206,8 @@ return [
 
 			// if value is a UUID, resolve to page/file model
 			// and use the URL as value
-			if ($uuid = Uuid::from($tag->value, ['page', 'file'])) {
-				$tag->value = $uuid->toUrl();
+			if (Uuid::is($tag->value, ['page', 'file']) === true) {
+				$tag->value = Uuid::from($tag->value)?->toUrl();
 			}
 
 			// if url is empty, throw exception or link to the error page

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -648,9 +648,9 @@ class App
 		bool $drafts = true
 	): File|null {
 		// find by global UUID
-		if (Uuid::is($path, 'file') === true) {
-			// prefer files of parent, when parent given
-			return Uuid::for($path, $parent?->files())->model();
+		// and prefer files of parent, when parent given
+		if ($uuid = Uuid::from($path, 'file', $parent?->files())) {
+			return $uuid->model();
 		}
 
 		$parent ??= $this->site();

--- a/src/Cms/HasFiles.php
+++ b/src/Cms/HasFiles.php
@@ -72,8 +72,8 @@ trait HasFiles
 		}
 
 		// find by global UUID
-		if (Uuid::is($filename, 'file') === true) {
-			return Uuid::for($filename, $this->$in())->model();
+		if ($uuid = Uuid::from($filename, 'file', $this->$in())) {
+			return $uuid->model();
 		}
 
 		if (str_contains($filename, '/') === true) {

--- a/src/Cms/HasFiles.php
+++ b/src/Cms/HasFiles.php
@@ -72,8 +72,8 @@ trait HasFiles
 		}
 
 		// find by global UUID
-		if ($uuid = Uuid::from($filename, 'file', $this->$in())) {
-			return $uuid->model();
+		if (Uuid::is($filename, 'file') === true) {
+			return Uuid::from($filename, context: $this->$in())->model();
 		}
 
 		if (str_contains($filename, '/') === true) {

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -116,28 +116,31 @@ class KirbyTag
 	 */
 	public function file(string $path): File|null
 	{
-		if ($parent = $this->parent()) {
-			// check first for UUID
-			if (method_exists($parent, 'files') === true) {
+		$parent = $this->parent();
+
+		// check first for UUID
+		if (Uuid::is($path, 'file') === true) {
+			if ($parent && method_exists($parent, 'files') === true) {
 				$context = $parent->files();
 			}
 
-			if ($uuid = Uuid::from($path, 'file', $context ?? null)) {
-				return $uuid->model();
-			}
-
-			if (method_exists($parent, 'file') === true) {
-				return $parent->file($path);
-			}
-
-			if (
-				$parent instanceof File &&
-				$file = $parent->page()?->file($path)
-			) {
-				return $file;
-			}
+			return Uuid::from($path, context: $context ?? null)->model();
 		}
 
+		if (
+			$parent &&
+			method_exists($parent, 'file') === true &&
+			$file = $parent->file($path)
+		) {
+			return $file;
+		}
+
+		if (
+			$parent instanceof File &&
+			$file = $parent->page()?->file($path)
+		) {
+			return $file;
+		}
 
 		return $this->kirby()->file($path, null, true);
 	}

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -116,34 +116,28 @@ class KirbyTag
 	 */
 	public function file(string $path): File|null
 	{
-		$parent = $this->parent();
-
-		// check first for UUID
-		if (Uuid::is($path, 'file') === true) {
-			if (
-				is_object($parent) === true &&
-				method_exists($parent, 'files') === true
-			) {
+		if ($parent = $this->parent()) {
+			// check first for UUID
+			if (method_exists($parent, 'files') === true) {
 				$context = $parent->files();
 			}
 
-			return Uuid::for($path, $context ?? null)->model();
+			if ($uuid = Uuid::from($path, 'file', $context ?? null)) {
+				return $uuid->model();
+			}
+
+			if (method_exists($parent, 'file') === true) {
+				return $parent->file($path);
+			}
+
+			if (
+				$parent instanceof File &&
+				$file = $parent->page()?->file($path)
+			) {
+				return $file;
+			}
 		}
 
-		if (
-			is_object($parent) === true &&
-			method_exists($parent, 'file') === true &&
-			$file = $parent->file($path)
-		) {
-			return $file;
-		}
-
-		if (
-			$parent instanceof File &&
-			$file = $parent->page()?->file($path)
-		) {
-			return $file;
-		}
 
 		return $this->kirby()->file($path, null, true);
 	}

--- a/src/Uuid/FieldUuid.php
+++ b/src/Uuid/FieldUuid.php
@@ -118,7 +118,7 @@ abstract class FieldUuid extends Uuid
 	public function value(): array
 	{
 		/**
-		 * @var \Kirby\Cms\Site|\Kirby\Cms\Page|\Kirby\Cms\User $model
+		 * @var \Kirby\Cms\ModelWithContent $model
 		 */
 		$model  = $this->model();
 		$parent = Uuid::for($model->parent());

--- a/src/Uuid/FieldUuid.php
+++ b/src/Uuid/FieldUuid.php
@@ -41,10 +41,12 @@ abstract class FieldUuid extends Uuid
 		// get mixed Uri from cache
 		if ($key = $this->key()) {
 			if ($value = Uuids::cache()->get($key)) {
-				// value is an array containing
-				// the UUID for the parent, the field name
-				// and the specific ID
-				$parent = Uuid::for($value['parent'])->model();
+				/**
+				 * $value is an array containing the UUID for the parent,
+				 * the field name and the specific ID
+				 * @var \Kirby\Cms\ModelWithContent|null $parent
+				 */
+				$parent = Uuid::from($value['parent'])->model();
 
 				if ($field = $parent?->content()->get($value['field'])) {
 					return static::fieldToCollection($field)->get($value['id']);
@@ -108,13 +110,16 @@ abstract class FieldUuid extends Uuid
 
 	/**
 	 * Returns value to be stored in cache,
-	 * constisting of three parts:
+	 * consisting of three parts:
 	 * - parent UUID including scheme
 	 * - field name
 	 * - UUID id string for model
 	 */
 	public function value(): array
 	{
+		/**
+		 * @var \Kirby\Cms\Site|\Kirby\Cms\Page|\Kirby\Cms\User $model
+		 */
 		$model  = $this->model();
 		$parent = Uuid::for($model->parent());
 

--- a/src/Uuid/FileUuid.php
+++ b/src/Uuid/FileUuid.php
@@ -39,7 +39,7 @@ class FileUuid extends ModelUuid
 			if ($value = Uuids::cache()->get($key)) {
 				// value is an array containing
 				// the UUID for the parent and the filename
-				$parent = Uuid::for($value['parent'])->model();
+				$parent = Uuid::from($value['parent'])->model();
 				return $parent?->file($value['filename']);
 			}
 		}

--- a/src/Uuid/HasUuids.php
+++ b/src/Uuid/HasUuids.php
@@ -26,10 +26,10 @@ trait HasUuids
 			$uuid = $scheme . '://' . substr($uuid, 1);
 		}
 
-		if (Uuid::is($uuid, $scheme) === true) {
-			// look up model by UUID while prioritizing
-			// $this collection when searching
-			return Uuid::for($uuid, $this)->model();
+		// look up model by UUID while prioritizing
+		// $this collection when searching
+		if ($uuid = Uuid::from($uuid, $scheme, $this)) {
+			return $uuid->model();
 		}
 
 		return null;

--- a/src/Uuid/Permalink.php
+++ b/src/Uuid/Permalink.php
@@ -26,7 +26,7 @@ class Permalink
 
 	public static function for(string $uuid): static|null
 	{
-		if ($uuid = Uuid::for($uuid)) {
+		if ($uuid = Uuid::from($uuid, ['page', 'file'])) {
 			return new static($uuid);
 		}
 

--- a/src/Uuid/Uuid.php
+++ b/src/Uuid/Uuid.php
@@ -159,41 +159,16 @@ abstract class Uuid implements Stringable
 	}
 
 	/**
-	 * Shorthand to create instance
-	 * by passing either UUID or model
+	 * Creates a UUID object for a model object
 	 */
 	final public static function for(
-		string|Identifiable $seed,
+		Identifiable $seed,
 		Collection|null $context = null
 	): static|null {
-		// if globally disabled, return null
 		if (Uuids::enabled() === false) {
 			return null;
 		}
 
-		// for UUID string
-		if (is_string($seed) === true) {
-			if ($uri = Str::before($seed, '://')) {
-				return match ($uri) {
-					'page'   => new PageUuid(uuid: $seed, context: $context),
-					'file'   => new FileUuid(uuid: $seed, context: $context),
-					'site'   => new SiteUuid(uuid: $seed, context: $context),
-					'user'   => new UserUuid(uuid: $seed, context: $context),
-					// TODO: activate for uuid-block-structure-support
-					// 'block'  => new BlockUuid(uuid: $seed, context: $context),
-					// 'struct' => new StructureUuid(uuid: $seed, context: $context),
-					default  => throw new InvalidArgumentException(
-						message: 'Invalid UUID URI: ' . $seed
-					)
-				};
-			}
-
-			throw new InvalidArgumentException(
-				message: 'Invalid UUID string: ' . $seed
-			);
-		}
-
-		// for model object
 		return match (true) {
 			$seed instanceof Page
 				=> new PageUuid(model: $seed, context: $context),
@@ -212,6 +187,43 @@ abstract class Uuid implements Stringable
 				message: 'UUID not supported for: ' . $seed::class
 			)
 		};
+	}
+
+	/**
+	 * Creates a UUID object from a UUID string
+	 * @since 6.0.0
+	 */
+	final public static function from(
+		string $uuid,
+		string|array|null $scheme = null,
+		Collection|null $context = null
+	): static|null {
+		if (Uuids::enabled() === false) {
+			return null;
+		}
+
+		if ($scheme !== null && static::is($uuid, $scheme) === false) {
+			return null;
+		}
+
+		if ($uri = Str::before($uuid, '://')) {
+			return match ($uri) {
+				'page'   => new PageUuid(uuid: $uuid, context: $context),
+				'file'   => new FileUuid(uuid: $uuid, context: $context),
+				'site'   => new SiteUuid(uuid: $uuid, context: $context),
+				'user'   => new UserUuid(uuid: $uuid, context: $context),
+				// TODO: activate for uuid-block-structure-support
+				// 'block'  => new BlockUuid(uuid: $seed, context: $context),
+				// 'struct' => new StructureUuid(uuid: $seed, context: $context),
+				default  => throw new InvalidArgumentException(
+					message: 'Invalid UUID URI "' . $uri . '" in ' . $uuid
+				)
+			};
+		}
+
+		throw new InvalidArgumentException(
+			message: 'Invalid UUID string: ' . $uuid
+		);
 	}
 
 	/**

--- a/src/Uuid/Uuid.php
+++ b/src/Uuid/Uuid.php
@@ -195,19 +195,19 @@ abstract class Uuid implements Stringable
 	 */
 	final public static function from(
 		string $uuid,
-		string|array|null $scheme = null,
+		string|array|null $type = null,
 		Collection|null $context = null
 	): static|null {
 		if (Uuids::enabled() === false) {
 			return null;
 		}
 
-		if ($scheme !== null && static::is($uuid, $scheme) === false) {
+		if ($type !== null && static::is($uuid, $type) === false) {
 			return null;
 		}
 
-		if ($uri = Str::before($uuid, '://')) {
-			return match ($uri) {
+		if ($type = Str::before($uuid, '://')) {
+			return match ($type) {
 				'page'   => new PageUuid(uuid: $uuid, context: $context),
 				'file'   => new FileUuid(uuid: $uuid, context: $context),
 				'site'   => new SiteUuid(uuid: $uuid, context: $context),
@@ -216,7 +216,7 @@ abstract class Uuid implements Stringable
 				// 'block'  => new BlockUuid(uuid: $seed, context: $context),
 				// 'struct' => new StructureUuid(uuid: $seed, context: $context),
 				default  => throw new InvalidArgumentException(
-					message: 'Invalid UUID URI "' . $uri . '" in ' . $uuid
+					message: 'Invalid UUID type "' . $type . '" in ' . $uuid
 				)
 			};
 		}

--- a/tests/Uuid/SiteUuidTest.php
+++ b/tests/Uuid/SiteUuidTest.php
@@ -27,7 +27,7 @@ class SiteUuidTest extends TestCase
 	public function testModel(): void
 	{
 		$site = $this->app->site();
-		$this->assertIsSite($site, Uuid::for('site://')->model());
+		$this->assertIsSite($site, Uuid::from('site://')->model());
 	}
 
 	public function testPopulate(): void

--- a/tests/Uuid/UserUuidTest.php
+++ b/tests/Uuid/UserUuidTest.php
@@ -21,7 +21,7 @@ class UserUuidTest extends TestCase
 	public function testModel(): void
 	{
 		$user = $this->app->user('my-user');
-		$this->assertIsUser($user, Uuid::for('user://my-user')->model());
+		$this->assertIsUser($user, Uuid::from('user://my-user')->model());
 	}
 
 	public function testPopulate(): void

--- a/tests/Uuid/UuidTest.php
+++ b/tests/Uuid/UuidTest.php
@@ -165,7 +165,7 @@ class UuidTest extends TestCase
 	public function testFromUuidInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid UUID URI "foo" in foo://my-id');
+		$this->expectExceptionMessage('Invalid UUID type "foo" in foo://my-id');
 		Uuid::from('foo://my-id');
 	}
 
@@ -419,10 +419,10 @@ class UuidTest extends TestCase
 
 	public function testType(): void
 	{
-		$this->assertSame('page', Uuid::for('page://my-page')->type());
-		$this->assertSame('file', Uuid::for('file://my-page')->type());
-		$this->assertSame('site', Uuid::for('site://my-page')->type());
-		$this->assertSame('user', Uuid::for('user://my-page')->type());
+		$this->assertSame('page', Uuid::from('page://my-page')->type());
+		$this->assertSame('file', Uuid::from('file://my-page')->type());
+		$this->assertSame('site', Uuid::from('site://my-page')->type());
+		$this->assertSame('user', Uuid::from('user://my-page')->type());
 	}
 
 	public function testValue(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

- [x] https://github.com/getkirby/kirby/pull/7543
- [x] https://github.com/getkirby/kirby/pull/7545

The motivation here is to break up some of the magic monster methods into separate, dedicated methods.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- New `Kirby\Uuid\Uuid::from(string $uuid)` method for creating an Uuid object from a UUID string. `Kirby\Uuid\Uuid::for()` remains to create a Uuid object for a model object.

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- `Kirby\Uuid\Uuid::for()`  cannot be called any longer with a string. Use `Kirby\Uuid\Uuid::from(string $uuid)` or `Kirby\Uuid\Permalink::from(string $permalink)` instead.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion