### PR TITLE
feat: New `session.cookieDomain` option

### DIFF
--- a/src/Session/AutoSession.php
+++ b/src/Session/AutoSession.php
@@ -26,6 +26,7 @@ class AutoSession
 	 *                       - `durationNormal`: Duration of normal sessions in seconds; defaults to 2 hours
 	 *                       - `durationLong`: Duration of "remember me" sessions in seconds; defaults to 2 weeks
 	 *                       - `timeout`: Activity timeout in seconds (integer or false for none); *only* used for normal sessions; defaults to `1800` (half an hour)
+	 *                       - `cookieDomain`: Domain to set the cookie to (this disables the cookie path restriction); defaults to none (default browser behavior)
 	 *                       - `cookieName`: Name to use for the session cookie; defaults to `kirby_session`
 	 *                       - `gcInterval`: How often should the garbage collector be run?; integer or `false` for never; defaults to `100`
 	 */
@@ -38,6 +39,7 @@ class AutoSession
 			'durationNormal' => 7200,
 			'durationLong'   => 1209600,
 			'timeout'        => 1800,
+			'cookieDomain'   => null,
 			'cookieName'     => 'kirby_session',
 			'gcInterval'     => 100,
 			...$options
@@ -45,8 +47,9 @@ class AutoSession
 
 		// create an internal instance of the low-level Sessions class
 		$this->sessions = new Sessions($store, [
-			'cookieName' => $this->options['cookieName'],
-			'gcInterval' => $this->options['gcInterval']
+			'cookieDomain' => $this->options['cookieDomain'],
+			'cookieName'   => $this->options['cookieName'],
+			'gcInterval'   => $this->options['gcInterval']
 		]);
 	}
 

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -465,9 +465,12 @@ class Session
 
 		// (re)transmit session token
 		if ($this->mode === 'cookie') {
+			$cookieDomain = $this->sessions->cookieDomain();
+
 			Cookie::set($this->sessions->cookieName(), $this->token(), [
 				'lifetime' => $this->tokenExpiry,
-				'path'     => Url::index(['host' => null, 'trailingSlash' => true]),
+				'path'     => $cookieDomain ? '/' : Url::index(['host' => null, 'trailingSlash' => true]),
+				'domain'   => $cookieDomain,
 				'secure'   => Url::scheme() === 'https',
 				'httpOnly' => true,
 				'sameSite' => 'Lax'

--- a/src/Session/Sessions.php
+++ b/src/Session/Sessions.php
@@ -23,6 +23,7 @@ class Sessions
 {
 	protected SessionStore $store;
 	protected string $mode;
+	protected string|null $cookieDomain;
 	protected string $cookieName;
 
 	protected array $cache = [];
@@ -33,6 +34,7 @@ class Sessions
 	 * @param \Kirby\Session\SessionStore|string $store SessionStore object or a path to the storage directory (uses the FileSessionStore)
 	 * @param array $options Optional additional options:
 	 *                       - `mode`: Default token transmission mode (cookie, header or manual); defaults to `cookie`
+	 *                       - `cookieDomain`: Domain to set the cookie to (this disables the cookie path restriction); defaults to none (default browser behavior)
 	 *                       - `cookieName`: Name to use for the session cookie; defaults to `kirby_session`
 	 *                       - `gcInterval`: How often should the garbage collector be run?; integer or `false` for never; defaults to `100`
 	 */
@@ -45,9 +47,10 @@ class Sessions
 			default                        => new FileSessionStore($store),
 		};
 
-		$this->mode       = $options['mode']       ?? 'cookie';
-		$this->cookieName = $options['cookieName'] ?? 'kirby_session';
-		$gcInterval       = $options['gcInterval'] ?? 100;
+		$this->mode         = $options['mode']         ?? 'cookie';
+		$this->cookieDomain = $options['cookieDomain'] ?? null;
+		$this->cookieName   = $options['cookieName']   ?? 'kirby_session';
+		$gcInterval         = $options['gcInterval']   ?? 100;
 
 		// validate options
 		if (in_array($this->mode, ['cookie', 'header', 'manual'], true) === false) {
@@ -192,6 +195,14 @@ class Sessions
 	public function store(): SessionStore
 	{
 		return $this->store;
+	}
+
+	/**
+	 * Getter for the cookie domain
+	 */
+	public function cookieDomain(): string|null
+	{
+		return $this->cookieDomain;
 	}
 
 	/**

--- a/tests/Session/AutoSessionTest.php
+++ b/tests/Session/AutoSessionTest.php
@@ -45,6 +45,14 @@ class AutoSessionTest extends TestCase
 		$autoSession = new AutoSession(static::FIXTURES);
 		$this->assertSame(static::FIXTURES, $pathProperty->getValue($sessionsProperty->getValue($autoSession)->store()));
 
+		// default cookie domain
+		$autoSession = new AutoSession($this->store);
+		$this->assertNull($sessionsProperty->getValue($autoSession)->cookieDomain());
+
+		// custom cookie domain
+		$autoSession = new AutoSession($this->store, ['cookieDomain' => 'getkirby.com']);
+		$this->assertSame('getkirby.com', $sessionsProperty->getValue($autoSession)->cookieDomain());
+
 		// default cookie name
 		$autoSession = new AutoSession($this->store);
 		$this->assertSame('kirby_session', $sessionsProperty->getValue($autoSession)->cookieName());

--- a/tests/Session/SessionsTest.php
+++ b/tests/Session/SessionsTest.php
@@ -63,10 +63,12 @@ class SessionsTest extends TestCase
 	public function testConstructorOptions(): void
 	{
 		$sessions = new Sessions(static::FIXTURES, [
-			'mode'       => 'header',
-			'cookieName' => 'my_cookie_name'
+			'mode'         => 'header',
+			'cookieDomain' => 'getkirby.com',
+			'cookieName'   => 'my_cookie_name'
 		]);
 
+		$this->assertSame('getkirby.com', $sessions->cookieDomain());
 		$this->assertSame('my_cookie_name', $sessions->cookieName());
 
 		$reflector = new ReflectionClass(Sessions::class);
@@ -80,6 +82,13 @@ class SessionsTest extends TestCase
 		$this->expectException(InvalidArgumentException::class);
 
 		new Sessions(static::FIXTURES, ['mode' => 'invalid']);
+	}
+
+	public function testConstructorInvalidCookieDomain(): void
+	{
+		$this->expectException(TypeError::class);
+
+		new Sessions(static::FIXTURES, ['cookieDomain' => ['foo']]);
 	}
 
 	public function testConstructorInvalidCookieName(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Implements <https://feedback.getkirby.com/628>.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features
<!-- 
e.g. New feature X which helps users to …
-->

- New `session.cookieDomain` option that allows to share the session cookie across subdomains with a shared `sessions` folder <https://feedback.getkirby.com/628>

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

For <https://getkirby.com/docs/reference/system/options/session>:

```md
return [
    'session' => [
        'durationNormal' => 7200,            // default: 2 hours
        'durationLong'   => 1209600,         // default: 2 weeks
        'timeout'        => 1800,            // default: half an hour
        'cookieDomain'   => 'getkirby.com',  // default: automatic browser behavior
        'cookieName'     => 'kirby_session',
        'gcInterval'     => 100              // default: cleanup every ~100 requests
    ]
];

...

<since v="5.1.0">
## `cookieDomain`

The topmost-level domain on which the session cookie should be sent.

<info>
You can read more about the behavior of the `domain` attribute for cookies in the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cookies#define_where_cookies_are_sent).

Note that setting the `cookieDomain` option disables Kirby setting the `path` attribute to the cookie (relevant in subfolder setups).
</info>
</since>
```

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion