### PR TITLE
fix: Remove margin below user profile

### DIFF
--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -94,7 +94,7 @@ export default {
 .k-user-view .k-user-profile {
 	margin-bottom: var(--spacing-12);
 }
-.k-user-view[data-has-tabs="true"] .k-user-profile {
+.k-user-view .k-user-profile:has(+ .k-tabs) {
 	margin-bottom: 0;
 }
 </style>


### PR DESCRIPTION
### 🐛 Bug fixes

- The large margin below the user profile in the user view is now gone and tabs are set directly below

<img width="778" height="485" alt="Screenshot 2025-10-31 at 16 30 01" src="https://github.com/user-attachments/assets/e6e29c07-23fa-4e05-9678-1635941ab4dd" />


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion