### PR TITLE
refact!: Clean up `VersionsButton`

### DIFF
--- a/config/areas/site/buttons.php
+++ b/config/areas/site/buttons.php
@@ -28,12 +28,10 @@ return [
 			);
 		}
 	},
-	'site.versions' => function (Site $site, string $versionId = 'latest') {
-		return new VersionsButton(
-			model: $site,
-			versionId: $versionId
-		);
-	},
+	'site.versions' => fn (Site $site, string $versionId = 'latest') => new VersionsButton(
+		model: $site,
+		mode: $versionId
+	),
 	'page.open' => function (Page $page, string $versionId = 'latest') {
 		$versionId = $versionId === 'compare' ? 'changes' : $versionId;
 		$link      = $page->previewUrl($versionId);
@@ -51,12 +49,10 @@ return [
 			);
 		}
 	},
-	'page.versions' => function (Page $page, string $versionId = 'latest') {
-		return new VersionsButton(
-			model: $page,
-			versionId: $versionId
-		);
-	},
+	'page.versions' => fn (Page $page, string $versionId = 'latest') => new VersionsButton(
+		model: $page,
+		mode: $versionId
+	),
 	'page.settings' => fn (Page $page) => new SettingsButton($page),
 	'page.status'   => fn (Page $page) => new PageStatusButton($page),
 

--- a/src/Panel/Ui/Button/VersionsButton.php
+++ b/src/Panel/Ui/Button/VersionsButton.php
@@ -21,37 +21,94 @@ class VersionsButton extends ViewButton
 {
 	public function __construct(
 		ModelWithContent $model,
-		VersionId|string $versionId = 'latest'
+		public string $mode = 'latest'
 	) {
-		$versionId = $versionId === 'compare' ? 'compare' : VersionId::from($versionId)->value();
-		$viewUrl   = $model->panel()->url(true) . '/preview';
-
 		parent::__construct(
+			model: $model,
 			class: 'k-versions-view-button',
-			icon: $versionId === 'compare' ? 'layout-columns' : 'git-branch',
-			options: [
-				[
-					'label'   => I18n::translate('version.latest'),
-					'icon'    => 'git-branch',
-					'link'    => $viewUrl . '/latest',
-					'current' => $versionId === 'latest'
-				],
-				[
-					'label'   => I18n::translate('version.changes'),
-					'icon'    => 'git-branch',
-					'link'    => $viewUrl . '/changes',
-					'current' => $versionId === 'changes'
-				],
-				'-',
-				[
-					'label'   => I18n::translate('version.compare'),
-					'icon'    => 'layout-columns',
-					'link'    => $viewUrl . '/compare',
-					'current' => $versionId === 'compare'
-				],
-
-			],
-			text: I18n::translate('version.' . $versionId),
+			icon: $this->icon(),
+			text: $this->i18n('version.' . $this->mode()),
 		);
+	}
+
+	/**
+	 * Returns the button icon based on the view's mode
+	 * @since 5.1.0
+	 */
+	public function icon(): string
+	{
+		return match ($this->mode) {
+			'compare' => 'layout-columns',
+			default   => 'git-branch',
+		};
+	}
+
+	/**
+	 * Whether the given mode is the current mode
+	 * @since 5.1.0
+	 */
+	public function isCurrent(string $mode): bool
+	{
+		return $this->mode() === $mode;
+	}
+
+	/**
+	 * Returns the view's mode using the proper
+	 * values for version IDs
+	 * @since 5.1.0
+	 */
+	public function mode(): string
+	{
+		return match ($this->mode) {
+			'compare' => 'compare',
+			default   => VersionId::from($this->mode)->value()
+		};
+	}
+
+	/**
+	 * Returns the options for the dropdown
+	 * @since 5.1.0
+	 */
+	public function options(): array
+	{
+		return $this->options ??= [
+			[
+				'label'   => I18n::translate('version.latest'),
+				'icon'    => 'git-branch',
+				'link'    => $this->url('latest'),
+				'current' => $this->isCurrent('latest')
+			],
+			[
+				'label'   => I18n::translate('version.changes'),
+				'icon'    => 'git-branch',
+				'link'    => $this->url('changes'),
+				'current' => $this->isCurrent('changes')
+			],
+			'-',
+			[
+				'label'   => I18n::translate('version.compare'),
+				'icon'    => 'layout-columns',
+				'link'    => $this->url('compare'),
+				'current' => $this->isCurrent('compare')
+			],
+
+		];
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'options' => $this->options()
+		];
+	}
+
+	/**
+	 * Returns the preview view URL for the given version ID
+	 * @since 5.1.0
+	 */
+	public function url(string $versionId): string
+	{
+		return $this->model->panel()->url(true) . '/preview/' . $versionId;
 	}
 }

--- a/src/Panel/Ui/Button/VersionsButton.php
+++ b/src/Panel/Ui/Button/VersionsButton.php
@@ -33,9 +33,9 @@ class VersionsButton extends ViewButton
 
 	/**
 	 * Returns the button icon based on the view's mode
-	 * @since 5.1.0
+	 * @since 6.0.0
 	 */
-	public function icon(): string
+	protected function icon(): string
 	{
 		return match ($this->mode) {
 			'compare' => 'layout-columns',
@@ -45,7 +45,7 @@ class VersionsButton extends ViewButton
 
 	/**
 	 * Whether the given mode is the current mode
-	 * @since 5.1.0
+	 * @since 6.0.0
 	 */
 	public function isCurrent(string $mode): bool
 	{
@@ -55,7 +55,7 @@ class VersionsButton extends ViewButton
 	/**
 	 * Returns the view's mode using the proper
 	 * values for version IDs
-	 * @since 5.1.0
+	 * @since 6.0.0
 	 */
 	public function mode(): string
 	{
@@ -67,7 +67,7 @@ class VersionsButton extends ViewButton
 
 	/**
 	 * Returns the options for the dropdown
-	 * @since 5.1.0
+	 * @since 6.0.0
 	 */
 	public function options(): array
 	{
@@ -105,7 +105,7 @@ class VersionsButton extends ViewButton
 
 	/**
 	 * Returns the preview view URL for the given version ID
-	 * @since 5.1.0
+	 * @since 6.0.0
 	 */
 	public function url(string $versionId): string
 	{

--- a/tests/Panel/Ui/Button/VersionsButtonTest.php
+++ b/tests/Panel/Ui/Button/VersionsButtonTest.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Panel\Ui\Button;
 
-use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -12,26 +11,76 @@ class VersionsButtonTest extends TestCase
 {
 	public function testButton(): void
 	{
-		// needed to load the translations
-		new App();
-
 		$page   = new Page(['slug' => 'test']);
-		$button = new VersionsButton(model: $page, versionId: 'latest');
+		$button = new VersionsButton(model: $page, mode: 'latest');
 
 		$this->assertSame('k-view-button', $button->component);
 		$this->assertSame('k-versions-view-button', $button->class);
 		$this->assertSame('git-branch', $button->icon);
+	}
 
-		$this->assertSame('Latest version', $button->text);
-		$this->assertSame('Latest version', $button->options[0]['label']);
-		$this->assertTrue($button->options[0]['current']);
+	public function testIcon(): void
+	{
+		$page   = new Page(['slug' => 'test']);
+		$button = new VersionsButton(model: $page, mode: 'latest');
+		$this->assertSame('git-branch', $button->icon());
 
-		$this->assertSame('Changed version', $button->options[1]['label']);
-		$this->assertFalse($button->options[1]['current']);
+		$button = new VersionsButton(model: $page, mode: 'compare');
+		$this->assertSame('layout-columns', $button->icon());
+	}
 
-		$this->assertSame('-', $button->options[2]);
+	public function testIsCurrent(): void
+	{
+		$page   = new Page(['slug' => 'test']);
+		$button = new VersionsButton(model: $page, mode: 'latest');
+		$this->assertTrue($button->isCurrent('latest'));
+		$this->assertFalse($button->isCurrent('changes'));
+	}
 
-		$this->assertSame('Compare versions', $button->options[3]['label']);
-		$this->assertFalse($button->options[3]['current']);
+	public function testMode(): void
+	{
+		$page   = new Page(['slug' => 'test']);
+
+		$button = new VersionsButton(model: $page, mode: 'latest');
+		$this->assertSame('latest', $button->mode());
+
+		$button = new VersionsButton(model: $page, mode: 'compare');
+		$this->assertSame('compare', $button->mode());
+	}
+
+	public function testOptions(): void
+	{
+		$page   = new Page(['slug' => 'test']);
+		$button = new VersionsButton(model: $page, mode: 'latest');
+
+		$options = $button->options();
+		$this->assertSame('Latest version', $options[0]['label']);
+		$this->assertTrue($options[0]['current']);
+
+		$this->assertSame('Changed version', $options[1]['label']);
+		$this->assertFalse($options[1]['current']);
+
+		$this->assertSame('-', $options[2]);
+
+		$this->assertSame('Compare versions', $options[3]['label']);
+		$this->assertFalse($options[3]['current']);
+	}
+
+	public function testProps(): void
+	{
+		$page   = new Page(['slug' => 'test']);
+		$button = new VersionsButton(model: $page, mode: 'latest');
+
+		$props = $button->props();
+		$this->assertIsArray($props['options']);
+	}
+
+	public function testUrl(): void
+	{
+		$page   = new Page(['slug' => 'test']);
+		$button = new VersionsButton(model: $page, mode: 'latest');
+
+		$this->assertSame('/pages/test/preview/latest', $button->url('latest'));
+		$this->assertSame('/pages/test/preview/changes', $button->url('changes'));
 	}
 }


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->


Splitting up the code in `VersionsButton` into smaller methods - makes it easier to customize it a bit further down the road in a v6 PR. But I think these changes could already go into v5.1.

## Changelog
### Breaking change
- `$versionId` parameter for `Kirby\Panel\Ui\Button\VersionsButton::__construct()` has been renamed to `$mode`