### PR TITLE
feat: Error lab examples & fixes

### DIFF
--- a/config/areas/lab.php
+++ b/config/areas/lab.php
@@ -2,10 +2,12 @@
 
 return function () {
 	return [
-		'icon'    => 'lab',
-		'label'   => 'Lab',
-		'menu'    => false,
-		'drawers' => require __DIR__ . '/lab/drawers.php',
-		'views'   => require __DIR__ . '/lab/views.php'
+		'icon'     => 'lab',
+		'label'    => 'Lab',
+		'menu'     => false,
+		'dialogs'  => require __DIR__ . '/lab/dialogs.php',
+		'drawers'  => require __DIR__ . '/lab/drawers.php',
+		'requests' => require __DIR__ . '/lab/requests.php',
+		'views'    => require __DIR__ . '/lab/views.php'
 	];
 };

--- a/config/areas/lab/dialogs.php
+++ b/config/areas/lab/dialogs.php
@@ -1,0 +1,10 @@
+<?php
+
+use Kirby\Panel\Lab\Responses;
+
+return [
+	'lab.errors' => [
+		'pattern' => 'lab/errors/(:any?)',
+		'load'    => fn (string|null $type = null) => Responses::errorResponseByType($type)
+	],
+];

--- a/config/areas/lab/drawers.php
+++ b/config/areas/lab/drawers.php
@@ -2,6 +2,7 @@
 
 use Kirby\Panel\Lab\Doc;
 use Kirby\Panel\Lab\Docs;
+use Kirby\Panel\Lab\Responses;
 
 return [
 	'lab.docs' => [
@@ -27,5 +28,9 @@ return [
 				]
 			];
 		},
+	],
+	'lab.errors' => [
+		'pattern' => 'lab/errors/(:any?)',
+		'load'    => fn (string|null $type = null) => Responses::errorResponseByType($type)
 	],
 ];

--- a/config/areas/lab/requests.php
+++ b/config/areas/lab/requests.php
@@ -1,0 +1,10 @@
+<?php
+
+use Kirby\Panel\Lab\Responses;
+
+return [
+	'lab.errors' => [
+		'pattern' => 'requests/lab/errors/(:any?)',
+		'action'  => fn (string|null $type = null) => Responses::errorResponseByType($type)
+	],
+];

--- a/config/areas/lab/views.php
+++ b/config/areas/lab/views.php
@@ -4,6 +4,7 @@ use Kirby\Cms\App;
 use Kirby\Panel\Lab\Category;
 use Kirby\Panel\Lab\Doc;
 use Kirby\Panel\Lab\Docs;
+use Kirby\Panel\Lab\Responses;
 
 return [
 	'lab' => [
@@ -128,6 +129,10 @@ return [
 				]
 			];
 		}
+	],
+	'lab.errors' => [
+		'pattern' => 'lab/errors/(:any?)',
+		'action'  => fn (string|null $type = null) => Responses::errorResponseByType($type)
 	],
 	'lab.vue' => [
 		'pattern' => [

--- a/panel/lab/internals/errors/index.vue
+++ b/panel/lab/internals/errors/index.vue
@@ -1,0 +1,84 @@
+<template>
+	<k-lab-examples class="k-lab-helpers-examples">
+		<k-lab-example label="Not found">
+			<k-button-group>
+				<k-button variant="filled" @click="$panel.view.open('/does-not-exist')">
+					View
+				</k-button>
+				<k-button
+					variant="filled"
+					@click="$panel.dialog.open('/does-not-exist')"
+				>
+					Dialog
+				</k-button>
+				<k-button
+					variant="filled"
+					@click="$panel.drawer.open('/does-not-exist')"
+				>
+					Drawer
+				</k-button>
+				<k-button variant="filled" @click="request('does-not-exist')">
+					Request
+				</k-button>
+				<k-button variant="filled" @click="apiCall()"> API call </k-button>
+			</k-button-group>
+		</k-lab-example>
+		<k-lab-example label="Backend issues">
+			<k-button-group>
+				<k-button variant="filled" @click="$panel.view.open('/lab/errors')">
+					View
+				</k-button>
+				<k-button variant="filled" @click="$panel.dialog.open('/lab/errors')">
+					Dialog
+				</k-button>
+				<k-button variant="filled" @click="$panel.drawer.open('/lab/errors')">
+					Drawer
+				</k-button>
+				<k-button variant="filled" @click="request('requests/lab/errors')">
+					Request
+				</k-button>
+			</k-button-group>
+		</k-lab-example>
+		<k-lab-example label="JS issues">
+			<k-button-group>
+				<k-button variant="filled" @click="throwError()">
+					Throw error (console)
+				</k-button>
+				<k-button variant="filled" @click="throwAndCatchError()">
+					Throw & catch error
+				</k-button>
+			</k-button-group>
+		</k-lab-example>
+	</k-lab-examples>
+</template>
+
+<script>
+export default {
+	methods: {
+		apiCall() {
+			try {
+				this.$panel.api.get("/does-not-exist");
+			} catch (e) {
+				this.$panel.error(e);
+			}
+		},
+		request(path) {
+			try {
+				this.$panel.get(path);
+			} catch (e) {
+				this.$panel.error(e);
+			}
+		},
+		throwAndCatchError() {
+			try {
+				throw new Error("This is a custom error");
+			} catch (e) {
+				this.$panel.error(e);
+			}
+		},
+		throwError() {
+			throw new Error("This is a custom error");
+		}
+	}
+};
+</script>

--- a/panel/lab/internals/errors/index.vue
+++ b/panel/lab/internals/errors/index.vue
@@ -1,29 +1,39 @@
 <template>
 	<k-lab-examples class="k-lab-helpers-examples">
 		<k-lab-example label="Not found">
+			<k-text>The backend route does not exist</k-text>
 			<k-button-group>
-				<k-button variant="filled" @click="$panel.view.open('/does-not-exist')">
+				<k-button
+					variant="filled"
+					@click="$panel.view.open('/lab/does-not-exist')"
+				>
 					View
 				</k-button>
 				<k-button
 					variant="filled"
-					@click="$panel.dialog.open('/does-not-exist')"
+					@click="$panel.dialog.open('/lab/does-not-exist')"
 				>
 					Dialog
 				</k-button>
 				<k-button
 					variant="filled"
-					@click="$panel.drawer.open('/does-not-exist')"
+					@click="$panel.drawer.open('/lab/does-not-exist')"
 				>
 					Drawer
 				</k-button>
-				<k-button variant="filled" @click="request('does-not-exist')">
+				<k-button variant="filled" @click="request('/lab/does-not-exist')">
 					Request
 				</k-button>
-				<k-button variant="filled" @click="apiCall()"> API call </k-button>
 			</k-button-group>
 		</k-lab-example>
 		<k-lab-example label="Backend issues">
+			<k-text>The backend route throws a standard exception</k-text>
+
+			<k-code language="php">{{
+				`throw new Exception('This is a custom backend error');`
+			}}</k-code>
+			<br />
+			<br />
 			<k-button-group>
 				<k-button variant="filled" @click="$panel.view.open('/lab/errors')">
 					View
@@ -34,7 +44,116 @@
 				<k-button variant="filled" @click="$panel.drawer.open('/lab/errors')">
 					Drawer
 				</k-button>
-				<k-button variant="filled" @click="request('requests/lab/errors')">
+				<k-button variant="filled" @click="request('/lab/errors')">
+					Request
+				</k-button>
+			</k-button-group>
+		</k-lab-example>
+		<k-lab-example label="Backend issues">
+			<k-text>
+				The backend route throws a Kirby exception with details (we use this for
+				form errors for example)
+			</k-text>
+
+			<k-code language="php">{{
+				`throw new Kirby\\Exception\\InvalidArgumentException(
+	fallback: 'Exception with details',
+	details: [
+		'a' => [
+			'label'   => 'Detail A',
+			'message' => [
+				'This is a message for Detail A',
+			],
+		],
+		'b' => [
+			'label'   => 'Detail B',
+			'message' => [
+				'This is the first message for Detail B',
+				'This is the second message for Detail B',
+			],
+		],
+	]
+);`
+			}}</k-code>
+			<br />
+			<br />
+			<k-button-group>
+				<k-button
+					variant="filled"
+					@click="$panel.view.open('/lab/errors/form')"
+				>
+					View
+				</k-button>
+				<k-button
+					variant="filled"
+					@click="$panel.dialog.open('/lab/errors/form')"
+				>
+					Dialog
+				</k-button>
+				<k-button
+					variant="filled"
+					@click="$panel.drawer.open('/lab/errors/form')"
+				>
+					Drawer
+				</k-button>
+				<k-button variant="filled" @click="request('/lab/errors/form')">
+					Request
+				</k-button>
+			</k-button-group>
+		</k-lab-example>
+		<k-lab-example label="JSON parsing issue">
+			<k-text>
+				The server returns a JSON response, but the JSON is not parseable
+			</k-text>
+			<k-button-group>
+				<k-button
+					variant="filled"
+					@click="$panel.view.open('/lab/errors/invalid-json')"
+				>
+					View
+				</k-button>
+				<k-button
+					variant="filled"
+					@click="$panel.dialog.open('/lab/errors/invalid-json')"
+				>
+					Dialog
+				</k-button>
+				<k-button
+					variant="filled"
+					@click="$panel.drawer.open('/lab/errors/invalid-json')"
+				>
+					Drawer
+				</k-button>
+				<k-button variant="filled" @click="request('/lab/errors/invalid-json')">
+					Request
+				</k-button>
+			</k-button-group>
+		</k-lab-example>
+		<k-lab-example label="HTML response">
+			<k-text>
+				The server responds with HTML instead of JSON. The request handler
+				should redirect to the route instead of trying to evaluate it.
+			</k-text>
+			<k-button-group>
+				<k-button
+					variant="filled"
+					@click="$panel.view.open('/lab/errors/html')"
+				>
+					View
+				</k-button>
+				<k-button
+					variant="filled"
+					@click="$panel.dialog.open('/lab/errors/html')"
+				>
+					Dialog
+				</k-button>
+				<k-button
+					variant="filled"
+					@click="$panel.drawer.open('/lab/errors/html')"
+				>
+					Drawer
+				</k-button>
+				<k-button variant="filled" @click="request('/lab/errors/html')">
 					Request
 				</k-button>
 			</k-button-group>
@@ -55,16 +174,9 @@
 <script>
 export default {
 	methods: {
-		apiCall() {
+		async request(path) {
 			try {
-				this.$panel.api.get("/does-not-exist");
-			} catch (e) {
-				this.$panel.error(e);
-			}
-		},
-		request(path) {
-			try {
-				this.$panel.get(path);
+				await this.$panel.get("/requests" + path);
 			} catch (e) {
 				this.$panel.error(e);
 			}

--- a/panel/src/errors/RequestError.js
+++ b/panel/src/errors/RequestError.js
@@ -5,10 +5,11 @@
  */
 export default class RequestError extends Error {
 	constructor(message, { request, response, cause }) {
-		super(response.json.message ?? message, { cause });
+		super(response.json.message ?? response.json.error ?? message, { cause });
 
 		this.request = request;
 		this.response = response;
+		this.details = response.json.details;
 	}
 
 	state() {

--- a/panel/src/panel/drawer.js
+++ b/panel/src/panel/drawer.js
@@ -90,13 +90,12 @@ export default (panel) => {
 				drawer = `/drawers/${drawer}`;
 			}
 
-			await parent.open.call(this, drawer, options);
+			const state = await parent.open.call(this, drawer, options);
 
 			// open the provided or first tab
 			this.tab(drawer.tab);
 
 			// get the current state and add it to the history
-			const state = this.state();
 			this.history.add(state, drawer.replace);
 
 			this.focus();

--- a/panel/src/panel/notification.js
+++ b/panel/src/panel/notification.js
@@ -85,6 +85,7 @@ export default (panel = {}) => {
 
 				if (broken) {
 					error.message = broken.error;
+					error.details = broken.details;
 				}
 			}
 

--- a/panel/src/panel/panel.js
+++ b/panel/src/panel/panel.js
@@ -230,12 +230,13 @@ export default {
 				this.isLoading = true;
 				const state = await this.get(url, options);
 				this.set(state);
-				this.isLoading = false;
 			}
 
 			return this.state();
 		} catch (error) {
 			return this.error(error);
+		} finally {
+			this.isLoading = false;
 		}
 	},
 

--- a/panel/src/panel/request.js
+++ b/panel/src/panel/request.js
@@ -153,11 +153,6 @@ export const responder = async (request, response) => {
 		});
 	}
 
-	// server error
-	if (response.json?.status === "error") {
-		throw response.json;
-	}
-
 	// request error
 	if (response.ok === false) {
 		throw new RequestError(`The request to ${response.url} failed`, {

--- a/src/Panel/Json.php
+++ b/src/Panel/Json.php
@@ -27,12 +27,18 @@ abstract class Json
 	/**
 	 * Renders the error response with the provided message
 	 */
-	public static function error(string $message, int $code = 404): array
+	public static function error(string $message, int $code = 404, array $details = []): array
 	{
-		return [
+		$response = [
 			'code'  => $code,
-			'error' => $message
+			'error' => $message,
 		];
+
+		if ($details !== []) {
+			$response['details'] = $details;
+		}
+
+		return $response;
 	}
 
 	/**
@@ -62,7 +68,7 @@ abstract class Json
 
 		// handle Kirby exceptions
 		if ($data instanceof Exception) {
-			return static::error($data->getMessage(), $data->getHttpCode());
+			return static::error($data->getMessage(), $data->getHttpCode(), $data->getDetails());
 		}
 
 		// handle exceptions

--- a/src/Panel/Lab/Responses.php
+++ b/src/Panel/Lab/Responses.php
@@ -6,6 +6,18 @@ use Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Http\Response;
 
+/**
+ * Example responses for test requests
+ *
+ * @package   Kirby Panel
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.2.0
+ * @internal
+ * @codeCoverageIgnore
+ */
 class Responses
 {
 	public static function errorResponseByType(string|null $type = null): Response|Exception

--- a/src/Panel/Lab/Responses.php
+++ b/src/Panel/Lab/Responses.php
@@ -35,4 +35,3 @@ class Responses
 		};
 	}
 }
-

--- a/src/Panel/Lab/Responses.php
+++ b/src/Panel/Lab/Responses.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Kirby\Panel\Lab;
+
+use Exception;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Http\Response;
+
+class Responses
+{
+	public static function errorResponseByType(string|null $type = null): Response|Exception
+	{
+		return match ($type) {
+			'form' => new InvalidArgumentException(
+				fallback: 'Exception with details',
+				details: [
+					'a' => [
+						'label'   => 'Detail A',
+						'message' => [
+							'This is a message for Detail A',
+						],
+					],
+					'b' => [
+						'label'   => 'Detail B',
+						'message' => [
+							'This is the first message for Detail B',
+							'This is the second message for Detail B',
+						],
+					],
+				]
+			),
+			'html'         => new Response('<h1>Hello</h1>', 'html'),
+			'invalid-json' => new Response('invalid json', 'json'),
+			default        => new Exception('This is a custom backend error'),
+		};
+	}
+}
+

--- a/src/Panel/View.php
+++ b/src/Panel/View.php
@@ -233,18 +233,21 @@ class View
 	/**
 	 * Renders the error view with provided message
 	 */
-	public static function error(string $message, int $code = 404)
+	public static function error(string $message, int $code = 404, array $details = [])
 	{
-		return [
-			'code'      => $code,
+		$response = [
+			...Json::error($message, $code, $details),
 			'component' => 'k-error-view',
-			'error'     => $message,
 			'props'     => [
 				'error'  => $message,
 				'layout' => Panel::hasAccess(App::instance()->user()) ? 'inside' : 'outside'
 			],
 			'title' => 'Error'
 		];
+
+		ksort($response);
+
+		return $response;
 	}
 
 	/**
@@ -326,7 +329,7 @@ class View
 
 		// handle Kirby exceptions
 		if ($data instanceof Exception) {
-			$data = static::error($data->getMessage(), $data->getHttpCode());
+			$data = static::error($data->getMessage(), $data->getHttpCode(), $data->getDetails());
 
 		// handle regular exceptions
 		} elseif ($data instanceof Throwable) {

--- a/tests/Panel/JsonTest.php
+++ b/tests/Panel/JsonTest.php
@@ -9,6 +9,20 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(Json::class)]
 class JsonTest extends TestCase
 {
+	public function testErrorWithDetails(): void
+	{
+		$response = Json::error('Test', 404, $details = [
+			'test' => [
+				'label'   => 'Label',
+				'message' => 'Message'
+			]
+		]);
+
+		$this->assertSame('Test', $response['error']);
+		$this->assertSame(404, $response['code']);
+		$this->assertSame($details, $response['details']);
+	}
+
 	public function testResponseEmptyArray(): void
 	{
 		$response = Json::response([]);


### PR DESCRIPTION
## Description

We have a couple of inconsistencies in the way that errors are handled in various parts of the panel. In order to tackle this, I started adding a first set of lab examples and already found the first issues and fixes. 

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements

- New error handling examples in the lab (/panel/lab/internals/errors) for various scenarios (opening views, dialogs, drawers, sending requests, etc.)

### 🐛 Bug fixes

- The RequestError class is polyfilling error messages stored in the error prop instead of the message prop to create more consistency. 
- The RequestError class is now responsible for all server errors to add another layer of consistency there. 
- The `details` array from custom Kirby Exceptions is now always properly passed forward in all error responses. 
- The `panel.notification.error()` method is now also passing details forward to the error object. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion