### PR TITLE
fix: Avoid remove button activation when clicking on the model field label

### DIFF
--- a/panel/src/components/Forms/Field/ModelsField.vue
+++ b/panel/src/components/Forms/Field/ModelsField.vue
@@ -1,8 +1,8 @@
 <template>
 	<k-field
 		v-bind="$props"
-		:input="id"
 		:class="['k-models-field', `k-${$options.type}-field`, $attrs.class]"
+		:input="false"
 		:style="$attrs.style"
 	>
 		<template v-if="!disabled" #options>
@@ -18,7 +18,7 @@
 
 		<k-dropzone :disabled="!hasDropzone" @drop="drop">
 			<k-input-validator
-				v-bind="{ id, min, max, required }"
+				v-bind="{ min, max, required }"
 				:value="JSON.stringify(value)"
 			>
 				<k-collection


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes

- The model fields no longer accidentally pass a click on the label to the remove button https://github.com/getkirby/kirby/issues/7631

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion