### PR TITLE
fix: Ensure pasting only into one blocks component

### DIFF
--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -374,6 +374,9 @@ export default {
 			set(block, "isHidden", true);
 			this.save();
 		},
+		isEventTarget(e) {
+			return e.target.closest(".k-blocks") === this.$el;
+		},
 		isInputEvent() {
 			const focused = document.querySelector(":focus");
 			return focused?.matches(
@@ -457,8 +460,8 @@ export default {
 		onClickGlobal(event) {
 			// ignore focus in dialogs or drawers to keep the current selection
 			if (
-				typeof event.target.closest === "function" &&
-				(event.target.closest(".k-dialog") || event.target.closest(".k-drawer"))
+				event.target.closest(".k-dialog") ||
+				event.target.closest(".k-drawer")
 			) {
 				return;
 			}
@@ -520,14 +523,13 @@ export default {
 				return false;
 			}
 
-			// not when any dialogs or drawers are open
-			if (this.isEditing === true || this.$panel.dialog.isOpen === true) {
+			// not when event doesn't belong to this blocks component
+			if (this.isEventTarget(e) === false) {
 				return false;
 			}
 
-			// not when nothing is selected and the paste event
-			// doesn't target something in the block component
-			if (this.selected.length === 0 && this.$el.contains(e.target) === false) {
+			// not when any dialogs or drawers are open
+			if (this.isEditing === true || this.$panel.dialog.isOpen === true) {
 				return false;
 			}
 


### PR DESCRIPTION

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Blocks field: when pasting blocks into a nested blocks field it is now ensured that only one blocks field receives the pasted content, not nested and parent blocks field both.
#7093


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion