### PR TITLE
fix: layout snippet inside of snippet (#7567)

### DIFF
--- a/src/Template/Snippet.php
+++ b/src/Template/Snippet.php
@@ -135,15 +135,30 @@ class Snippet extends Tpl
 	}
 
 	/**
-	 * Closes any potentially open layout snippet.
+	 * Renders the given template.
+	 * This method supports the use of layout snippets inside the template.
 	 *
-	 * @param Snippet|null $outsideSnippet The expected value for `Snippet::$current`.
-	 * @param string|null $template The content of the currently processed template or snippet.
-	 * @param array $data Additional data provided to any potential layout snippet.
-	 * @return string|null The new adjusted content of the template if `$template` was given.
+	 * @param string|null $file Path to the template file.
+	 * @param array $data Data available inside the template.
+	 * @param array $layoutData Data available inside any potential layout snippet.
+	 * @return string The rendered content of the given template file.
+	 * @throws Throwable
+	 *
+	 * @see Tpl::load() Base implementation without support for layout snippets.
 	 */
-	public static function endlayout(Snippet|null $outsideSnippet, string|null $template = null, array $data = []): string|null
-	{
+	public static function load(
+		string|null $file = null,
+		array $data = [],
+		array $layoutData = [],
+	): string {
+		// if the template is rendered inside a snippet,
+		// we need to keep the "outside" snippet object
+		// to compare it later
+		$outsideSnippet = Snippet::$current;
+
+		// load the template
+		$template = parent::load($file, $data);
+
 		// if last `endsnippet()` inside the current template
 		// has been omitted (= snippet was used as layout snippet),
 		// `Snippet::$current` will point to a snippet that was
@@ -159,21 +174,16 @@ class Snippet extends Tpl
 			return $template;
 		}
 
-		if (!isset($template)) {
-			// let the snippet close and render natively
-			echo static::$current?->render($data);
-			return null;
-		}
 		if (Snippet::$current->slots()->count() === 0) {
 			// no slots have been defined, but the template code
 			// should be used as default slot
-			return Snippet::$current->render($data, [
+			return Snippet::$current->render($layoutData, [
 				'default' => $template
 			]);
 		}
 		// swallow any "unslotted" content
 		// between start and end
-		return Snippet::$current->render($data);
+		return Snippet::$current->render($layoutData);
 	}
 
 	/**
@@ -289,16 +299,8 @@ class Snippet extends Tpl
 		// custom data overrides for the data that was passed to the snippet instance
 		$data = array_replace_recursive($this->data, $data);
 
-		// if the template is rendered inside a snippet,
-		// we need to keep the "outside" snippet object
-		// to compare it later
-		$snippet = Snippet::$current;
-
 		// load the template representing this snippet
-		$template = static::load($this->file, static::scope($data, $this->slots()));
-
-		// handle any potentially open layout snippet
-		return static::endlayout($snippet, $template);
+		return static::load($this->file, static::scope($data, $this->slots()));
 	}
 
 	/**

--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -5,7 +5,6 @@ namespace Kirby\Template;
 use Exception;
 use Kirby\Cms\App;
 use Kirby\Filesystem\F;
-use Kirby\Toolkit\Tpl;
 use Stringable;
 
 /**
@@ -155,16 +154,7 @@ class Template implements Stringable
 	 */
 	public function render(array $data = []): string
 	{
-		// if the template is rendered inside a snippet,
-		// we need to keep the "outside" snippet object
-		// to compare it later
-		$snippet = Snippet::$current;
-
-		// load the template
-		$template = Tpl::load($this->file(), $data);
-
-		// handle any potentially open layout snippet
-		return Snippet::endlayout($snippet, $template, $data);
+		return Snippet::load($this->file(), $data, $data);
 	}
 
 	/**

--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -163,31 +163,8 @@ class Template implements Stringable
 		// load the template
 		$template = Tpl::load($this->file(), $data);
 
-		// if last `endsnippet()` inside the current template
-		// has been omitted (= snippet was used as layout snippet),
-		// `Snippet::$current` will point to a snippet that was
-		// opened inside the template; if that snippet is the direct
-		// child of the snippet that was open before the template was
-		// rendered (which could be `null` if no snippet was open),
-		// take the buffer output from the template as default slot
-		// and render the snippet as final template output
-		if (
-			Snippet::$current === null ||
-			Snippet::$current->parent() !== $snippet
-		) {
-			return $template;
-		}
-
-		// no slots have been defined, but the template code
-		// should be used as default slot
-		if (Snippet::$current->slots()->count() === 0) {
-			return Snippet::$current->render($data, [
-				'default' => $template
-			]);
-		}
-
-		// let the snippet close and render natively
-		return Snippet::$current->render($data);
+		// handle any potentially open layout snippet
+		return Snippet::endlayout($snippet, $template, $data);
 	}
 
 	/**

--- a/tests/Template/SnippetTest.php
+++ b/tests/Template/SnippetTest.php
@@ -259,6 +259,24 @@ class SnippetTest extends TestCase
 	/**
 	 * @covers ::render
 	 */
+	public function testRenderOpenLayoutSnippet()
+	{
+		// all output must be captured
+		$this->expectOutputString('');
+
+		new App([
+			'roots' => [
+				'snippets'  => static::FIXTURES
+			]
+		]);
+
+		$snippet = new Snippet(static::FIXTURES . '/with-layout.php');
+		$this->assertSame("<h1>Layout</h1>\nMy content\n<footer>with other stuff</footer>\n", $snippet->render());
+	}
+
+	/**
+	 * @covers ::render
+	 */
 	public function testRenderWithLazySlots()
 	{
 		$snippet = new Snippet(static::FIXTURES . '/slots.php');


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Fixes #7567. Implement handling of [layout snippets](https://getkirby.com/docs/guide/templates/snippets#passing-slots-to-snippets__layout-snippets) within snippets.

Extract implementation from `Template::render` into `Snippet::load`. `Snippet::load` overrides `Tpl::load`. The calls to `static::load` inside `Snippet::render` and `Snippet::factory` are now referencing `Snippet::load` instead of `Tpl::load`. As a result, these two methods are now correctly handling layout snippets.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Fix layout snippet used within another snippet (#7567)

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

- https://getkirby.com/docs/guide/templates/snippets#passing-slots-to-snippets__layout-snippets

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion