### PR TITLE
feat: Use Str::label in various places throughout the system

### DIFF
--- a/config/sections/mixins/headline.php
+++ b/config/sections/mixins/headline.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Str;
 
 return [
 	'props' => [
@@ -30,7 +31,7 @@ return [
 				return $this->model()->toString($this->headline);
 			}
 
-			return ucfirst($this->name);
+			return Str::label($this->name);
 		}
 	]
 ];

--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -10,6 +10,7 @@ use Kirby\Filesystem\F;
 use Kirby\Form\Field;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Str;
 use Throwable;
 
 /**
@@ -70,7 +71,7 @@ class Blueprint
 		$props['name'] ??= 'default';
 
 		// normalize and translate the title
-		$props['title'] ??= ucfirst($props['name']);
+		$props['title'] ??= Str::label($props['name']);
 		$props['title']   = $this->i18n($props['title']);
 
 		// convert all shortcuts
@@ -441,7 +442,7 @@ class Blueprint
 		$props['name'] ??= $name;
 
 		// normalize the title
-		$title = $props['title'] ?? ucfirst($props['name']);
+		$title = $props['title'] ?? Str::label($props['name']);
 
 		// translate the title
 		$props['title'] = I18n::translate($title) ?? $title;
@@ -567,7 +568,7 @@ class Blueprint
 		// add some useful defaults
 		return [
 			...$props,
-			'label' => $props['label'] ?? ucfirst($name),
+			'label' => $props['label'] ?? Str::label($name),
 			'name'  => $name,
 			'type'  => $type,
 			'width' => $props['width'] ?? '1/1',
@@ -795,7 +796,7 @@ class Blueprint
 				...$tabProps,
 				'columns' => $this->normalizeColumns($tabName, $tabProps['columns'] ?? []),
 				'icon'    => $tabProps['icon']  ?? null,
-				'label'   => $this->i18n($tabProps['label'] ?? ucfirst($tabName)),
+				'label'   => $this->i18n($tabProps['label'] ?? Str::label($tabName)),
 				'link'    => $this->model->panel()->url(true) . '/?tab=' . $tabName,
 				'name'    => $tabName,
 			];

--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -54,7 +54,7 @@ class Fieldset extends Item
 		$this->disabled    = $params['disabled'] ?? false;
 		$this->editable    = $params['editable'] ?? true;
 		$this->icon        = $params['icon'] ?? null;
-		$params['title'] ??= $params['name'] ?? Str::ucfirst($this->type);
+		$params['title'] ??= $params['name'] ?? Str::label($this->type);
 		$this->name        = $this->createName($params['title']);
 		$this->label       = $this->createLabel($params['label'] ?? null);
 		$this->preview     = $params['preview'] ?? null;

--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -119,7 +119,7 @@ class Fieldset extends Item
 			$tab = Blueprint::extend($tab);
 
 			$tab['fields']  = $this->createFields($tab['fields'] ?? []);
-			$tab['label'] ??= Str::ucfirst($name);
+			$tab['label'] ??= Str::label($name);
 			$tab['label']   = $this->createLabel($tab['label']);
 			$tab['name']    = $name;
 

--- a/src/Cms/Fieldsets.php
+++ b/src/Cms/Fieldsets.php
@@ -56,7 +56,7 @@ class Fieldsets extends Items
 			if ($fieldset['type'] === 'group') {
 				$result    = static::createFieldsets($fieldset['fieldsets'] ?? []);
 				$fieldsets = [...$fieldsets, ...$result['fieldsets']];
-				$label     = $fieldset['label'] ?? Str::ucfirst($type);
+				$label     = $fieldset['label'] ?? Str::label($type);
 
 				$groups[$type] = [
 					'label'     => I18n::translate($label, $label),

--- a/src/Cms/Role.php
+++ b/src/Cms/Role.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Kirby\Data\Data;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Str;
 use Stringable;
 
 /**
@@ -127,7 +128,7 @@ class Role implements Stringable
 
 	public function title(): string
 	{
-		return $this->title ??= ucfirst($this->name());
+		return $this->title ??= Str::label($this->name());
 	}
 
 	/**

--- a/src/Panel/Lab/Category.php
+++ b/src/Panel/Lab/Category.php
@@ -99,7 +99,7 @@ class Category
 
 	public function name(): string
 	{
-		return $this->props['name'] ?? ucfirst($this->id);
+		return $this->props['name'] ?? Str::label($this->id);
 	}
 
 	public function root(): string

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -370,7 +370,7 @@ class View
 				foreach ($area['searches'] ?? [] as $id => $params) {
 					$searches[$id] = [
 						'icon'  => $params['icon'] ?? 'search',
-						'label' => $params['label'] ?? Str::ucfirst($id),
+						'label' => $params['label'] ?? Str::label($id),
 						'id'    => $id
 					];
 				}

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -498,22 +498,6 @@ class BlueprintTest extends TestCase
 		$this->assertSame('My custom role', $role);
 	}
 
-	public function testTitleFromName(): void
-	{
-		$blueprint = new Blueprint([
-			'model' => $this->model
-		]);
-
-		$this->assertSame('Default', $blueprint->title());
-
-		$blueprint = new Blueprint([
-			'model' => $this->model,
-			'name'  => 'test'
-		]);
-
-		$this->assertSame('Test', $blueprint->title());
-	}
-
 	public function testExtend(): void
 	{
 		new App([
@@ -765,5 +749,33 @@ class BlueprintTest extends TestCase
 		$this->assertSame('Main', $preset['tabs']['main']['label']);
 		$this->assertSame('/pages/a/?tab=main', $preset['tabs']['main']['link']);
 		$this->assertSame('main', $preset['tabs']['main']['name']);
+	}
+
+	public function testAutomaticLabelForFields()
+	{
+		$blueprint = new Blueprint([
+			'model' => $this->model,
+			'fields' => [
+				'emailAddress' => [
+					'type' => 'email'
+				],
+			]
+		]);
+
+		$this->assertSame('Email address', $blueprint->fields()['emailAddress']['label']);
+	}
+
+	public function testAutomaticLabelForTabs()
+	{
+		$blueprint = new Blueprint([
+			'model' => $this->model,
+			'tabs'  => [
+				'contentTab' => [
+
+				],
+			]
+		]);
+
+		$this->assertSame('Content tab', $blueprint->tabs()[0]['label']);
 	}
 }

--- a/tests/Cms/Fieldsets/FieldsetTest.php
+++ b/tests/Cms/Fieldsets/FieldsetTest.php
@@ -206,6 +206,15 @@ class FieldsetTest extends TestCase
 		$this->assertSame('English name', $fieldset->name());
 	}
 
+	public function testNameFromType(): void
+	{
+		$fieldset = new Fieldset([
+			'type'  => 'testFieldset',
+		]);
+
+		$this->assertSame('Test fieldset', $fieldset->name());
+	}
+
 	public function testPreview(): void
 	{
 		$fieldset = new Fieldset([

--- a/tests/Cms/Fieldsets/FieldsetTest.php
+++ b/tests/Cms/Fieldsets/FieldsetTest.php
@@ -242,6 +242,20 @@ class FieldsetTest extends TestCase
 		$this->assertCount(2, $fieldset->tabs()['content']['fields']);
 	}
 
+	public function testTabsWithAutoLabels(): void
+	{
+		$fieldset = new Fieldset([
+			'type' => 'test',
+			'tabs' => [
+				'contentTab' => [],
+				'settingsTab' => []
+			]
+		]);
+
+		$this->assertSame('Content tab', $fieldset->tabs()['contentTab']['label']);
+		$this->assertSame('Settings tab', $fieldset->tabs()['settingsTab']['label']);
+	}
+
 	public function testTranslate(): void
 	{
 		$fieldset = new Fieldset([

--- a/tests/Cms/Fieldsets/FieldsetsTest.php
+++ b/tests/Cms/Fieldsets/FieldsetsTest.php
@@ -79,4 +79,19 @@ class FieldsetsTest extends TestCase
 		$this->assertArrayHasKey('content', $fieldset->tabs());
 		$this->assertArrayNotHasKey('seo', $fieldset->tabs());
 	}
+
+	public function testGroupsWithAutoLabels()
+	{
+		$fieldsets = Fieldsets::factory([
+			'mediaBlocks' => [
+				'type' => 'group',
+				'fieldsets' => [
+					'image'
+				]
+			]
+		]);
+
+		$this->assertSame('Media blocks', $fieldsets->groups()['mediaBlocks']['label']);
+	}
+
 }

--- a/tests/Cms/Roles/RoleTest.php
+++ b/tests/Cms/Roles/RoleTest.php
@@ -67,6 +67,15 @@ class RoleTest extends TestCase
 		$this->assertTrue($role->isNobody());
 	}
 
+	public function testTitleFromName(): void
+	{
+		$role = new Role([
+			'name' => 'editorInChief',
+		]);
+
+		$this->assertSame('Editor in chief', $role->title());
+	}
+
 	public function testTranslateTitle(): void
 	{
 		$role = new Role([

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -107,6 +107,17 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('Files', $section->headline());
 	}
 
+	public function testHeadlineFromName(): void
+	{
+		// single label
+		$section = new Section('files', [
+			'name'  => 'photoGallery',
+			'model' => new Page(['slug' => 'test']),
+		]);
+
+		$this->assertSame('Photo gallery', $section->headline());
+	}
+
 	public function testMax(): void
 	{
 		$model = new Page([

--- a/tests/Cms/Sections/InfoSectionTest.php
+++ b/tests/Cms/Sections/InfoSectionTest.php
@@ -41,6 +41,17 @@ class InfoSectionTest extends TestCase
 		$this->assertSame('Information', $section->headline());
 	}
 
+	public function testHeadlineFromName(): void
+	{
+		// single label
+		$section = new Section('info', [
+			'name'  => 'helpSection',
+			'model' => new Page(['slug' => 'test']),
+		]);
+
+		$this->assertSame('Help section', $section->headline());
+	}
+
 	public function testText(): void
 	{
 		// single language text

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -114,6 +114,16 @@ class PagesSectionTest extends TestCase
 		$this->assertSame('Pages', $section->headline());
 	}
 
+	public function testHeadlineFromName(): void
+	{
+		// single label
+		$section = new Section('pages', [
+			'name'  => 'blogArticles',
+			'model' => new Page(['slug' => 'test']),
+		]);
+
+		$this->assertSame('Blog articles', $section->headline());
+	}
 
 	public function testParent(): void
 	{

--- a/tests/Cms/Sections/StatsSectionTest.php
+++ b/tests/Cms/Sections/StatsSectionTest.php
@@ -81,6 +81,17 @@ class StatsSectionTest extends TestCase
 		$this->assertSame('Stats', $section->headline());
 	}
 
+	public function testHeadlineFromName(): void
+	{
+		// single label
+		$section = new Section('stats', [
+			'name'  => 'shopStats',
+			'model' => new Page(['slug' => 'test']),
+		]);
+
+		$this->assertSame('Shop stats', $section->headline());
+	}
+
 	public function testReports(): void
 	{
 		$section = new Section('stats', [

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -646,4 +646,23 @@ class ViewTest extends TestCase
 		$this->assertArrayNotHasKey('bar', $searches);
 		$this->assertArrayHasKey('test', $searches);
 	}
+
+	public function testSearchesWithAutoLabel(): void
+	{
+		$areas = [
+			'a' => [
+				'searches' => [
+					'fooBar' => [],
+				]
+			],
+		];
+
+		$searches = View::searches($areas, [
+			'access' => [
+				'a' => true
+			]
+		]);
+
+		$this->assertSame('Foo bar', $searches['fooBar']['label']);
+	}
 }


### PR DESCRIPTION
## Merge first

- https://github.com/getkirby/kirby/pull/7655

## Changelog 

### ✨ Enhancements

- The new `Str::label()` method is used to create better fallback labels, titles and more in various places of the system. This will often save you from defining additional label/title/name options. This can now help you in the following places: 
  - Blueprint title 
  - Blueprint tab labels
  - Section headlines
  - Form field labels
  - Block field: fieldset names
  - Block field: fieldset tab names
  - Block field: fieldset group names
  - Role titles
  - Custom panel search labels

### For review team
<!--
We will take care of the following before merging the PR.
-->

I've split the PR into multiple commits to help with the review process. The field class needed a new `nameUnmodified` property to store the name before lower-casing, otherwise `Str::label()` would have no effect on the lowercase name. This could also help us in the future if we want to improve the mapping of field names with the names in storage. 

- [ ] Add changes & docs to release notes draft in Notion