### PR TITLE
fix: Return first item from iso speed rating array

### DIFF
--- a/src/Image/Exif.php
+++ b/src/Image/Exif.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Image;
 
+use Kirby\Toolkit\A;
 use Kirby\Toolkit\V;
 
 /**
@@ -25,7 +26,7 @@ class Exif
 	protected string|null $exposure = null;
 	protected string|null $focalLength = null;
 	protected bool|null $isColor = null;
-	protected string|null $iso = null;
+	protected array|string|null $iso = null;
 	protected Location|null $location = null;
 	protected string|null $timestamp = null;
 	protected int $orientation;
@@ -96,6 +97,10 @@ class Exif
 	 */
 	public function iso(): string|null
 	{
+		if (is_array($this->iso) === true) {
+			return A::first($this->iso);
+		}
+
 		return $this->iso;
 	}
 

--- a/tests/Image/ExifTest.php
+++ b/tests/Image/ExifTest.php
@@ -8,9 +8,14 @@ use ReflectionClass;
 #[CoversClass(Exif::class)]
 class ExifTest extends TestCase
 {
+	protected function _image($filename = 'image/cat.jpg')
+	{
+		return new Image(static::FIXTURES . '/' . $filename);
+	}
+
 	protected function _exif($filename = 'image/cat.jpg')
 	{
-		$image = new Image(static::FIXTURES . '/' . $filename);
+		$image = $this->_image($filename);
 		return new Exif($image);
 	}
 
@@ -70,6 +75,38 @@ class ExifTest extends TestCase
 	}
 
 	public function testIso(): void
+	{
+		$image = $this->_image();
+		$exif = new class ($image) extends Exif {
+			public static function read(string $root): array
+			{
+				return [
+					...parent::read($root),
+					'ISOSpeedRatings' => 100
+				];
+			}
+		};
+
+		$this->assertSame('100', $exif->iso());
+	}
+
+	public function testIsoWithArrayValue(): void
+	{
+		$image = $this->_image();
+		$exif = new class ($image) extends Exif {
+			public static function read(string $root): array
+			{
+				return [
+					...parent::read($root),
+					'ISOSpeedRatings' => [100, 200]
+				];
+			}
+		};
+
+		$this->assertSame('100', $exif->iso());
+	}
+
+	public function testIsoWithoutValue(): void
 	{
 		$exif  = $this->_exif();
 		$this->assertNull($exif->iso());


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
- `Exif::iso()` now returns the first array item if `ISOSpeedRatings` is an array #7569

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion