### PR TITLE
fix: Don’t hide the required asterisk in the label

### DIFF
--- a/panel/src/components/Text/Label.vue
+++ b/panel/src/components/Text/Label.vue
@@ -12,16 +12,14 @@
 		<span v-else class="k-label-text">
 			<slot />
 		</span>
-		<template v-if="input !== false">
-			<abbr v-if="required" :title="$t(type + '.required')">✶</abbr>
-			<abbr
-				:title="$t(type + '.invalid')"
-				data-theme="negative"
-				class="k-label-invalid"
-			>
-				&times;
-			</abbr>
-		</template>
+		<abbr v-if="required" :title="$t(type + '.required')">✶</abbr>
+		<abbr
+			:title="$t(type + '.invalid')"
+			data-theme="negative"
+			class="k-label-invalid"
+		>
+			&times;
+		</abbr>
 	</component>
 </template>
 


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes

- Don’t hide the required asterisk in the field label if the input prop is false. https://github.com/getkirby/kirby/issues/7642

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion