### PR TITLE
Underscore-prefixed folders

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1658,6 +1658,14 @@ class App
 	}
 
 	/**
+	 * Returns a registered folder handler
+	 */
+	public function folder(string $name): Closure|null
+	{
+		return $this->extensions['folders'][$name] ?? null;
+	}
+
+	/**
 	 * Returns a system url
 	 *
 	 * @param bool $object If set to `true`, the URL is converted to an object

--- a/src/Cms/HasChildren.php
+++ b/src/Cms/HasChildren.php
@@ -172,6 +172,20 @@ trait HasChildren
 	}
 
 	/**
+	 * Returns the result of a registered folder handler
+	 */
+	public function folder(string $name): mixed
+	{
+		$handler = $this->kirby()->folder($name);
+
+		if ($handler === null) {
+			return null;
+		}
+
+		return $handler($this);
+	}
+
+	/**
 	 * Sets the published children collection
 	 *
 	 * @return $this

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -227,6 +227,7 @@ class Dir
 			'children' => [],
 			'files'    => [],
 			'template' => 'default',
+			'folders'  => [],
 		];
 
 		$dir = realpath($dir);
@@ -244,15 +245,21 @@ class Dir
 
 		// loop through all directory items and collect all relevant information
 		foreach ($items as $item) {
-			// ignore all items with a leading dot or underscore
-			if (
-				str_starts_with($item, '.') ||
-				str_starts_with($item, '_')
-			) {
+			// ignore all items with a leading dot
+			if (str_starts_with($item, '.') === true) {
 				continue;
 			}
 
 			$root = $dir . '/' . $item;
+
+			// collect underscore-prefixed folders
+			if (str_starts_with($item, '_') === true) {
+				if (is_dir($root) === true) {
+					$name = substr($item, 1);
+					$inventory['folders'][$name] = $root;
+				}
+				continue;
+			}
 
 			// collect all directories as children
 			if (is_dir($root) === true) {


### PR DESCRIPTION
## Description

Building upon the underscore concept introduced with `_drafts` and `_changes`, this PR adds a generic system to register underscore-prefixed folders like `_modules`, `_media`, etc.

I really like this "readable/understandable on the filesystem level" way of going about non-pages and as a plugin developer I'd love to use it myself. I tried to keep it as simple and unopinionated as possible but I know there's always a more elegant solution, no matter how long I work on something. Consider this a first draft.

## Changelog 

### 🎉 Features

New `folders` extension for registering handlers for underscore-prefixed folders. These folders are discovered in content but excluded from regular page children, allowing plugins to handle them with custom logic. You could display them in the Panel or not, but this way they definitely get excluded from things like the sitemap because they are not "pages" in the first place.

Example use case for the modules plugin. There are simpler examples but this is why I started working on this PR, so I still wanted to use it:

```php
Kirby::plugin('medienbaecker/modules', [
    'folders' => [
        'modules' => function ($parent) {
            $path = $parent->inventory()['folders']['modules'] ?? null;

            return new class($parent, $path) {
                private $parent;
                private $path;

                public function __construct($parent, $path) {
                    $this->parent = $parent;
                    $this->path = $path;
                }

                public function pages(): Pages {
                    if (!$this->path) {
                        return new Pages([], $this->parent);
                    }

                    $inventory = Dir::inventory($this->path, ...);
                    return Pages::factory($inventory['children'], $this->parent);
                }
            };
        }
    ]
]);
```

Usage in templates:
```php
$modules = $page->folder('modules')->pages();
```

Usage in blueprints ("pages" section):
```yml
parent: page.folder("modules").pages()
```

Things I learned along the way:

1. First I had a simpler, more direct wrapper but decided to go with storing only the path to not have a performance downgrade. That's why I have to go to the inventory first.
2. First I returned the pages collection directly but found it to be more in line with other Kirby functionality to use a class with a `pages()` method (or `files()` in other cases). This also allows for additional methods like `exists()` or `create()`.
3. I've changed the name of this functionality a dozen times but ended up with "folders" in the end.

### ♻️ Refactored
`_drafts` uses the same folder handler system instead of being hardcoded. I've also included a placeholder for `_changes` so it can not be overwritten.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion