### PR TITLE
fix: Form performance improvements

### DIFF
--- a/config/fields/checkboxes.php
+++ b/config/fields/checkboxes.php
@@ -50,9 +50,8 @@ return [
 			return $this->sanitizeOptions($this->value);
 		},
 	],
-	'fillWithEmptyValue' => function () {
-		$this->value = [];
-		return $this;
+	'emptyValue' => function () {
+		return [];
 	},
 	'save' => function ($value): string {
 		return A::join($value, ', ');

--- a/config/fields/checkboxes.php
+++ b/config/fields/checkboxes.php
@@ -50,7 +50,7 @@ return [
 			return $this->sanitizeOptions($this->value);
 		},
 	],
-	'fillWithEmptyValue' => function (): static {
+	'fillWithEmptyValue' => function () {
 		$this->value = [];
 		return $this;
 	},

--- a/config/fields/checkboxes.php
+++ b/config/fields/checkboxes.php
@@ -50,6 +50,10 @@ return [
 			return $this->sanitizeOptions($this->value);
 		},
 	],
+	'fillWithEmptyValue' => function (): static {
+		$this->value = [];
+		return $this;
+	},
 	'save' => function ($value): string {
 		return A::join($value, ', ');
 	},

--- a/config/fields/color.php
+++ b/config/fields/color.php
@@ -65,9 +65,8 @@ return [
 			return $this->optionsCache ??= $this->getOptions();
 		}
 	],
