### PR TITLE
feat: `Uri::inherit()`

### DIFF
--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -304,6 +304,27 @@ class Uri implements Stringable
 	}
 
 	/**
+	 * Inherit query, params and fragment from a parent Uri
+	 * @since 5.2.0
+	 * @return $this
+	 */
+	public function inherit(Uri|string $parent): static
+	{
+		if (is_string($parent) === true) {
+			$parent = new static($parent);
+		}
+
+		$this->query->merge($parent->query());
+		$this->params->merge($parent->params());
+
+		if ($fragment = $parent->fragment()) {
+			$this->setFragment($fragment);
+		}
+
+		return $this;
+	}
+
+	/**
 	 * Checks if the host exists
 	 */
 	public function isAbsolute(): bool

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -164,6 +164,21 @@ class UriTest extends TestCase
 		$this->assertSame('/', $uri->toString());
 	}
 
+	public function testInherit(): void
+	{
+		$base = new Uri('https://getkirby.com');
+
+		$uri = $base->inherit('https://foo.com/this/is/a/path');
+		$this->assertSame('https://getkirby.com', $uri->toString());
+
+		$uri = $base->inherit('https://foo.com/fox:bax?foo=bar#anchor');
+		$this->assertSame('https://getkirby.com/fox:bax?foo=bar#anchor', $uri->toString());
+
+		$base = new Uri('https://getkirby.com?one=two');
+		$uri  = $base->inherit('https://foo.com/?foo=bar');
+		$this->assertSame('https://getkirby.com?one=two&foo=bar', $uri->toString());
+	}
+
 	public function testInvalidScheme(): void
 	{
 		$this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

New method used to preserve/copy query, params and fragment from an old URL onto a new URL for a redirect.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- New `Kirby\Http\Uri::inherit()` methods that copies over query, params and fragment from another URL


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion