### PR TITLE
fix: Use `$fields->toProps()` in object field

### DIFF
--- a/config/fields/object.php
+++ b/config/fields/object.php
@@ -50,7 +50,7 @@ return [
 				return [];
 			}
 
-			return $this->form()->fields()->toArray();
+			return $this->form()->fields()->toProps();
 		},
 		'value' => function () {
 			$data = Data::decode($this->value, 'yaml');

--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -112,7 +112,7 @@ return [
 				return [];
 			}
 
-			return $this->form()->fields()->toArray();
+			return $this->form()->fields()->toProps();
 		},
 		'columns' => function () {
 			$columns   = [];


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

With v5 we refactored the fields classes and added the new `::toProps()` method which we also do need to use there for the subfields of a, object or structure field.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Object and structure field: some properties for the subfields (e.g. `translate`) are working properly again
#7570


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion