### PR TITLE
refact: New ::emptyValue and ::fillWithEmptyValue methods for Field and FieldClass

### DIFF
--- a/config/fields/checkboxes.php
+++ b/config/fields/checkboxes.php
@@ -50,6 +50,11 @@ return [
 			return $this->sanitizeOptions($this->value);
 		},
 	],
+	'methods' => [
+		'emptyValue' => function () {
+			return [];
+		}
+	],
 	'save' => function ($value): string {
 		return A::join($value, ', ');
 	},

--- a/config/fields/color.php
+++ b/config/fields/color.php
@@ -106,6 +106,9 @@ return [
 		}
 	],
 	'methods' => [
+		'emptyValue' => function () {
+			return '';
+		},
 		'isColor' => function (string $value): bool {
 			return
 				$this->isHex($value) ||

--- a/config/fields/mixins/datetime.php
+++ b/config/fields/mixins/datetime.php
@@ -12,6 +12,9 @@ return [
 		}
 	],
 	'methods' => [
+		'emptyValue' => function () {
+			return '';
+		},
 		'toDatetime' => function ($value, string $format = 'Y-m-d H:i:s') {
 			if ($date = Date::optional($value)) {
 				if ($this->step) {

--- a/config/fields/mixins/picker.php
+++ b/config/fields/mixins/picker.php
@@ -90,4 +90,9 @@ return [
 			return $text;
 		},
 	],
+	'methods' => [
+		'emptyValue' => function () {
+			return [];
+		}
+	]
 ];

--- a/config/fields/number.php
+++ b/config/fields/number.php
@@ -30,11 +30,11 @@ return [
 		'step' => function ($step = null): float|string {
 			return match ($step) {
 				'any'   => 'any',
-				default => $this->toNumber($step) ?? ''
+				default => $this->toNumber($step) ?? $this->emptyValue()
 			};
 		},
 		'value' => function ($value = null) {
-			return $this->toNumber($value) ?? '';
+			return $this->toNumber($value) ?? $this->emptyValue();
 		}
 	],
 	'computed' => [
@@ -45,10 +45,13 @@ return [
 				$default = $this->model()->toString($default);
 			}
 
-			return $this->toNumber($default) ?? '';
+			return $this->toNumber($default) ?? $this->emptyValue();
 		}
 	],
 	'methods' => [
+		'emptyValue' => function () {
+			return '';
+		},
 		'toNumber' => function ($value): float|null {
 			if ($this->isEmptyValue($value) === true) {
 				return null;

--- a/config/fields/radio.php
+++ b/config/fields/radio.php
@@ -26,5 +26,10 @@ return [
 		'value' => function () {
 			return $this->sanitizeOption($this->value) ?? '';
 		}
+	],
+	'methods' => [
+		'emptyValue' => function () {
+			return '';
+		}
 	]
 ];

--- a/config/fields/structure.php
+++ b/config/fields/structure.php
@@ -164,6 +164,9 @@ return [
 		}
 	],
 	'methods' => [
+		'emptyValue' => function () {
+			return [];
+		},
 		'rows' => function ($value) {
 			$rows  = Data::decode($value, 'yaml');
 			$value = [];

--- a/config/fields/tags.php
+++ b/config/fields/tags.php
@@ -77,6 +77,9 @@ return [
 		}
 	],
 	'methods' => [
+		'emptyValue' => function () {
+			return [];
+		},
 		'toValues' => function ($value) {
 			if (is_null($value) === true) {
 				return [];

--- a/config/fields/text.php
+++ b/config/fields/text.php
@@ -103,6 +103,9 @@ return [
 				},
 			];
 		},
+		'emptyValue' => function () {
+			return '';
+		}
 	],
 	'validations' => [
 		'minlength',

--- a/config/fields/textarea.php
+++ b/config/fields/textarea.php
@@ -113,6 +113,11 @@ return [
 			]
 		];
 	},
+	'methods' => [
+		'emptyValue' => function () {
+			return '';
+		}
+	],
 	'validations' => [
 		'minlength',
 		'maxlength'

--- a/config/fields/toggles.php
+++ b/config/fields/toggles.php
@@ -37,5 +37,10 @@ return [
 		'value' => function () {
 			return $this->sanitizeOption($this->value) ?? '';
 		},
+	],
+	'methods' => [
+		'emptyValue' => function () {
+			return '';
+		}
 	]
 ];

--- a/config/fields/writer.php
+++ b/config/fields/writer.php
@@ -73,6 +73,11 @@ return [
 			return $value;
 		}
 	],
+	'methods' => [
+		'emptyValue' => function () {
+			return '';
+		},
+	],
 	'validations' => [
 		'minlength' => function ($value) {
 			if (

--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -184,6 +184,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -207,6 +208,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1589,6 +1591,7 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2257,6 +2260,7 @@
 			"integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -3659,6 +3663,7 @@
 			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -3694,6 +3699,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.8",
 				"picocolors": "^1.1.1",
@@ -4477,6 +4483,7 @@
 			"integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.14.0",
@@ -4697,6 +4704,7 @@
 			"integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",
@@ -4898,6 +4906,7 @@
 			"integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
 			"deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vue/compiler-sfc": "2.7.16",
 				"csstype": "^3.1.0"

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -250,6 +250,20 @@ class Field extends Component
 	}
 
 	/**
+	 * Returns the preferred empty state for the field
+	 *
+	 * @since 5.2.0
+	 */
+	public function emptyValue(): mixed
+	{
+		if (isset($this->methods['emptyValue']) === true) {
+			return $this->methods['emptyValue']->call($this);
+		}
+
+		return null;
+	}
+
+	/**
 	 * Creates a new field instance
 	 */
 	public static function factory(
@@ -293,6 +307,18 @@ class Field extends Component
 		$this->options = $options;
 		$this->type    = $type;
 
+		return $this;
+	}
+
+	/**
+	 * Preferred name would be `::reset` but this is
+	 * taken by options in other fields.
+	 *
+	 * @since 5.2.0
+	 */
+	public function fillWithEmptyValue(): static
+	{
+		$this->value = $this->emptyValue();
 		return $this;
 	}
 

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -77,6 +77,11 @@ class BlocksField extends FieldClass
 		return $result;
 	}
 
+	public function emptyValue(): mixed
+	{
+		return [];
+	}
+
 	public function fields(string $type): array
 	{
 		return $this->fieldset($type)->fields();

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -77,11 +77,6 @@ class BlocksField extends FieldClass
 		return $result;
 	}
 
-	public function emptyValue(): mixed
-	{
-		return [];
-	}
-
 	public function fields(string $type): array
 	{
 		return $this->fieldset($type)->fields();

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -43,6 +43,11 @@ class EntriesField extends FieldClass
 		$this->setSortable($params['sortable'] ?? true);
 	}
 
+	public function emptyValue(): mixed
+	{
+		return [];
+	}
+
 	public function field(): array
 	{
 		return $this->field;
@@ -133,7 +138,7 @@ class EntriesField extends FieldClass
 	public function toFormValue(): mixed
 	{
 		$form  = $this->form();
-		$value = parent::toFormValue() ?? [];
+		$value = parent::toFormValue() ?? $this->emptyValue();
 
 		return A::map(
 			$value,

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -31,6 +31,7 @@ class EntriesField extends FieldClass
 	protected array $field;
 	protected Form $form;
 	protected bool  $sortable = true;
+	protected mixed $value = [];
 
 	public function __construct(array $params = [])
 	{
@@ -41,11 +42,6 @@ class EntriesField extends FieldClass
 		$this->setMax($params['max'] ?? null);
 		$this->setMin($params['min'] ?? null);
 		$this->setSortable($params['sortable'] ?? true);
-	}
-
-	public function emptyValue(): mixed
-	{
-		return [];
 	}
 
 	public function field(): array

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -30,11 +30,6 @@ class LayoutField extends BlocksField
 		parent::__construct($params);
 	}
 
-	public function emptyValue(): mixed
-	{
-		return [];
-	}
-
 	/**
 	 * @psalm-suppress MethodSignatureMismatch
 	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -30,6 +30,11 @@ class LayoutField extends BlocksField
 		parent::__construct($params);
 	}
 
+	public function emptyValue(): mixed
+	{
+		return [];
+	}
+
 	/**
 	 * @psalm-suppress MethodSignatureMismatch
 	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -161,6 +161,16 @@ abstract class FieldClass
 		];
 	}
 
+	/**
+	 * @since 5.2.0
+	 * @todo Move to `Value` mixin once array-based fields are unsupported
+	 */
+	public function reset(): static
+	{
+		$this->value = $this->emptyValue();
+		return $this;
+	}
+
 	protected function setDisabled(bool $disabled = false): void
 	{
 		$this->disabled = $disabled;

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -268,7 +268,11 @@ class Fields extends Collection
 
 		// reset the values of each field
 		foreach ($this->data as $field) {
-			$field->fillWithEmptyValue();
+			if ($field instanceof Field) {
+				$field->fillWithEmptyValue();
+			} else {
+				$field->reset();
+			}
 		}
 
 		return $this;

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -268,7 +268,7 @@ class Fields extends Collection
 
 		// reset the values of each field
 		foreach ($this->data as $field) {
-			$field->fill(null);
+			$field->fillWithEmptyValue();
 		}
 
 		return $this;

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -52,11 +52,31 @@ trait Value
 	}
 
 	/**
+	 * Returns the fallback value when the field should be empty
+	 */
+	public function emptyValue(): mixed
+	{
+		return null;
+	}
+
+	/**
 	 * Sets a new value for the field
 	 */
 	public function fill(mixed $value): static
 	{
 		$this->value = $value;
+		return $this;
+	}
+
+	/**
+	 * Preferred name would be `::reset` but this is
+	 * taken by options in other fields.
+	 *
+	 * @since 5.2.0
+	 */
+	public function fillWithEmptyValue(): static
+	{
+		$this->value = $this->emptyValue();
 		return $this;
 	}
 

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -3,6 +3,7 @@
 namespace Kirby\Form\Mixin;
 
 use Kirby\Cms\Language;
+use ReflectionProperty;
 
 /**
  * @package   Kirby Form
@@ -56,7 +57,7 @@ trait Value
 	 */
 	public function emptyValue(): mixed
 	{
-		return null;
+		return (new ReflectionProperty($this, 'value'))->getDefaultValue();
 	}
 
 	/**
@@ -65,18 +66,6 @@ trait Value
 	public function fill(mixed $value): static
 	{
 		$this->value = $value;
-		return $this;
-	}
-
-	/**
-	 * Preferred name would be `::reset` but this is
-	 * taken by options in other fields.
-	 *
-	 * @since 5.2.0
-	 */
-	public function fillWithEmptyValue(): static
-	{
-		$this->value = $this->emptyValue();
 		return $this;
 	}
 

--- a/tests/Form/Field/BlocksFieldTest.php
+++ b/tests/Form/Field/BlocksFieldTest.php
@@ -22,32 +22,6 @@ class BlocksFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testFillWithEmptyValue(): void
-	{
-		$field = $this->field('blocks');
-
-		$field->fill([
-			[
-				'type'    => 'heading',
-				'content' => [
-					'text' => 'a'
-				]
-			],
-			[
-				'type'    => 'heading',
-				'content' => [
-					'text' => 'b'
-				]
-			],
-		]);
-
-		$this->assertCount(2, $field->toFormValue());
-
-		$field->fillWithEmptyValue();
-
-		$this->assertSame([], $field->toFormValue());
-	}
-
 	public function testGroups(): void
 	{
 		$field = $this->field('blocks', [
@@ -227,6 +201,32 @@ class BlocksFieldTest extends TestCase
 		]);
 
 		$this->assertTrue($field->isValid());
+	}
+
+	public function testReset(): void
+	{
+		$field = $this->field('blocks');
+
+		$field->fill([
+			[
+				'type'    => 'heading',
+				'content' => [
+					'text' => 'a'
+				]
+			],
+			[
+				'type'    => 'heading',
+				'content' => [
+					'text' => 'b'
+				]
+			],
+		]);
+
+		$this->assertCount(2, $field->toFormValue());
+
+		$field->reset();
+
+		$this->assertSame([], $field->toFormValue());
 	}
 
 	public function testRoutes(): void

--- a/tests/Form/Field/BlocksFieldTest.php
+++ b/tests/Form/Field/BlocksFieldTest.php
@@ -22,6 +22,32 @@ class BlocksFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('blocks');
+
+		$field->fill([
+			[
+				'type'    => 'heading',
+				'content' => [
+					'text' => 'a'
+				]
+			],
+			[
+				'type'    => 'heading',
+				'content' => [
+					'text' => 'b'
+				]
+			],
+		]);
+
+		$this->assertCount(2, $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame([], $field->toFormValue());
+	}
+
 	public function testGroups(): void
 	{
 		$field = $this->field('blocks', [

--- a/tests/Form/Field/CheckboxesFieldTest.php
+++ b/tests/Form/Field/CheckboxesFieldTest.php
@@ -51,6 +51,25 @@ class CheckboxesFieldTest extends TestCase
 		$this->assertSame('a, b', $field->data(true));
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('checkboxes', [
+			'options' => [
+				'a',
+				'b',
+				'c'
+			],
+		]);
+
+		$field->fill(['a', 'b']);
+
+		$this->assertSame(['a', 'b'], $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame([], $field->toFormValue());
+	}
+
 	public function testStringConversion(): void
 	{
 		$field = $this->field('checkboxes', [

--- a/tests/Form/Field/ColorFieldTest.php
+++ b/tests/Form/Field/ColorFieldTest.php
@@ -39,6 +39,18 @@ class ColorFieldTest extends TestCase
 		$this->assertSame('#fff', $field->default());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('color');
+		$field->fill('#efefef');
+
+		$this->assertSame('#efefef', $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame('', $field->toFormValue());
+	}
+
 	public function testFormatInvalid(): void
 	{
 		$this->expectException(InvalidArgumentException::class);

--- a/tests/Form/Field/DateFieldTest.php
+++ b/tests/Form/Field/DateFieldTest.php
@@ -128,6 +128,18 @@ class DateFieldTest extends TestCase
 		], $field->errors());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('date');
+		$field->fill('2012-12-12');
+
+		$this->assertSame('2012-12-12 00:00:00', $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame('', $field->toFormValue());
+	}
+
 	public static function valueProvider(): array
 	{
 		return [

--- a/tests/Form/Field/EntriesFieldTest.php
+++ b/tests/Form/Field/EntriesFieldTest.php
@@ -126,6 +126,25 @@ class EntriesFieldTest extends TestCase
 		$this->assertArrayNotHasKey('counter', $field->field());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$value = [
+			'https://getkirby.com',
+			'https://forum.getkirby.com',
+			'https://plugins.getkirby.com',
+		];
+
+		$field = $this->field('entries');
+
+		$field->fill($value);
+
+		$this->assertSame($value, $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame([], $field->toFormValue());
+	}
+
 	public function testDefaultValue(): void
 	{
 		$field = $this->field('entries', [

--- a/tests/Form/Field/EntriesFieldTest.php
+++ b/tests/Form/Field/EntriesFieldTest.php
@@ -126,25 +126,6 @@ class EntriesFieldTest extends TestCase
 		$this->assertArrayNotHasKey('counter', $field->field());
 	}
 
-	public function testFillWithEmptyValue(): void
-	{
-		$value = [
-			'https://getkirby.com',
-			'https://forum.getkirby.com',
-			'https://plugins.getkirby.com',
-		];
-
-		$field = $this->field('entries');
-
-		$field->fill($value);
-
-		$this->assertSame($value, $field->toFormValue());
-
-		$field->fillWithEmptyValue();
-
-		$this->assertSame([], $field->toFormValue());
-	}
-
 	public function testDefaultValue(): void
 	{
 		$field = $this->field('entries', [
@@ -273,6 +254,25 @@ class EntriesFieldTest extends TestCase
 
 		$this->assertFalse($field->isValid());
 		$this->assertSame(1, $field->min());
+	}
+
+	public function testReset(): void
+	{
+		$value = [
+			'https://getkirby.com',
+			'https://forum.getkirby.com',
+			'https://plugins.getkirby.com',
+		];
+
+		$field = $this->field('entries');
+
+		$field->fill($value);
+
+		$this->assertSame($value, $field->toFormValue());
+
+		$field->reset();
+
+		$this->assertSame([], $field->toFormValue());
 	}
 
 	public static function supportsProvider(): array

--- a/tests/Form/Field/LayoutFieldTest.php
+++ b/tests/Form/Field/LayoutFieldTest.php
@@ -71,33 +71,6 @@ class LayoutFieldTest extends TestCase
 		$this->assertArrayHasKey('background-color', $fields);
 	}
 
-	public function testFillWithEmptyValue(): void
-	{
-		$value = [
-			[
-				'columns' => [
-					[
-						'blocks' => [
-							[
-								'type' => 'heading',
-							]
-						]
-					]
-				]
-			]
-		];
-
-		$field = $this->field('layout');
-
-		$field->fill($value);
-
-		$this->assertCount(1, $field->toFormValue());
-
-		$field->fillWithEmptyValue();
-
-		$this->assertSame([], $field->toFormValue());
-	}
-
 	public function testLayouts(): void
 	{
 		$field = $this->field('layout', [
@@ -144,6 +117,33 @@ class LayoutFieldTest extends TestCase
 		$this->assertSame('1/1', $props['width']);
 		$this->assertNull($props['settings']);
 		$this->assertSame([['1/1']], $props['layouts']);
+	}
+
+	public function testReset(): void
+	{
+		$value = [
+			[
+				'columns' => [
+					[
+						'blocks' => [
+							[
+								'type' => 'heading',
+							]
+						]
+					]
+				]
+			]
+		];
+
+		$field = $this->field('layout');
+
+		$field->fill($value);
+
+		$this->assertCount(1, $field->toFormValue());
+
+		$field->reset();
+
+		$this->assertSame([], $field->toFormValue());
 	}
 
 	public function testRoutes(): void

--- a/tests/Form/Field/LayoutFieldTest.php
+++ b/tests/Form/Field/LayoutFieldTest.php
@@ -71,6 +71,33 @@ class LayoutFieldTest extends TestCase
 		$this->assertArrayHasKey('background-color', $fields);
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$value = [
+			[
+				'columns' => [
+					[
+						'blocks' => [
+							[
+								'type' => 'heading',
+							]
+						]
+					]
+				]
+			]
+		];
+
+		$field = $this->field('layout');
+
+		$field->fill($value);
+
+		$this->assertCount(1, $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame([], $field->toFormValue());
+	}
+
 	public function testLayouts(): void
 	{
 		$field = $this->field('layout', [

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -25,6 +25,33 @@ class StructureFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('structure', [
+			'fields' => [
+				'test' => [
+					'type' => 'text'
+				],
+			],
+		]);
+
+		$field->fill($value = [
+			[
+				'test' => 'Test A'
+			],
+			[
+				'test' => 'Test B'
+			]
+		]);
+
+		$this->assertSame($value, $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame([], $field->toFormValue());
+	}
+
+
 	public function testTagsFieldInStructure(): void
 	{
 		$field = $this->field('structure', [

--- a/tests/Form/Field/TagsFieldTest.php
+++ b/tests/Form/Field/TagsFieldTest.php
@@ -22,6 +22,18 @@ class TagsFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('tags');
+		$field->fill($value = ['a', 'b', 'c']);
+
+		$this->assertSame($value, $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame([], $field->toFormValue());
+	}
+
 	public function testOptionsQuery(): void
 	{
 		$app = $this->app()->clone([

--- a/tests/Form/Field/TextFieldTest.php
+++ b/tests/Form/Field/TextFieldTest.php
@@ -49,6 +49,18 @@ class TextFieldTest extends TestCase
 		$this->assertSame($expected, $field->default());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('text');
+		$field->fill('test');
+
+		$this->assertSame('test', $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame('', $field->toFormValue());
+	}
+
 	public function testInvalidConverter(): void
 	{
 		$this->expectException(InvalidArgumentException::class);

--- a/tests/Form/Field/TextareaFieldTest.php
+++ b/tests/Form/Field/TextareaFieldTest.php
@@ -83,6 +83,18 @@ class TextareaFieldTest extends TestCase
 		$this->assertSame([], $field->files());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('textarea');
+		$field->fill('test');
+
+		$this->assertSame('test', $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame('', $field->toFormValue());
+	}
+
 	public function testMaxLength(): void
 	{
 		$field = $this->field('textarea', [

--- a/tests/Form/Field/WriterFieldTest.php
+++ b/tests/Form/Field/WriterFieldTest.php
@@ -17,6 +17,18 @@ class WriterFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		$field = $this->field('writer');
+		$field->fill('test');
+
+		$this->assertSame('test', $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame('', $field->toFormValue());
+	}
+
 	public function testValueSanitized(): void
 	{
 		$field = $this->field('writer', [

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -158,6 +158,12 @@ class FieldClassTest extends TestCase
 		$this->assertSame([], $field->drawers());
 	}
 
+	public function testEmptyValue(): void
+	{
+		$field = new TestField();
+		$this->assertNull($field->emptyValue());
+	}
+
 	public function testErrors(): void
 	{
 		$field = new TestField();

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -369,6 +369,34 @@ class FieldTest extends TestCase
 		$this->assertSame('test2 computed', $field->computedValue());
 	}
 
+	public function testFillWithEmptyValue(): void
+	{
+		Field::$types = [
+			'test' => [
+				'methods' => [
+					'emptyValue' => function () {
+						return 'foo';
+					}
+				]
+			]
+		];
+
+		$page = new Page(['slug' => 'test']);
+
+		// default state
+		$field = new Field('test', [
+			'model'  => $page
+		]);
+
+		$field->fill('test');
+
+		$this->assertSame('test', $field->toFormValue());
+
+		$field->fillWithEmptyValue();
+
+		$this->assertSame('foo', $field->toFormValue());
+	}
+
 	public function testFillWithRestoredState(): void
 	{
 		Field::$types = [

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -534,16 +534,21 @@ class FieldsTest extends TestCase
 			'b' => [
 				'type'  => 'text',
 			],
+			'c' => [
+				'type' => 'entries'
+			]
 		], $this->model);
 
 		$fields->fill([
 			'a' => 'A',
 			'b' => 'B',
+			'c' => ['a', 'b', 'c']
 		]);
 
 		$this->assertSame([
 			'a' => 'A',
 			'b' => 'B',
+			'c' => ['a', 'b', 'c']
 		], $fields->toFormValues());
 
 		$fields->reset();
@@ -551,6 +556,7 @@ class FieldsTest extends TestCase
 		$this->assertSame([
 			'a' => '',
 			'b' => '',
+			'c' => []
 		], $fields->toFormValues());
 	}
 


### PR DESCRIPTION
## Description

This PR extracts a big portion from https://github.com/getkirby/kirby/pull/7658. It seems that this alone has already major positive performance implications. 

### Before & After

```
kirby sandbox:bench:fields - 00:06.198 -> 00:03.855
kirby sandbox:bench:views - 00:19.390 -> 00:11.257
```

## Context for reviewers

- I still had to stick with `::fillWithEmptyValue` even for the `FieldClass`. We use the Value mixin in the old Field class as well, so using `::reset` would already lead to the collision with the toggles field. 
- I moved `emptyValue` into the methods array for field components, which is lot nicer than defining the method outside of it. (see @distantnative's comments in the review of the original PR)

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements

- New `::emptyValue()` method for `Kirby\Form\Field` and `Kirby\Form\FieldClass`, which can be overwritten to define the preferred empty value when the field is being reset
- New `::fillWithEmptyValue()` method for `Kirby\Form\Field` and `Kirby\Form\FieldClass`, which is used in `Kirby\Form\Fields` to reset field values without evaluating computed props again if not necessary. This is the part that leads to the performance improvements. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion