### PR TITLE
feat: Collapse/Expand all for blocks options

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -15,7 +15,7 @@
 	"changes": "Changes",
 	"confirm": "Ok",
 	"collapse": "Collapse",
-	"collapse.all": "Collapse All",
+	"collapse.all": "Collapse all",
 	"color": "Color",
 	"coordinates": "Coordinates",
 	"copy": "Copy",
@@ -295,7 +295,7 @@
 	"error.validation.url": "Please enter a valid URL",
 
 	"expand": "Expand",
-	"expand.all": "Expand All",
+	"expand.all": "Expand all",
 
 	"field.invalid": "The field is invalid",
 	"field.required": "The field is required",

--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -246,6 +246,12 @@ export default {
 		close() {
 			this.$panel.drawer.close(this.id);
 		},
+		collapse() {
+			this.$refs.editor?.collapse?.();
+		},
+		expand() {
+			this.$refs.editor?.expand?.();
+		},
 		focus() {
 			if (typeof this.$refs.editor?.focus === "function") {
 				this.$refs.editor.focus();
@@ -258,6 +264,15 @@ export default {
 				block.$refs.container?.focus();
 				block.open(null, true);
 			}
+		},
+		isCollapsed() {
+			return (this.$refs.editor?.collapsed ?? false) === true;
+		},
+		isCollapsible() {
+			return typeof this.$refs.editor?.collapse === "function";
+		},
+		isExpandable() {
+			return typeof this.$refs.editor?.expand === "function";
 		},
 		isSplitable() {
 			if (this.isFull === true) {

--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -226,6 +226,14 @@ export default {
 				}
 			});
 		},
+		collapse(block) {
+			this.ref(block)?.collapse?.();
+		},
+		collapseAll() {
+			for (const block of this.blocks) {
+				this.collapse(block);
+			}
+		},
 		copy(e) {
 			// don't copy when there are no blocks yet
 			if (this.blocks.length === 0) {
@@ -337,6 +345,14 @@ export default {
 			this.blocks.splice(index + 1, 0, copy);
 			this.save();
 		},
+		expand(block) {
+			this.ref(block)?.expand?.();
+		},
+		expandAll() {
+			for (const block of this.blocks) {
+				this.expand(block);
+			}
+		},
 		fieldset(block) {
 			return (
 				this.fieldsets[block.type] ?? {
@@ -373,6 +389,24 @@ export default {
 		hide(block) {
 			set(block, "isHidden", true);
 			this.save();
+		},
+		isFullyCollapsed() {
+			return this.blocks.every((block) => {
+				block = this.ref(block);
+				return block.isCollapsible() === false || block.isCollapsed() === true;
+			});
+		},
+		isCollapsible() {
+			return this.blocks.some((block) => this.ref(block).isCollapsible());
+		},
+		isFullyExpanded() {
+			return this.blocks.every((block) => {
+				block = this.ref(block);
+				return block.isCollapsible() === false || block.isCollapsed() === false;
+			});
+		},
+		isExpandable() {
+			return this.blocks.some((block) => this.ref(block).isExpandable());
 		},
 		isInputEvent() {
 			const focused = document.querySelector(":focus");

--- a/panel/src/components/Forms/Blocks/Types/Fields.vue
+++ b/panel/src/components/Forms/Blocks/Types/Fields.vue
@@ -70,8 +70,13 @@ export default {
 			}
 		},
 		toggle() {
-			this.collapsed = !this.collapsed;
-			this.state(this.collapsed);
+			this.state((this.collapsed = !this.collapsed));
+		},
+		collapse() {
+			this.state((this.collapsed = true));
+		},
+		expand() {
+			this.state((this.collapsed = false));
 		}
 	}
 };

--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -74,9 +74,14 @@ export default {
 		},
 		isFull() {
 			return this.max && this.value.length >= this.max;
+		}
+	},
+	methods: {
+		focus() {
+			this.$refs.blocks.focus();
 		},
-		options() {
-			return [
+		options(ready) {
+			const options = [
 				{
 					click: () => this.$refs.blocks.copyAll(),
 					disabled: this.isEmpty,
@@ -88,20 +93,43 @@ export default {
 					disabled: this.isFull,
 					icon: "download",
 					text: this.$t("paste")
-				},
-				"-",
-				{
-					click: () => this.$refs.blocks.removeAll(),
-					disabled: this.isEmpty,
-					icon: "trash",
-					text: this.$t("delete.all")
 				}
 			];
-		}
-	},
-	methods: {
-		focus() {
-			this.$refs.blocks.focus();
+
+			if (
+				this.$refs.blocks.isCollapsible() === true ||
+				this.$refs.blocks.isExpandable() === true
+			) {
+				options.push("-");
+			}
+
+			if (this.$refs.blocks.isCollapsible() === true) {
+				options.push({
+					click: () => this.$refs.blocks.collapseAll(),
+					disabled: this.isEmpty || this.$refs.blocks.isFullyCollapsed(),
+					icon: "collapse",
+					text: this.$t("collapse.all")
+				});
+			}
+
+			if (this.$refs.blocks.isExpandable() === true) {
+				options.push({
+					click: () => this.$refs.blocks.expandAll(),
+					disabled: this.isEmpty || this.$refs.blocks.isFullyExpanded(),
+					icon: "expand",
+					text: this.$t("expand.all")
+				});
+			}
+
+			options.push("-");
+			options.push({
+				click: () => this.$refs.blocks.removeAll(),
+				disabled: this.isEmpty,
+				icon: "trash",
+				text: this.$t("delete.all")
+			});
+
+			return ready(options);
 		}
 	}
 };


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- New options to expand or collapse all blocks at once in the blocks options dropdown (if there are collapsible blocks used, e.g. with `preview: fields`) (thx @dennisbaum)

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion