### PR TITLE
fix: Add Kirby query `users` entry point

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -9,6 +9,7 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Cms\User;
+use Kirby\Cms\Users;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Image\QrCode;
 use Kirby\Query\Runners\Runner;
@@ -163,4 +164,8 @@ Query::$entries['t'] = function (
 
 Query::$entries['user'] = function (string|null $id = null): User|null {
 	return App::instance()->user($id);
+};
+
+Query::$entries['users'] = function (): Users {
+	return App::instance()->users();
 };

--- a/tests/Query/QueryDefaultFunctionsTest.php
+++ b/tests/Query/QueryDefaultFunctionsTest.php
@@ -183,4 +183,17 @@ class QueryDefaultFunctionsTest extends TestCase
 		$query = new Query('user("user-b")');
 		$this->assertNull($query->resolve());
 	}
+
+	public function testUsers(): void
+	{
+		new App([
+			'users' => [
+				['id' => 'user-a', 'email' => 'foo@getkirby.com'],
+				['id' => 'user-b', 'email' => 'bar@getkirby.com']
+			]
+		]);
+
+		$query = new Query('users()');
+		$this->assertCount(2, $query->resolve());
+	}
 }

--- a/tests/Query/QueryLegacyDefaultFunctionsTest.php
+++ b/tests/Query/QueryLegacyDefaultFunctionsTest.php
@@ -170,4 +170,17 @@ class QueryLegacyDefaultFunctionsTest extends TestCase
 		$query = new Query('user("user-b")');
 		$this->assertNull($query->resolve());
 	}
+
+	public function testUsers(): void
+	{
+		new App([
+			'users' => [
+				['id' => 'user-a', 'email' => 'foo@getkirby.com'],
+				['id' => 'user-b', 'email' => 'bar@getkirby.com']
+			]
+		]);
+
+		$query = new Query('users()');
+		$this->assertCount(2, $query->resolve());
+	}
 }

--- a/tests/Query/QueryTest.php
+++ b/tests/Query/QueryTest.php
@@ -211,4 +211,17 @@ class QueryTest extends TestCase
 		$bar = $query->resolve($data);
 		$this->assertSame('homer simpson', $bar);
 	}
+
+	public function testDefaultEntries(): void
+	{
+		$expectedEntries = [
+			'kirby', 'collection', 'file', 'page', 'qr',
+			'site', 't', 'user', 'users'
+		];
+
+		foreach ($expectedEntries as $entryName) {
+			$this->assertArrayHasKey($entryName, Query::$entries);
+			$this->assertInstanceOf(Closure::class, Query::$entries[$entryName]);
+		}
+	}
 }


### PR DESCRIPTION

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Added back `users` as entry point for Kirby queries
#7597

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion