### PR TITLE
feat: New Str::label method

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -601,6 +601,40 @@ class Str
 	}
 
 	/**
+	 * Converts keys or ids into human-readable labels by
+	 * normalizing punctuation, splitting camel- or kebab-case,
+	 * and title-casing the result.
+	 *
+	 * Example: `workEmailAddress` will turn into `Work email address`
+	 *
+	 * @since 5.2.0
+	 */
+	public static function label(string $value): string
+	{
+		// replace punctuation with spaces
+		$value = str_replace(['_', '-', '.'], ' ', $value);
+
+		// add a space before every uppercase character by matching
+		// all characters that are not Unicode lowercase or numbers
+		$value = preg_replace_callback('/[^\p{Ll}\p{Nd}]/u', fn ($match) => ' ' . $match[0], $value);
+
+		// add a space before every first number
+		$value = preg_replace('/([^\d])(\d)/', '$1 $2', $value);
+
+		// remove duplicate spaces
+		$value = preg_replace('/[\s]{2,}+/', ' ', $value);
+
+		// trim leading or trailing spaces
+		$value = trim($value);
+
+		// convert the entire string into lowercase
+		$value = static::lower($value);
+
+		// turn the first character into uppercase
+		return static::ucfirst($value);
+	}
+
+	/**
 	 * A UTF-8 safe version of strlen()
 	 */
 	public static function length(string|null $string): int

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -484,6 +484,19 @@ class StrTest extends TestCase
 		$this->assertSame('king-cobra', Str::kebab($string));
 	}
 
+	public function testLabel(): void
+	{
+		$this->assertSame('Foo bar', Str::label('fooBar'));
+		$this->assertSame('Foo bar', Str::label('foo_bar'));
+		$this->assertSame('Foo bar', Str::label('foo-bar'));
+		$this->assertSame('Foo bar', Str::label('foo.bar'));
+		$this->assertSame('Foo a bar', Str::label('fooABar'));
+		$this->assertSame('Foo bar 42', Str::label('fooBar42'));
+		$this->assertSame('Foo bar 42', Str::label('fooBar_42'));
+		$this->assertSame('Foo bar 42', Str::label('fooBar-42'));
+		$this->assertSame('Foo bar 42', Str::label('fooBar.42'));
+	}
+
 	public function testLength(): void
 	{
 		$this->assertSame(0, Str::length(''));


### PR DESCRIPTION
## Description

This is the first step to improve automatic labels in all relevant parts in blueprints (fields, sections, etc.) when the keys are written in camelCase or kebab_case. It's based on a suggestion from one of the meetup attendees at btconf. 

In the next step, the method needs to be used in various places, but I wanted to separate this to simplify the PR reviews.

## Changelog 

### ✨ Enhancements

- New `Str::label($string)` method to convert keys or ids into human-readable labels by normalizing punctuation, splitting camel- or kebab-case, and title-casing the result. It’s very helpful to turn a blueprint field key like `workEmailAddress` into `Work email address`

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion