### PR TITLE
test: Add coverage attributes for `Kirby\Http`

### DIFF
--- a/src/Http/Cookie.php
+++ b/src/Http/Cookie.php
@@ -222,7 +222,6 @@ class Cookie
 	protected static function trackUsage(string $key): void
 	{
 		// lazily request the instance for non-CMS use cases
-		$kirby = App::instance(null, true);
-		$kirby?->response()->usesCookie($key);
+		App::instance(lazy: true)?->response()->usesCookie($key);
 	}
 }

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -13,13 +13,13 @@ use Kirby\Toolkit\Str;
  * secure host and base URL detection, as
  * well as loading the dedicated
  * environment options.
- * @since 3.7.0
  *
  * @package   Kirby Http
  * @author    Bastian Allgeier <bastian@getkirby.com>
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
+ * @since     3.7.0
  */
 class Environment
 {

--- a/src/Http/Header.php
+++ b/src/Http/Header.php
@@ -68,7 +68,7 @@ class Header
 
 		$header = 'Content-type: ' . $mime;
 
-		if (empty($charset) === false) {
+		if ($charset !== '') {
 			$header .= '; charset=' . $charset;
 		}
 

--- a/src/Http/Params.php
+++ b/src/Http/Params.php
@@ -38,7 +38,7 @@ class Params extends Obj implements Stringable
 	 */
 	public static function extract(string|array|null $path = null): array
 	{
-		if (empty($path) === true) {
+		if ($path === null || $path === '' || $path === []) {
 			return [
 				'path'   => null,
 				'params' => null,
@@ -62,12 +62,16 @@ class Params extends Obj implements Stringable
 					continue;
 				}
 
-				$paramParts = Str::split($p, $separator);
-				$paramKey   = $paramParts[0] ?? null;
-				$paramValue = $paramParts[1] ?? null;
+				$parts = Str::split($p, $separator);
 
-				if ($paramKey !== null) {
-					$params[rawurldecode($paramKey)] = $paramValue !== null ? rawurldecode($paramValue) : null;
+				if ($key = $parts[0] ?? null) {
+					$key = rawurldecode($key);
+
+					if ($value = $parts[1] ?? null) {
+						$value = rawurldecode($value);
+					}
+
+					$params[$key] = $value;
 				}
 
 				unset($path[$index]);
@@ -89,7 +93,7 @@ class Params extends Obj implements Stringable
 
 	public function isEmpty(): bool
 	{
-		return empty((array)$this) === true;
+		return (array)$this === [];
 	}
 
 	public function isNotEmpty(): bool
@@ -106,15 +110,7 @@ class Params extends Obj implements Stringable
 	 */
 	public static function separator(): string
 	{
-		if (static::$separator !== null) {
-			return static::$separator;
-		}
-
-		if (DIRECTORY_SEPARATOR === '/') {
-			return static::$separator = ':';
-		}
-
-		return static::$separator = ';';
+		return static::$separator ??= DIRECTORY_SEPARATOR === '/' ? ':' : ';';
 	}
 
 	/**
@@ -134,7 +130,9 @@ class Params extends Obj implements Stringable
 
 		foreach ($this as $key => $value) {
 			if ($value !== null && $value !== '') {
-				$params[] = rawurlencode($key) . $separator . rawurlencode($value);
+				$key      = rawurlencode($key);
+				$value    = rawurlencode($value);
+				$params[] = $key . $separator . $value;
 			}
 		}
 

--- a/src/Http/Query.php
+++ b/src/Http/Query.php
@@ -29,7 +29,7 @@ class Query extends Obj implements Stringable
 
 	public function isEmpty(): bool
 	{
-		return empty((array)$this) === true;
+		return (array)$this === [];
 	}
 
 	public function isNotEmpty(): bool
@@ -41,7 +41,7 @@ class Query extends Obj implements Stringable
 	{
 		$query = http_build_query($this, '', '&', PHP_QUERY_RFC3986);
 
-		if (empty($query) === true) {
+		if ($query === '') {
 			return '';
 		}
 

--- a/src/Http/Remote.php
+++ b/src/Http/Remote.php
@@ -47,13 +47,14 @@ class Remote
 	public string $errorMessage;
 	public array $headers = [];
 	public array $info = [];
-	public array $options = [];
 
 	/**
 	 * @throws \Exception when the curl request failed
 	 */
-	public function __construct(string $url, array $options = [])
-	{
+	public function __construct(
+		string $url,
+		public array $options = []
+	) {
 		$defaults = static::$defaults;
 
 		// use the system CA store by default if
@@ -71,11 +72,8 @@ class Remote
 			$defaults = [...$defaults, ...$app->option('remote', [])];
 		}
 
-		// set all options
-		$this->options = [...$defaults, ...$options];
-
-		// add the url
-		$this->options['url'] = $url;
+		// set all options, incl. url
+		$this->options = [...$defaults, ...$options, 'url' => $url];
 
 		// send the request
 		$this->fetch();
@@ -277,7 +275,7 @@ class Remote
 
 		$query = http_build_query($options['data']);
 
-		if (empty($query) === false) {
+		if ($query !== '') {
 			$url = match (Url::hasQuery($url)) {
 				true    => $url . '&' . $query,
 				default => $url . '?' . $query
@@ -339,7 +337,7 @@ class Remote
 	 */
 	protected function postfields($data)
 	{
-		if (is_object($data) || is_array($data)) {
+		if (is_object($data) === true || is_array($data) === true) {
 			return http_build_query($data);
 		}
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -68,12 +68,6 @@ class Request
 	protected string $method;
 
 	/**
-	 * All options that have been passed to
-	 * the request in the constructor
-	 */
-	protected array $options;
-
-	/**
 	 * The Query object is a wrapper around
 	 * the URL query string, which parses the
 	 * string and provides a clean API to fetch
@@ -96,9 +90,9 @@ class Request
 	 * data via the $options array or use
 	 * the data from the incoming request.
 	 */
-	public function __construct(array $options = [])
-	{
-		$this->options = $options;
+	public function __construct(
+		protected array $options = []
+	) {
 		$this->method  = $this->detectRequestMethod($options['method'] ?? null);
 
 		if (isset($options['body']) === true) {
@@ -155,7 +149,7 @@ class Request
 		}
 
 		// lazily request the instance for non-CMS use cases
-		$kirby = App::instance(null, true);
+		$kirby = App::instance(lazy: true);
 
 		// tell the CMS responder that the response relies on
 		// the `Authorization` header and its value (even if
@@ -224,13 +218,26 @@ class Request
 	public function detectRequestMethod(string|null $method = null): string
 	{
 		// all possible methods
-		$methods = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH'];
+		$methods = [
+			'CONNECT',
+			'DELETE',
+			'GET',
+			'HEAD',
+			'OPTIONS',
+			'PATCH',
+			'POST',
+			'PUT',
+			'TRACE',
+		];
 
 		// the request method can be overwritten with a header
-		$methodOverride = strtoupper(Environment::getGlobally('HTTP_X_HTTP_METHOD_OVERRIDE', ''));
+		if ($method === null) {
+			$override = Environment::getGlobally('HTTP_X_HTTP_METHOD_OVERRIDE', '');
+			$override = strtoupper($override);
 
-		if (in_array($methodOverride, $methods, true) === true) {
-			$method ??= $methodOverride;
+			if (in_array($override, $methods, true) === true) {
+				$method = $override;
+			}
 		}
 
 		// final chain of options to detect the method
@@ -411,14 +418,16 @@ class Request
 		// because empty strings are treated as invalid
 		// but the `??` operator wouldn't do the fallback
 
-		$option = $this->options['auth'] ?? null;
-		if (empty($option) === false) {
-			return $option;
+		if ($option = $this->options['auth'] ?? null) {
+			if ($option !== '') {
+				return $option;
+			}
 		}
 
-		$header = $this->header('authorization');
-		if (empty($header) === false) {
-			return $header;
+		if ($header = $this->header('authorization')) {
+			if ($header !== '') {
+				return $header;
+			}
 		}
 
 		return null;

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -417,17 +417,16 @@ class Request
 		// both variants need to be checked separately
 		// because empty strings are treated as invalid
 		// but the `??` operator wouldn't do the fallback
+		$option = $this->options['auth'] ?? null;
 
-		if ($option = $this->options['auth'] ?? null) {
-			if ($option !== '') {
-				return $option;
-			}
+		if (is_string($option) === true && $option !== '') {
+			return $option;
 		}
 
-		if ($header = $this->header('authorization')) {
-			if ($header !== '') {
-				return $header;
-			}
+		$header = $this->header('authorization');
+
+		if (is_string($header) === true && $header !== '') {
+			return $header;
 		}
 
 		return null;

--- a/src/Http/Request/Body.php
+++ b/src/Http/Request/Body.php
@@ -21,11 +21,6 @@ class Body implements Stringable
 	use Data;
 
 	/**
-	 * The raw body content
-	 */
-	protected string|array|null $contents;
-
-	/**
 	 * The parsed content as array
 	 */
 	protected array|null $data = null;
@@ -36,10 +31,12 @@ class Body implements Stringable
 	 * If null is being passed, the class will
 	 * fetch the body either from the $_POST global
 	 * or from php://input.
+	 *
+	 * @param array|string|null $contents The raw body content
 	 */
-	public function __construct(array|string|null $contents = null)
-	{
-		$this->contents = $contents;
+	public function __construct(
+		protected array|string|null $contents = null
+	) {
 	}
 
 	/**
@@ -52,7 +49,7 @@ class Body implements Stringable
 			return $this->contents;
 		}
 
-		if (empty($_POST) === false) {
+		if ($_POST !== []) {
 			return $this->contents = $_POST;
 		}
 
@@ -90,7 +87,7 @@ class Body implements Stringable
 			// try to parse the body as query string
 			parse_str($contents, $parsed);
 
-			if (is_array($parsed)) {
+			if (is_array($parsed) === true) {
 				return $this->data = $parsed;
 			}
 		}

--- a/src/Http/Request/Data.php
+++ b/src/Http/Request/Data.php
@@ -45,9 +45,11 @@ trait Data
 	{
 		if (is_array($key) === true) {
 			$result = [];
+
 			foreach ($key as $k) {
 				$result[$k] = $this->get($k);
 			}
+
 			return $result;
 		}
 

--- a/src/Http/Request/Files.php
+++ b/src/Http/Request/Files.php
@@ -34,7 +34,7 @@ class Files
 		$files ??= $_FILES;
 
 		foreach ($files as $key => $file) {
-			if (is_array($file['name'])) {
+			if (is_array($file['name']) === true) {
 				foreach ($file['name'] as $i => $name) {
 					$this->files[$key][] = [
 						'name'     => $file['name'][$i]      ?? null,

--- a/src/Http/Request/Query.php
+++ b/src/Http/Request/Query.php
@@ -22,7 +22,7 @@ class Query implements Stringable
 	/**
 	 * The Query data array
 	 */
-	protected array|null $data = null;
+	protected array $data;
 
 	/**
 	 * Creates a new Query object.
@@ -56,7 +56,7 @@ class Query implements Stringable
 	 */
 	public function isEmpty(): bool
 	{
-		return empty($this->data) === true;
+		return $this->data === [];
 	}
 
 	/**
@@ -64,7 +64,7 @@ class Query implements Stringable
 	 */
 	public function isNotEmpty(): bool
 	{
-		return empty($this->data) === false;
+		return $this->data !== [];
 	}
 
 	/**

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -281,8 +281,11 @@ class Response implements Stringable
 	 *
 	 * @since 5.0.3
 	 */
-	public static function refresh(string $location = '/', int $code = 302, int $refresh = 0): static
-	{
+	public static function refresh(
+		string $location = '/',
+		int $code = 302,
+		int $refresh = 0
+	): static {
 		return new static([
 			'code'    => $code,
 			'headers' => [

--- a/src/Http/Route.php
+++ b/src/Http/Route.php
@@ -14,24 +14,9 @@ use Closure;
 class Route
 {
 	/**
-	 * The callback action function
-	 */
-	protected Closure $action;
-
-	/**
 	 * Listed of parsed arguments
 	 */
 	protected array $arguments = [];
-
-	/**
-	 * An array of all passed attributes
-	 */
-	protected array $attributes = [];
-
-	/**
-	 * The registered request method
-	 */
-	protected string $method;
 
 	/**
 	 * The registered pattern
@@ -74,14 +59,11 @@ class Route
 	 */
 	public function __construct(
 		string $pattern,
-		string $method,
-		Closure $action,
-		array $attributes = []
+		protected string $method,
+		protected Closure $action,
+		protected array $attributes = []
 	) {
-		$this->action     = $action;
-		$this->attributes = $attributes;
-		$this->method     = $method;
-		$this->pattern    = $this->regex(ltrim($pattern, '/'));
+		$this->pattern = $this->regex(ltrim($pattern, '/'));
 	}
 
 	/**

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -172,16 +172,14 @@ class Router
 		}
 
 		// remove leading and trailing slashes
-		$path = trim($path, '/');
+		$path     = trim($path, '/');
+		$ignore ??= [];
 
 		foreach ($this->routes[$method] as $route) {
 			$arguments = $route->parse($route->pattern(), $path);
 
 			if ($arguments !== false) {
-				if (
-					empty($ignore) === true ||
-					in_array($route, $ignore, true) === false
-				) {
+				if (in_array($route, $ignore, true) === false) {
 					return $this->route = $route;
 				}
 			}

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -158,6 +158,9 @@ class Router
 	 * The Route's arguments method is used to
 	 * find matches and return all the found
 	 * arguments in the path.
+	 *
+	 * @param array|null $ignore (Passing null has been deprecated)
+	 * @todo Remove support for `$ignore = null` in v6
 	 */
 	public function find(
 		string $path,

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -281,7 +281,7 @@ class Uri implements Stringable
 	 */
 	public function idn(): static
 	{
-		if ($this->host !== null && $this->host !== '') {
+		if ($this->isAbsolute() === true) {
 			$host = Idn::decode($this->host);
 			$this->setHost($host);
 		}
@@ -504,7 +504,7 @@ class Uri implements Stringable
 	 */
 	public function unIdn(): static
 	{
-		if ($this->host !== null && $this->host !== '') {
+		if ($this->isAbsolute() === true) {
 			$host = Idn::encode($this->host);
 			$this->setHost($host);
 		}

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -216,9 +216,9 @@ class Uri implements Stringable
 
 		if ($app = App::instance(null, true)) {
 			$environment = $app->environment();
-		} else {
-			$environment = new Environment();
 		}
+
+		$environment ??= new Environment();
 
 		return new static($environment->requestUrl(), $props);
 	}
@@ -230,7 +230,7 @@ class Uri implements Stringable
 	 */
 	public function domain(): string|null
 	{
-		if (empty($this->host) === true || $this->host === '/') {
+		if ($this->host === null || $this->host === '' || $this->host === '/') {
 			return null;
 		}
 
@@ -281,8 +281,9 @@ class Uri implements Stringable
 	 */
 	public function idn(): static
 	{
-		if (empty($this->host) === false) {
-			$this->setHost(Idn::decode($this->host));
+		if ($this->host !== null && $this->host !== '') {
+			$host = Idn::decode($this->host);
+			$this->setHost($host);
 		}
 		return $this;
 	}
@@ -295,9 +296,9 @@ class Uri implements Stringable
 	{
 		if ($app = App::instance(null, true)) {
 			$url = $app->url('index');
-		} else {
-			$url = (new Environment())->baseUrl();
 		}
+
+		$url ??= (new Environment())->baseUrl();
 
 		return new static($url, $props);
 	}
@@ -307,7 +308,7 @@ class Uri implements Stringable
 	 */
 	public function isAbsolute(): bool
 	{
-		return empty($this->host) === false;
+		return $this->host !== null && $this->host !== '';
 	}
 
 	/**
@@ -474,7 +475,7 @@ class Uri implements Stringable
 		$url   = $this->base();
 		$slash = true;
 
-		if (empty($url) === true) {
+		if ($url === null || $url === '') {
 			$url   = '/';
 			$slash = false;
 		}
@@ -503,8 +504,9 @@ class Uri implements Stringable
 	 */
 	public function unIdn(): static
 	{
-		if (empty($this->host) === false) {
-			$this->setHost(Idn::encode($this->host));
+		if ($this->host !== null && $this->host !== '') {
+			$host = Idn::encode($this->host);
+			$this->setHost($host);
 		}
 		return $this;
 	}

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -110,8 +110,10 @@ class Url
 	/**
 	 * Convert a relative path into an absolute URL
 	 */
-	public static function makeAbsolute(string|null $path = null, string|null $home = null): string
-	{
+	public static function makeAbsolute(
+		string|null $path = null,
+		string|null $home = null
+	): string {
 		if ($path === '' || $path === '/' || $path === null) {
 			return $home ?? static::home();
 		}
@@ -120,7 +122,7 @@ class Url
 			return $path;
 		}
 
-		if (static::isAbsolute($path)) {
+		if (static::isAbsolute($path) === true) {
 			return $path;
 		}
 
@@ -128,11 +130,15 @@ class Url
 		$path   = ltrim($path, '/');
 		$home ??= static::home();
 
-		if (empty($path) === true) {
+		if ($path === '') {
 			return $home;
 		}
 
-		return $home === '/' ? '/' . $path : $home . '/' . $path;
+		if ($home === '/') {
+			return '/' . $path;
+		}
+
+		return $home . '/' . $path;
 	}
 
 	/**

--- a/src/Http/Visitor.php
+++ b/src/Http/Visitor.php
@@ -165,16 +165,16 @@ class Visitor
 	 */
 	public function preferredMimeType(string ...$mimeTypes): string|null
 	{
-		foreach ($this->acceptedMimeTypes() as $acceptedMime) {
+		foreach ($this->acceptedMimeTypes() as $accepted) {
 			// look for direct matches
-			if (in_array($acceptedMime->type(), $mimeTypes, true)) {
-				return $acceptedMime->type();
+			if (in_array($accepted->type(), $mimeTypes, true) === true) {
+				return $accepted->type();
 			}
 
 			// test each option against wildcard `Accept` values
-			foreach ($mimeTypes as $expectedMime) {
-				if (Mime::matches($expectedMime, $acceptedMime->type()) === true) {
-					return $expectedMime;
+			foreach ($mimeTypes as $expected) {
+				if (Mime::matches($expected, $accepted->type()) === true) {
+					return $expected;
 				}
 			}
 		}

--- a/tests/Http/CookieTest.php
+++ b/tests/Http/CookieTest.php
@@ -4,7 +4,9 @@ namespace Kirby\Http;
 
 use Kirby\Cms\App;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Cookie::class)]
 class CookieTest extends TestCase
 {
 	protected string $cookieKey;

--- a/tests/Http/HeaderTest.php
+++ b/tests/Http/HeaderTest.php
@@ -3,7 +3,9 @@
 namespace Kirby\Http;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Header::class)]
 class HeaderTest extends TestCase
 {
 	// incomplete list compared to Header::$codes, mostly for

--- a/tests/Http/IdnTest.php
+++ b/tests/Http/IdnTest.php
@@ -3,7 +3,9 @@
 namespace Kirby\Http;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Idn::class)]
 class IdnTest extends TestCase
 {
 	public function testDecodeEmail(): void

--- a/tests/Http/ParamsTest.php
+++ b/tests/Http/ParamsTest.php
@@ -3,7 +3,9 @@
 namespace Kirby\Http;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Params::class)]
 class ParamsTest extends TestCase
 {
 	public function testConstructWithArray(): void

--- a/tests/Http/ParamsTest.php
+++ b/tests/Http/ParamsTest.php
@@ -90,6 +90,24 @@ class ParamsTest extends TestCase
 		$this->assertSame($expected, $params);
 	}
 
+	public function testIsEmpty(): void
+	{
+		$params = new Params([]);
+		$this->assertTrue($params->isEmpty());
+
+		$params = new Params(['a' => 'value-a']);
+		$this->assertFalse($params->isEmpty());
+	}
+
+	public function testIsNotEmpty(): void
+	{
+		$params = new Params(['a' => 'value-a']);
+		$this->assertTrue($params->isNotEmpty());
+
+		$params = new Params([]);
+		$this->assertFalse($params->isNotEmpty());
+	}
+
 	public function testToString(): void
 	{
 		$params = new Params([

--- a/tests/Http/QueryTest.php
+++ b/tests/Http/QueryTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Kirby\Http;
+
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Query::class)]
+class QueryTest extends TestCase
+{
+	public function testConstructWithArray(): void
+	{
+		$query = new Query([
+			'a' => 'value-a',
+			'b' => 'value-b'
+		]);
+
+		$this->assertSame('value-a', $query->a);
+		$this->assertSame('value-b', $query->b);
+	}
+
+	public function testConstructWithString(): void
+	{
+		$query = new Query('?a=value-a&b=value-b');
+
+		$this->assertSame('value-a', $query->a);
+		$this->assertSame('value-b', $query->b);
+	}
+
+	public function testConstructWithEmptyValue(): void
+	{
+		$query = new Query('?a=&b=');
+
+		$this->assertSame('', $query->a);
+		$this->assertSame('', $query->b);
+	}
+
+	public function testIsEmpty(): void
+	{
+		$query = new Query('');
+		$this->assertTrue($query->isEmpty());
+
+		$query = new Query('?a=value-a');
+		$this->assertFalse($query->isEmpty());
+	}
+
+	public function testIsNotEmpty(): void
+	{
+		$query = new Query('?a=value-a');
+		$this->assertTrue($query->isNotEmpty());
+
+		$query = new Query('');
+		$this->assertFalse($query->isNotEmpty());
+	}
+
+	public function testToString(): void
+	{
+		$query = new Query([
+			'a' => 'value-a',
+			'b' => 'value-b'
+		]);
+
+		$this->assertSame('a=value-a&b=value-b', $query->toString());
+		$this->assertSame('?a=value-a&b=value-b', $query->toString(true));
+		$this->assertSame('a=value-a&b=value-b', (string)$query);
+	}
+
+	public function testToStringEmpty(): void
+	{
+		$query = new Query('');
+		$this->assertSame('', $query->toString());
+		$this->assertSame('', (string)$query);
+
+		$query = new Query(null);
+		$this->assertSame('', $query->toString());
+		$this->assertSame('', (string)$query);
+	}
+
+	public function testUnsetQuery(): void
+	{
+		$query = new Query(['foo' => 'bar']);
+		$query->foo = null;
+
+		$this->assertSame('', $query->toString());
+	}
+}

--- a/tests/Http/RemoteTest.php
+++ b/tests/Http/RemoteTest.php
@@ -6,7 +6,9 @@ use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Remote::class)]
 class RemoteTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Http.Remote';

--- a/tests/Http/Request/BodyTest.php
+++ b/tests/Http/Request/BodyTest.php
@@ -3,7 +3,9 @@
 namespace Kirby\Http\Request;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Body::class)]
 class BodyTest extends TestCase
 {
 	public function testContents(): void

--- a/tests/Http/Request/FilesTest.php
+++ b/tests/Http/Request/FilesTest.php
@@ -3,7 +3,9 @@
 namespace Kirby\Http\Request;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Files::class)]
 class FilesTest extends TestCase
 {
 	public function testMultipleUploads(): void

--- a/tests/Http/Request/QueryTest.php
+++ b/tests/Http/Request/QueryTest.php
@@ -3,7 +3,9 @@
 namespace Kirby\Http\Request;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Query::class)]
 class QueryTest extends TestCase
 {
 	public function testData(): void

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -9,8 +9,10 @@ use Kirby\Http\Request\Body;
 use Kirby\Http\Request\Files;
 use Kirby\Http\Request\Query;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversClass(Request::class)]
 class RequestTest extends TestCase
 {
 	public function tearDown(): void

--- a/tests/Http/RouteTest.php
+++ b/tests/Http/RouteTest.php
@@ -3,14 +3,15 @@
 namespace Kirby\Http;
 
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversClass(Route::class)]
 class RouteTest extends TestCase
 {
 	public function _route()
 	{
-		$route = new Route('a', 'GET', function () {
-		});
+		$route = new Route('a', 'GET', function () {});
 		return $route;
 	}
 

--- a/tests/Http/RouterTest.php
+++ b/tests/Http/RouterTest.php
@@ -5,8 +5,10 @@ namespace Kirby\Http;
 use Exception;
 use InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use TypeError;
 
+#[CoversClass(Router::class)]
 class RouterTest extends TestCase
 {
 	public function testRegisterSingleRoute(): void

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -5,9 +5,11 @@ namespace Kirby\Http;
 use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
+#[CoversClass(Uri::class)]
 class UriTest extends TestCase
 {
 	protected static string $example1 = 'https://getkirby.com';

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -138,6 +138,13 @@ class UriTest extends TestCase
 		$this->assertSame('https', $url->scheme());
 	}
 
+	public function testIdn(): void
+	{
+		$url = new Uri('https://xn--bcher-kva.ch');
+		$this->assertSame('xn--bcher-kva.ch', $url->host());
+		$this->assertSame('bücher.ch', $url->idn()->host());
+	}
+
 	public function testIndex(): void
 	{
 		new App([
@@ -518,5 +525,12 @@ class UriTest extends TestCase
 
 		$uri = new Uri('https://getkirby.com');
 		$this->assertFalse($uri->hasQuery());
+	}
+
+	public function testUnIdn(): void
+	{
+		$url = new Uri('https://bücher.ch');
+		$this->assertSame('bücher.ch', $url->host());
+		$this->assertSame('xn--bcher-kva.ch', $url->unIdn()->host());
 	}
 }

--- a/tests/Http/UrlTest.php
+++ b/tests/Http/UrlTest.php
@@ -4,8 +4,10 @@ namespace Kirby\Http;
 
 use Kirby\Cms\App;
 use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversClass(Url::class)]
 class UrlTest extends TestCase
 {
 	protected string $_yt   = 'http://www.youtube.com/watch?v=9q_aXttJduk';

--- a/tests/Http/VisitorTest.php
+++ b/tests/Http/VisitorTest.php
@@ -5,7 +5,9 @@ namespace Kirby\Http;
 use Kirby\TestCase;
 use Kirby\Toolkit\Collection;
 use Kirby\Toolkit\Obj;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Visitor::class)]
 class VisitorTest extends TestCase
 {
 	public function testVisitorDefaults(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

This PR
- Adds coverage attributes to `Kirby\Http` (we missed adding them before)
- Updates the code style of the classes to modernize the code a bit

## Changelog

### Housekeeping

- Clean up code style of the `Http` classes

### Deprecated

- `Kirby\Http\Router::find()`: Passing `$ignore = null` has been deprecated (pass an empty array or omit the argument instead)