### PR TITLE
fix: PagePicker parent handling when same as start model

### DIFF
--- a/src/Cms/PagePicker.php
+++ b/src/Cms/PagePicker.php
@@ -130,7 +130,12 @@ class PagePicker extends Picker
 		// when subpage navigation is enabled, a parent
 		// might be passed in addition to the query.
 		// The parent then takes priority.
-		} elseif ($this->options['subpages'] === true && empty($this->options['parent']) === false) {
+		// Don't use the parent if it's the same as the start/top-most model.
+		} elseif (
+			$this->options['subpages'] === true &&
+			empty($this->options['parent']) === false &&
+			$this->model()->id() !== $this->start()->id()
+		) {
 			$items = $this->itemsForParent();
 
 		// search by query

--- a/tests/Cms/Page/PagePickerTest.php
+++ b/tests/Cms/Page/PagePickerTest.php
@@ -22,9 +22,9 @@ class PagePickerTest extends ModelTestCase
 							[
 								'slug' => 'mother',
 								'children' => [
-									['slug' => 'child-a'],
-									['slug' => 'child-b'],
-									['slug' => 'child-c']
+									['slug' => 'child-a', 'template' => 'child-a'],
+									['slug' => 'child-b', 'template' => 'child-b'],
+									['slug' => 'child-c', 'template' => 'child-c']
 								]
 							]
 						]
@@ -96,5 +96,17 @@ class PagePickerTest extends ModelTestCase
 		]);
 
 		$this->assertSame('grandmother', $picker->start()->id());
+	}
+
+	public function testSameQueryAndParent(): void
+	{
+		$picker = new PagePicker([
+			'query'  => 'site.find("grandmother/mother").children.filterBy("intendedTemplate", "in", ["child-a", "child-c"])',
+			'parent' => 'grandmother/mother'
+		]);
+
+		$this->assertCount(2, $picker->items());
+		$this->assertSame('grandmother/mother/child-a', $picker->items()->first()->id());
+		$this->assertSame('grandmother/mother/child-c', $picker->items()->last()->id());
 	}
 }


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Prevents the parent option from being used in PagePicker if it is the same as the start/top-most model. Adds a test to verify correct behavior when query and parent refer to the same page.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Pages field dialog lists unwanted pages after navigating back from subpages #7624

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion