### PR TITLE
refact: Cache block forms for each fieldset

### DIFF
--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -26,6 +26,7 @@ class BlocksField extends FieldClass
 	use Min;
 
 	protected Fieldsets $fieldsets;
+	protected array $forms;
 	protected string|null $group;
 	protected bool $pretty;
 	protected mixed $value = [];
@@ -51,19 +52,13 @@ class BlocksField extends FieldClass
 		string $to = 'toFormValues'
 	): array {
 		$result = [];
-		$fields = [];
-		$forms  = [];
 
 		foreach ($blocks as $block) {
 			try {
-				$type = $block['type'];
-
-				// get and cache fields at the same time
-				$fields[$type] ??= $this->fields($block['type']);
-				$forms[$type]  ??= $this->form($fields[$type]);
+				$form = $this->fieldsetForm($block['type']);
 
 				// overwrite the block content with form values
-				$block['content'] = $forms[$type]->reset()->fill(input: $block['content'])->$to();
+				$block['content'] = $form->reset()->fill(input: $block['content'])->$to();
 
 				// create id if not exists
 				$block['id'] ??= Str::uuid();
@@ -96,6 +91,11 @@ class BlocksField extends FieldClass
 		throw new NotFoundException(
 			'The fieldset ' . $type . ' could not be found'
 		);
+	}
+
+	protected function fieldsetForm(string $type): Form
+	{
+		return $this->forms[$type] ??= $this->form($this->fields($type));
 	}
 
 	public function fieldsets(): Fieldsets


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7663
- [x] https://github.com/getkirby/kirby/pull/7664

## Description

Leads to roughly 50ms in improvements in the views benchmark compared to the previous PR. I think this could potentially add up with more complex block setups. But we should probably spend more time on block benchmarks with really complex setups later. 

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored

- New protected `BlocksField::fieldsetForm` method to cache forms for each fieldset type. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion