### PR TITLE
fix: Add CSS class for page status button

### DIFF
--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -19,6 +19,7 @@ export default {
 						page.status,
 						page.permissions.changeStatus === false
 					),
+					class: "k-page-status-button",
 					click: () => this.$dialog(page.link + "/changeStatus")
 				};
 

--- a/panel/src/components/Sections/PagesSection.vue
+++ b/panel/src/components/Sections/PagesSection.vue
@@ -19,7 +19,7 @@ export default {
 						page.status,
 						page.permissions.changeStatus === false
 					),
-					class: "k-page-status-button",
+					class: "k-page-status-icon-option",
 					click: () => this.$dialog(page.link + "/changeStatus")
 				};
 


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Working on the Hub, I realized that this button is missing a specific class, making it hard to e.g. hide it via CSS.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- Page status button in sections received a `.k-page-status-icon-option` CSS class


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion