### PR TITLE
fix: Prevent page create dialog from nesting when changing template

### DIFF
--- a/panel/src/components/Dialogs/PageCreateDialog.vue
+++ b/panel/src/components/Dialogs/PageCreateDialog.vue
@@ -58,7 +58,7 @@ export default {
 	},
 	methods: {
 		pick(template) {
-			this.$panel.dialog.reload({
+			this.$panel.dialog.refresh({
 				query: {
 					...this.$panel.dialog.query,
 					slug: this.value.slug,

--- a/panel/src/panel/feature.js
+++ b/panel/src/panel/feature.js
@@ -209,6 +209,7 @@ export default (panel, key, defaults) => {
 
 		/**
 		 * Reloads the properties for the feature
+		 * to refresh its state
 		 */
 		async refresh(options = {}) {
 			options.url ??= this.url();
@@ -228,7 +229,7 @@ export default (panel, key, defaults) => {
 
 		/**
 		 * If the feature has a path, it can be reloaded
-		 * with this method to replace/refresh its state
+		 * with this method to replace its state
 		 *
 		 * @example
 		 * panel.view.reload();

--- a/panel/src/panel/modal.js
+++ b/panel/src/panel/modal.js
@@ -187,6 +187,26 @@ export default (panel, key, defaults) => {
 		},
 
 		/**
+		 * If the feature has a path, it can be reloaded
+		 * with this method to replace the current modal
+		 *
+		 * @example
+		 * panel.view.reload();
+		 *
+		 * @param {Object, Boolean} options
+		 */
+		async reload(options = {}) {
+			if (!this.path) {
+				return false;
+			}
+
+			const url = this.url();
+
+			await this.close();
+			this.open(url, options);
+		},
+
+		/**
 		 * Sets a new active state for the modal
 		 * This is done whenever the state is an object
 		 * and not undefined or null


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Reloading a dialog/drawer will no longer nest the new dialog/drawer but replace the previous one


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion