### PR TITLE
fix: Dark theme for current item in block selector

### DIFF
--- a/panel/src/components/Forms/Blocks/BlockSelector.vue
+++ b/panel/src/components/Forms/Blocks/BlockSelector.vue
@@ -166,7 +166,7 @@ export default {
 }
 .k-block-types .k-button[aria-disabled="true"] {
 	opacity: var(--opacity-disabled);
-	--button-color-back: var(--color-gray-200);
+	--button-color-back: transparent;
 	box-shadow: none;
 }
 .k-clipboard-hint {


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

I think the UI of the block selector could be better in general, but this is a simple patch that bring dark theme to parity with light theme:

<img width="596" height="597" alt="Screenshot 2025-08-30 at 11 36 23" src="https://github.com/user-attachments/assets/f7d5c605-5513-47ee-80dc-2926d8d13202" /> <img width="570" height="591" alt="Screenshot 2025-08-30 at 11 36 37" src="https://github.com/user-attachments/assets/5a1887d1-05c6-4555-b361-8fa417c06c9d" />



## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Block selector: fixed UI for currently selected block in dark theme
#7564

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion