### PR TITLE
refact: Cache field options

### DIFF
--- a/config/fields/color.php
+++ b/config/fields/color.php
@@ -51,6 +51,9 @@ return [
 		 * to directly select them
 		 */
 		'options' => function (array $options = []): array {
+			// make sure to flush the options cache when
+			// new options are being passed
+			$this->optionsCache = null;
 			return $options;
 		}
 	],
@@ -59,6 +62,14 @@ return [
 			return Str::lower($this->default);
 		},
 		'options' => function (): array {
+			return $this->optionsCache ??= $this->getOptions();
+		}
+	],
+	'methods' => [
+		'emptyValue' => function () {
+			return '';
+		},
+		'getOptions' => function () {
 			// resolve options to support manual arrays
 			// alongside api and query options
 			$props   = FieldOptions::polyfill($this->props);
@@ -103,11 +114,6 @@ return [
 			}
 
 			return $options;
-		}
-	],
-	'methods' => [
-		'emptyValue' => function () {
-			return '';
 		},
 		'isColor' => function (string $value): bool {
 			return

--- a/config/fields/mixins/options.php
+++ b/config/fields/mixins/options.php
@@ -14,6 +14,9 @@ return [
 		 * An array with options
 		 */
 		'options' => function ($options = []) {
+			// make sure to flush the options cache when
+			// new options are being passed
+			$this->optionsCache = null;
 			return $options;
 		},
 		/**
@@ -25,7 +28,7 @@ return [
 	],
 	'computed' => [
 		'options' => function (): array {
-			return $this->getOptions();
+			return $this->optionsCache ??= $this->getOptions();
 		}
 	],
 	'methods' => [


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7663

## Description

This is the second smaller chunk that will lead to another significant performance improvment by caching field options in memory of fields such as tags, multiselect, radio, colors, etc. 

## Performance: Before & After

```
# compared to develop-minor
kirby sandbox:bench:fields - 00:06.198 -> 00:03.045
kirby sandbox:bench:views - 00:19.390 -> 00:05.900

# compared to forms/empty-value
kirby sandbox:bench:fields - 00:03.855 -> 00:03.045
kirby sandbox:bench:views - 00:11.257 -> 00:05.900
```

The improvement is not that big for the fields benchmark test, but still visible. For the views, the difference is massive though. This is probably related to reusing the form multiple times for changes. 

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements

- Field options are now cached in memory to improve the performance of fields. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion