### PR TITLE
feat: New create option for the files section

### DIFF
--- a/config/sections/files.php
+++ b/config/sections/files.php
@@ -23,6 +23,12 @@ return [
 	],
 	'props' => [
 		/**
+		 * Option to switch off the upload button
+		 */
+		'create' => function (bool $create = true) {
+			return $create;
+		},
+		/**
 		 * Filters pages by a query. Sorting will be disabled
 		 */
 		'query' => function (string|null $query = null) {
@@ -39,7 +45,7 @@ return [
 		 */
 		'text' => function ($text = '{{ file.filename }}') {
 			return I18n::translate($text, $text);
-		}
+		},
 	],
 	'computed' => [
 		'accept' => function () {
@@ -137,6 +143,10 @@ return [
 			return $this->pagination();
 		},
 		'upload' => function () {
+			if ($this->create === false) {
+				return false;
+			}
+
 			if ($this->isFull() === true) {
 				return false;
 			}

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -783,4 +783,37 @@ class FilesSectionTest extends TestCase
 
 		$this->assertSame(4, $section->upload()['attributes']['sort']);
 	}
+
+	public function testUpload(): void
+	{
+		$section = new Section('files', [
+			'name'  => 'test',
+			'model' => new Page(['slug' => 'test']),
+		]);
+
+		$expected = [
+			'accept' => null,
+			'api' => 'pages/test/files',
+			'attributes' => [
+				'sort' => 1,
+				'template' => null,
+			],
+			'max' => null,
+			'multiple' => true,
+			'preview' => []
+		];
+
+		$this->assertSame($expected, $section->upload());
+	}
+
+	public function testUploadSwitchedOff(): void
+	{
+		$section = new Section('files', [
+			'name'   => 'test',
+			'model'  => new Page(['slug' => 'test']),
+			'create' => false
+		]);
+
+		$this->assertFalse($section->upload());
+	}
 }


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- A new `create` option for the files section lets you disable the upload button. This is useful if you are using queries in files sections and the upload would not actually show up in the list. It is comparable to the `create` option in the pages section. 
```yaml
sections: 
  images: 
    type: files
    query: page.images.filter('customField', 'customFilter')
    create: false
```

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion