### PR TITLE
fix: `BlockConverter::builderBlock` content

### DIFF
--- a/src/Cms/BlockConverter.php
+++ b/src/Cms/BlockConverter.php
@@ -25,8 +25,10 @@ class BlockConverter
 			return $params;
 		}
 
+		$ignore = array_flip(['field', 'options', 'parent', 'siblings', 'params', '_key', '_uid']);
+		$params['content'] = array_diff_key($params, $ignore);
 		$params['type']    = $params['_key'];
-		$params['content'] = $params;
+
 		unset($params['_uid']);
 
 		return $params;


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Converted blocks from old builder field do not store anymore system data as additional content (thx @mrflix)
#7616

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion