### PR TITLE
fix: Show placeholder when site title is missing

### DIFF
--- a/panel/src/components/Layout/Header.vue
+++ b/panel/src/components/Layout/Header.vue
@@ -138,4 +138,12 @@ export default {
 :root:has(.k-header .k-header-buttons) {
 	--header-sticky-offset: calc(var(--scroll-top) + 4rem);
 }
+
+.k-header .k-header-title-placeholder {
+	color: var(--color-gray-500);
+	transition: color 0.3s;
+}
+.k-header[data-editable="true"] .k-header-title-placeholder:hover {
+	color: var(--color-text-dimmed);
+}
 </style>

--- a/panel/src/components/Layout/Header.vue
+++ b/panel/src/components/Layout/Header.vue
@@ -1,5 +1,5 @@
 <template>
-	<header class="k-header">
+	<header :data-editable="editable" class="k-header">
 		<h1 class="k-header-title">
 			<!--
 				Edit button has been clicked

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -12,7 +12,7 @@
 		>
 			<span
 				v-if="!title || title.length === 0"
-				class="k-site-title-placeholder"
+				class="k-header-title-placeholder"
 			>
 				{{ $t("view.site") }} …
 			</span>
@@ -62,13 +62,6 @@ export default {
 </script>
 
 <style>
-.k-site-title-placeholder {
-	color: var(--color-gray-500);
-	transition: color 0.3s;
-}
-.k-site-view-header[data-editable="true"] .k-site-title-placeholder:hover {
-	color: var(--color-gray-900);
-}
 .k-site-view[data-has-tabs="true"] .k-site-view-header {
 	margin-bottom: 0;
 }

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -10,7 +10,15 @@
 			class="k-site-view-header"
 			@edit="$dialog(api + '/changeTitle')"
 		>
-			{{ title }}
+			<span
+				v-if="!title || title.length === 0"
+				class="k-site-title-placeholder"
+			>
+				{{ $t("view.site") }} …
+			</span>
+			<template v-else>
+				{{ title }}
+			</template>
 
 			<template #buttons>
 				<k-view-buttons :buttons="buttons" />
@@ -54,6 +62,13 @@ export default {
 </script>
 
 <style>
+.k-site-title-placeholder {
+	color: var(--color-gray-500);
+	transition: color 0.3s;
+}
+.k-site-view-header[data-editable="true"] .k-site-title-placeholder:hover {
+	color: var(--color-gray-900);
+}
 .k-site-view[data-has-tabs="true"] .k-site-view-header {
 	margin-bottom: 0;
 }

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -14,7 +14,10 @@
 			class="k-user-view-header"
 			@edit="$dialog(api + '/changeName')"
 		>
-			<span v-if="!name || name.length === 0" class="k-user-name-placeholder">
+			<span
+				v-if="!name || name.length === 0"
+				class="k-header-title-placeholder k-user-name-placeholder"
+			>
 				{{ $t("name") }} …
 			</span>
 			<template v-else>
@@ -84,13 +87,6 @@ export default {
 </script>
 
 <style>
-.k-user-name-placeholder {
-	color: var(--color-gray-500);
-	transition: color 0.3s;
-}
-.k-user-view-header[data-editable="true"] .k-user-name-placeholder:hover {
-	color: var(--color-gray-900);
-}
 .k-user-view-header {
 	margin-bottom: 0;
 	border-bottom: 0;


### PR DESCRIPTION
Fixes #7628

## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

- Added back `data-editable` to `k-header` as the user view already had a CSS rule for that. Seems like we removed it overeagerly.
- While the site change title dialog does not allow to remove the site title completely, it is possible via the content file. Without any backfill like e.g. for pages. I think a placeholder like in the user view makes sense here.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Shows placeholder in Panel view when site title is missing
#7628
- Fix placeholder color in dark mode in the user view header. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion