### PR TITLE
refact: Use item classes for the dropdownOption method

### DIFF
--- a/src/Panel/ChangesDialog.php
+++ b/src/Panel/ChangesDialog.php
@@ -3,7 +3,13 @@
 namespace Kirby\Panel;
 
 use Kirby\Cms\Collection;
+use Kirby\Cms\File;
+use Kirby\Cms\Page;
+use Kirby\Cms\User;
 use Kirby\Content\Changes;
+use Kirby\Panel\Ui\Item\FileItem;
+use Kirby\Panel\Ui\Item\PageItem;
+use Kirby\Panel\Ui\Item\UserItem;
 
 /**
  * Manages the Panel dialog for content changes in
@@ -32,13 +38,25 @@ class ChangesDialog
 	}
 
 	/**
+	 * Helper method to return item props for a single given model
+	 */
+	public function item(File|Page|User $model): array
+	{
+		$item = match (true) {
+			$model instanceof File => new FileItem(file: $model),
+			$model instanceof Page => new PageItem(page: $model),
+			$model instanceof User => new UserItem(user: $model),
+		};
+
+		return $item->props();
+	}
+
+	/**
 	 * Helper method to return item props for the given models
 	 */
 	public function items(Collection $models): array
 	{
-		return $models->values(
-			fn ($model) => $model->panel()->dropdownOption()
-		);
+		return $models->values($this->item(...));
 	}
 
 	/**

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -196,14 +196,12 @@ class File extends Model
 	 * Returns the setup for a dropdown option
 	 * which is used in the changes dropdown
 	 * for example
+	 *
+	 * @deprecated 5.1.4 Use the Kirby\Panel\Ui\Item\FileItem class instead
 	 */
 	public function dropdownOption(): array
 	{
-		return (new FileItem(
-			file: $this->model,
-			text: '{{ file.filename }}'
-		))->props() + [
-			// Todo: This part can be removed in 6.0.0
+		return (new FileItem(file: $this->model))->props() + [
 			'icon' => 'image'
 		];
 	}

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -199,10 +199,13 @@ class File extends Model
 	 */
 	public function dropdownOption(): array
 	{
-		return [
-			'icon' => 'image',
-			'text' => $this->model->filename(),
-		] + parent::dropdownOption();
+		return (new FileItem(
+			file: $this->model,
+			text: '{{ file.filename }}'
+		))->props() + [
+			// Todo: This part can be removed in 6.0.0
+			'icon' => 'image'
+		];
 	}
 
 	/**

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -197,14 +197,12 @@ class Page extends Model
 	 * Returns the setup for a dropdown option
 	 * which is used in the changes dropdown
 	 * for example.
+	 *
+	 * @deprecated 5.1.4 Use the Kirby\Panel\Ui\Item\PageItem class instead
 	 */
 	public function dropdownOption(): array
 	{
-		return (new PageItem(
-			page: $this->model,
-			text: '{{ page.title }}'
-		))->props() + [
-			// TODO: This part can be removed in 6.0.0
+		return (new PageItem(page: $this->model))->props() + [
 			'icon' => 'page'
 		];
 	}

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -200,9 +200,13 @@ class Page extends Model
 	 */
 	public function dropdownOption(): array
 	{
-		return [
-			'text' => $this->model->title()->value(),
-		] + parent::dropdownOption();
+		return (new PageItem(
+			page: $this->model,
+			text: '{{ page.title }}'
+		))->props() + [
+			// TODO: This part can be removed in 6.0.0
+			'icon' => 'page'
+		];
 	}
 
 	/**

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -41,12 +41,14 @@ class Site extends Model
 	 * Returns the setup for a dropdown option
 	 * which is used in the changes dropdown
 	 * for example.
+	 *
+	 * @deprecated 5.1.4
 	 */
 	public function dropdownOption(): array
 	{
 		return [
 			'icon' => 'home',
-			'text' => $this->model->title()->value(),
+			'text' => $this->model->toSafeString('{{ site.title }}'),
 		] + parent::dropdownOption();
 	}
 

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -138,14 +138,12 @@ class User extends Model
 	 * Returns the setup for a dropdown option
 	 * which is used in the changes dropdown
 	 * for example.
+	 *
+	 * @deprecated 5.1.4 Use the Kirby\Panel\Ui\Item\UserItem class instead
 	 */
 	public function dropdownOption(): array
 	{
-		return (new UserItem(
-			user: $this->model,
-			text: '{{ user.username }}'
-		))->props() + [
-			// TODO: This part can be removed in 6.0.0
+		return (new UserItem(user: $this->model))->props() + [
 			'icon' => 'user'
 		];
 	}

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -141,10 +141,13 @@ class User extends Model
 	 */
 	public function dropdownOption(): array
 	{
-		return [
-			'icon' => 'user',
-			'text' => $this->model->username(),
-		] + parent::dropdownOption();
+		return (new UserItem(
+			user: $this->model,
+			text: '{{ user.username }}'
+		))->props() + [
+			// TODO: This part can be removed in 6.0.0
+			'icon' => 'user'
+		];
 	}
 
 	public function home(): string|null

--- a/tests/Panel/ChangesDialogTest.php
+++ b/tests/Panel/ChangesDialogTest.php
@@ -84,6 +84,20 @@ class ChangesDialogTest extends AreaTestCase
 		$this->assertSame([], $dialog->files());
 	}
 
+	public function testItem(): void
+	{
+		$this->setUpModels();
+		$page = $this->app->page('page://test');
+		$page->version('latest')->save([]);
+		$page->version('changes')->save([]);
+
+		$dialog = new ChangesDialog();
+		$item   = $dialog->item($page);
+
+		$this->assertSame('test', $item['text']);
+		$this->assertSame('/pages/test', $item['link']);
+	}
+
 	public function testItems(): void
 	{
 		$this->setUpModels();


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored

- Use the new UI Item classes to create the props for model's dropdown options. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion