### PR TITLE
test: Add unit tests for delete actions that should pass

### DIFF
--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -145,6 +145,7 @@ class Pages extends Collection
 				}
 
 				$model->delete();
+				$this->remove($id);
 			} catch (Throwable $e) {
 				$exceptions[$id] = $e;
 			}

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -132,19 +132,28 @@ class Pages extends Collection
 	public function delete(array $ids): void
 	{
 		$exceptions = [];
+		$kirby      = App::instance();
 
 		// delete all pages and collect errors
 		foreach ($ids as $id) {
 			try {
-				$model = $this->get($id);
+				// Explanation: We get the page object from the global context
+				// as the objects in the pages collection itself could have rendered
+				// outdated from a sibling delete action in this loop (e.g. resorting
+				// after deleting a sibling page and leaving the object in this collection
+				// with an old root path).
+				//
+				// TODO: We can remove this part as soon
+				// as we move away from our immutable object architecture.
+				$page = $kirby->page($id);
 
-				if ($model instanceof Page === false) {
+				if ($page === null || $this->get($id) instanceof Page === false) {
 					throw new NotFoundException(
 						key: 'page.undefined',
 					);
 				}
 
-				$model->delete();
+				$page->delete();
 				$this->remove($id);
 			} catch (Throwable $e) {
 				$exceptions[$id] = $e;

--- a/tests/Cms/Page/PageDeleteTest.php
+++ b/tests/Cms/Page/PageDeleteTest.php
@@ -145,6 +145,31 @@ class PageDeleteTest extends ModelTestCase
 		$this->assertFalse($page->exists());
 	}
 
+	public function testDeletePageWithSortedChildren(): void
+	{
+		$page = Page::create([
+			'slug'  => 'test',
+			'draft' => false
+		]);
+
+		$num = 1;
+
+		foreach (['a', 'b', 'c', 'd'] as $slug) {
+			$child = $page->createChild([
+				'slug'  => 'child-' . $slug,
+				'draft' => false
+			]);
+
+			$child->changeNum($num);
+			$num++;
+		}
+
+		$page->delete(force: true);
+
+		$this->assertFalse($page->exists());
+		$this->assertDirectoryDoesNotExist($page->root());
+	}
+
 	public function testDeleteHookWithUUIDAccess(): void
 	{
 		$phpunit = $this;


### PR DESCRIPTION
### 🐛 Bug fixes

- Immediately remove a page id from the Pages collection in `Pages::delete()`

### 🧹 Housekeeping

- Added a unit test for deleting pages with sorted children to replicate https://github.com/getkirby/kirby/issues/7615
- Added a unit test for batch-deleting sorted and filtered pages to replicate https://github.com/getkirby/kirby/issues/7623

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion