### PR TITLE
feat: New Kirby\Reflection\Constructor class

### DIFF
--- a/src/Reflection/Constructor.php
+++ b/src/Reflection/Constructor.php
@@ -14,6 +14,7 @@ use ReflectionParameter;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
+ * @since     5.2.0
  */
 class Constructor extends ReflectionMethod
 {

--- a/src/Reflection/Constructor.php
+++ b/src/Reflection/Constructor.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Kirby\Reflection;
+
+use ReflectionMethod;
+use ReflectionParameter;
+
+/**
+ * Specialized Reflection Method class to
+ * inspect a class constructor
+ *
+ * @package   Kirby Reflection
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+class Constructor extends ReflectionMethod
+{
+	public function __construct(object|string $objectOrClass)
+	{
+		parent::__construct($objectOrClass, '__construct');
+	}
+
+	/**
+	 * Group arguments into 'accepted' and 'ignored' arrays
+	 */
+	public function classifyArguments(array $arguments): array
+	{
+		$parameterNames = $this->getParameterNames();
+
+		$accepted = [];
+		$ignored  = [];
+
+		foreach ($arguments as $argumentName => $argumentValue) {
+			if (in_array($argumentName, $parameterNames) === true) {
+				$accepted[$argumentName] = $argumentValue;
+			} else {
+				$ignored[$argumentName] = $argumentValue;
+			}
+		}
+
+		return [
+			'accepted' => $accepted,
+			'ignored'  => $ignored
+		];
+	}
+
+	/**
+	 * Returns all arguments that are defined as constructor parameters
+	 */
+	public function getAcceptedArguments(array $arguments): array
+	{
+		return $this->classifyArguments($arguments)['accepted'];
+	}
+
+	/**
+	 * Returns all arguments that are not defined as constructor parameters
+	 */
+	public function getIgnoredArguments(array $arguments): array
+	{
+		return $this->classifyArguments($arguments)['ignored'];
+	}
+
+	/**
+	 * Returns an array of all parameter names
+	 */
+	public function getParameterNames(): array
+	{
+		return array_values(array_map(fn (ReflectionParameter $param) => $param->name, $this->getParameters()));
+	}
+}

--- a/src/Reflection/Constructor.php
+++ b/src/Reflection/Constructor.php
@@ -33,7 +33,7 @@ class Constructor extends ReflectionMethod
 		$ignored  = [];
 
 		foreach ($arguments as $argumentName => $argumentValue) {
-			if (in_array($argumentName, $parameterNames) === true) {
+			if (in_array($argumentName, $parameterNames, true) === true) {
 				$accepted[$argumentName] = $argumentValue;
 			} else {
 				$ignored[$argumentName] = $argumentValue;

--- a/tests/Reflection/ConstructorTest.php
+++ b/tests/Reflection/ConstructorTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Kirby\Reflection;
+
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+class ReflectableTestClass
+{
+	public function __construct(
+		protected $a,
+		protected $b
+	) {
+	}
+}
+
+#[CoversClass(Constructor::class)]
+class ConstructorTest extends TestCase
+{
+	public function reflection(): Constructor
+	{
+		return new Constructor(ReflectableTestClass::class);
+	}
+
+	public function testClassifyArguments(): void
+	{
+		$accepted = [
+			'a' => 'Test A',
+			'b' => 'Test B',
+		];
+
+		$ignored = [
+			'c' => 'Test C'
+		];
+
+		$result = $this->reflection()->classifyArguments([
+			...$accepted,
+			...$ignored
+		]);
+
+		$this->assertSame($accepted, $result['accepted']);
+		$this->assertSame($ignored, $result['ignored']);
+	}
+
+	public function testGetAcceptedArguments(): void
+	{
+		$accepted = [
+			'a' => 'Test A',
+			'b' => 'Test B',
+		];
+
+		$ignored = [
+			'c' => 'Test C'
+		];
+
+		$result = $this->reflection()->getAcceptedArguments($accepted);
+
+		$this->assertSame($accepted, $result);
+
+		$result = $this->reflection()->getAcceptedArguments([
+			...$accepted,
+			...$ignored
+		]);
+
+		$this->assertSame($accepted, $result);
+
+		$result = $this->reflection()->getAcceptedArguments([]);
+
+		$this->assertSame([], $result);
+	}
+
+	public function testGetIgnoredArguments(): void
+	{
+		$accepted = [
+			'a' => 'Test A',
+			'b' => 'Test B',
+		];
+
+		$ignored = [
+			'c' => 'Test C'
+		];
+
+		$result = $this->reflection()->getIgnoredArguments($ignored);
+
+		$this->assertSame($ignored, $result);
+
+		$result = $this->reflection()->getIgnoredArguments([
+			...$accepted,
+			...$ignored
+		]);
+
+		$this->assertSame($ignored, $result);
+
+		$result = $this->reflection()->getIgnoredArguments([]);
+
+		$this->assertSame([], $result);
+	}
+
+	public function testParamsNames(): void
+	{
+		$result = $this->reflection()->getParameterNames();
+
+		$this->assertSame(['a', 'b'], $result);
+	}
+}

--- a/tests/Reflection/ConstructorTest.php
+++ b/tests/Reflection/ConstructorTest.php
@@ -67,6 +67,10 @@ class ConstructorTest extends TestCase
 		$result = $this->reflection()->getAcceptedArguments([]);
 
 		$this->assertSame([], $result);
+
+		$result = $this->reflection()->getAcceptedArguments($ignored);
+
+		$this->assertSame([], $result);
 	}
 
 	public function testGetIgnoredArguments(): void
@@ -92,6 +96,10 @@ class ConstructorTest extends TestCase
 		$this->assertSame($ignored, $result);
 
 		$result = $this->reflection()->getIgnoredArguments([]);
+
+		$this->assertSame([], $result);
+
+		$result = $this->reflection()->getIgnoredArguments($accepted);
 
 		$this->assertSame([], $result);
 	}


### PR DESCRIPTION
## Description

This is a small step towards an easier transition to classes with named parameters. By being able to reflect which arguments are accepted or ignored in a class constructor, we can pass arrays of arguments (e.g. from blueprints) more reliably and without risiking exceptions because of unknown arguments. 

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Enhancements

- New `Kirby\Reflection\Constructor` class

## Docs

```php
use Kirby\Reflection\Constructor;

class Reflectable
{
  public function __construct( 
      protected $a,
      protected $b
  ) {
  }
}

$constructor = new Constructor(Reflectable::class);

$constructor->getAcceptedArguments([
  'a' => 'Test A',
  'b' => 'Test B',
  'c' => 'Test C'
]);
// will keep 'a' and 'b'

$constructor->getIgnoredArguments([
  'a' => 'Test A',
  'b' => 'Test B',
  'c' => 'Test C'
]);
// will keep 'c'
```

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion