### PR TITLE
feat: Constant to disable the PHP version check

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -3,10 +3,23 @@
 /**
  * Validate the PHP version to already
  * stop at older or too recent versions
+ *
+ * This check can be disabled by setting:
+ * define('KIRBY_PHP_VERSION_CHECK', false);
+ * in your `index.php`.
+ *
+ * ATTENTION: Set this constant at your own risk only.
+ * PHP releases contain backward-incompatible changes that can
+ * cause and have caused unexpected behavior and security impact.
+ * We strongly advise against disabling the PHP version check
+ * in production.
  */
 if (
-	version_compare(PHP_VERSION, '8.2.0', '>=') === false ||
-	version_compare(PHP_VERSION, '8.5.0', '<')  === false
+	(defined('KIRBY_PHP_VERSION_CHECK') !== true || KIRBY_PHP_VERSION_CHECK !== false) &&
+	(
+		version_compare(PHP_VERSION, '8.2.0', '>=') === false ||
+		version_compare(PHP_VERSION, '8.5.0', '<')  === false
+	)
 ) {
 	die(include __DIR__ . '/views/php.php');
 }


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

As discussed, we want to allow developers to temporarily disable the PHP version check e.g. during an upgrade process or for debugging.

I've added the lengthy warning both as a disclaimer and also as a real warning because of the risks of unsupported PHP versions (too old = does not support our use of new PHP features; too new = possible breaking changes in PHP that are not accounted for).

Because of these risks, we will not document the constant but keep it just documented in the code for those who are running into PHP version related issues and have so far needed to comment out the check in the core.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements

- The PHP version check can now temporarily be disabled with a new `KIRBY_PHP_VERSION_CHECK` constant. This is for very specific cases and comes with risks, please note the code comment in `bootstrap.php`.

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

None

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion