### PR TITLE
fix: Make the position field required

### DIFF
--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -181,7 +181,7 @@ class Field
 		return [
 			'label'    => I18n::translate('page.changeStatus.position'),
 			'type'     => 'select',
-			'empty'    => false,
+			'required' => true,
 			'options'  => $options,
 			...$props
 		];

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -127,7 +127,7 @@ class FieldTest extends TestCase
 
 		$this->assertSame('Please select a position', $field['label']);
 		$this->assertSame('select', $field['type']);
-		$this->assertFalse($field['empty']);
+		$this->assertTrue($field['required']);
 
 		// check options
 		$this->assertCount(5, $field['options']);


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes

- The position select field is now required (as it should be) https://github.com/getkirby/kirby/issues/7633

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion