### PR TITLE
fix: Improve typing of model collections

### DIFF
--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -38,6 +38,7 @@ class Collection extends BaseCollection
 	/**
 	 * Creates a new Collection with the given objects
 	 *
+	 * @param iterable<TValue> $objects
 	 * @param object|null $parent Stores the parent object,
 	 *                            which is needed in some collections
 	 *                            to get the finder methods right
@@ -88,7 +89,7 @@ class Collection extends BaseCollection
 	 * an entire second collection to the
 	 * current collection
 	 *
-	 * @param static|TValue|array $object
+	 * @param \Kirby\Cms\Collection<TValue>|array<TValue>|TValue $object
 	 * @return $this
 	 */
 	public function add($object): static

--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -23,7 +23,8 @@ use Throwable;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\Collection<\Kirby\Cms\File>
+ * @template TFile of \Kirby\Cms\File
+ * @extends \Kirby\Cms\Collection<TFile>
  */
 class Files extends Collection
 {
@@ -44,7 +45,7 @@ class Files extends Collection
 	 * an entire second collection to the
 	 * current collection
 	 *
-	 * @param static|\Kirby\Cms\File|string $object
+	 * @param \Kirby\Cms\Files<TFile>|TFile|string $object
 	 * @return $this
 	 * @throws \Kirby\Exception\InvalidArgumentException When no `File` or `Files` object or an ID of an existing file is passed
 	 */
@@ -155,6 +156,7 @@ class Files extends Collection
 	/**
 	 * Finds a file by its filename
 	 * @internal Use `$files->find()` instead
+	 * @return TFile|null
 	 */
 	public function findByKey(string $key): File|null
 	{
@@ -193,6 +195,7 @@ class Files extends Collection
 	/**
 	 * Returns the collection sorted by
 	 * the sort number and the filename
+	 * @return \Kirby\Cms\Files<TFile>
 	 */
 	public function sorted(): static
 	{

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -24,7 +24,8 @@ use Throwable;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\Collection<\Kirby\Cms\Page>
+ * @template TPage of \Kirby\Cms\Page
+ * @extends \Kirby\Cms\Collection<TPage>
  */
 class Pages extends Collection
 {
@@ -55,7 +56,7 @@ class Pages extends Collection
 	 * an entire second collection to the
 	 * current collection
 	 *
-	 * @param \Kirby\Cms\Pages|\Kirby\Cms\Page|string $object
+	 * @param \Kirby\Cms\Pages<TPage>|TPage|string $object
 	 * @return $this
 	 * @throws \Kirby\Exception\InvalidArgumentException When no `Page` or `Pages` object or an ID of an existing page is passed
 	 */
@@ -99,6 +100,7 @@ class Pages extends Collection
 
 	/**
 	 * Returns all children for each page in the array
+	 * @return \Kirby\Cms\Pages<TPage>
 	 */
 	public function children(): static
 	{
@@ -166,6 +168,7 @@ class Pages extends Collection
 
 	/**
 	 * Fetch all drafts for all pages in the collection
+	 * @return \Kirby\Cms\Pages<TPage>
 	 */
 	public function drafts(): static
 	{
@@ -231,6 +234,7 @@ class Pages extends Collection
 	/**
 	 * Finds a page by its ID or URI
 	 * @internal Use `$pages->find()` instead
+	 * @return TPage|null
 	 */
 	public function findByKey(string|null $key = null): Page|null
 	{
@@ -286,6 +290,7 @@ class Pages extends Collection
 
 	/**
 	 * Finds a child or child of a child recursively
+	 * @return TPage|null
 	 */
 	protected function findByKeyRecursive(
 		string $id,
@@ -326,6 +331,7 @@ class Pages extends Collection
 
 	/**
 	 * Finds the currently open page
+	 * @return TPage|null
 	 */
 	public function findOpen(): Page|null
 	{
@@ -335,6 +341,7 @@ class Pages extends Collection
 	/**
 	 * Custom getter that is able to find
 	 * extension pages
+	 * @return TPage|null
 	 */
 	public function get(string $key, mixed $default = null): Page|null
 	{
@@ -392,6 +399,7 @@ class Pages extends Collection
 
 	/**
 	 * Returns all listed pages in the collection
+	 * @return \Kirby\Cms\Pages<TPage>
 	 */
 	public function listed(): static
 	{
@@ -400,6 +408,7 @@ class Pages extends Collection
 
 	/**
 	 * Returns all unlisted pages in the collection
+	 * @return \Kirby\Cms\Pages<TPage>
 	 */
 	public function unlisted(): static
 	{
@@ -489,7 +498,10 @@ class Pages extends Collection
 		return $this->pluck('num');
 	}
 
-	// Returns all listed and unlisted pages in the collection
+	/**
+	 * Returns all listed and unlisted pages in the collection
+	 * @return \Kirby\Cms\Pages<TPage>
+	 */
 	public function published(): static
 	{
 		return $this->filter('isDraft', '==', false);

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -20,7 +20,8 @@ use Kirby\Uuid\HasUuids;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\Collection<\Kirby\Cms\User>
+ * @template TUser of \Kirby\Cms\User
+ * @extends \Kirby\Cms\Collection<TUser>
  */
 class Users extends Collection
 {
@@ -41,7 +42,7 @@ class Users extends Collection
 	 * an entire second collection to the
 	 * current collection
 	 *
-	 * @param \Kirby\Cms\Users|\Kirby\Cms\User|string $object
+	 * @param \Kirby\Cms\Users<TUser>|TUser|string $object
 	 * @return $this
 	 * @throws \Kirby\Exception\InvalidArgumentException When no `User` or `Users` object or an ID of an existing user is passed
 	 */
@@ -109,6 +110,7 @@ class Users extends Collection
 	/**
 	 * Finds a user in the collection by ID or email address
 	 * @internal Use `$users->find()` instead
+	 * @return TUser|null
 	 */
 	public function findByKey(string $key): User|null
 	{


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- Allow specifying the page model class of a `Kirby\Cms\Pages` collection via PHP DocBlock type tags

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion