### PR TITLE
fix: `Exif::iso()` supports array

### DIFF
--- a/src/Image/Exif.php
+++ b/src/Image/Exif.php
@@ -25,7 +25,7 @@ class Exif
 	protected string|null $exposure = null;
 	protected string|null $focalLength = null;
 	protected bool|null $isColor = null;
-	protected string|null $iso = null;
+	protected string|array|null $iso = null;
 	protected Location|null $location = null;
 	protected string|null $timestamp = null;
 	protected int $orientation;
@@ -94,7 +94,7 @@ class Exif
 	/**
 	 * Returns the iso value
 	 */
-	public function iso(): string|null
+	public function iso(): string|array|null
 	{
 		return $this->iso;
 	}


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- `Exif` class now supports arrays for `ISOSpeedRatings `
#7569

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion