### PR TITLE
fix: Range input label necessary width

### DIFF
--- a/panel/src/components/Forms/Input/RangeInput.vue
+++ b/panel/src/components/Forms/Input/RangeInput.vue
@@ -103,7 +103,10 @@ export default {
 				: "–";
 		},
 		maxLength() {
-			return Math.floor(Math.abs(this.max)).toString().length;
+			return Math.max(
+				this.format(this.min).length,
+				this.format(this.max).length
+			);
 		},
 		position() {
 			return this.value || this.value === 0
@@ -204,7 +207,7 @@ export default {
 .k-range-input-tooltip-text {
 	font-family: var(--font-mono);
 	width: calc(var(--digits) + var(--spacing-1) * 2);
-	text-align: center;
+	text-align: right;
 }
 
 .k-range-input[data-disabled="true"] {


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Range field: Fixed tooltip width for negative/decimal values
#7614

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion