### PR TITLE
fix: Support query for ViewButton `options` string

### DIFF
--- a/src/Panel/Ui/Buttons/ViewButton.php
+++ b/src/Panel/Ui/Buttons/ViewButton.php
@@ -165,10 +165,16 @@ class ViewButton extends Button
 	public function props(): array
 	{
 		// helper for props that support Kirby queries
-		$resolve = fn ($value) =>
+		$resolve = fn (string|null $value) =>
 			$value ?
 			$this->model?->toSafeString($value) ?? $value :
 			null;
+
+		$options = $this->options;
+
+		if (is_string($options) === true) {
+			$options = $resolve($options);
+		}
 
 		return [
 			...$props = parent::props(),
@@ -178,7 +184,7 @@ class ViewButton extends Button
 			'link'    => $resolve($props['link']),
 			'text'    => $resolve($props['text']),
 			'theme'   => $resolve($props['theme']),
-			'options' => $this->options
+			'options' => $options
 		];
 	}
 

--- a/tests/Panel/Ui/Buttons/ViewButtonTest.php
+++ b/tests/Panel/Ui/Buttons/ViewButtonTest.php
@@ -212,11 +212,13 @@ class ViewButtonTest extends AreaTestCase
 			model: $model,
 			text: 'Page: {{ page.url }}',
 			link: 'https://getkirby.com/{{ page.slug }}',
+			options: 'my/options/{{ page.slug }}'
 		);
 
 		$props = $component->props();
 		$this->assertSame('Page: /test', $props['text']);
 		$this->assertSame('https://getkirby.com/test', $props['link']);
+		$this->assertSame('my/options/test', $props['options']);
 	}
 
 	public function testResolve(): void


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- View button: `options` string supports Kirby query syntax

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion