### PR TITLE
fix: Disable all fields in a table layout of a models section

### DIFF
--- a/panel/src/components/Sections/ModelsSection.vue
+++ b/panel/src/components/Sections/ModelsSection.vue
@@ -69,6 +69,7 @@ export default {
 				batch: false,
 				columns: {},
 				empty: null,
+				fields: {},
 				headline: null,
 				help: null,
 				layout: "list",
@@ -144,7 +145,7 @@ export default {
 			return {
 				columns: this.options.columns,
 				empty: this.emptyPropsWithSearch,
-				fields: this.options.fields,
+				fields: this.fields,
 				layout: this.options.layout,
 				help: this.options.help,
 				items: this.items,
@@ -167,6 +168,18 @@ export default {
 					? this.$t("search.results.none")
 					: (this.options.empty ?? this.emptyProps.text)
 			};
+		},
+		fields() {
+			const fields = {};
+
+			for (const field in this.options.columns ?? {}) {
+				fields[field] = {
+					...(this.options.fields?.[field] ?? this.options.columns[field]),
+					disabled: true
+				};
+			}
+
+			return fields;
 		},
 		items() {
 			return this.data;


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Editable field previews are disabled in pages and files sections (instead of intractable but non-functional)
#6582

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion