### PR TITLE
(Field PR X) feat: Field reflection

### DIFF
--- a/src/Reflection/Attributes/DefaultValue.php
+++ b/src/Reflection/Attributes/DefaultValue.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Kirby\Reflection\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class DefaultValue
+{
+	public function __construct(
+		protected mixed $value
+	) {
+	}
+
+	public function value(): mixed
+	{
+		return $this->value;
+	}
+}

--- a/src/Reflection/DocComment.php
+++ b/src/Reflection/DocComment.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Kirby\Reflection;
+
+use ReflectionClass;
+use ReflectionFunction;
+use ReflectionMethod;
+use ReflectionProperty;
+
+class DocComment
+{
+	public function __construct(
+		protected string $comment,
+	) {
+	}
+
+	public static function from(
+		ReflectionClass|ReflectionFunction|ReflectionMethod|ReflectionProperty|null $object
+	) {
+		return new static($object?->getDocComment() ?? '');
+	}
+
+	/**
+	 * Returns the cleaned docblock text of the given property.
+	 */
+	public function description(): string|null
+	{
+		$comment = preg_replace(['#^/\*\*#', '#\*/$#'], '', $this->comment);
+		$lines   = preg_split('/\R/', (string)$comment) ?: [];
+		$lines   = array_map(static fn (string $line): string => ltrim(trim($line), "* \t"), $lines);
+		$lines   = array_filter(
+			$lines,
+			static fn (string $line): bool => $line !== '' && str_starts_with($line, '@') === false
+		);
+
+		return implode(' ', $lines);
+	}
+}

--- a/src/Reflection/Field.php
+++ b/src/Reflection/Field.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Kirby\Reflection;
+
+use Kirby\Form\FieldClass;
+use ReflectionClass;
+
+class Field
+{
+	protected Constructor $constructor;
+	protected ReflectionClass $class;
+
+	public function __construct(
+		protected FieldClass|string $field
+	) {
+		$this->class       = new ReflectionClass($field);
+		$this->constructor = new Constructor($field);
+	}
+
+	protected function parentClass(): ReflectionClass
+	{
+		return $this->class->getParentClass();
+	}
+
+	protected function parentProps(): array
+	{
+		return $this->parentReflection()->props();
+	}
+
+	protected function parentReflection(): static
+	{
+		return new static($this->parentClass()->getName());
+	}
+
+	/**
+	 * Returns field properties based on the constructor signature.
+	 */
+	public function props(): array
+	{
+		$props  = [];
+		$ignore = ['model', 'siblings'];
+
+		foreach ($this->constructor->getParameters() as $parameter) {
+			$name = $parameter->getName();
+
+			if (in_array($name, $ignore) === true) {
+				continue;
+			}
+
+			// resolve ... by getting props from the parent class
+			if ($parameter->isVariadic()) {
+				$props = [
+					...$this->parentProps(),
+					...$props,
+				];
+				continue;
+			}
+
+			$property = $this->class->hasProperty($name) ? $this->class->getProperty($name) : null;
+			$comment  = DocComment::from($property);
+
+			$props[$name] = [
+				'name'        => $name,
+				'type'        => (string)$parameter->getType(),
+				'default'     => $parameter->getDefaultValue(),
+				'description' => $comment->description()
+			];
+		}
+
+		ksort($props);
+
+		return $props;
+	}
+}


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7608

## Description

In this PR, I'm trying to explore how well we can reflect the new Field classes with named arguments. Turns out: very well. But we need to define them all in the constructor. I'm torn here. It can be a lot of work and there are arguments that are super annoying to repeat (model, siblings, when, width, translate, etc.) But on the other hand it really gives a fantastic overview of all the capabilities of a field. It's somehow very close to the property table in our docs, which I like a lot. Maybe we can find a way to not have to pass at least Model and Siblings each time and only focus on the props that also turn up in our table? 

We can now reflect such classes like this: 
```php
use Kirby\Form\Field\BlocksField;
use Kirby\Reflection\Field;

$blocks = new BlocksField();
$field = new Field($blocks);

$field->props();  
```
Here's the output for the blocks field …

```php
[
    "autofocus" => [
      "name" => "autofocus",
      "type" => "bool",
      "default" => false,
      "description" => "Sets the focus on this field when the form loads. Only the first field with this label gets",
    ],
    "default" => [
      "name" => "default",
      "type" => "array",
      "default" => [],
      "description" => "Default value for the field, which will be used when a page/file/user is created",
    ],
    "disabled" => [
      "name" => "disabled",
      "type" => "bool",
      "default" => false,
      "description" => "If `true`, the field is no longer editable and will not be saved",
    ],
    "empty" => [
      "name" => "empty",
      "type" => "array|string|null",
      "default" => null,
      "description" => "Sets the text for the empty state box",
    ],
    "fieldsets" => [
      "name" => "fieldsets",
      "type" => "array|string|null",
      "default" => null,
      "description" => "Defines the allowed block types in the blocks field. See below.",
    ],
    "help" => [
      "name" => "help",
      "type" => "array|string|null",
      "default" => null,
      "description" => "Optional help text below the field",
    ],
    "group" => [
      "name" => "group",
      "type" => "?string",
      "default" => null,
      "description" => "Group name to identify all block fields that can share blocks via drag & drop",
    ],
    "label" => [
      "name" => "label",
      "type" => "array|string|null",
      "default" => null,
      "description" => "The field label can be set as string or associative array with translations",
    ],
    "name" => [
      "name" => "name",
      "type" => "?string",
      "default" => null,
      "description" => "",
    ],
    "max" => [
      "name" => "max",
      "type" => "?int",
      "default" => null,
      "description" => "Sets the maximum number of allowed items in the field",
    ],
    "min" => [
      "name" => "min",
      "type" => "?int",
      "default" => null,
      "description" => "Sets the minimum number of required items in the field",
    ],
    "pretty" => [
      "name" => "pretty",
      "type" => "bool",
      "default" => false,
      "description" => "Saves pretty printed JSON in text files",
    ],
    "required" => [
      "name" => "required",
      "type" => "bool",
      "default" => false,
      "description" => "If `true`, the field has to be filled in correctly to be saved.",
    ],
    "translate" => [
      "name" => "translate",
      "type" => "bool",
      "default" => true,
      "description" => "Should the field be translatable?",
    ],
    "when" => [
      "name" => "when",
      "type" => "array",
      "default" => [],
      "description" => "Conditions when the field will be shown",
    ],
    "width" => [
      "name" => "width",
      "type" => "?string",
      "default" => "1/1",
      "description" => "The width of the field in the field grid. Available widths: `1/1`, `1/2`, `1/3`, `1/4`, `2/3`, `3/4`",
    ],
  ]
```