-	'fillWithEmptyValue' => function () {
-		$this->value = '';
-		return $this;
+	'emptyValue' => function () {
+		return '';
 	},
 	'methods' => [
 		'getOptions' => function () {

--- a/config/fields/color.php
+++ b/config/fields/color.php
@@ -51,6 +51,9 @@ return [
 		 * to directly select them
 		 */
 		'options' => function (array $options = []): array {
+			// make sure to flush the options cache when
+			// new options are being passed
+			$this->optionsCache = null;
 			return $options;
 		}
 	],
@@ -59,6 +62,11 @@ return [
 			return Str::lower($this->default);
 		},
 		'options' => function (): array {
+			return $this->optionsCache ??= $this->getOptions();
+		}
+	],
+	'methods' => [
+		'getOptions' => function () {
 			// resolve options to support manual arrays
 			// alongside api and query options
 			$props   = FieldOptions::polyfill($this->props);
@@ -103,9 +111,7 @@ return [
 			}
 
 			return $options;
-		}
-	],
-	'methods' => [
+		},
 		'isColor' => function (string $value): bool {
 			return
 				$this->isHex($value) ||

--- a/config/fields/color.php
+++ b/config/fields/color.php
@@ -65,6 +65,10 @@ return [
 			return $this->optionsCache ??= $this->getOptions();
 		}
 	],
+	'fillWithEmptyValue' => function () {
+		$this->value = '';
+		return $this;
+	},
 	'methods' => [
 		'getOptions' => function () {
 			// resolve options to support manual arrays

--- a/config/fields/mixins/datetime.php
+++ b/config/fields/mixins/datetime.php
@@ -11,7 +11,7 @@ return [
 			return $format;
 		}
 	],
-	'fillWithEmptyValue' => function (): static {
+	'fillWithEmptyValue' => function () {
 		$this->value = '';
 		return $this;
 	},

--- a/config/fields/mixins/datetime.php
+++ b/config/fields/mixins/datetime.php
@@ -11,9 +11,8 @@ return [
 			return $format;
 		}
 	],
-	'fillWithEmptyValue' => function () {
-		$this->value = '';
-		return $this;
+	'emptyValue' => function () {
+		return '';
 	},
 	'methods' => [
 		'toDatetime' => function ($value, string $format = 'Y-m-d H:i:s') {

--- a/config/fields/mixins/datetime.php
+++ b/config/fields/mixins/datetime.php
@@ -11,6 +11,10 @@ return [
 			return $format;
 		}
 	],
+	'fillWithEmptyValue' => function (): static {
+		$this->value = '';
+		return $this;
+	},
 	'methods' => [
 		'toDatetime' => function ($value, string $format = 'Y-m-d H:i:s') {
 			if ($date = Date::optional($value)) {

--- a/config/fields/mixins/options.php
+++ b/config/fields/mixins/options.php
@@ -14,6 +14,9 @@ return [
 		 * An array with options
 		 */
 		'options' => function ($options = []) {
+			// make sure to flush the options cache when
+			// new options are being passed
+			$this->optionsCache = null;
 			return $options;
 		},
 		/**
@@ -25,7 +28,7 @@ return [
 	],
 	'computed' => [
 		'options' => function (): array {
-			return $this->getOptions();
+			return $this->optionsCache ??= $this->getOptions();
 		}
 	],
 	'methods' => [

--- a/config/fields/mixins/options.php
+++ b/config/fields/mixins/options.php
@@ -32,7 +32,7 @@ return [
 		}
 	],
 	'methods' => [
-		'getOptions' => function () {
+		'getOptions' => function (): array {
 			$props   = FieldOptions::polyfill($this->props);
 			$options = FieldOptions::factory($props['options']);
 			return $options->render($this->model());
@@ -41,7 +41,7 @@ return [
 			$options = array_column($this->options(), 'value');
 			return in_array($value, $options) ? $value : null;
 		},
-		'sanitizeOptions' => function ($values) {
+		'sanitizeOptions' => function ($values): array {
 			$options = array_column($this->options(), 'value');
 			$options = array_intersect($values, $options);
 			return array_values($options);

--- a/config/fields/mixins/picker.php
+++ b/config/fields/mixins/picker.php
@@ -90,4 +90,8 @@ return [
 			return $text;
 		},
 	],
+	'fillWithEmptyValue' => function (): static {
+		$this->value = [];
+		return $this;
+	},
 ];

--- a/config/fields/mixins/picker.php
+++ b/config/fields/mixins/picker.php
@@ -90,8 +90,7 @@ return [
 			return $text;
 		},
 	],
-	'fillWithEmptyValue' => function () {
-		$this->value = [];
-		return $this;
+	'emptyValue' => function () {
+		return [];
 	},
 ];

--- a/config/fields/mixins/picker.php
+++ b/config/fields/mixins/picker.php
@@ -90,7 +90,7 @@ return [
 			return $text;
 		},
 	],
-	'fillWithEmptyValue' => function (): static {
+	'fillWithEmptyValue' => function () {
 		$this->value = [];
 		return $this;
 	},

--- a/config/fields/multiselect.php
+++ b/config/fields/multiselect.php
@@ -20,7 +20,7 @@ return [
 		},
 	],
 	'methods' => [
-		'toValues' => function ($value) {
+		'toValues' => function ($value): array {
 			if (is_null($value) === true) {
 				return [];
 			}

--- a/config/fields/number.php
+++ b/config/fields/number.php
@@ -48,7 +48,7 @@ return [
 			return $this->toNumber($default) ?? '';
 		}
 	],
-	'fillWithEmptyValue' => function (): static {
+	'fillWithEmptyValue' => function () {
 		$this->value = '';
 		return $this;
 	},

--- a/config/fields/number.php
+++ b/config/fields/number.php
@@ -48,6 +48,10 @@ return [
 			return $this->toNumber($default) ?? '';
 		}
 	],
+	'fillWithEmptyValue' => function (): static {
+		$this->value = '';
+		return $this;
+	},
 	'methods' => [
 		'toNumber' => function ($value): float|null {
 			if ($this->isEmptyValue($value) === true) {

--- a/config/fields/number.php
+++ b/config/fields/number.php
@@ -30,11 +30,11 @@ return [
 		'step' => function ($step = null): float|string {
 			return match ($step) {
 				'any'   => 'any',
-				default => $this->toNumber($step) ?? ''
+				default => $this->toNumber($step) ?? $this->emptyValue()
 			};
 		},
 		'value' => function ($value = null) {
-			return $this->toNumber($value) ?? '';
+			return $this->toNumber($value) ?? $this->emptyValue();
 		}
 	],
 	'computed' => [
@@ -45,12 +45,11 @@ return [
 				$default = $this->model()->toString($default);
 			}
 
-			return $this->toNumber($default) ?? '';
+			return $this->toNumber($default) ?? $this->emptyValue();
 		}
 	],
-	'fillWithEmptyValue' => function () {
-		$this->value = '';
-		return $this;
+	'emptyValue' => function () {
+		return '';
 	},
 	'methods' => [
 		'toNumber' => function ($value): float|null {

--- a/config/fields/radio.php
+++ b/config/fields/radio.php
@@ -26,5 +26,9 @@ return [
 		'value' => function () {
 			return $this->sanitizeOption($this->value) ?? '';
 		}
-	]
+	],
+	'fillWithEmptyValue' => function (): static {
+		$this->value = '';
+		return $this;
+	},
 ];

--- a/config/fields/radio.php
+++ b/config/fields/radio.php
@@ -27,7 +27,7 @@ return [
 			return $this->sanitizeOption($this->value) ?? '';
 		}
 	],
-	'fillWithEmptyValue' => function (): static {
+	'fillWithEmptyValue' => function () {
 		$this->value = '';
 		return $this;
 	},

--- a/config/fields/radio.php
+++ b/config/fields/radio.php
@@ -27,8 +27,7 @@ return [
 			return $this->sanitizeOption($this->value) ?? '';
 		}
 	],
-	'fillWithEmptyValue' => function () {
-		$this->value = '';
-		return $this;
+	'emptyValue' => function () {
+		return '';
 	},
 ];

--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -170,7 +170,7 @@ return [
 			return $this->columnsCache ??= $columns;
 		}
 	],
-	'fillWithEmptyValue' => function (): static {
+	'fillWithEmptyValue' => function () {
 		$this->value = [];
 		return $this;
 	},

--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -170,6 +170,10 @@ return [
 			return $this->columnsCache ??= $columns;
 		}
 	],
+	'fillWithEmptyValue' => function (): static {
+		$this->value = [];
+		return $this;
+	},
 	'methods' => [
 		'rows' => function ($value) {
 			$rows  = Data::decode($value, 'yaml');

--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -170,9 +170,8 @@ return [
 			return $this->columnsCache ??= $columns;
 		}
 	],
-	'fillWithEmptyValue' => function () {
-		$this->value = [];
-		return $this;
+	'emptyValue' => function () {
+		return [];
 	},
 	'methods' => [
 		'rows' => function ($value) {

--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -30,6 +30,9 @@ return [
 		 * Optional columns definition to only show selected fields in the structure table.
 		 */
 		'columns' => function (array $columns = []) {
+			// flush the columns cache
+			$this->columnsCache = null;
+
 			// lower case all keys, because field names will
 			// be lowercase as well.
 			return array_change_key_case($columns);
@@ -115,6 +118,10 @@ return [
 			return $this->form()->fields()->toProps();
 		},
 		'columns' => function () {
+			if (is_array($this->columnsCache) === true) {
+				return $this->columnsCache;
+			}
+
 			$columns   = [];
 			$blueprint = $this->columns;
 
@@ -160,7 +167,7 @@ return [
 				$columns[array_key_first($columns)]['mobile'] = true;
 			}
 
-			return $columns;
+			return $this->columnsCache ??= $columns;
 		}
 	],
 	'methods' => [

--- a/config/fields/tags.php
+++ b/config/fields/tags.php
@@ -76,8 +76,12 @@ return [
 			return $this->toValues($this->value);
 		}
 	],
+	'fillWithEmptyValue' => function (): static {
+		$this->value = [];
+		return $this;
+	},
 	'methods' => [
-		'toValues' => function ($value) {
+		'toValues' => function ($value): array {
 			if (is_null($value) === true) {
 				return [];
 			}

--- a/config/fields/tags.php
+++ b/config/fields/tags.php
@@ -76,7 +76,7 @@ return [
 			return $this->toValues($this->value);
 		}
 	],
-	'fillWithEmptyValue' => function (): static {
+	'fillWithEmptyValue' => function () {
 		$this->value = [];
 		return $this;
 	},

--- a/config/fields/tags.php
+++ b/config/fields/tags.php
@@ -76,9 +76,8 @@ return [
 			return $this->toValues($this->value);
 		}
 	],
-	'fillWithEmptyValue' => function () {
-		$this->value = [];
-		return $this;
+	'emptyValue' => function () {
+		return [];
 	},
 	'methods' => [
 		'toValues' => function ($value): array {

--- a/config/fields/text.php
+++ b/config/fields/text.php
@@ -73,9 +73,8 @@ return [
 			return (string)$this->convert($this->value);
 		}
 	],
-	'fillWithEmptyValue' => function () {
-		$this->value = '';
-		return $this;
+	'emptyValue' => function () {
+		return '';
 	},
 	'methods' => [
 		'convert' => function ($value) {

--- a/config/fields/text.php
+++ b/config/fields/text.php
@@ -73,6 +73,10 @@ return [
 			return (string)$this->convert($this->value);
 		}
 	],
+	'fillWithEmptyValue' => function (): static {
+		$this->value = '';
+		return $this;
+	},
 	'methods' => [
 		'convert' => function ($value) {
 			if ($this->converter() === null) {

--- a/config/fields/text.php
+++ b/config/fields/text.php
@@ -73,7 +73,7 @@ return [
 			return (string)$this->convert($this->value);
 		}
 	],
-	'fillWithEmptyValue' => function (): static {
+	'fillWithEmptyValue' => function () {
 		$this->value = '';
 		return $this;
 	},

--- a/config/fields/textarea.php
+++ b/config/fields/textarea.php
@@ -113,7 +113,7 @@ return [
 			]
 		];
 	},
-	'fillWithEmptyValue' => function (): static {
+	'fillWithEmptyValue' => function () {
 		$this->value = '';
 		return $this;
 	},

--- a/config/fields/textarea.php
+++ b/config/fields/textarea.php
@@ -113,6 +113,10 @@ return [
 			]
 		];
 	},
+	'fillWithEmptyValue' => function (): static {
+		$this->value = '';
+		return $this;
+	},
 	'validations' => [
 		'minlength',
 		'maxlength'

--- a/config/fields/textarea.php
+++ b/config/fields/textarea.php
@@ -113,9 +113,8 @@ return [
 			]
 		];
 	},
-	'fillWithEmptyValue' => function () {
-		$this->value = '';
-		return $this;
+	'emptyValue' => function () {
+		return '';
 	},
 	'validations' => [
 		'minlength',

--- a/config/fields/toggles.php
+++ b/config/fields/toggles.php
@@ -38,7 +38,7 @@ return [
 			return $this->sanitizeOption($this->value) ?? '';
 		},
 	],
-	'fillWithEmptyValue' => function (): static {
+	'fillWithEmptyValue' => function () {
 		$this->value = '';
 		return $this;
 	},

--- a/config/fields/toggles.php
+++ b/config/fields/toggles.php
@@ -37,5 +37,9 @@ return [
 		'value' => function () {
 			return $this->sanitizeOption($this->value) ?? '';
 		},
-	]
+	],
+	'fillWithEmptyValue' => function (): static {
+		$this->value = '';
+		return $this;
+	},
 ];

--- a/config/fields/toggles.php
+++ b/config/fields/toggles.php
@@ -38,8 +38,7 @@ return [
 			return $this->sanitizeOption($this->value) ?? '';
 		},
 	],
-	'fillWithEmptyValue' => function () {
-		$this->value = '';
-		return $this;
+	'emptyValue' => function () {
+		return '';
 	},
 ];

--- a/config/fields/writer.php
+++ b/config/fields/writer.php
@@ -73,7 +73,7 @@ return [
 			return $value;
 		}
 	],
-	'fillWithEmptyValue' => function (): static {
+	'fillWithEmptyValue' => function () {
 		$this->value = '';
 		return $this;
 	},

--- a/config/fields/writer.php
+++ b/config/fields/writer.php
@@ -73,9 +73,8 @@ return [
 			return $value;
 		}
 	],
-	'fillWithEmptyValue' => function () {
-		$this->value = '';
-		return $this;
+	'emptyValue' => function () {
+		return '';
 	},
 	'validations' => [
 		'minlength' => function ($value) {

--- a/config/fields/writer.php
+++ b/config/fields/writer.php
@@ -73,6 +73,10 @@ return [
 			return $value;
 		}
 	],
+	'fillWithEmptyValue' => function (): static {
+		$this->value = '';
+		return $this;
+	},
 	'validations' => [
 		'minlength' => function ($value) {
 			if (

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -297,6 +297,21 @@ class Field extends Component
 	}
 
 	/**
+	 * Preferred name would be `::reset` but this is
+	 * taken by options in other fields.
+	 *
+	 * @since 5.2.0
+	 */
+	public function fillWithEmptyValue(): static
+	{
+		if ($this->handlerExists('fillWithEmptyValue') === true) {
+			return $this->handlerCall('fillWithEmptyValue');
+		}
+
+		return $this->fill(null);
+	}
+
+	/**
 	 * @deprecated 5.0.0 Use `::siblings() instead
 	 */
 	public function formFields(): Fields

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -243,6 +243,15 @@ class Field extends Component
 		return [];
 	}
 
+	public function emptyValue(): mixed
+	{
+		if ($this->handlerExists('emptyValue') === true) {
+			return $this->handlerCall('emptyValue');
+		}
+
+		return null;
+	}
+
 	/**
 	 * Creates a new field instance
 	 */
@@ -302,7 +311,8 @@ class Field extends Component
 			return $this->handlerCall('fillWithEmptyValue');
 		}
 
-		return $this->fill(null);
+		$this->value = $this->emptyValue();
+		return $this;
 	}
 
 	/**

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -224,11 +224,8 @@ class Field extends Component
 	 */
 	public function dialogs(): array
 	{
-		if (
-			isset($this->options['dialogs']) === true &&
-			$this->options['dialogs'] instanceof Closure
-		) {
-			return $this->options['dialogs']->call($this);
+		if ($this->handlerExists('dialogs') === true) {
+			return $this->handlerCall('dialogs');
 		}
 
 		return [];
@@ -239,11 +236,8 @@ class Field extends Component
 	 */
 	public function drawers(): array
 	{
-		if (
-			isset($this->options['drawers']) === true &&
-			$this->options['drawers'] instanceof Closure
-		) {
-			return $this->options['drawers']->call($this);
+		if ($this->handlerExists('drawers') === true) {
+			return $this->handlerCall('drawers');
 		}
 
 		return [];
@@ -319,6 +313,16 @@ class Field extends Component
 		return $this->siblings;
 	}
 
+	protected function handlerCall(string $handler, ...$args): mixed
+	{
+		return $this->options[$handler]->call($this, ...$args);
+	}
+
+	protected function handlerExists(string $handler): bool
+	{
+		return isset($this->options[$handler]) === true && $this->options[$handler] instanceof Closure;
+	}
+
 	/**
 	 * Checks if the field has a value
 	 */
@@ -340,11 +344,8 @@ class Field extends Component
 	 */
 	public function isEmptyValue(mixed $value = null): bool
 	{
-		if (
-			isset($this->options['isEmpty']) === true &&
-			$this->options['isEmpty'] instanceof Closure
-		) {
-			return $this->options['isEmpty']->call($this, $value);
+		if ($this->handlerExists('isEmpty') === true) {
+			return $this->handlerCall('isEmpty', $value);
 		}
 
 		return $this->isEmptyValueFromMixin($value);
@@ -363,11 +364,8 @@ class Field extends Component
 	 */
 	public function routes(): array
 	{
-		if (
-			isset($this->options['api']) === true &&
-			$this->options['api'] instanceof Closure
-		) {
-			return $this->options['api']->call($this);
+		if ($this->handlerExists('api') === true) {
+			return $this->handlerCall('api');
 		}
 
 		return [];

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -26,6 +26,7 @@ class BlocksField extends FieldClass
 	use Min;
 
 	protected Fieldsets $fieldsets;
+	protected array $forms;
 	protected string|null $group;
 	protected bool $pretty;
 	protected mixed $value = [];
@@ -51,19 +52,13 @@ class BlocksField extends FieldClass
 		string $to = 'toFormValues'
 	): array {
 		$result = [];
-		$fields = [];
-		$forms  = [];
 
 		foreach ($blocks as $block) {
 			try {
-				$type = $block['type'];
-
-				// get and cache fields at the same time
-				$fields[$type] ??= $this->fields($block['type']);
-				$forms[$type]  ??= $this->form($fields[$type]);
+				$form = $this->fieldsetForm($block['type']);
 
 				// overwrite the block content with form values
-				$block['content'] = $forms[$type]->reset()->fill(input: $block['content'])->$to();
+				$block['content'] = $form->reset()->fill(input: $block['content'])->$to();
 
 				// create id if not exists
 				$block['id'] ??= Str::uuid();
@@ -91,6 +86,11 @@ class BlocksField extends FieldClass
 		throw new NotFoundException(
 			'The fieldset ' . $type . ' could not be found'
 		);
+	}
+
+	protected function fieldsetForm(string $type): Form
+	{
+		return $this->forms[$type] ??= $this->form($this->fields($type));
 	}
 
 	public function fieldsets(): Fieldsets

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -121,6 +121,10 @@ class BlocksField extends FieldClass
 		return $this;
 	}
 
+	/**
+	 * @psalm-suppress MethodSignatureMismatch
+	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
+	 */
 	public function fillWithEmptyValue(): static
 	{
 		$this->value = [];

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -110,10 +110,20 @@ class BlocksField extends FieldClass
 	 */
 	public function fill(mixed $value): static
 	{
+		if ($this->isEmptyValue($value) === true) {
+			return $this->fillWithEmptyValue();
+		}
+
 		$value  = BlocksCollection::parse($value);
 		$blocks = BlocksCollection::factory($value)->toArray();
 		$this->value = $this->blocksToValues($blocks);
 
+		return $this;
+	}
+
+	public function fillWithEmptyValue(): static
+	{
+		$this->value = [];
 		return $this;
 	}
 

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -72,6 +72,11 @@ class BlocksField extends FieldClass
 		return $result;
 	}
 
+	public function emptyValue(): mixed
+	{
+		return [];
+	}
+
 	public function fields(string $type): array
 	{
 		return $this->fieldset($type)->fields();
@@ -118,16 +123,6 @@ class BlocksField extends FieldClass
 		$blocks = BlocksCollection::factory($value)->toArray();
 		$this->value = $this->blocksToValues($blocks);
 
-		return $this;
-	}
-
-	/**
-	 * @psalm-suppress MethodSignatureMismatch
-	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
-	 */
-	public function fillWithEmptyValue(): static
-	{
-		$this->value = [];
 		return $this;
 	}
 

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -59,7 +59,17 @@ class EntriesField extends FieldClass
 	 */
 	public function fill(mixed $value): static
 	{
+		if ($this->isEmptyValue($value) === true) {
+			return $this->fillWithEmptyValue();
+		}
+
 		$this->value = Data::decode($value ?? '', 'yaml');
+		return $this;
+	}
+
+	public function fillWithEmptyValue(): static
+	{
+		$this->value = [];
 		return $this;
 	}
 

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -43,6 +43,11 @@ class EntriesField extends FieldClass
 		$this->setSortable($params['sortable'] ?? true);
 	}
 
+	public function emptyValue(): mixed
+	{
+		return [];
+	}
+
 	public function field(): array
 	{
 		return $this->field;
@@ -64,16 +69,6 @@ class EntriesField extends FieldClass
 		}
 
 		$this->value = Data::decode($value ?? '', 'yaml');
-		return $this;
-	}
-
-	/**
-	 * @psalm-suppress MethodSignatureMismatch
-	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
-	 */
-	public function fillWithEmptyValue(): static
-	{
-		$this->value = [];
 		return $this;
 	}
 
@@ -147,7 +142,7 @@ class EntriesField extends FieldClass
 	public function toFormValue(): mixed
 	{
 		$form  = $this->form();
-		$value = parent::toFormValue() ?? [];
+		$value = parent::toFormValue() ?? $this->emptyValue();
 
 		return A::map(
 			$value,

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -67,6 +67,10 @@ class EntriesField extends FieldClass
 		return $this;
 	}
 
+	/**
+	 * @psalm-suppress MethodSignatureMismatch
+	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
+	 */
 	public function fillWithEmptyValue(): static
 	{
 		$this->value = [];

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -30,6 +30,11 @@ class LayoutField extends BlocksField
 		parent::__construct($params);
 	}
 
+	public function emptyValue(): mixed
+	{
+		return [];
+	}
+
 	/**
 	 * @psalm-suppress MethodSignatureMismatch
 	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
@@ -56,16 +61,6 @@ class LayoutField extends BlocksField
 
 		$this->value = $layouts;
 
-		return $this;
-	}
-
-	/**
-	 * @psalm-suppress MethodSignatureMismatch
-	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
-	 */
-	public function fillWithEmptyValue(): static
-	{
-		$this->value = [];
 		return $this;
 	}
 

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -59,6 +59,10 @@ class LayoutField extends BlocksField
 		return $this;
 	}
 
+	/**
+	 * @psalm-suppress MethodSignatureMismatch
+	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
+	 */
 	public function fillWithEmptyValue(): static
 	{
 		$this->value = [];

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -36,6 +36,10 @@ class LayoutField extends BlocksField
 	 */
 	public function fill(mixed $value): static
 	{
+		if ($this->isEmptyValue($value) === true) {
+			return $this->fillWithEmptyValue();
+		}
+
 		$attrs   = $this->attrsForm();
 		$value   = Data::decode($value, type: 'json', fail: false);
 		$layouts = Layouts::factory($value, ['parent' => $this->model])->toArray();
@@ -52,6 +56,12 @@ class LayoutField extends BlocksField
 
 		$this->value = $layouts;
 
+		return $this;
+	}
+
+	public function fillWithEmptyValue(): static
+	{
+		$this->value = [];
 		return $this;
 	}
 

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -268,7 +268,7 @@ class Fields extends Collection
 
 		// reset the values of each field
 		foreach ($this->data as $field) {
-			$field->fill(null);
+			$field->fillWithEmptyValue();
 		}
 
 		return $this;

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Form;
 
-use Kirby\Cms\File;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Data\Data;

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -52,6 +52,14 @@ trait Value
 	}
 
 	/**
+	 * Returns the fallback value when the field should be empty
+	 */
+	public function emptyValue(): mixed
+	{
+		return null;
+	}
+
+	/**
 	 * Sets a new value for the field
 	 */
 	public function fill(mixed $value): static
@@ -68,7 +76,8 @@ trait Value
 	 */
 	public function fillWithEmptyValue(): static
 	{
-		return $this->fill(null);
+		$this->value = $this->emptyValue();
+		return $this;
 	}
 
 	/**

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -61,6 +61,17 @@ trait Value
 	}
 
 	/**
+	 * Preferred name would be `::reset` but this is
+	 * taken by options in other fields.
+	 *
+	 * @since 5.2.0
+	 */
+	public function fillWithEmptyValue(): static
+	{
+		return $this->fill(null);
+	}
+
+	/**
 	 * Checks if the field has a value
 	 */
 	public function hasValue(): bool

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -7,7 +7,7 @@ use Kirby\Cms\File as CmsFile;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Filesystem\Asset;
-use Kirby\Form\Fields;
+use Kirby\Form\Form;
 use Kirby\Http\Uri;
 use Kirby\Panel\Ui\Item\ModelItem;
 use Kirby\Toolkit\A;
@@ -454,7 +454,7 @@ abstract class Model
 	public function versions(): array
 	{
 		$language = Language::ensure('current');
-		$fields   = Fields::for($this->model, $language);
+		$form     = Form::for(model: $this->model, language: $language);
 
 		$latestVersion  = $this->model->version('latest');
 		$changesVersion = $this->model->version('changes');
@@ -467,8 +467,8 @@ abstract class Model
 		}
 
 		return [
-			'latest'  => $fields->reset()->fill($latestContent)->toFormValues(),
-			'changes' => $fields->reset()->fill($changesContent)->toFormValues()
+			'latest'  => $form->fill($latestContent)->toFormValues(),
+			'changes' => $form->reset()->fill($changesContent)->toFormValues()
 		];
 	}
 

--- a/tests/Form/Field/BlocksFieldTest.php
+++ b/tests/Form/Field/BlocksFieldTest.php
@@ -22,6 +22,32 @@ class BlocksFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('blocks');
+
+		$field->fill([
+			[
+				'type'    => 'heading',
+				'content' => [
+					'text' => 'a'
+				]
+			],
+			[
+				'type'    => 'heading',
+				'content' => [
+					'text' => 'b'
+				]
+			],
+		]);
+
+		$this->assertCount(2, $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame([], $field->toFormValue());
+	}
+
 	public function testGroups(): void
 	{
 		$field = $this->field('blocks', [

--- a/tests/Form/Field/CheckboxesFieldTest.php
+++ b/tests/Form/Field/CheckboxesFieldTest.php
@@ -51,6 +51,25 @@ class CheckboxesFieldTest extends TestCase
 		$this->assertSame('a, b', $field->data(true));
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('checkboxes', [
+			'options' => [
+				'a',
+				'b',
+				'c'
+			],
+		]);
+
+		$field->fill(['a', 'b']);
+
+		$this->assertSame(['a', 'b'], $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame([], $field->toFormValue());
+	}
+
 	public function testStringConversion(): void
 	{
 		$field = $this->field('checkboxes', [

--- a/tests/Form/Field/ColorFieldTest.php
+++ b/tests/Form/Field/ColorFieldTest.php
@@ -39,6 +39,18 @@ class ColorFieldTest extends TestCase
 		$this->assertSame('#fff', $field->default());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('color');
+		$field->fill('#efefef');
+
+		$this->assertSame('#efefef', $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame('', $field->toFormValue());
+	}
+
 	public function testFormatInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);

--- a/tests/Form/Field/DateFieldTest.php
+++ b/tests/Form/Field/DateFieldTest.php
@@ -128,6 +128,18 @@ class DateFieldTest extends TestCase
 		], $field->errors());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('date');
+		$field->fill('2012-12-12');
+
+		$this->assertSame('2012-12-12 00:00:00', $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame('', $field->toFormValue());
+	}
+
 	public static function valueProvider(): array
 	{
 		return [

--- a/tests/Form/Field/EntriesFieldTest.php
+++ b/tests/Form/Field/EntriesFieldTest.php
@@ -126,6 +126,25 @@ class EntriesFieldTest extends TestCase
 		$this->assertArrayNotHasKey('counter', $field->field());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$value = [
+			'https://getkirby.com',
+			'https://forum.getkirby.com',
+			'https://plugins.getkirby.com',
+		];
+
+		$field = $this->field('entries');
+
+		$field->fill($value);
+
+		$this->assertSame($value, $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame([], $field->toFormValue());
+	}
+
 	public function testDefaultValue(): void
 	{
 		$field = $this->field('entries', [

--- a/tests/Form/Field/LayoutFieldTest.php
+++ b/tests/Form/Field/LayoutFieldTest.php
@@ -71,6 +71,33 @@ class LayoutFieldTest extends TestCase
 		$this->assertArrayHasKey('background-color', $fields);
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$value = [
+			[
+				'columns' => [
+					[
+						'blocks' => [
+							[
+								'type' => 'heading',
+							]
+						]
+					]
+				]
+			]
+		];
+
+		$field = $this->field('layout');
+
+		$field->fill($value);
+
+		$this->assertCount(1, $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame([], $field->toFormValue());
+	}
+
 	public function testLayouts(): void
 	{
 		$field = $this->field('layout', [

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -25,6 +25,33 @@ class StructureFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('structure', [
+			'fields' => [
+				'test' => [
+					'type' => 'text'
+				],
+			],
+		]);
+
+		$field->fill($value = [
+			[
+				'test' => 'Test A'
+			],
+			[
+				'test' => 'Test B'
+			]
+		]);
+
+		$this->assertSame($value, $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame([], $field->toFormValue());
+	}
+
+
 	public function testTagsFieldInStructure(): void
 	{
 		$field = $this->field('structure', [

--- a/tests/Form/Field/TagsFieldTest.php
+++ b/tests/Form/Field/TagsFieldTest.php
@@ -22,6 +22,18 @@ class TagsFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('tags');
+		$field->fill($value = ['a', 'b', 'c']);
+
+		$this->assertSame($value, $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame([], $field->toFormValue());
+	}
+
 	public function testOptionsQuery(): void
 	{
 		$app = $this->app()->clone([

--- a/tests/Form/Field/TextFieldTest.php
+++ b/tests/Form/Field/TextFieldTest.php
@@ -49,6 +49,18 @@ class TextFieldTest extends TestCase
 		$this->assertSame($expected, $field->default());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('text');
+		$field->fill('test');
+
+		$this->assertSame('test', $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame('', $field->toFormValue());
+	}
+
 	public function testInvalidConverter(): void
 	{
 		$this->expectException(InvalidArgumentException::class);

--- a/tests/Form/Field/TextareaFieldTest.php
+++ b/tests/Form/Field/TextareaFieldTest.php
@@ -83,6 +83,18 @@ class TextareaFieldTest extends TestCase
 		$this->assertSame([], $field->files());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('textarea');
+		$field->fill('test');
+
+		$this->assertSame('test', $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame('', $field->toFormValue());
+	}
+
 	public function testMaxLength(): void
 	{
 		$field = $this->field('textarea', [

--- a/tests/Form/Field/WriterFieldTest.php
+++ b/tests/Form/Field/WriterFieldTest.php
@@ -17,6 +17,18 @@ class WriterFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('writer');
+		$field->fill('test');
+
+		$this->assertSame('test', $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame('', $field->toFormValue());
+	}
+
 	public function testValueSanitized(): void
 	{
 		$field = $this->field('writer', [

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -158,6 +158,12 @@ class FieldClassTest extends TestCase
 		$this->assertSame([], $field->drawers());
 	}
 
+	public function testEmptyValue(): void
+	{
+		$field = new TestField();
+		$this->assertNull($field->emptyValue());
+	}
+
 	public function testErrors(): void
 	{
 		$field = new TestField();

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -400,6 +400,32 @@ class FieldTest extends TestCase
 		$this->assertEquals(Field::setup('test'), $field->optionsDebugger());
 	}
 
+	public function testFillWithEmptyValueCustomHandler(): void
+	{
+		Field::$types = [
+			'test' => [
+				'fillWithEmptyValue' => function () {
+					$this->value = 'foo';
+					return $this;
+				}
+			]
+		];
+
+		$page = new Page(['slug' => 'test']);
+
+		$field = new Field('test', [
+			'model' => $page,
+		]);
+
+		$field->fill('test');
+
+		$this->assertSame('test', $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame('foo', $field->toFormValue());
+	}
+
 	public function testHelp(): void
 	{
 		Field::$types = [


### PR DESCRIPTION
## Chunks: 

- [ ] https://github.com/getkirby/kirby/pull/7663
- [ ] https://github.com/getkirby/kirby/pull/7664
- [ ] https://github.com/getkirby/kirby/pull/7665

## Description

After looking closer at this issue and @afbora research https://github.com/getkirby/kirby/issues/7641 I found multiple ways how we can improve/fix this. We have to decide if we do all the steps at once, or if we want to break them down, but I'm using this PR as a big sweep first to give you the bigger picture. 

## Benchmark results

To not step in the dark with premature improvements, I've created a little benchmark setup for the sandbox with a new CLI command that can help us test our changes more easily. 

The results of this PR are impressive. I'm benchmarking two scenarios. 

### `Form::reset()` 

To reset all form fields took forever before the PR because the old Field class needed to rerun all prop and computed prop methods to make sure that there's not an invalid state for one of them which depends on the value. 

I'm running this 10 times in a loop. 

```php
foreach (page('fields')->children() as $fieldPage) {
  Form::for($fieldPage)->reset();
}
```

**Before**
```
Bench: Time: 00:11.542, Memory: 24.00 MB
```

**After (2 times faster)**
```
Bench: Time: 00:05.704, Memory: 24.00 MB
```

### `$page->panel()->view()`

Creating all the props for the view needs to create two forms: one for the latest version and one for the changed version (if it exists) This makes the reset problem from above even worse because we need to reset the form when we want to reuse it for two versions and this could also add up even more if there are nested forms (structures, blocks, etc.)

Again, I'm running this 10 times in a loop. 

```php
foreach (page('fields')->children() as $fieldPage) {
  $fieldPage->panel()->view();
}
```

**Before**
```
Bench: Time: 00:16.887, Memory: 24.00 MB
```

**After (3,2 times faster)**
```
Bench: Time: 00:05.832, Memory: 24.00 MB
```

This clearly shows how the problem escalates with more form setup and reset tasks. 

This should have positive performance side-effects to pretty much any part of the panel. 

## Running benchmarks

To test the differences, you can use the Kirby CLI in the sandbox root directory. Make sure to pull the latest sandbox changes. There's a new way to set the sandbox URL with a new custom sandbox config. In the root directory, you'll find a new sandbox.config.sample.php. Rename it to sandbox.config.php and add your custom URL in there. All options in the file will be merged with the Kirby config of the sandbox. The sandbox.config.php is automatically ignored. 

Once this is done, you can run

```
kirby sandbox:bench:fields
```

… and …

``` 
kirby sandbox:bench:views
```

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- Cache options in the options mixin for fields.
- Cache block forms by type in the blocks field. 
- Cache columns in the structure field
- Cache color options in the color field
- Cleaned up object field with the new form methods and caching, similar to the structure field. 
- Improve type hinting in the options mixin for fields
- New `::fillWithEmptyValue` method for Field and FieldClass. This is used in `Fields::reset` to reset the value to a correct empty one. The naming is not great, but we cannot use reset, as it exists as option in the toggles field and would collide. It's at least clear enough. This will make sure that resetting a field will be as fast as possible without reevaluating props and computed props in the old rusty Field component. This is one big source for performance hits. 
- New `Field::handlerExists` and `Field::handlerCall` methods. Those are not directly related to this PR, but simply help to remove some redundant code. We can totally do this in a separate PR. 

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- Use Form instead of the Fields class in Kirby\Panel\Model
- Remove an unused class declaration in the Form class

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion