### PR TITLE
fix: Avoid content loss by allowing disabled value submission

### DIFF
--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -112,10 +112,6 @@ trait Value
 			return false;
 		}
 
-		if ($this->isDisabled() === true) {
-			return false;
-		}
-
 		if ($this->isTranslatable($language) === false) {
 			return false;
 		}

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -479,7 +479,7 @@ class StructureFieldTest extends TestCase
 
 		$value = $field->toStoredValue();
 
-		$this->assertSame('Default Title', $value[0]['a']);
+		$this->assertSame('A', $value[0]['a']);
 		$this->assertSame('B', $value[0]['b']);
 	}
 

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -367,7 +367,7 @@ class FieldClassTest extends TestCase
 		$language = Language::ensure('current');
 
 		$field = new TestField(['disabled' => true]);
-		$this->assertFalse($field->isSubmittable($language));
+		$this->assertTrue($field->isSubmittable($language));
 	}
 
 	public function testIsSubmittableWithNonDefaultLanguage()

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -742,7 +742,7 @@ class FieldsTest extends TestCase
 
 		$this->assertSame([
 			'a' => 'A updated',
-			'b' => 'B'
+			'b' => 'B updated'
 		], $fields->toStoredValues());
 	}
 


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes

- Avoid lost values in structure forms by keeping disabled values on submit. github.com/getkirby/kirby/issues/7526

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion