### PR TITLE
fix: Input validator overriding id with null

### DIFF
--- a/panel/src/components/Forms/Input/Validator.js
+++ b/panel/src/components/Forms/Input/Validator.js
@@ -27,8 +27,12 @@ export default class InputValidator extends HTMLElement {
 		this.tabIndex = 0;
 
 		// pass-through the id attribute
-		this.input.setAttribute("id", this.getAttribute("id"));
-		this.removeAttribute("id");
+		const id = this.getAttribute("id");
+
+		if (id) {
+			this.input.setAttribute("id", id);
+			this.removeAttribute("id");
+		}
 
 		this.validate();
 	}


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Fixes #7575

Toggles field sets its own IDs on each toggle input. The regression occurred as `k-input-validator` would pass through its own `id` to the first input, even when it actually didn't get any `id` provided. This resulted in setting the `id` of the first input of the toggles input to `null`.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

None as it is a fixed regression from 5.1.0-rc.1
