### PR TITLE
fix: respect case preferences when grouping by callable

### DIFF
--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -553,7 +553,7 @@ class Collection extends Iterator implements Stringable
 				}
 			}
 
-			return new self($groups);
+			return new self($groups, !$caseInsensitive);
 		}
 
 		throw new Exception(

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -276,7 +276,7 @@ class CollectionTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Invalid grouping value for key: a');
 
-		$collection->group(fn($item) => false);
+		$collection->group(fn ($item) => false);
 	}
 
 	public function testGroupArray(): void
@@ -286,7 +286,7 @@ class CollectionTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('You cannot group by arrays or objects');
 
-		$collection->group(fn($item) => ['a' => 'b']);
+		$collection->group(fn ($item) => ['a' => 'b']);
 	}
 
 	public function testGroupObject(): void
@@ -296,7 +296,7 @@ class CollectionTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('You cannot group by arrays or objects');
 
-		$collection->group(fn($item) => new Obj(['a' => 'b']));
+		$collection->group(fn ($item) => new Obj(['a' => 'b']));
 	}
 
 	public function testGroupStringObject(): void
@@ -318,7 +318,7 @@ class CollectionTest extends TestCase
 			'group'    => new StringObject('client')
 		];
 
-		$groups = $collection->group(fn($item) => $item['group']);
+		$groups = $collection->group(fn ($item) => $item['group']);
 		$this->assertCount(2, $groups->admin());
 		$this->assertCount(1, $groups->client());
 
@@ -537,7 +537,7 @@ class CollectionTest extends TestCase
 	public function testMap(): void
 	{
 		$collection = new Collection(['a' => 1, 'b' => 2]);
-		$collection->map(fn($item) => $item * 2);
+		$collection->map(fn ($item) => $item * 2);
 		$this->assertSame(['a' => 2, 'b' => 4], $collection->data());
 	}
 
@@ -833,9 +833,9 @@ class CollectionTest extends TestCase
 
 	public function testValuesMap(): void
 	{
-	       $values = $this->collection->values(
-		       fn ($item) => Str::after($item, 'My ')
-	       );
+		$values = $this->collection->values(
+			fn ($item) => Str::after($item, 'My ')
+		);
 
 		$this->assertSame([
 			'first element',

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -383,15 +383,23 @@ class CollectionTest extends TestCase
 			'genre' => 'Hip-Hop',
 		];
 
+		$collection->kayne = [
+			'name' => 'kayne',
+			'genre' => 'hip-hop',
+		];
+
 		$groupsCaseInsensitive = $collection->group(fn (array $item) => $item['genre'], true);
 
+		$this->assertCount(2, $groupsCaseInsensitive);
 		$this->assertTrue($groupsCaseInsensitive->has('pop'));
 		$this->assertTrue($groupsCaseInsensitive->has('hip-hop'));
 
 		$groupsCaseSensitive = $collection->group(fn (array $item) => $item['genre'], false);
 
+		$this->assertCount(3, $groupsCaseSensitive);
 		$this->assertTrue($groupsCaseSensitive->has('Pop'));
 		$this->assertTrue($groupsCaseSensitive->has('Hip-Hop'));
+		$this->assertTrue($groupsCaseSensitive->has('hip-hop'));
 	}
 
 	public function testIndexOf(): void

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -7,10 +7,10 @@ use PHPUnit\Framework\Attributes\CoversClass;
 
 class StringObject
 {
-       public function __construct(
-	       protected string $value
-       ) {
-       }
+	public function __construct(
+		protected string $value
+	) {
+	}
 
 	public function __toString(): string
 	{
@@ -154,9 +154,9 @@ class CollectionTest extends TestCase
 
 	public function testFilter(): void
 	{
-	       $filtered = $this->collection->filter(
-		       fn ($element) => $element === 'My second element'
-	       );
+		$filtered = $this->collection->filter(
+			fn ($element) => $element === 'My second element'
+		);
 
 		$this->assertSame('My second element', $filtered->first());
 		$this->assertSame('My second element', $filtered->last());
@@ -256,7 +256,7 @@ class CollectionTest extends TestCase
 			'group'    => 'client'
 		];
 
-			   $groups = $collection->group(fn ($item) => $item['group']);
+		$groups = $collection->group(fn ($item) => $item['group']);
 		$this->assertCount(2, $groups->admin());
 		$this->assertCount(1, $groups->client());
 
@@ -264,7 +264,7 @@ class CollectionTest extends TestCase
 		$this->assertSame('peter', $firstAdmin['username']);
 
 		// alias
-			   $groups = $collection->groupBy(fn ($item) => $item['group']);
+		$groups = $collection->groupBy(fn ($item) => $item['group']);
 		$this->assertCount(2, $groups->admin());
 		$this->assertCount(1, $groups->client());
 	}
@@ -797,7 +797,7 @@ class CollectionTest extends TestCase
 
 		// with mapping
 		$collection = new Collection(['a' => 1, 'b' => 2]);
-			   $this->assertSame(['a' => 2, 'b' => 4], $collection->toArray(fn ($item) => $item * 2));
+		$this->assertSame(['a' => 2, 'b' => 4], $collection->toArray(fn ($item) => $item * 2));
 	}
 
 	public function testToJson(): void

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -9,8 +9,7 @@ class StringObject
 {
 	public function __construct(
 		protected string $value
-	) {
-	}
+	) {}
 
 	public function __toString(): string
 	{
@@ -155,7 +154,7 @@ class CollectionTest extends TestCase
 	public function testFilter(): void
 	{
 		$filtered = $this->collection->filter(
-			fn ($element) => $element === 'My second element'
+			fn($element) => $element === 'My second element'
 		);
 
 		$this->assertSame('My second element', $filtered->first());
@@ -256,7 +255,7 @@ class CollectionTest extends TestCase
 			'group'    => 'client'
 		];
 
-		$groups = $collection->group(fn ($item) => $item['group']);
+		$groups = $collection->group(fn($item) => $item['group']);
 		$this->assertCount(2, $groups->admin());
 		$this->assertCount(1, $groups->client());
 
@@ -264,7 +263,7 @@ class CollectionTest extends TestCase
 		$this->assertSame('peter', $firstAdmin['username']);
 
 		// alias
-		$groups = $collection->groupBy(fn ($item) => $item['group']);
+		$groups = $collection->groupBy(fn($item) => $item['group']);
 		$this->assertCount(2, $groups->admin());
 		$this->assertCount(1, $groups->client());
 	}
@@ -276,7 +275,7 @@ class CollectionTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Invalid grouping value for key: a');
 
-		$collection->group(fn ($item) => false);
+		$collection->group(fn($item) => false);
 	}
 
 	public function testGroupArray(): void
@@ -286,7 +285,7 @@ class CollectionTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('You cannot group by arrays or objects');
 
-		$collection->group(fn ($item) => ['a' => 'b']);
+		$collection->group(fn($item) => ['a' => 'b']);
 	}
 
 	public function testGroupObject(): void
@@ -296,7 +295,7 @@ class CollectionTest extends TestCase
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('You cannot group by arrays or objects');
 
-		$collection->group(fn ($item) => new Obj(['a' => 'b']));
+		$collection->group(fn($item) => new Obj(['a' => 'b']));
 	}
 
 	public function testGroupStringObject(): void
@@ -318,7 +317,7 @@ class CollectionTest extends TestCase
 			'group'    => new StringObject('client')
 		];
 
-		$groups = $collection->group(fn ($item) => $item['group']);
+		$groups = $collection->group(fn($item) => $item['group']);
 		$this->assertCount(2, $groups->admin());
 		$this->assertCount(1, $groups->client());
 
@@ -362,6 +361,36 @@ class CollectionTest extends TestCase
 		$this->expectExceptionMessage('Can only group by string values or by providing a callback function');
 
 		$collection->group(1);
+	}
+
+	public function testGroupByCallableCaseSensitive(): void
+	{
+		$collection = new Collection();
+
+		$collection->taylor = [
+			'name' => 'Taylor',
+			'genre' => 'Pop',
+		];
+
+		$collection->justin = [
+			'name' => 'Justin',
+			'genre' => 'Pop',
+		];
+
+		$collection->aubrey = [
+			'name' => 'Aubrey',
+			'genre' => 'Hip-Hop',
+		];
+
+		$groupsCaseInsensitive = $collection->group(fn(array $item) => $item['genre'], true);
+
+		$this->assertTrue($groupsCaseInsensitive->has('pop'));
+		$this->assertTrue($groupsCaseInsensitive->has('hip-hop'));
+
+		$groupsCaseSensitive = $collection->group(fn(array $item) => $item['genre'], false);
+
+		$this->assertTrue($groupsCaseSensitive->has('Pop'));
+		$this->assertTrue($groupsCaseSensitive->has('Hip-Hop'));
 	}
 
 	public function testIndexOf(): void
@@ -507,7 +536,7 @@ class CollectionTest extends TestCase
 	public function testMap(): void
 	{
 		$collection = new Collection(['a' => 1, 'b' => 2]);
-		$collection->map(fn ($item) => $item * 2);
+		$collection->map(fn($item) => $item * 2);
 		$this->assertSame(['a' => 2, 'b' => 4], $collection->data());
 	}
 
@@ -767,7 +796,7 @@ class CollectionTest extends TestCase
 
 		// with mapping
 		$collection = new Collection(['a' => 1, 'b' => 2]);
-		$this->assertSame(['a' => 2, 'b' => 4], $collection->toArray(fn ($item) => $item * 2));
+		$this->assertSame(['a' => 2, 'b' => 4], $collection->toArray(fn($item) => $item * 2));
 	}
 
 	public function testToJson(): void
@@ -804,7 +833,7 @@ class CollectionTest extends TestCase
 	public function testValuesMap(): void
 	{
 		$values = $this->collection->values(
-			fn ($item) => Str::after($item, 'My ')
+			fn($item) => Str::after($item, 'My ')
 		);
 
 		$this->assertSame([

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -7,9 +7,10 @@ use PHPUnit\Framework\Attributes\CoversClass;
 
 class StringObject
 {
-	public function __construct(
-		protected string $value
-	) {}
+       public function __construct(
+	       protected string $value
+       ) {
+       }
 
 	public function __toString(): string
 	{
@@ -153,9 +154,9 @@ class CollectionTest extends TestCase
 
 	public function testFilter(): void
 	{
-		$filtered = $this->collection->filter(
-			fn($element) => $element === 'My second element'
-		);
+	       $filtered = $this->collection->filter(
+		       fn ($element) => $element === 'My second element'
+	       );
 
 		$this->assertSame('My second element', $filtered->first());
 		$this->assertSame('My second element', $filtered->last());
@@ -255,7 +256,7 @@ class CollectionTest extends TestCase
 			'group'    => 'client'
 		];
 
-		$groups = $collection->group(fn($item) => $item['group']);
+			   $groups = $collection->group(fn ($item) => $item['group']);
 		$this->assertCount(2, $groups->admin());
 		$this->assertCount(1, $groups->client());
 
@@ -263,7 +264,7 @@ class CollectionTest extends TestCase
 		$this->assertSame('peter', $firstAdmin['username']);
 
 		// alias
-		$groups = $collection->groupBy(fn($item) => $item['group']);
+			   $groups = $collection->groupBy(fn ($item) => $item['group']);
 		$this->assertCount(2, $groups->admin());
 		$this->assertCount(1, $groups->client());
 	}
@@ -796,7 +797,7 @@ class CollectionTest extends TestCase
 
 		// with mapping
 		$collection = new Collection(['a' => 1, 'b' => 2]);
-		$this->assertSame(['a' => 2, 'b' => 4], $collection->toArray(fn($item) => $item * 2));
+			   $this->assertSame(['a' => 2, 'b' => 4], $collection->toArray(fn ($item) => $item * 2));
 	}
 
 	public function testToJson(): void
@@ -832,9 +833,9 @@ class CollectionTest extends TestCase
 
 	public function testValuesMap(): void
 	{
-		$values = $this->collection->values(
-			fn($item) => Str::after($item, 'My ')
-		);
+	       $values = $this->collection->values(
+		       fn ($item) => Str::after($item, 'My ')
+	       );
 
 		$this->assertSame([
 			'first element',

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -383,12 +383,12 @@ class CollectionTest extends TestCase
 			'genre' => 'Hip-Hop',
 		];
 
-		$groupsCaseInsensitive = $collection->group(fn(array $item) => $item['genre'], true);
+		$groupsCaseInsensitive = $collection->group(fn (array $item) => $item['genre'], true);
 
 		$this->assertTrue($groupsCaseInsensitive->has('pop'));
 		$this->assertTrue($groupsCaseInsensitive->has('hip-hop'));
 
-		$groupsCaseSensitive = $collection->group(fn(array $item) => $item['genre'], false);
+		$groupsCaseSensitive = $collection->group(fn (array $item) => $item['genre'], false);
 
 		$this->assertTrue($groupsCaseSensitive->has('Pop'));
 		$this->assertTrue($groupsCaseSensitive->has('Hip-Hop'));


### PR DESCRIPTION
## Changelog 

### 🐛 Bug fixes
Keep original case intact when grouping a collection by callable. See issue #7562.

