### PR TITLE
fix: Query for `default` in number, date, time

### DIFF
--- a/config/fields/date.php
+++ b/config/fields/date.php
@@ -24,8 +24,8 @@ return [
 		/**
 		 * Default date when a new page/file/user gets created
 		 */
-		'default' => function (string|null $default = null): string {
-			return $this->toDatetime($default) ?? '';
+		'default' => function (string|null $default = null) {
+			return $default;
 		},
 
 		/**
@@ -77,6 +77,15 @@ return [
 		}
 	],
 	'computed' => [
+		'default' => function () {
+			$default = $this->default;
+
+			if (is_string($default) === true) {
+				$default = $this->model()->toString($default);
+			}
+
+			return $this->toDatetime($default) ?? '';
+		},
 		'display' => function () {
 			if ($this->display) {
 				return Str::upper($this->display);

--- a/config/fields/number.php
+++ b/config/fields/number.php
@@ -5,10 +5,11 @@ use Kirby\Toolkit\Str;
 return [
 	'props' => [
 		/**
-		 * Default number that will be saved when a new page/user/file is created
+		 * Default number that will be saved
+		 * when a new page/user/file is created
 		 */
 		'default' => function ($default = null) {
-			return $this->toNumber($default) ?? '';
+			return $default;
 		},
 		/**
 		 * The lowest allowed number
@@ -34,6 +35,17 @@ return [
 		},
 		'value' => function ($value = null) {
 			return $this->toNumber($value) ?? '';
+		}
+	],
+	'computed' => [
+		'default' => function () {
+			$default = $this->default;
+
+			if (is_string($default) === true) {
+				$default = $this->model()->toString($default);
+			}
+
+			return $this->toNumber($default) ?? '';
 		}
 	],
 	'methods' => [

--- a/config/fields/time.php
+++ b/config/fields/time.php
@@ -67,15 +67,21 @@ return [
 		}
 	],
 	'computed' => [
+		'default' => function (): string {
+			$default = $this->default;
+
+			if (is_string($default) === true) {
+				$default = $this->model()->toString($default);
+			}
+
+			return $this->toDatetime($default, 'H:i:s') ?? '';
+		},
 		'display' => function () {
 			if ($this->display) {
 				return $this->display;
 			}
 
 			return $this->notation === 24 ? 'HH:mm' : 'hh:mm a';
-		},
-		'default' => function (): string {
-			return $this->toDatetime($this->default, 'H:i:s') ?? '';
 		},
 		'format' => function () {
 			return $this->props['format'] ?? 'H:i:s';


### PR DESCRIPTION

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Fixed query support for `default` option of the number, date and time fields
#7594


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion