### PR TITLE
refact!: Validators as regular `V` methods

### DIFF
--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -9,6 +9,7 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Http\Idn;
 use Kirby\Uuid\Uuid;
 use ReflectionFunction;
+use ReflectionMethod;
 use Throwable;
 
 /**
@@ -23,9 +24,187 @@ use Throwable;
 class V
 {
 	/**
-	 * An array with all installed validators
+	 * All custom validators
 	 */
 	public static array $validators = [];
+
+	/**
+	 * Calls an installed validator and passes all arguments
+	 */
+	public static function __callStatic(string $method, array $arguments): bool
+	{
+		$method     = strtolower($method);
+		$validators = array_change_key_case(static::$validators);
+
+		// check for missing validators
+		if (isset($validators[$method]) === false) {
+			throw new Exception('The validator does not exist: ' . $method);
+		}
+
+		return call_user_func_array($validators[$method], $arguments);
+	}
+
+	/**
+	 * Valid: `'yes' | true | 1 | 'on'`
+	 */
+	public static function accepted($value): bool
+	{
+		return static::in($value, [1, true, 'yes', 'true', '1', 'on'], true) === true;
+	}
+
+	/**
+	 * Valid: `a-z | A-Z`
+	 */
+	public static function alpha($value, bool $unicode = false): bool
+	{
+		return static::match($value, ($unicode === true ? '/^([\pL])+$/u' : '/^([a-z])+$/i')) === true;
+	}
+
+	/**
+	 * Valid: `a-z | A-Z | 0-9`
+	 */
+	public static function alphanum($value, bool $unicode = false): bool
+	{
+		return static::match($value, ($unicode === true ? '/^[\pL\pN]+$/u' : '/^([a-z0-9])+$/i')) === true;
+	}
+
+	/**
+	 * Checks for numbers within the given range
+	 */
+	public static function between($value, $min, $max): bool
+	{
+		return
+			static::min($value, $min) === true &&
+			static::max($value, $max) === true;
+	}
+
+	/**
+	 * Checks with the callback sent by the user
+	 * It's ideal for one-time custom validations
+	 */
+	public static function callback($value, callable $callback): bool
+	{
+		return $callback($value);
+	}
+
+	/**
+	 * Checks if the given string contains the given value
+	 */
+	public static function contains($value, $needle): bool
+	{
+		return Str::contains($value, $needle);
+	}
+
+	/**
+	 * Checks for a valid date or compares two
+	 * dates with each other.
+	 *
+	 * Pass only the first argument to check for a valid date.
+	 * Pass an operator as second argument and another date as
+	 * third argument to compare them.
+	 */
+	public static function date(
+		string|null $value,
+		string|null $operator = null,
+		string|null $test = null
+	): bool {
+		// make sure $value is a string
+		$value ??= '';
+
+		$args = func_get_args();
+
+		// simple date validation
+		if (count($args) === 1) {
+			$date = date_parse($value);
+			return $date !== false &&
+					$date['error_count'] === 0 &&
+					$date['warning_count'] === 0;
+		}
+
+		$value = strtotime($value);
+		$test  = strtotime($test);
+
+		if (is_int($value) !== true || is_int($test) !== true) {
+			return false;
+		}
+
+		return match ($operator) {
+			'!=' => $value !== $test,
+			'<'  => $value < $test,
+			'>'  => $value > $test,
+			'<='  => $value <= $test,
+			'>='  => $value >= $test,
+			'=='  => $value === $test,
+
+			default => throw new InvalidArgumentException(
+				message: 'Invalid date comparison operator: "' . $operator . '". Allowed operators: "==", "!=", "<", "<=", ">", ">="'
+			)
+		};
+	}
+
+	/**
+	 * Valid: `'no' | false | 0 | 'off'`
+	 */
+	public static function denied($value): bool
+	{
+		return static::in($value, [0, false, 'no', 'false', '0', 'off'], true) === true;
+	}
+
+	/**
+	 * Checks for a value, which does not equal the given value
+	 */
+	public static function different($value, $other, $strict = false): bool
+	{
+		if ($strict === true) {
+			return $value !== $other;
+		}
+
+		return $value != $other;
+	}
+
+	/**
+	 * Checks for valid email addresses
+	 */
+	public static function email($value): bool
+	{
+		if (filter_var($value, FILTER_VALIDATE_EMAIL) === false) {
+			try {
+				$email = Idn::encodeEmail($value);
+			} catch (Throwable) {
+				return false;
+			}
+
+			return filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks for empty values
+	 */
+	public static function empty($value = null): bool
+	{
+		$empty = ['', null, []];
+
+		if (in_array($value, $empty, true) === true) {
+			return true;
+		}
+
+		if (is_countable($value) === true) {
+			return count($value) === 0;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if the given string ends with the given value
+	 */
+	public static function endsWith(string $value, string $end): bool
+	{
+		return Str::endsWith($value, $end);
+	}
 
 	/**
 	 * Validates the given input with all passed rules
@@ -43,6 +222,72 @@ class V
 			true    => [],
 			default => $errors
 		};
+	}
+
+	/**
+	 * Checks for a valid filename
+	 */
+	public static function filename($value): bool
+	{
+		return
+			static::match($value, '/^[a-z0-9@._-]+$/i') === true &&
+			static::min($value, 2) === true;
+	}
+
+	/**
+	 * Checks if the value exists in a list of given values
+	 */
+	public static function in($value, array $in, bool $strict = false): bool
+	{
+		return in_array($value, $in, $strict) === true;
+	}
+
+
+	/**
+	 * Validate an input array against
+	 * a set of rules, using all registered
+	 * validators
+	 */
+	public static function input(array $input, array $rules): bool
+	{
+		foreach ($rules as $field => $rules) {
+			$value = $input[$field] ?? null;
+
+			// first check for required fields
+			if (
+				($rules['required'] ?? false) === true &&
+				$value === null
+			) {
+				throw new Exception(sprintf('The "%s" field is missing', $field));
+			}
+
+			// remove the required rule
+			unset($rules['required']);
+
+			// skip validation for empty fields
+			if ($value === null) {
+				continue;
+			}
+
+			try {
+				static::value($value, $rules);
+			} catch (Exception $e) {
+				throw new Exception(sprintf($e->getMessage() . ' for field "%s"', $field));
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks for a valid integer
+	 */
+	public static function integer($value, bool $strict = false): bool
+	{
+		if ($strict === true) {
+			return is_int($value) === true;
+		}
+		return filter_var($value, FILTER_VALIDATE_INT) !== false;
 	}
 
 	/**
@@ -114,6 +359,68 @@ class V
 	}
 
 	/**
+	 * Checks for a valid IP address
+	 */
+	public static function ip($value): bool
+	{
+		return filter_var($value, FILTER_VALIDATE_IP) !== false;
+	}
+
+	/**
+	 * Checks for valid json
+	 */
+	public static function json($value): bool
+	{
+		if (is_string($value) === false) {
+			return false;
+		}
+
+		return json_validate($value);
+	}
+
+	/**
+	 * Checks if the value is lower than the second value
+	 */
+	public static function less($value, float $max): bool
+	{
+		return static::size($value, $max, '<') === true;
+	}
+
+	/**
+	 * Checks if the value matches the given regular expression
+	 */
+	public static function match($value, string $pattern): bool
+	{
+		return preg_match($pattern, (string)$value) === 1;
+	}
+
+	/**
+	 * Checks if the value does not exceed the maximum value
+	 */
+	public static function max($value, float $max): bool
+	{
+		return static::size($value, $max, '<=') === true;
+	}
+
+	/**
+	 * Checks if the number of characters in the value equals
+	 * or is below the given maximum
+	 */
+	public static function maxLength(string|null $value, $max): bool
+	{
+		return Str::length(trim($value)) <= $max;
+	}
+
+	/**
+	 * Checks if the number of words in the value equals or
+	 * is below the given maximum
+	 */
+	public static function maxWords(string|null $value, $max): bool
+	{
+		return static::max(explode(' ', trim($value)), $max) === true;
+	}
+
+	/**
 	 * Creates a useful error message for the given validator
 	 * and the arguments. This is used mainly internally
 	 * to create error messages
@@ -122,17 +429,20 @@ class V
 		string $validatorName,
 		...$params
 	): string|null {
-		$validatorName  = strtolower($validatorName);
-		$translationKey = 'error.validation.' . $validatorName;
-		$validators     = array_change_key_case(static::$validators);
-		$validator      = $validators[$validatorName] ?? null;
+		$validatorName = strtolower($validatorName);
+		$validators    = array_change_key_case(static::$validators);
 
-		if ($validator === null) {
+		if (method_exists(static::class, $validatorName) === true) {
+			$reflection = new ReflectionMethod(static::class, $validatorName);
+		} else if ($validator  = $validators[$validatorName] ?? null) {
+			$reflection = new ReflectionFunction($validator);
+		}
+
+		if (isset($reflection) === false) {
 			return null;
 		}
 
-		$reflection = new ReflectionFunction($validator);
-		$arguments  = [];
+		$arguments = [];
 
 		foreach ($reflection->getParameters() as $index => $parameter) {
 			$value = $params[$index] ?? null;
@@ -151,10 +461,181 @@ class V
 		}
 
 		return I18n::template(
-			$translationKey,
+			'error.validation.' . $validatorName,
 			'The "' . $validatorName . '" validation failed',
 			$arguments
 		);
+	}
+
+	/**
+	 * Checks if the value is higher than the minimum value
+	 */
+	public static function min($value, float $min): bool
+	{
+		return static::size($value, $min, '>=') === true;
+	}
+
+	/**
+	 * Checks if the number of characters in the value equals or
+	 * is greater than the given minimum
+	 */
+	public static function minLength(string|null $value, $min): bool
+	{
+		return Str::length(trim($value)) >= $min;
+	}
+
+	/**
+	 * Checks if the number of words in the value equals or
+	 * is below the given maximum
+	 */
+	public static function minWords(string|null $value, $min): bool
+	{
+		return static::min(explode(' ', trim($value)), $min) === true;
+	}
+
+	/**
+	 * Checks if the first value is higher than the second value
+	 */
+	public static function more($value, float $min): bool
+	{
+		return static::size($value, $min, '>') === true;
+	}
+
+	/**
+	 * Checks that the given string does not contain the second value
+	 */
+	public static function notContains($value, $needle): bool
+	{
+		return static::contains($value, $needle) === false;
+	}
+
+	/**
+	 * Checks that the given value is not empty
+	 */
+	public static function notEmpty($value): bool
+	{
+		return static::empty($value) === false;
+	}
+
+	/**
+	 * Checks that the given value is not in the given list of values
+	 */
+	public static function notIn($value, $notIn): bool
+	{
+		return static::in($value, $notIn) === false;
+	}
+
+	/**
+	 * Checks for a valid number / numeric value (float, int, double)
+	 */
+	public static function num($value): bool
+	{
+		return is_numeric($value) === true;
+	}
+
+	/**
+	 * Checks if the value is present
+	 */
+	public static function required($value, $array = null): bool
+	{
+		// with reference array
+		if (is_array($array) === true) {
+			return isset($array[$value]) === true && static::notEmpty($array[$value]) === true;
+		}
+
+		// without reference array
+		return static::notEmpty($value);
+	}
+
+	/**
+	 * Checks that the first value equals the second value
+	 */
+	public static function same($value, $other, bool $strict = false): bool
+	{
+		if ($strict === true) {
+			return $value === $other;
+		}
+
+		return $value == $other;
+	}
+
+	/**
+	 * Checks that the value has the given size
+	 */
+	public static function size($value, $size, $operator = '=='): bool
+	{
+		// if value is field object, first convert it to a readable value
+		// it is important to check at the beginning as the value can be string or numeric
+		if ($value instanceof Field) {
+			$value = $value->value();
+		}
+
+		$count = match (true) {
+			is_numeric($value) => $value,
+			is_string($value)  => Str::length(trim($value)),
+			is_array($value)   => count($value),
+			is_object($value)  => match (true) {
+				$value instanceof Countable    => count($value),
+				method_exists($value, 'count') => $value->count(),
+
+				default => throw new Exception('$value is an uncountable object')
+			},
+
+			default => throw new Exception('$value is of type without size')
+		};
+
+		return match ($operator) {
+			'<'     => $count < $size,
+			'>'     => $count > $size,
+			'<='    => $count <= $size,
+			'>='    => $count >= $size,
+			default => $count == $size
+		};
+	}
+
+	/**
+	 * Checks that the string starts with the given start value
+	 */
+	public static function startsWith(string $value, string $start): bool
+	{
+		return Str::startsWith($value, $start);
+	}
+
+	/**
+	 * Checks for a valid unformatted telephone number
+	 */
+	public static function tel($value): bool
+	{
+		return static::match($value, '!^[+]{0,1}[0-9]+$!');
+	}
+
+	/**
+	 * Checks for valid time
+	 */
+	public static function time($value): bool
+	{
+		return static::date($value);
+	}
+
+	/**
+	 * Checks for a valid Url
+	 */
+	public static function url($value): bool
+	{
+		// In search for the perfect regular expression: https://mathiasbynens.be/demo/url-regex
+		// Added localhost support and removed 127.*.*.* ip restriction
+		$regex = '_^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:localhost)|(?:(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)(?:\.(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)*(?:\.(?:[a-z\x{00a1}-\x{ffff}]{2,})))(?::\d{2,5})?(?:\/[^\s]*)?$_iu';
+		return preg_match($regex, $value ?? '') !== 0;
+	}
+
+	/**
+	 * Checks for a valid Uuid, optionally for specific model type
+	 */
+	public static function uuid(
+		string $value,
+		string|array|null $type = null
+	): bool {
+		return Uuid::is($value, $type);
 	}
 
 	/**
@@ -184,10 +665,7 @@ class V
 				$options   = [];
 			}
 
-			if (is_array($options) === false) {
-				$options = [$options];
-			}
-
+			$options   = A::wrap($options);
 			$validator = strtolower($validator);
 
 			if (static::$validator($value, ...$options) === false) {
@@ -201,442 +679,10 @@ class V
 			}
 		}
 
-		return match ($errors) {
-			[]      => true,
-			default => $errors
-		};
-	}
-
-	/**
-	 * Validate an input array against
-	 * a set of rules, using all registered
-	 * validators
-	 */
-	public static function input(array $input, array $rules): bool
-	{
-		foreach ($rules as $field => $rules) {
-			$value = $input[$field] ?? null;
-
-			// first check for required fields
-			if (
-				($rules['required'] ?? false) === true &&
-				$value === null
-			) {
-				throw new Exception(sprintf('The "%s" field is missing', $field));
-			}
-
-			// remove the required rule
-			unset($rules['required']);
-
-			// skip validation for empty fields
-			if ($value === null) {
-				continue;
-			}
-
-			try {
-				static::value($value, $rules);
-			} catch (Exception $e) {
-				throw new Exception(sprintf($e->getMessage() . ' for field "%s"', $field));
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * Calls an installed validator and passes all arguments
-	 */
-	public static function __callStatic(string $method, array $arguments): bool
-	{
-		$method     = strtolower($method);
-		$validators = array_change_key_case(static::$validators);
-
-		// check for missing validators
-		if (isset($validators[$method]) === false) {
-			throw new Exception('The validator does not exist: ' . $method);
-		}
-
-		return call_user_func_array($validators[$method], $arguments);
-	}
-}
-
-
-/**
- * Default set of validators
- */
-V::$validators = [
-	/**
-	 * Valid: `'yes' | true | 1 | 'on'`
-	 */
-	'accepted' => function ($value): bool {
-		return V::in($value, [1, true, 'yes', 'true', '1', 'on'], true) === true;
-	},
-
-	/**
-	 * Valid: `a-z | A-Z`
-	 */
-	'alpha' => function ($value, bool $unicode = false): bool {
-		return V::match($value, ($unicode === true ? '/^([\pL])+$/u' : '/^([a-z])+$/i')) === true;
-	},
-
-	/**
-	 * Valid: `a-z | A-Z | 0-9`
-	 */
-	'alphanum' => function ($value, bool $unicode = false): bool {
-		return V::match($value, ($unicode === true ? '/^[\pL\pN]+$/u' : '/^([a-z0-9])+$/i')) === true;
-	},
-
-	/**
-	 * Checks for numbers within the given range
-	 */
-	'between' => function ($value, $min, $max): bool {
-		return
-			V::min($value, $min) === true &&
-			V::max($value, $max) === true;
-	},
-
-	/**
-	 * Checks with the callback sent by the user
-	 * It's ideal for one-time custom validations
-	 */
-	'callback' => function ($value, callable $callback): bool {
-		return $callback($value);
-	},
-
-	/**
-	 * Checks if the given string contains the given value
-	 */
-	'contains' => function ($value, $needle): bool {
-		return Str::contains($value, $needle);
-	},
-
-	/**
-	 * Checks for a valid date or compares two
-	 * dates with each other.
-	 *
-	 * Pass only the first argument to check for a valid date.
-	 * Pass an operator as second argument and another date as
-	 * third argument to compare them.
-	 */
-	'date' => function (string|null $value, string|null $operator = null, string|null $test = null): bool {
-		// make sure $value is a string
-		$value ??= '';
-
-		$args = func_get_args();
-
-		// simple date validation
-		if (count($args) === 1) {
-			$date = date_parse($value);
-			return $date !== false &&
-					$date['error_count'] === 0 &&
-					$date['warning_count'] === 0;
-		}
-
-		$value = strtotime($value);
-		$test  = strtotime($test);
-
-		if (is_int($value) !== true || is_int($test) !== true) {
-			return false;
-		}
-
-		return match ($operator) {
-			'!=' => $value !== $test,
-			'<'  => $value < $test,
-			'>'  => $value > $test,
-			'<='  => $value <= $test,
-			'>='  => $value >= $test,
-			'=='  => $value === $test,
-
-			default => throw new InvalidArgumentException(
-				message: 'Invalid date comparison operator: "' . $operator . '". Allowed operators: "==", "!=", "<", "<=", ">", ">="'
-			)
-		};
-	},
-
-	/**
-	 * Valid: `'no' | false | 0 | 'off'`
-	 */
-	'denied' => function ($value): bool {
-		return V::in($value, [0, false, 'no', 'false', '0', 'off'], true) === true;
-	},
-
-	/**
-	 * Checks for a value, which does not equal the given value
-	 */
-	'different' => function ($value, $other, $strict = false): bool {
-		if ($strict === true) {
-			return $value !== $other;
-		}
-		return $value != $other;
-	},
-
-	/**
-	 * Checks for valid email addresses
-	 */
-	'email' => function ($value): bool {
-		if (filter_var($value, FILTER_VALIDATE_EMAIL) === false) {
-			try {
-				$email = Idn::encodeEmail($value);
-			} catch (Throwable) {
-				return false;
-			}
-
-			return filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
-		}
-
-		return true;
-	},
-
-	/**
-	 * Checks for empty values
-	 */
-	'empty' => function ($value = null): bool {
-		$empty = ['', null, []];
-
-		if (in_array($value, $empty, true) === true) {
+		if ($errors === []) {
 			return true;
 		}
 
-		if (is_countable($value) === true) {
-			return count($value) === 0;
-		}
-
-		return false;
-	},
-
-	/**
-	 * Checks if the given string ends with the given value
-	 */
-	'endsWith' => function (string $value, string $end): bool {
-		return Str::endsWith($value, $end);
-	},
-
-	/**
-	 * Checks for a valid filename
-	 */
-	'filename' => function ($value): bool {
-		return
-			V::match($value, '/^[a-z0-9@._-]+$/i') === true &&
-			V::min($value, 2) === true;
-	},
-
-	/**
-	 * Checks if the value exists in a list of given values
-	 */
-	'in' => function ($value, array $in, bool $strict = false): bool {
-		return in_array($value, $in, $strict) === true;
-	},
-
-	/**
-	 * Checks for a valid integer
-	 */
-	'integer' => function ($value, bool $strict = false): bool {
-		if ($strict === true) {
-			return is_int($value) === true;
-		}
-		return filter_var($value, FILTER_VALIDATE_INT) !== false;
-	},
-
-	/**
-	 * Checks for a valid IP address
-	 */
-	'ip' => function ($value): bool {
-		return filter_var($value, FILTER_VALIDATE_IP) !== false;
-	},
-
-	/**
-	 * Checks for valid json
-	 */
-	'json' => function ($value): bool {
-		if (is_string($value) === false) {
-			return false;
-		}
-
-		return json_validate($value);
-	},
-
-	/**
-	 * Checks if the value is lower than the second value
-	 */
-	'less' => function ($value, float $max): bool {
-		return V::size($value, $max, '<') === true;
-	},
-
-	/**
-	 * Checks if the value matches the given regular expression
-	 */
-	'match' => function ($value, string $pattern): bool {
-		return preg_match($pattern, (string)$value) === 1;
-	},
-
-	/**
-	 * Checks if the value does not exceed the maximum value
-	 */
-	'max' => function ($value, float $max): bool {
-		return V::size($value, $max, '<=') === true;
-	},
-
-	/**
-	 * Checks if the value is higher than the minimum value
-	 */
-	'min' => function ($value, float $min): bool {
-		return V::size($value, $min, '>=') === true;
-	},
-
-	/**
-	 * Checks if the number of characters in the value equals or is below the given maximum
-	 */
-	'maxLength' => function (string|null $value, $max): bool {
-		return Str::length(trim($value)) <= $max;
-	},
-
-	/**
-	 * Checks if the number of characters in the value equals or is greater than the given minimum
-	 */
-	'minLength' => function (string|null $value, $min): bool {
-		return Str::length(trim($value)) >= $min;
-	},
-
-	/**
-	 * Checks if the number of words in the value equals or is below the given maximum
-	 */
-	'maxWords' => function (string|null $value, $max): bool {
-		return V::max(explode(' ', trim($value)), $max) === true;
-	},
-
-	/**
-	 * Checks if the number of words in the value equals or is below the given maximum
-	 */
-	'minWords' => function (string|null $value, $min): bool {
-		return V::min(explode(' ', trim($value)), $min) === true;
-	},
-
-	/**
-	 * Checks if the first value is higher than the second value
-	 */
-	'more' => function ($value, float $min): bool {
-		return V::size($value, $min, '>') === true;
-	},
-
-	/**
-	 * Checks that the given string does not contain the second value
-	 */
-	'notContains' => function ($value, $needle): bool {
-		return V::contains($value, $needle) === false;
-	},
-
-	/**
-	 * Checks that the given value is not empty
-	 */
-	'notEmpty' => function ($value): bool {
-		return V::empty($value) === false;
-	},
-
-	/**
-	 * Checks that the given value is not in the given list of values
-	 */
-	'notIn' => function ($value, $notIn): bool {
-		return V::in($value, $notIn) === false;
-	},
-
-	/**
-	 * Checks for a valid number / numeric value (float, int, double)
-	 */
-	'num' => function ($value): bool {
-		return is_numeric($value) === true;
-	},
-
-	/**
-	 * Checks if the value is present
-	 */
-	'required' => function ($value, $array = null): bool {
-		// with reference array
-		if (is_array($array) === true) {
-			return isset($array[$value]) === true && V::notEmpty($array[$value]) === true;
-		}
-
-		// without reference array
-		return V::notEmpty($value);
-	},
-
-	/**
-	 * Checks that the first value equals the second value
-	 */
-	'same' => function ($value, $other, bool $strict = false): bool {
-		if ($strict === true) {
-			return $value === $other;
-		}
-		return $value == $other;
-	},
-
-	/**
-	 * Checks that the value has the given size
-	 */
-	'size' => function ($value, $size, $operator = '=='): bool {
-		// if value is field object, first convert it to a readable value
-		// it is important to check at the beginning as the value can be string or numeric
-		if ($value instanceof Field) {
-			$value = $value->value();
-		}
-
-		$count = match (true) {
-			is_numeric($value) => $value,
-			is_string($value)  => Str::length(trim($value)),
-			is_array($value)   => count($value),
-			is_object($value)  => match (true) {
-				$value instanceof Countable    => count($value),
-				method_exists($value, 'count') => $value->count(),
-
-				default => throw new Exception('$value is an uncountable object')
-			},
-
-			default => throw new Exception('$value is of type without size')
-		};
-
-		return match ($operator) {
-			'<'     => $count < $size,
-			'>'     => $count > $size,
-			'<='    => $count <= $size,
-			'>='    => $count >= $size,
-			default => $count == $size
-		};
-	},
-
-	/**
-	 * Checks that the string starts with the given start value
-	 */
-	'startsWith' => function (string $value, string $start): bool {
-		return Str::startsWith($value, $start);
-	},
-
-	/**
-	 * Checks for a valid unformatted telephone number
-	 */
-	'tel' => function ($value): bool {
-		return V::match($value, '!^[+]{0,1}[0-9]+$!');
-	},
-
-	/**
-	 * Checks for valid time
-	 */
-	'time' => function ($value): bool {
-		return V::date($value);
-	},
-
-	/**
-	 * Checks for a valid Url
-	 */
-	'url' => function ($value): bool {
-		// In search for the perfect regular expression: https://mathiasbynens.be/demo/url-regex
-		// Added localhost support and removed 127.*.*.* ip restriction
-		$regex = '_^(?:(?:https?|ftp):\/\/)(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:localhost)|(?:(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)(?:\.(?:[a-z\x{00a1}-\x{ffff}0-9]+-?)*[a-z\x{00a1}-\x{ffff}0-9]+)*(?:\.(?:[a-z\x{00a1}-\x{ffff}]{2,})))(?::\d{2,5})?(?:\/[^\s]*)?$_iu';
-		return preg_match($regex, $value ?? '') !== 0;
-	},
-
-	/**
-	 * Checks for a valid Uuid, optionally for specific model type
-	 */
-	'uuid' => function (string $value, string|array|null $type = null): bool {
-		return Uuid::is($value, $type);
+		return $errors;
 	}
-];
+}

--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -434,7 +434,7 @@ class V
 
 		if (method_exists(static::class, $validatorName) === true) {
 			$reflection = new ReflectionMethod(static::class, $validatorName);
-		} else if ($validator  = $validators[$validatorName] ?? null) {
+		} elseif ($validator  = $validators[$validatorName] ?? null) {
 			$reflection = new ReflectionFunction($validator);
 		}
 

--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -218,10 +218,11 @@ class V
 	): array {
 		$errors = static::value($input, $rules, $messages, false);
 
-		return match ($errors) {
-			true    => [],
-			default => $errors
-		};
+		if ($errors === true) {
+			return [];
+		}
+
+		return $errors;
 	}
 
 	/**

--- a/tests/Toolkit/VTest.php
+++ b/tests/Toolkit/VTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Toolkit;
 
+use Countable;
 use Exception;
 use Kirby\Cms\App;
 use Kirby\Content\Field;
@@ -11,7 +12,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
-class CanBeCounted implements \Countable
+class CanBeCounted implements Countable
 {
 	public function count(): int
 	{
@@ -37,8 +38,8 @@ class VTest extends TestCase
 
 	public function testValidators(): void
 	{
-		$this->assertNotEmpty(V::$validators);
-		$this->assertNotEmpty(V::validators());
+		$this->assertSame([], V::$validators);
+		$this->assertSame([], V::validators());
 	}
 
 	public function testCustomValidator(): void

--- a/tests/Toolkit/VTest.php
+++ b/tests/Toolkit/VTest.php
@@ -247,6 +247,25 @@ class VTest extends TestCase
 		$this->assertFalse(V::endsWith('test', 'te'));
 	}
 
+	public function testErrors(): void
+	{
+		$result = V::errors('test@getkirby.com', [
+			'email',
+			'maxLength' => 17,
+			'minLength' => 17
+		]);
+
+		$this->assertSame([], $result);
+
+		$result = V::errors('a', [
+			'same' => 'b'
+		]);
+
+		$this->assertSame([
+			'same' => 'Please enter "b"',
+		], $result);
+	}
+
 	public function testFilename(): void
 	{
 		$this->assertTrue(V::filename('size.txt'));
@@ -545,6 +564,26 @@ class VTest extends TestCase
 		$this->assertTrue(V::maxWords('This is Kirby ', 3));
 
 		$this->assertFalse(V::maxWords('This is Kirby', 2));
+	}
+
+	public function testMessage(): void
+	{
+		$message = V::message('same', 'a', 'b');
+		$this->assertSame('Please enter "b"', $message);
+	}
+
+	public function testMessageInvalidValidator(): void
+	{
+		$message = V::message('foo', 'a', 'b');
+		$this->assertNull($message);
+	}
+
+	public function testMessageCustomValidator(): void
+	{
+		V::$validators['foo'] = fn (string $bar) => false;
+
+		$message = V::message('foo', 'bar');
+		$this->assertSame('The "foo" validation failed', $message);
 	}
 
 	public function testMinLength(): void
@@ -872,5 +911,13 @@ class VTest extends TestCase
 		V::value('a', [
 			'same' => 'b'
 		]);
+	}
+
+	public function testValueFailsNotThrowing(): void
+	{
+		$result = V::value('a', ['same' => 'b'], fail: false);
+		$this->assertSame([
+			'same' => 'Please enter "b"'
+		], $result);
 	}
 }

--- a/tests/Toolkit/VTest.php
+++ b/tests/Toolkit/VTest.php
@@ -33,20 +33,14 @@ class VTest extends TestCase
 {
 	public function tearDown(): void
 	{
+		V::$validators = [];
 		App::destroy();
 	}
 
-	public function testValidators(): void
+	public function testCallCustomValidator(): void
 	{
-		$this->assertSame([], V::$validators);
-		$this->assertSame([], V::validators());
-	}
-
-	public function testCustomValidator(): void
-	{
-		V::$validators['me'] = function ($name): bool {
-			return V::in($name, ['I', 'me', 'myself']);
-		};
+		V::$validators['me'] =
+			fn ($name): bool => V::in($name, ['I', 'me', 'myself']);
 
 		$this->assertTrue(V::me('I'));
 		$this->assertTrue(V::me('me'));
@@ -58,7 +52,6 @@ class VTest extends TestCase
 	{
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('The validator does not exist: fool');
-
 		V::fool('me');
 	}
 
@@ -79,37 +72,6 @@ class VTest extends TestCase
 		$this->assertFalse(V::accepted('0'));
 		$this->assertFalse(V::accepted(null));
 		$this->assertFalse(V::accepted('off'));
-	}
-
-	public function testCallback(): void
-	{
-		$this->assertTrue(V::callback('foo', fn ($value) => $value === 'foo'));
-		$this->assertFalse(V::callback('bar', fn ($value) => $value === 'foo'));
-	}
-
-	public function testContains(): void
-	{
-		$this->assertTrue(V::contains('word', 'or'));
-		$this->assertFalse(V::contains('word', 'test'));
-	}
-
-	public function testDenied(): void
-	{
-		$this->assertTrue(V::denied(false));
-		$this->assertTrue(V::denied('false'));
-		$this->assertTrue(V::denied(0));
-		$this->assertTrue(V::denied('0'));
-		$this->assertTrue(V::denied('no'));
-		$this->assertTrue(V::denied('off'));
-
-		$this->assertFalse(V::denied('word'));
-		$this->assertFalse(V::denied(true));
-		$this->assertFalse(V::denied('true'));
-		$this->assertFalse(V::denied(5));
-		$this->assertFalse(V::denied(1));
-		$this->assertFalse(V::denied('1'));
-		$this->assertFalse(V::denied('on'));
-		$this->assertFalse(V::denied(null));
 	}
 
 	public function testAlpha(): void
@@ -157,6 +119,18 @@ class VTest extends TestCase
 		$this->assertFalse(V::between('kirby', 2, 4));
 	}
 
+	public function testCallback(): void
+	{
+		$this->assertTrue(V::callback('foo', fn ($value) => $value === 'foo'));
+		$this->assertFalse(V::callback('bar', fn ($value) => $value === 'foo'));
+	}
+
+	public function testContains(): void
+	{
+		$this->assertTrue(V::contains('word', 'or'));
+		$this->assertFalse(V::contains('word', 'test'));
+	}
+
 	public function testDate(): void
 	{
 		$this->assertTrue(V::date('2017-12-24'));
@@ -166,81 +140,6 @@ class VTest extends TestCase
 		$this->assertFalse(V::date('äöüß'));
 		$this->assertFalse(V::date('2017-02-31'));
 		$this->assertFalse(V::date('January 32, 1989'));
-	}
-
-	public function testDifferent(): void
-	{
-		$this->assertTrue(V::different('foo', 'bar'));
-		$this->assertTrue(V::different('bar', 'foo'));
-		$this->assertTrue(V::different(1, 2));
-		$this->assertTrue(V::different(null, 'bar'));
-
-		$this->assertFalse(V::different('foo', 'foo'));
-		$this->assertFalse(V::different('bar', 'bar'));
-		$this->assertFalse(V::different(1, 1));
-		$this->assertFalse(V::different('true', 'true'));
-		$this->assertFalse(V::different(null, null));
-
-		// non-strict
-		$this->assertFalse(V::different('true', true));
-
-		// strict
-		$this->assertTrue(V::different('true', true, true));
-	}
-
-	public function testEndsWith(): void
-	{
-		$this->assertTrue(V::endsWith('test', 'st'));
-		$this->assertFalse(V::endsWith('test', 'te'));
-	}
-
-	public function testSame(): void
-	{
-		$this->assertTrue(V::same('foo', 'foo'));
-		$this->assertTrue(V::same('bar', 'bar'));
-		$this->assertTrue(V::same(1, 1));
-		$this->assertTrue(V::same('true', 'true'));
-		$this->assertTrue(V::same(null, null));
-
-		$this->assertFalse(V::same('foo', 'bar'));
-		$this->assertFalse(V::same('bar', 'foo'));
-		$this->assertFalse(V::same(1, 2));
-		$this->assertFalse(V::same(null, 'bar'));
-
-		// non-strict
-		$this->assertTrue(V::same('true', true));
-
-		// strict
-		$this->assertFalse(V::same('true', true, true));
-	}
-
-	public function testEmail(): void
-	{
-		$this->assertTrue(V::email('bastian@getkirby.com'));
-		$this->assertTrue(V::email('bastian-v3@getkirby.com'));
-		$this->assertTrue(V::email('bastian.allgeier@getkirby.com'));
-		$this->assertTrue(V::email('bastian@getkürby.com'));
-
-		$this->assertFalse(V::email('bastian@getkirby'));
-		$this->assertFalse(V::email('bastiangetkirby.com'));
-		$this->assertFalse(V::email('bastian[at]getkirby.com'));
-		$this->assertFalse(V::email('bastian@getkürby'));
-		$this->assertFalse(V::email('@getkirby.com'));
-	}
-
-	public function testEmpty(): void
-	{
-		$this->assertTrue(V::empty(''));
-		$this->assertTrue(V::empty(null));
-		$this->assertTrue(V::empty([]));
-		$this->assertTrue(V::empty(new Collection()));
-
-		$this->assertFalse(V::empty(0));
-		$this->assertFalse(V::empty('0'));
-		$this->assertFalse(V::empty(false));
-		$this->assertFalse(V::empty(true));
-		$this->assertFalse(V::empty(['']));
-		$this->assertFalse(V::empty(new Collection(['a'])));
 	}
 
 	public function testDateComparison(): void
@@ -273,6 +172,81 @@ class VTest extends TestCase
 		V::date('2345-01-01', '<>', '2345-01-01');
 	}
 
+	public function testDenied(): void
+	{
+		$this->assertTrue(V::denied(false));
+		$this->assertTrue(V::denied('false'));
+		$this->assertTrue(V::denied(0));
+		$this->assertTrue(V::denied('0'));
+		$this->assertTrue(V::denied('no'));
+		$this->assertTrue(V::denied('off'));
+
+		$this->assertFalse(V::denied('word'));
+		$this->assertFalse(V::denied(true));
+		$this->assertFalse(V::denied('true'));
+		$this->assertFalse(V::denied(5));
+		$this->assertFalse(V::denied(1));
+		$this->assertFalse(V::denied('1'));
+		$this->assertFalse(V::denied('on'));
+		$this->assertFalse(V::denied(null));
+	}
+
+	public function testDifferent(): void
+	{
+		$this->assertTrue(V::different('foo', 'bar'));
+		$this->assertTrue(V::different('bar', 'foo'));
+		$this->assertTrue(V::different(1, 2));
+		$this->assertTrue(V::different(null, 'bar'));
+
+		$this->assertFalse(V::different('foo', 'foo'));
+		$this->assertFalse(V::different('bar', 'bar'));
+		$this->assertFalse(V::different(1, 1));
+		$this->assertFalse(V::different('true', 'true'));
+		$this->assertFalse(V::different(null, null));
+
+		// non-strict
+		$this->assertFalse(V::different('true', true));
+
+		// strict
+		$this->assertTrue(V::different('true', true, true));
+	}
+
+
+	public function testEmail(): void
+	{
+		$this->assertTrue(V::email('bastian@getkirby.com'));
+		$this->assertTrue(V::email('bastian-v3@getkirby.com'));
+		$this->assertTrue(V::email('bastian.allgeier@getkirby.com'));
+		$this->assertTrue(V::email('bastian@getkürby.com'));
+
+		$this->assertFalse(V::email('bastian@getkirby'));
+		$this->assertFalse(V::email('bastiangetkirby.com'));
+		$this->assertFalse(V::email('bastian[at]getkirby.com'));
+		$this->assertFalse(V::email('bastian@getkürby'));
+		$this->assertFalse(V::email('@getkirby.com'));
+	}
+
+	public function testEmpty(): void
+	{
+		$this->assertTrue(V::empty(''));
+		$this->assertTrue(V::empty(null));
+		$this->assertTrue(V::empty([]));
+		$this->assertTrue(V::empty(new Collection()));
+
+		$this->assertFalse(V::empty(0));
+		$this->assertFalse(V::empty('0'));
+		$this->assertFalse(V::empty(false));
+		$this->assertFalse(V::empty(true));
+		$this->assertFalse(V::empty(['']));
+		$this->assertFalse(V::empty(new Collection(['a'])));
+	}
+
+	public function testEndsWith(): void
+	{
+		$this->assertTrue(V::endsWith('test', 'st'));
+		$this->assertFalse(V::endsWith('test', 'te'));
+	}
+
 	public function testFilename(): void
 	{
 		$this->assertTrue(V::filename('size.txt'));
@@ -288,6 +262,94 @@ class VTest extends TestCase
 
 		$this->assertFalse(V::in('bastian', ['lukas', 'nico', 'sonja']));
 		$this->assertFalse(V::in('bastian', []));
+	}
+
+	public static function inputProvider(): array
+	{
+		return [
+			// everything alright
+			[
+				[
+					'a' => 'a',
+					'b' => 'b'
+				],
+				[],
+				true
+			],
+			// invalid email
+			[
+				[
+					'email' => 'test'
+				],
+				[
+					'email' => [
+						'email'
+					]
+				],
+				false,
+				'Please enter a valid email address for field "email"',
+			],
+			// missing required field
+			[
+				[
+				],
+				[
+					'email' => [
+						'required' => true
+					]
+				],
+				false,
+				'The "email" field is missing',
+			],
+			// skipping missing non-required field
+			[
+				[
+				],
+				[
+					'email' => [
+						'email'
+					],
+					'name' => [
+						'required' => true
+					]
+				],
+				false,
+				'The "name" field is missing',
+			],
+		];
+	}
+
+	#[DataProvider('inputProvider')]
+	public function testInput(
+		array $input,
+		array $rules,
+		bool $result,
+		string|null $message = null
+	): void {
+		// load the translation strings
+		new App();
+
+		if ($result === false) {
+			$this->expectException(Exception::class);
+			$this->expectExceptionMessage($message);
+		}
+
+		$this->assertTrue(V::input($input, $rules));
+	}
+
+	public function testInteger(): void
+	{
+		$this->assertTrue(V::integer(5));
+		$this->assertTrue(V::integer(0));
+		$this->assertTrue(V::integer('5'));
+		$this->assertTrue(V::integer(5, true));
+		$this->assertTrue(V::integer(0, true));
+
+		$this->assertFalse(V::integer(5.1));
+		$this->assertFalse(V::integer([5]));
+		$this->assertFalse(V::integer(5.1, true));
+		$this->assertFalse(V::integer('5', true));
+		$this->assertFalse(V::integer(null, true));
 	}
 
 	public function testInvalid(): void
@@ -437,35 +499,6 @@ class VTest extends TestCase
 		$this->assertSame([], $result);
 	}
 
-	public function testNotEmpty(): void
-	{
-		$this->assertFalse(V::notEmpty(''));
-		$this->assertTrue(V::notEmpty(0));
-	}
-
-	public function testNotIn(): void
-	{
-		$this->assertFalse(V::notIn('bastian', ['bastian', 'nico', 'sonja']));
-
-		$this->assertTrue(V::notIn('bastian', ['lukas', 'nico', 'sonja']));
-		$this->assertTrue(V::notIn('bastian', []));
-	}
-
-	public function testInteger(): void
-	{
-		$this->assertTrue(V::integer(5));
-		$this->assertTrue(V::integer(0));
-		$this->assertTrue(V::integer('5'));
-		$this->assertTrue(V::integer(5, true));
-		$this->assertTrue(V::integer(0, true));
-
-		$this->assertFalse(V::integer(5.1));
-		$this->assertFalse(V::integer([5]));
-		$this->assertFalse(V::integer(5.1, true));
-		$this->assertFalse(V::integer('5', true));
-		$this->assertFalse(V::integer(null, true));
-	}
-
 	public function testIp(): void
 	{
 		$this->assertTrue(V::ip('192.168.255.1'));
@@ -505,15 +538,6 @@ class VTest extends TestCase
 		$this->assertFalse(V::maxLength('Kirby', 3));
 	}
 
-	public function testMinLength(): void
-	{
-		$this->assertTrue(V::minLength('Kirby', 2));
-		$this->assertTrue(V::minLength('Kirby', 5));
-
-		$this->assertFalse(V::minLength('Kirby', 6));
-		$this->assertFalse(V::minLength(' Kirby ', 6));
-	}
-
 	public function testMaxWords(): void
 	{
 		$this->assertTrue(V::maxWords('This is Kirby', 10));
@@ -521,6 +545,15 @@ class VTest extends TestCase
 		$this->assertTrue(V::maxWords('This is Kirby ', 3));
 
 		$this->assertFalse(V::maxWords('This is Kirby', 2));
+	}
+
+	public function testMinLength(): void
+	{
+		$this->assertTrue(V::minLength('Kirby', 2));
+		$this->assertTrue(V::minLength('Kirby', 5));
+
+		$this->assertFalse(V::minLength('Kirby', 6));
+		$this->assertFalse(V::minLength(' Kirby ', 6));
 	}
 
 	public function testMinWords(): void
@@ -542,6 +575,20 @@ class VTest extends TestCase
 	{
 		$this->assertFalse(V::notContains('word', 'or'));
 		$this->assertTrue(V::notContains('word', 'test'));
+	}
+
+	public function testNotEmpty(): void
+	{
+		$this->assertFalse(V::notEmpty(''));
+		$this->assertTrue(V::notEmpty(0));
+	}
+
+	public function testNotIn(): void
+	{
+		$this->assertFalse(V::notIn('bastian', ['bastian', 'nico', 'sonja']));
+
+		$this->assertTrue(V::notIn('bastian', ['lukas', 'nico', 'sonja']));
+		$this->assertTrue(V::notIn('bastian', []));
 	}
 
 	public function testNum(): void
@@ -574,6 +621,26 @@ class VTest extends TestCase
 		$this->assertFalse(V::required('a', ['a' => '']));
 		$this->assertFalse(V::required('a', ['a' => null]));
 		$this->assertFalse(V::required('a', ['a' => []]));
+	}
+
+	public function testSame(): void
+	{
+		$this->assertTrue(V::same('foo', 'foo'));
+		$this->assertTrue(V::same('bar', 'bar'));
+		$this->assertTrue(V::same(1, 1));
+		$this->assertTrue(V::same('true', 'true'));
+		$this->assertTrue(V::same(null, null));
+
+		$this->assertFalse(V::same('foo', 'bar'));
+		$this->assertFalse(V::same('bar', 'foo'));
+		$this->assertFalse(V::same(1, 2));
+		$this->assertFalse(V::same(null, 'bar'));
+
+		// non-strict
+		$this->assertTrue(V::same('true', true));
+
+		// strict
+		$this->assertFalse(V::same('true', true, true));
 	}
 
 	public function testSize(): void
@@ -770,77 +837,17 @@ class VTest extends TestCase
 		$this->assertFalse(V::url('http://.www.foo.bar./'));
 	}
 
-	public static function inputProvider(): array
+	public function testValidators(): void
 	{
-		return [
-			// everything alright
-			[
-				[
-					'a' => 'a',
-					'b' => 'b'
-				],
-				[],
-				true
-			],
-			// invalid email
-			[
-				[
-					'email' => 'test'
-				],
-				[
-					'email' => [
-						'email'
-					]
-				],
-				false,
-				'Please enter a valid email address for field "email"',
-			],
-			// missing required field
-			[
-				[
-				],
-				[
-					'email' => [
-						'required' => true
-					]
-				],
-				false,
-				'The "email" field is missing',
-			],
-			// skipping missing non-required field
-			[
-				[
-				],
-				[
-					'email' => [
-						'email'
-					],
-					'name' => [
-						'required' => true
-					]
-				],
-				false,
-				'The "name" field is missing',
-			],
-		];
+		$this->assertSame([], V::$validators);
+		$this->assertSame([], V::validators());
 	}
 
-	#[DataProvider('inputProvider')]
-	public function testInput(
-		array $input,
-		array $rules,
-		bool $result,
-		string|null $message = null
-	): void {
-		// load the translation strings
-		new App();
-
-		if ($result === false) {
-			$this->expectException(Exception::class);
-			$this->expectExceptionMessage($message);
-		}
-
-		$this->assertTrue(V::input($input, $rules));
+	public function testValidatorsCustomValidator(): void
+	{
+		$this->assertCount(0, V::validators());
+		V::$validators['foo'] = fn (): bool => true;
+		$this->assertCount(1, V::validators());
 	}
 
 	public function testValue(): void


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- Implemented default validators as regular class methods of `Kirby\Toolkit\V`

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- Custom validators cannot overwrite default validators from the `Kirby\Toolkit\V` class any longer.


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion