### PR TITLE
fix: `App::detectedLanguage()` with partial locale

### DIFF
--- a/src/Http/Visitor.php
+++ b/src/Http/Visitor.php
@@ -70,6 +70,8 @@ class Visitor
 	/**
 	 * Returns an array of all accepted languages
 	 * including their quality and locale
+	 *
+	 * @return \Kirby\Toolkit\Collection<\Kirby\Toolkit\Obj>
 	 */
 	public function acceptedLanguages(): Collection
 	{

--- a/tests/Cms/App/AppLanguagesTest.php
+++ b/tests/Cms/App/AppLanguagesTest.php
@@ -134,6 +134,12 @@ class AppLanguagesTest extends TestCase
 					'locale'  => 'en_GB'
 				],
 				[
+					'code'    => 'at',
+					'name'    => 'Deutsch (Österreich)',
+					'default' => false,
+					'locale'  => 'de_AT'
+				],
+				[
 					'code'    => 'de',
 					'name'    => 'Deutsch',
 					'default' => false,


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

The preference order with this PR is:
- First exact match of full locale
- First exact match of code
- First match of partial locale


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Fixed language detection when browser provides partial locale/code that could refer to multiple supported languages. Kirby now will prefer the language where the language code is an exact match. 
#7604

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion