### PR TITLE
refact: Support button props for `k-dropdown-item`

### DIFF
--- a/panel/src/components/Dropdowns/DropdownItem.vue
+++ b/panel/src/components/Dropdowns/DropdownItem.vue
@@ -4,7 +4,7 @@
 		v-bind="$props"
 		:class="['k-dropdown-item', $attrs.class]"
 		:style="$attrs.style"
-		@click="onClick"
+		@click="$emit('click', $event)"
 	>
 		<!-- @slot The item's content/text -->
 		<slot />
@@ -12,28 +12,20 @@
 </template>
 
 <script>
+import { props as Button } from "@/components/Navigation/Button.vue";
+
 /**
  * Item to be used within `<k-dropdown-content>`
  * @example <k-dropdown-item>Option A</k-dropdown-item>
  * @unstable
  */
 export default {
+	mixins: [Button],
 	inheritAttrs: false,
-	props: {
-		current: [Boolean, String],
-		disabled: Boolean,
-		download: Boolean,
-		icon: String,
-		link: String,
-		target: String
-	},
 	emit: ["click"],
 	methods: {
 		focus() {
 			this.$refs.button.focus();
-		},
-		onClick(event) {
-			this.$emit("click", event);
 		},
 		tab() {
 			this.$refs.button.tab();

--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -64,11 +64,11 @@ export const props = {
 		/**
 		 * Name/path of a dialog to open on click
 		 */
-		dialog: String,
+		dialog: [String, Object],
 		/**
 		 * Name/path of a drawer to open on click
 		 */
-		drawer: String,
+		drawer: [String, Object],
 		/**
 		 * Whether the button opens a dropdown
 		 */
@@ -209,11 +209,11 @@ export default {
 			}
 
 			if (this.dialog) {
-				return this.$dialog(this.dialog);
+				return this.$panel.dialog.open(this.dialog);
 			}
 
 			if (this.drawer) {
-				return this.$drawer(this.drawer);
+				return this.$panel.drawer.open(this.drawer);
 			}
 
 			this.click?.(e);

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -19,7 +19,7 @@ export default {
 						page.status,
 						page.permissions.changeStatus === false
 					),
-					click: () => this.$dialog(page.link + "/changeStatus")
+					dialog: page.link + "/changeStatus"
 				};
 
 				return {

--- a/panel/src/components/View/Menu.vue
+++ b/panel/src/components/View/Menu.vue
@@ -70,14 +70,14 @@ export default {
 		activationButton() {
 			if (this.$panel.license === "missing") {
 				return {
-					click: () => this.$dialog("registration"),
+					dialog: "registration",
 					text: this.$t("activate")
 				};
 			}
 
 			if (this.$panel.license === "legacy") {
 				return {
-					click: () => this.$dialog("license"),
+					dialog: "license",
 					text: this.$t("renew")
 				};
 			}

--- a/panel/src/components/Views/Languages/LanguagesView.vue
+++ b/panel/src/components/Views/Languages/LanguagesView.vue
@@ -83,15 +83,15 @@ export default {
 					{
 						icon: "cog",
 						text: this.$t("settings"),
-						disabled: !this.$panel.permissions.languages.update,
-						click: () => this.$dialog(`languages/${language.id}/update`)
+						dialog: `languages/${language.id}/update`,
+						disabled: !this.$panel.permissions.languages.update
 					},
 					{
 						when: language.deletable,
 						icon: "trash",
 						text: this.$t("delete"),
-						disabled: !this.$panel.permissions.languages.delete,
-						click: () => this.$dialog(`languages/${language.id}/delete`)
+						dialog: `languages/${language.id}/delete`,
+						disabled: !this.$panel.permissions.languages.delete
 					}
 				]
 			}));

--- a/panel/src/panel/dialog.js
+++ b/panel/src/panel/dialog.js
@@ -1,5 +1,6 @@
-import { reactive } from "vue";
 import Modal, { defaults as modalDefaults } from "./modal.js";
+import { isObject } from "@/helpers/object.js";
+import { reactive } from "vue";
 
 export const defaults = () => {
 	return {
@@ -86,6 +87,13 @@ export default (panel) => {
 			// check for legacy Vue components
 			if (dialog instanceof window.Vue) {
 				return this.openComponent(dialog);
+			}
+
+			// handle drawer object with url property
+			if (isObject(dialog) && dialog.url) {
+				options = dialog;
+				dialog = dialog.url;
+				delete options.url;
 			}
 
 			// prefix URLs

--- a/panel/src/panel/drawer.js
+++ b/panel/src/panel/drawer.js
@@ -1,4 +1,5 @@
 import Modal, { defaults as modalDefaults } from "./modal.js";
+import { isObject } from "@/helpers/object.js";
 import { reactive, set } from "vue";
 
 export const defaults = () => {
@@ -77,6 +78,13 @@ export default (panel) => {
 		 * @returns {Object}
 		 */
 		async open(drawer, options = {}) {
+			// handle drawer object with url property
+			if (isObject(drawer) && drawer.url) {
+				options = drawer;
+				drawer = drawer.url;
+				delete options.url;
+			}
+
 			// prefix URLs
 			if (typeof drawer === "string") {
 				drawer = `/drawers/${drawer}`;

--- a/panel/src/panel/dropdown.js
+++ b/panel/src/panel/dropdown.js
@@ -1,5 +1,5 @@
-import { reactive } from "vue";
 import Feature, { defaults } from "./feature.js";
+import { reactive } from "vue";
 
 /**
  * @since 4.0.0
@@ -53,23 +53,7 @@ export default (panel) => {
 				return [];
 			}
 
-			return this.props.options.map((option) => {
-				if (!option.dialog) {
-					return option;
-				}
-
-				option.click = () => {
-					const url =
-						typeof option.dialog === "string"
-							? option.dialog
-							: option.dialog.url;
-					const options =
-						typeof option.dialog === "object" ? option.dialog : {};
-					return panel.dialog.open(url, options);
-				};
-
-				return option;
-			});
+			return this.props.options;
 		},
 
 		set(state) {


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

`k-dropdown-item` so far has not supported `dialog`/`drawer` props. Instead, one had to take the route via the `click` handler. However, in many backend-driven scenarios (e.g. view buttons) this is not an option.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- `k-dropdown-item` supports all button props (esp. `dialog` and `drawer`)

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- `k-button` supports dialog/drawer objects as props
- `$panel.dialog.open()`/`$panel.drawer.open()` accept a single object argument if it has a `url` key

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion