### PR TITLE
(Fields PR 1) refact: New FieldClass mixins

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -25,6 +25,7 @@ class Field extends Component
 {
 	use HasSiblings;
 	use Mixin\Api;
+	use Mixin\DefaultValue;
 	use Mixin\Model;
 	use Mixin\Required;
 	use Mixin\Translatable;
@@ -186,7 +187,7 @@ class Field extends Component
 				},
 				'default' => function () {
 					/** @var \Kirby\Form\Field $this */
-					if ($this->default === null) {
+					if (isset($this->default) === false) {
 						return;
 					}
 

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -26,6 +26,7 @@ class Field extends Component
 	use HasSiblings;
 	use Mixin\Api;
 	use Mixin\Model;
+	use Mixin\Required;
 	use Mixin\Translatable;
 	use Mixin\Validation;
 	use Mixin\When;

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -42,10 +42,10 @@ class BlocksField extends FieldClass
 		parent::__construct($params);
 
 		$this->setEmpty($params['empty'] ?? null);
-		$this->setGroup($params['group'] ?? 'blocks');
+		$this->setGroup($params['group'] ?? null);
 		$this->setMax($params['max'] ?? null);
 		$this->setMin($params['min'] ?? null);
-		$this->setPretty($params['pretty'] ?? false);
+		$this->setPretty($params['pretty'] ?? null);
 	}
 
 	public function blocksToValues(
@@ -134,7 +134,7 @@ class BlocksField extends FieldClass
 
 	public function group(): string
 	{
-		return $this->group;
+		return $this->group ?? 'blocks';
 	}
 
 	/**
@@ -265,7 +265,7 @@ class BlocksField extends FieldClass
 		);
 	}
 
-	protected function setGroup(string|null $group = null): void
+	protected function setGroup(string|null $group): void
 	{
 		$this->group = $group;
 	}

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -16,6 +16,7 @@ use Kirby\Form\Form;
 use Kirby\Form\Mixin\EmptyState;
 use Kirby\Form\Mixin\Max;
 use Kirby\Form\Mixin\Min;
+use Kirby\Form\Mixin\Pretty;
 use Kirby\Toolkit\Str;
 use Throwable;
 
@@ -24,11 +25,11 @@ class BlocksField extends FieldClass
 	use EmptyState;
 	use Max;
 	use Min;
+	use Pretty;
 
 	protected Fieldsets $fieldsets;
 	protected array $forms;
 	protected string|null $group;
-	protected bool $pretty;
 	protected mixed $value = [];
 
 	public function __construct(array $params = [])
@@ -134,11 +135,6 @@ class BlocksField extends FieldClass
 	public function group(): string
 	{
 		return $this->group;
-	}
-
-	public function pretty(): bool
-	{
-		return $this->pretty;
 	}
 
 	/**
@@ -272,11 +268,6 @@ class BlocksField extends FieldClass
 	protected function setGroup(string|null $group = null): void
 	{
 		$this->group = $group;
-	}
-
-	protected function setPretty(bool $pretty = false): void
-	{
-		$this->pretty = $pretty;
 	}
 
 	public function toStoredValue(bool $default = false): mixed

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -9,6 +9,7 @@ use Kirby\Form\Form;
 use Kirby\Form\Mixin\EmptyState;
 use Kirby\Form\Mixin\Max;
 use Kirby\Form\Mixin\Min;
+use Kirby\Form\Mixin\Sortable;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
 
@@ -27,10 +28,10 @@ class EntriesField extends FieldClass
 	use EmptyState;
 	use Max;
 	use Min;
+	use Sortable;
 
 	protected array $field;
 	protected Form $form;
-	protected bool  $sortable = true;
 	protected mixed $value = [];
 
 	public function __construct(array $params = [])
@@ -103,16 +104,6 @@ class EntriesField extends FieldClass
 		unset($attrs['counter'], $attrs['label']);
 
 		$this->field = $attrs;
-	}
-
-	protected function setSortable(bool|null $sortable = true): void
-	{
-		$this->sortable = $sortable;
-	}
-
-	public function sortable(): bool
-	{
-		return $this->sortable;
 	}
 
 	public function supports(): array

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -42,7 +42,7 @@ class EntriesField extends FieldClass
 		$this->setField($params['field'] ?? null);
 		$this->setMax($params['max'] ?? null);
 		$this->setMin($params['min'] ?? null);
-		$this->setSortable($params['sortable'] ?? true);
+		$this->setSortable($params['sortable'] ?? null);
 	}
 
 	public function field(): array

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -22,8 +22,8 @@ class LayoutField extends BlocksField
 
 	public function __construct(array $params)
 	{
-		$this->setModel($params['model'] ?? App::instance()->site());
-		$this->setLayouts($params['layouts'] ?? ['1/1']);
+		$this->setModel($params['model'] ?? null);
+		$this->setLayouts($params['layouts'] ?? null);
 		$this->setSelector($params['selector'] ?? null);
 		$this->setSettings($params['settings'] ?? null);
 
@@ -63,9 +63,9 @@ class LayoutField extends BlocksField
 		);
 	}
 
-	public function layouts(): array|null
+	public function layouts(): array
 	{
-		return $this->layouts;
+		return $this->layouts ?? [['1/1']];
 	}
 
 	/**
@@ -235,12 +235,16 @@ class LayoutField extends BlocksField
 		parent::setDefault($default);
 	}
 
-	protected function setLayouts(array $layouts = []): void
+	protected function setLayouts(array|null $layouts): void
 	{
-		$this->layouts = array_map(
-			fn ($layout) => Str::split($layout),
-			$layouts
-		);
+		if ($layouts) {
+			$layouts = array_map(
+				fn ($layout) => Str::split($layout),
+				$layouts
+			);
+		}
+
+		$this->layouts = $layouts;
 	}
 
 	/**

--- a/src/Form/Field/StatsField.php
+++ b/src/Form/Field/StatsField.php
@@ -25,7 +25,7 @@ class StatsField extends FieldClass
 	/**
 	 * The size of the report cards. Available sizes: `tiny`, `small`, `medium`, `large`
 	 */
-	protected string $size;
+	protected string|null $size;
 
 	/**
 	 * Cache for the Stats UI component
@@ -37,7 +37,7 @@ class StatsField extends FieldClass
 		parent::__construct($params);
 
 		$this->reports = $params['reports'] ?? [];
-		$this->size    = $params['size']    ?? 'large';
+		$this->size    = $params['size']    ?? null;
 	}
 
 	public function hasValue(): bool
@@ -58,9 +58,9 @@ class StatsField extends FieldClass
 	public function stats(): Stats
 	{
 		return $this->stats ??= Stats::from(
-			model: $this->model,
+			model:   $this->model,
 			reports: $this->reports,
-			size: $this->size
+			size:    $this->size ?? 'large'
 		);
 	}
 

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -57,7 +57,7 @@ abstract class FieldClass
 		$this->setPlaceholder($params['placeholder'] ?? null);
 		$this->setRequired($params['required'] ?? false);
 		$this->setSiblings($params['siblings'] ?? null);
-		$this->setTranslate($params['translate'] ?? true);
+		$this->setTranslate($params['translate'] ?? null);
 		$this->setWhen($params['when'] ?? null);
 		$this->setWidth($params['width'] ?? null);
 

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -45,7 +45,7 @@ abstract class FieldClass
 		protected array $params = []
 	) {
 		$this->setAfter($params['after'] ?? null);
-		$this->setAutofocus($params['autofocus'] ?? false);
+		$this->setAutofocus($params['autofocus'] ?? null);
 		$this->setBefore($params['before'] ?? null);
 		$this->setDefault($params['default'] ?? null);
 		$this->setDisabled($params['disabled'] ?? false);

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -33,6 +33,7 @@ abstract class FieldClass
 	use Mixin\Model;
 	use Mixin\Name;
 	use Mixin\Placeholder;
+	use Mixin\Required;
 	use Mixin\Translatable;
 	use Mixin\Validation;
 	use Mixin\Value;

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -31,6 +31,7 @@ abstract class FieldClass
 	use Mixin\Icon;
 	use Mixin\Label;
 	use Mixin\Model;
+	use Mixin\Name;
 	use Mixin\Placeholder;
 	use Mixin\Translatable;
 	use Mixin\Validation;
@@ -38,7 +39,6 @@ abstract class FieldClass
 	use Mixin\When;
 	use Mixin\Width;
 
-	protected string|null $name;
 	protected Fields $siblings;
 
 	public function __construct(
@@ -102,14 +102,6 @@ abstract class FieldClass
 	}
 
 	/**
-	 * Returns the field name
-	 */
-	public function name(): string
-	{
-		return $this->name ?? $this->type();
-	}
-
-	/**
 	 * Returns all original params for the field
 	 */
 	public function params(): array
@@ -152,11 +144,6 @@ abstract class FieldClass
 	{
 		$this->value = $this->emptyValue();
 		return $this;
-	}
-
-	protected function setName(string|null $name = null): void
-	{
-		$this->name = strtolower($name ?? $this->type());
 	}
 
 	protected function setSiblings(Fields|null $siblings = null): void

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -26,6 +26,7 @@ abstract class FieldClass
 	use Mixin\Api;
 	use Mixin\Autofocus;
 	use Mixin\Before;
+	use Mixin\DefaultValue;
 	use Mixin\Disabled;
 	use Mixin\Help;
 	use Mixin\Icon;

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -50,14 +50,14 @@ abstract class FieldClass
 		$this->setAutofocus($params['autofocus'] ?? null);
 		$this->setBefore($params['before'] ?? null);
 		$this->setDefault($params['default'] ?? null);
-		$this->setDisabled($params['disabled'] ?? false);
+		$this->setDisabled($params['disabled'] ?? null);
 		$this->setHelp($params['help'] ?? null);
 		$this->setIcon($params['icon'] ?? null);
 		$this->setLabel($params['label'] ?? null);
 		$this->setModel($params['model'] ?? null);
 		$this->setName($params['name'] ?? null);
 		$this->setPlaceholder($params['placeholder'] ?? null);
-		$this->setRequired($params['required'] ?? false);
+		$this->setRequired($params['required'] ?? null);
 		$this->setSiblings($params['siblings'] ?? null);
 		$this->setTranslate($params['translate'] ?? null);
 		$this->setWhen($params['when'] ?? null);

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -26,6 +26,7 @@ abstract class FieldClass
 	use Mixin\Api;
 	use Mixin\Autofocus;
 	use Mixin\Before;
+	use Mixin\Disabled;
 	use Mixin\Help;
 	use Mixin\Icon;
 	use Mixin\Label;
@@ -37,7 +38,6 @@ abstract class FieldClass
 	use Mixin\When;
 	use Mixin\Width;
 
-	protected bool $disabled;
 	protected string|null $name;
 	protected Fields $siblings;
 
@@ -84,14 +84,6 @@ abstract class FieldClass
 	}
 
 	/**
-	 * If `true`, the field is no longer editable and will not be saved
-	 */
-	public function disabled(): bool
-	{
-		return $this->disabled;
-	}
-
-	/**
 	 * Returns optional drawer routes for the field
 	 */
 	public function drawers(): array
@@ -102,11 +94,6 @@ abstract class FieldClass
 	public function id(): string
 	{
 		return $this->name();
-	}
-
-	public function isDisabled(): bool
-	{
-		return $this->disabled;
 	}
 
 	public function isHidden(): bool
@@ -165,11 +152,6 @@ abstract class FieldClass
 	{
 		$this->value = $this->emptyValue();
 		return $this;
-	}
-
-	protected function setDisabled(bool $disabled = false): void
-	{
-		$this->disabled = $disabled;
 	}
 
 	protected function setName(string|null $name = null): void

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -164,7 +164,7 @@ abstract class FieldClass
 	protected function stringTemplate(string|null $string = null): string|null
 	{
 		if ($string !== null) {
-			return $this->model->toString($string);
+			return $this->model()->toString($string);
 		}
 
 		return null;

--- a/src/Form/Mixin/After.php
+++ b/src/Form/Mixin/After.php
@@ -7,7 +7,7 @@ trait After
 	/**
 	 * Optional text that will be shown after the input
 	 */
-	protected array|string|null $after = null;
+	protected array|string|null $after;
 
 	public function after(): string|null
 	{

--- a/src/Form/Mixin/After.php
+++ b/src/Form/Mixin/After.php
@@ -7,15 +7,15 @@ trait After
 	/**
 	 * Optional text that will be shown after the input
 	 */
-	protected string|null $after;
+	protected array|string|null $after = null;
 
 	public function after(): string|null
 	{
-		return $this->stringTemplate($this->after);
+		return $this->stringTemplate($this->i18n($this->after));
 	}
 
-	protected function setAfter(array|string|null $after = null): void
+	protected function setAfter(array|string|null $after): void
 	{
-		$this->after = $this->i18n($after);
+		$this->after = $after;
 	}
 }

--- a/src/Form/Mixin/Autofocus.php
+++ b/src/Form/Mixin/Autofocus.php
@@ -7,14 +7,14 @@ trait Autofocus
 	/**
 	 * Sets the focus on this field when the form loads. Only the first field with this label gets
 	 */
-	protected bool $autofocus = false;
+	protected bool|null $autofocus;
 
 	public function autofocus(): bool
 	{
-		return $this->autofocus;
+		return $this->autofocus ?? false;
 	}
 
-	protected function setAutofocus(bool $autofocus): void
+	protected function setAutofocus(bool|null $autofocus): void
 	{
 		$this->autofocus = $autofocus;
 	}

--- a/src/Form/Mixin/Autofocus.php
+++ b/src/Form/Mixin/Autofocus.php
@@ -7,14 +7,14 @@ trait Autofocus
 	/**
 	 * Sets the focus on this field when the form loads. Only the first field with this label gets
 	 */
-	protected bool $autofocus;
+	protected bool $autofocus = false;
 
 	public function autofocus(): bool
 	{
 		return $this->autofocus;
 	}
 
-	protected function setAutofocus(bool $autofocus = false): void
+	protected function setAutofocus(bool $autofocus): void
 	{
 		$this->autofocus = $autofocus;
 	}

--- a/src/Form/Mixin/Before.php
+++ b/src/Form/Mixin/Before.php
@@ -7,15 +7,15 @@ trait Before
 	/**
 	 * Optional text that will be shown before the input
 	 */
-	protected string|null $before;
+	protected array|string|null $before = null;
 
 	public function before(): string|null
 	{
-		return $this->stringTemplate($this->before);
+		return $this->stringTemplate($this->i18n($this->before));
 	}
 
-	protected function setBefore(array|string|null $before = null): void
+	protected function setBefore(array|string|null $before): void
 	{
-		$this->before = $this->i18n($before);
+		$this->before = $before;
 	}
 }

--- a/src/Form/Mixin/Before.php
+++ b/src/Form/Mixin/Before.php
@@ -7,7 +7,7 @@ trait Before
 	/**
 	 * Optional text that will be shown before the input
 	 */
-	protected array|string|null $before = null;
+	protected array|string|null $before;
 
 	public function before(): string|null
 	{

--- a/src/Form/Mixin/DefaultValue.php
+++ b/src/Form/Mixin/DefaultValue.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait DefaultValue
+{
+	/**
+	 * Default value for the field, which will be used when a page/file/user is created
+	 */
+	protected mixed $default;
+
+	/**
+	 * Returns the default value of the field
+	 */
+	public function default(): mixed
+	{
+		if (isset($this->default) === false) {
+			return null;
+		}
+
+		if (is_string($this->default) === false) {
+			return $this->default;
+		}
+
+		return $this->model()->toString($this->default);
+	}
+
+	protected function setDefault(mixed $default): void
+	{
+		$this->default = $default;
+	}
+}

--- a/src/Form/Mixin/Disabled.php
+++ b/src/Form/Mixin/Disabled.php
@@ -7,19 +7,19 @@ trait Disabled
 	/**
 	 * If `true`, the field is no longer editable and will not be saved
 	 */
-	protected bool $disabled = false;
+	protected bool|null $disabled;
 
 	public function disabled(): bool
 	{
-		return $this->disabled;
+		return $this->disabled ?? false;
 	}
 
 	public function isDisabled(): bool
 	{
-		return $this->disabled;
+		return $this->disabled();
 	}
 
-	protected function setDisabled(bool $disabled): void
+	protected function setDisabled(bool|null $disabled): void
 	{
 		$this->disabled = $disabled;
 	}

--- a/src/Form/Mixin/Disabled.php
+++ b/src/Form/Mixin/Disabled.php
@@ -19,7 +19,7 @@ trait Disabled
 		return $this->disabled;
 	}
 
-	protected function setDisabled(bool $disabled = false): void
+	protected function setDisabled(bool $disabled): void
 	{
 		$this->disabled = $disabled;
 	}

--- a/src/Form/Mixin/Disabled.php
+++ b/src/Form/Mixin/Disabled.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait Disabled
+{
+	/**
+	 * If `true`, the field is no longer editable and will not be saved
+	 */
+	protected bool $disabled = false;
+
+	public function disabled(): bool
+	{
+		return $this->disabled;
+	}
+
+	public function isDisabled(): bool
+	{
+		return $this->disabled;
+	}
+
+	protected function setDisabled(bool $disabled = false): void
+	{
+		$this->disabled = $disabled;
+	}
+}

--- a/src/Form/Mixin/EmptyState.php
+++ b/src/Form/Mixin/EmptyState.php
@@ -7,15 +7,15 @@ trait EmptyState
 	/**
 	 * Sets the text for the empty state box
 	 */
-	protected string|null $empty;
-
-	protected function setEmpty(string|array|null $empty = null): void
-	{
-		$this->empty = $this->i18n($empty);
-	}
+	protected array|string|null $empty = null;
 
 	public function empty(): string|null
 	{
-		return $this->stringTemplate($this->empty);
+		return $this->stringTemplate($this->i18n($this->empty));
+	}
+
+	protected function setEmpty(string|array|null $empty): void
+	{
+		$this->empty = $empty;
 	}
 }

--- a/src/Form/Mixin/EmptyState.php
+++ b/src/Form/Mixin/EmptyState.php
@@ -14,7 +14,7 @@ trait EmptyState
 		return $this->stringTemplate($this->i18n($this->empty));
 	}
 
-	protected function setEmpty(string|array|null $empty): void
+	protected function setEmpty(array|string|null $empty): void
 	{
 		$this->empty = $empty;
 	}

--- a/src/Form/Mixin/EmptyState.php
+++ b/src/Form/Mixin/EmptyState.php
@@ -7,7 +7,7 @@ trait EmptyState
 	/**
 	 * Sets the text for the empty state box
 	 */
-	protected array|string|null $empty = null;
+	protected array|string|null $empty;
 
 	public function empty(): string|null
 	{

--- a/src/Form/Mixin/Help.php
+++ b/src/Form/Mixin/Help.php
@@ -11,7 +11,7 @@ trait Help
 
 	public function help(): string|null
 	{
-		if ($this->help !== null && $this->help !== []) {
+		if ($this->help !== null && $this->help !== [] && $this->help !== '') {
 			$help = $this->i18n($this->help);
 			$help = $this->stringTemplate($help);
 			$help = $this->kirby()->kirbytext($help);

--- a/src/Form/Mixin/Help.php
+++ b/src/Form/Mixin/Help.php
@@ -7,7 +7,7 @@ trait Help
 	/**
 	 * Optional help text below the field
 	 */
-	protected array|string|null $help = null;
+	protected array|string|null $help;
 
 	public function help(): string|null
 	{

--- a/src/Form/Mixin/Help.php
+++ b/src/Form/Mixin/Help.php
@@ -14,12 +14,13 @@ trait Help
 	/**
 	 * Optional help text below the field
 	 */
-	protected string|null $help;
+	protected array|string|null $help = null;
 
 	public function help(): string|null
 	{
-		if (empty($this->help) === false) {
-			$help = $this->stringTemplate($this->help);
+		if ($this->help !== null && $this->help !== []) {
+			$help = $this->i18n($this->help);
+			$help = $this->stringTemplate($help);
 			$help = $this->kirby()->kirbytext($help);
 			return $help;
 		}
@@ -27,8 +28,8 @@ trait Help
 		return null;
 	}
 
-	protected function setHelp(array|string|null $help = null): void
+	protected function setHelp(array|string|null $help): void
 	{
-		$this->help = $this->i18n($help);
+		$this->help = $help;
 	}
 }

--- a/src/Form/Mixin/Help.php
+++ b/src/Form/Mixin/Help.php
@@ -2,13 +2,6 @@
 
 namespace Kirby\Form\Mixin;
 
-/**
- * @package   Kirby Form
- * @author    Bastian Allgeier <bastian@getkirby.com>
- * @link      https://getkirby.com
- * @copyright Bastian Allgeier
- * @license   https://opensource.org/licenses/MIT
- */
 trait Help
 {
 	/**

--- a/src/Form/Mixin/Icon.php
+++ b/src/Form/Mixin/Icon.php
@@ -14,14 +14,14 @@ trait Icon
 	/**
 	 * Optional icon that will be shown at the end of the field
 	 */
-	protected string|null $icon;
+	protected string|null $icon = null;
 
 	public function icon(): string|null
 	{
 		return $this->icon;
 	}
 
-	protected function setIcon(string|null $icon = null): void
+	protected function setIcon(string|null $icon): void
 	{
 		$this->icon = $icon;
 	}

--- a/src/Form/Mixin/Icon.php
+++ b/src/Form/Mixin/Icon.php
@@ -2,13 +2,6 @@
 
 namespace Kirby\Form\Mixin;
 
-/**
- * @package   Kirby Form
- * @author    Bastian Allgeier <bastian@getkirby.com>
- * @link      https://getkirby.com
- * @copyright Bastian Allgeier
- * @license   https://opensource.org/licenses/MIT
- */
 trait Icon
 {
 	/**

--- a/src/Form/Mixin/Icon.php
+++ b/src/Form/Mixin/Icon.php
@@ -7,7 +7,7 @@ trait Icon
 	/**
 	 * Optional icon that will be shown at the end of the field
 	 */
-	protected string|null $icon = null;
+	protected string|null $icon;
 
 	public function icon(): string|null
 	{

--- a/src/Form/Mixin/Label.php
+++ b/src/Form/Mixin/Label.php
@@ -16,17 +16,19 @@ trait Label
 	/**
 	 * The field label can be set as string or associative array with translations
 	 */
-	protected string|null $label;
+	protected array|string|null $label = null;
 
 	public function label(): string|null
 	{
-		return $this->stringTemplate(
-			$this->label ?? Str::ucfirst($this->name())
-		);
+		if ($this->label === null || $this->label === []) {
+			return Str::ucfirst($this->name());
+		}
+
+		return $this->stringTemplate($this->i18n($this->label));
 	}
 
-	protected function setLabel(array|string|null $label = null): void
+	protected function setLabel(array|string|null $label): void
 	{
-		$this->label = $this->i18n($label);
+		$this->label = $label;
 	}
 }

--- a/src/Form/Mixin/Label.php
+++ b/src/Form/Mixin/Label.php
@@ -9,7 +9,7 @@ trait Label
 	/**
 	 * The field label can be set as string or associative array with translations
 	 */
-	protected array|string|null $label = null;
+	protected array|string|null $label;
 
 	public function label(): string|null
 	{

--- a/src/Form/Mixin/Label.php
+++ b/src/Form/Mixin/Label.php
@@ -4,13 +4,6 @@ namespace Kirby\Form\Mixin;
 
 use Kirby\Toolkit\Str;
 
-/**
- * @package   Kirby Form
- * @author    Bastian Allgeier <bastian@getkirby.com>
- * @link      https://getkirby.com
- * @copyright Bastian Allgeier
- * @license   https://opensource.org/licenses/MIT
- */
 trait Label
 {
 	/**

--- a/src/Form/Mixin/Max.php
+++ b/src/Form/Mixin/Max.php
@@ -7,11 +7,11 @@ trait Max
 	/**
 	 * Sets the maximum number of allowed items in the field
 	 */
-	protected int|null $max = null;
+	protected int|null $max;
 
 	public function max(): int|null
 	{
-		return $this->max;
+		return $this->max ?? null;
 	}
 
 	protected function setMax(int|null $max): void

--- a/src/Form/Mixin/Max.php
+++ b/src/Form/Mixin/Max.php
@@ -7,14 +7,14 @@ trait Max
 	/**
 	 * Sets the maximum number of allowed items in the field
 	 */
-	protected int|null $max;
+	protected int|null $max = null;
 
 	public function max(): int|null
 	{
 		return $this->max;
 	}
 
-	protected function setMax(int|null $max = null)
+	protected function setMax(int|null $max): void
 	{
 		$this->max = $max;
 	}

--- a/src/Form/Mixin/Max.php
+++ b/src/Form/Mixin/Max.php
@@ -11,7 +11,7 @@ trait Max
 
 	public function max(): int|null
 	{
-		return $this->max ?? null;
+		return $this->max;
 	}
 
 	protected function setMax(int|null $max): void

--- a/src/Form/Mixin/Min.php
+++ b/src/Form/Mixin/Min.php
@@ -7,7 +7,7 @@ trait Min
 	/**
 	 * Sets the minimum number of required items in the field
 	 */
-	protected int|null $min;
+	protected int|null $min = null;
 
 	public function min(): int|null
 	{
@@ -19,7 +19,7 @@ trait Min
 		return $this->min;
 	}
 
-	protected function setMin(int|null $min = null)
+	protected function setMin(int|null $min): void
 	{
 		$this->min = $min;
 	}

--- a/src/Form/Mixin/Min.php
+++ b/src/Form/Mixin/Min.php
@@ -31,6 +31,6 @@ trait Min
 			return true;
 		}
 
-		return $this->required;
+		return $this->required();
 	}
 }

--- a/src/Form/Mixin/Min.php
+++ b/src/Form/Mixin/Min.php
@@ -7,7 +7,7 @@ trait Min
 	/**
 	 * Sets the minimum number of required items in the field
 	 */
-	protected int|null $min = null;
+	protected int|null $min;
 
 	public function min(): int|null
 	{
@@ -16,7 +16,7 @@ trait Min
 			return $this->min ?? 1;
 		}
 
-		return $this->min;
+		return $this->min ?? null;
 	}
 
 	protected function setMin(int|null $min): void

--- a/src/Form/Mixin/Min.php
+++ b/src/Form/Mixin/Min.php
@@ -16,7 +16,7 @@ trait Min
 			return $this->min ?? 1;
 		}
 
-		return $this->min ?? null;
+		return $this->min;
 	}
 
 	protected function setMin(int|null $min): void

--- a/src/Form/Mixin/Model.php
+++ b/src/Form/Mixin/Model.php
@@ -7,14 +7,14 @@ use Kirby\Cms\ModelWithContent;
 
 trait Model
 {
-	protected ModelWithContent $model;
+	protected ModelWithContent|null $model;
 
 	/**
 	 * Returns the Kirby instance
 	 */
 	public function kirby(): App
 	{
-		return $this->model->kirby();
+		return $this->model()->kirby();
 	}
 
 	/**
@@ -22,14 +22,14 @@ trait Model
 	 */
 	public function model(): ModelWithContent
 	{
-		return $this->model;
+		return $this->model ?? App::instance()->site();
 	}
 
 	/**
 	 * Sets the parent model
 	 */
-	protected function setModel(ModelWithContent|null $model = null): void
+	protected function setModel(ModelWithContent|null $model): void
 	{
-		$this->model = $model ?? App::instance()->site();
+		$this->model = $model;
 	}
 }

--- a/src/Form/Mixin/Name.php
+++ b/src/Form/Mixin/Name.php
@@ -4,15 +4,15 @@ namespace Kirby\Form\Mixin;
 
 trait Name
 {
-	protected string|null $name;
+	protected string|null $name = null;
 
 	public function name(): string
 	{
-		return $this->name ?? $this->type();
+		return strtolower($this->name ?? $this->type());
 	}
 
-	protected function setName(string|null $name = null): void
+	protected function setName(string|null $name): void
 	{
-		$this->name = strtolower($name ?? $this->type());
+		$this->name = $name;
 	}
 }

--- a/src/Form/Mixin/Name.php
+++ b/src/Form/Mixin/Name.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait Name
+{
+	protected string|null $name;
+
+	public function name(): string
+	{
+		return $this->name ?? $this->type();
+	}
+
+	protected function setName(string|null $name = null): void
+	{
+		$this->name = strtolower($name ?? $this->type());
+	}
+}

--- a/src/Form/Mixin/Name.php
+++ b/src/Form/Mixin/Name.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Mixin;
 
 trait Name
 {
-	protected string|null $name = null;
+	protected string|null $name;
 
 	public function name(): string
 	{

--- a/src/Form/Mixin/Placeholder.php
+++ b/src/Form/Mixin/Placeholder.php
@@ -14,17 +14,15 @@ trait Placeholder
 	/**
 	 * Optional placeholder value that will be shown when the field is empty
 	 */
-	protected array|string|null $placeholder;
+	protected array|string|null $placeholder = null;
 
 	public function placeholder(): string|null
 	{
-		return $this->stringTemplate(
-			$this->placeholder
-		);
+		return $this->stringTemplate($this->i18n($this->placeholder));
 	}
 
-	protected function setPlaceholder(array|string|null $placeholder = null): void
+	protected function setPlaceholder(array|string|null $placeholder): void
 	{
-		$this->placeholder = $this->i18n($placeholder);
+		$this->placeholder = $placeholder;
 	}
 }

--- a/src/Form/Mixin/Placeholder.php
+++ b/src/Form/Mixin/Placeholder.php
@@ -7,7 +7,7 @@ trait Placeholder
 	/**
 	 * Optional placeholder value that will be shown when the field is empty
 	 */
-	protected array|string|null $placeholder = null;
+	protected array|string|null $placeholder;
 
 	public function placeholder(): string|null
 	{

--- a/src/Form/Mixin/Placeholder.php
+++ b/src/Form/Mixin/Placeholder.php
@@ -2,13 +2,6 @@
 
 namespace Kirby\Form\Mixin;
 
-/**
- * @package   Kirby Form
- * @author    Bastian Allgeier <bastian@getkirby.com>
- * @link      https://getkirby.com
- * @copyright Bastian Allgeier
- * @license   https://opensource.org/licenses/MIT
- */
 trait Placeholder
 {
 	/**

--- a/src/Form/Mixin/Pretty.php
+++ b/src/Form/Mixin/Pretty.php
@@ -7,14 +7,14 @@ trait Pretty
 	/**
 	 * Saves pretty printed JSON in text files
 	 */
-	protected bool $pretty = false;
+	protected bool|null $pretty;
 
 	public function pretty(): bool
 	{
-		return $this->pretty;
+		return $this->pretty ?? false;
 	}
 
-	protected function setPretty(bool $pretty): void
+	protected function setPretty(bool|null $pretty): void
 	{
 		$this->pretty = $pretty;
 	}

--- a/src/Form/Mixin/Pretty.php
+++ b/src/Form/Mixin/Pretty.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait Pretty
+{
+	/**
+	 * Saves pretty printed JSON in text files
+	 */
+	protected bool $pretty = false;
+
+	public function pretty(): bool
+	{
+		return $this->pretty;
+	}
+
+	protected function setPretty(bool $pretty): void
+	{
+		$this->pretty = $pretty;
+	}
+}

--- a/src/Form/Mixin/Required.php
+++ b/src/Form/Mixin/Required.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait Required
+{
+	/**
+	 * If `true`, the field has to be filled in correctly to be saved.
+	 */
+	protected bool|null $required;
+
+	/**
+	 * Checks if the field is required
+	 */
+	public function isRequired(): bool
+	{
+		return $this->required();
+	}
+
+	public function required(): bool
+	{
+		return $this->required ?? false;
+	}
+
+	protected function setRequired(bool|null $required): void
+	{
+		$this->required = $required;
+	}
+}

--- a/src/Form/Mixin/Sortable.php
+++ b/src/Form/Mixin/Sortable.php
@@ -7,14 +7,14 @@ trait Sortable
 	/**
 	 * If `true`, entries are sortable via drag & drop
 	 */
-	protected bool $sortable = true;
+	protected bool|null $sortable;
 
 	public function sortable(): bool
 	{
-		return $this->sortable;
+		return $this->sortable ?? true;
 	}
 
-	protected function setSortable(bool $sortable): void
+	protected function setSortable(bool|null $sortable): void
 	{
 		$this->sortable = $sortable;
 	}

--- a/src/Form/Mixin/Sortable.php
+++ b/src/Form/Mixin/Sortable.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait Sortable
+{
+	/**
+	 * If `true`, entries are sortable via drag & drop
+	 */
+	protected bool $sortable = true;
+
+	public function sortable(): bool
+	{
+		return $this->sortable;
+	}
+
+	protected function setSortable(bool $sortable): void
+	{
+		$this->sortable = $sortable;
+	}
+}

--- a/src/Form/Mixin/Translatable.php
+++ b/src/Form/Mixin/Translatable.php
@@ -32,7 +32,7 @@ trait Translatable
 		return true;
 	}
 
-	protected function setTranslate(bool $translate = true): void
+	protected function setTranslate(bool $translate): void
 	{
 		$this->translate = $translate;
 	}

--- a/src/Form/Mixin/Translatable.php
+++ b/src/Form/Mixin/Translatable.php
@@ -4,13 +4,6 @@ namespace Kirby\Form\Mixin;
 
 use Kirby\Cms\Language;
 
-/**
- * @package   Kirby Form
- * @author    Bastian Allgeier <bastian@getkirby.com>
- * @link      https://getkirby.com
- * @copyright Bastian Allgeier
- * @license   https://opensource.org/licenses/MIT
- */
 trait Translatable
 {
 	/**

--- a/src/Form/Mixin/Translatable.php
+++ b/src/Form/Mixin/Translatable.php
@@ -9,7 +9,7 @@ trait Translatable
 	/**
 	 * Should the field be translatable?
 	 */
-	protected bool $translate = true;
+	protected bool|null $translate;
 
 	/**
 	 * Should the field be translatable into the given language?
@@ -25,13 +25,13 @@ trait Translatable
 		return true;
 	}
 
-	protected function setTranslate(bool $translate): void
+	protected function setTranslate(bool|null $translate): void
 	{
 		$this->translate = $translate;
 	}
 
 	public function translate(): bool
 	{
-		return $this->translate;
+		return $this->translate ?? true;
 	}
 }

--- a/src/Form/Mixin/Validation.php
+++ b/src/Form/Mixin/Validation.php
@@ -12,11 +12,6 @@ use Kirby\Toolkit\V;
 trait Validation
 {
 	/**
-	 * If `true`, the field has to be filled in correctly to be saved.
-	 */
-	protected bool $required = false;
-
-	/**
 	 * Runs all validations and returns an array of
 	 * error messages
 	 */
@@ -67,14 +62,6 @@ trait Validation
 	}
 
 	/**
-	 * Checks if the field is required
-	 */
-	public function isRequired(): bool
-	{
-		return $this->required;
-	}
-
-	/**
 	 * Checks if the field is invalid
 	 */
 	public function isInvalid(): bool
@@ -88,16 +75,6 @@ trait Validation
 	public function isValid(): bool
 	{
 		return $this->errors() === [];
-	}
-
-	public function required(): bool
-	{
-		return $this->required;
-	}
-
-	protected function setRequired(bool $required): void
-	{
-		$this->required = $required;
 	}
 
 	/**

--- a/src/Form/Mixin/Validation.php
+++ b/src/Form/Mixin/Validation.php
@@ -9,13 +9,6 @@ use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\V;
 
-/**
- * @package   Kirby Form
- * @author    Bastian Allgeier <bastian@getkirby.com>
- * @link      https://getkirby.com
- * @copyright Bastian Allgeier
- * @license   https://opensource.org/licenses/MIT
- */
 trait Validation
 {
 	/**

--- a/src/Form/Mixin/Validation.php
+++ b/src/Form/Mixin/Validation.php
@@ -21,7 +21,7 @@ trait Validation
 	/**
 	 * If `true`, the field has to be filled in correctly to be saved.
 	 */
-	protected bool $required;
+	protected bool $required = false;
 
 	/**
 	 * Runs all validations and returns an array of
@@ -102,7 +102,7 @@ trait Validation
 		return $this->required;
 	}
 
-	protected function setRequired(bool $required = false): void
+	protected function setRequired(bool $required): void
 	{
 		$this->required = $required;
 	}

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -10,7 +10,7 @@ trait Value
 	/**
 	 * The value of the field
 	 */
-	protected mixed $value;
+	protected mixed $value = null;
 
 	/**
 	 * @deprecated 5.0.0 Use `::toStoredValue()` instead to receive

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -8,14 +8,9 @@ use ReflectionProperty;
 trait Value
 {
 	/**
-	 * Default value for the field, which will be used when a page/file/user is created
-	 */
-	protected mixed $default = null;
-
-	/**
 	 * The value of the field
 	 */
-	protected mixed $value = null;
+	protected mixed $value;
 
 	/**
 	 * @deprecated 5.0.0 Use `::toStoredValue()` instead to receive
@@ -31,18 +26,6 @@ trait Value
 		}
 
 		return $this->toStoredValue();
-	}
-
-	/**
-	 * Returns the default value of the field
-	 */
-	public function default(): mixed
-	{
-		if (is_string($this->default) === false) {
-			return $this->default;
-		}
-
-		return $this->model->toString($this->default);
 	}
 
 	/**
@@ -159,11 +142,6 @@ trait Value
 		return $this->hasValue();
 	}
 
-	protected function setDefault(mixed $default): void
-	{
-		$this->default = $default;
-	}
-
 	/**
 	 * Submits a new value for the field.
 	 * Fields can overwrite this method to provide custom
@@ -188,7 +166,7 @@ trait Value
 			return null;
 		}
 
-		return $this->value;
+		return $this->value ?? null;
 	}
 
 	/**

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -5,13 +5,6 @@ namespace Kirby\Form\Mixin;
 use Kirby\Cms\Language;
 use ReflectionProperty;
 
-/**
- * @package   Kirby Form
- * @author    Bastian Allgeier <bastian@getkirby.com>
- * @link      https://getkirby.com
- * @copyright Bastian Allgeier
- * @license   https://opensource.org/licenses/MIT
- */
 trait Value
 {
 	/**

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -166,7 +166,7 @@ trait Value
 		return $this->hasValue();
 	}
 
-	protected function setDefault(mixed $default = null): void
+	protected function setDefault(mixed $default): void
 	{
 		$this->default = $default;
 	}

--- a/src/Form/Mixin/When.php
+++ b/src/Form/Mixin/When.php
@@ -45,7 +45,7 @@ trait When
 		return true;
 	}
 
-	protected function setWhen(array|null $when = null): void
+	protected function setWhen(array|null $when): void
 	{
 		$this->when = $when;
 	}

--- a/src/Form/Mixin/When.php
+++ b/src/Form/Mixin/When.php
@@ -2,13 +2,6 @@
 
 namespace Kirby\Form\Mixin;
 
-/**
- * @package   Kirby Form
- * @author    Bastian Allgeier <bastian@getkirby.com>
- * @link      https://getkirby.com
- * @copyright Bastian Allgeier
- * @license   https://opensource.org/licenses/MIT
- */
 trait When
 {
 	/**

--- a/src/Form/Mixin/When.php
+++ b/src/Form/Mixin/When.php
@@ -9,7 +9,7 @@ trait When
 	 *
 	 * @since 3.1.0
 	 */
-	protected array|null $when = null;
+	protected array|null $when;
 
 	/**
 	 * Checks if the field is currently active
@@ -17,13 +17,15 @@ trait When
 	 */
 	public function isActive(): bool
 	{
-		if ($this->when === null || $this->when === []) {
+		$when = $this->when();
+
+		if ($when === null || $when === []) {
 			return true;
 		}
 
 		$siblings = $this->siblings();
 
-		foreach ($this->when as $field => $value) {
+		foreach ($when as $field => $value) {
 			$field = $siblings->get($field);
 			$input = $field?->value() ?? '';
 
@@ -45,6 +47,6 @@ trait When
 
 	public function when(): array|null
 	{
-		return $this->when;
+		return $this->when ?? null;
 	}
 }

--- a/src/Form/Mixin/When.php
+++ b/src/Form/Mixin/When.php
@@ -47,6 +47,6 @@ trait When
 
 	public function when(): array|null
 	{
-		return $this->when ?? null;
+		return $this->when;
 	}
 }

--- a/src/Form/Mixin/Width.php
+++ b/src/Form/Mixin/Width.php
@@ -8,7 +8,7 @@ trait Width
 	 * The width of the field in the field grid.
 	 * Available widths: `1/1`, `1/2`, `1/3`, `1/4`, `2/3`, `3/4`
 	 */
-	protected string|null $width = null;
+	protected string|null $width;
 
 	protected function setWidth(string|null $width): void
 	{

--- a/src/Form/Mixin/Width.php
+++ b/src/Form/Mixin/Width.php
@@ -15,9 +15,9 @@ trait Width
 	 * The width of the field in the field grid.
 	 * Available widths: `1/1`, `1/2`, `1/3`, `1/4`, `2/3`, `3/4`
 	 */
-	protected string|null $width;
+	protected string|null $width = null;
 
-	protected function setWidth(string|null $width = null): void
+	protected function setWidth(string|null $width): void
 	{
 		$this->width = $width;
 	}

--- a/src/Form/Mixin/Width.php
+++ b/src/Form/Mixin/Width.php
@@ -2,13 +2,6 @@
 
 namespace Kirby\Form\Mixin;
 
-/**
- * @package   Kirby Form
- * @author    Bastian Allgeier <bastian@getkirby.com>
- * @link      https://getkirby.com
- * @copyright Bastian Allgeier
- * @license   https://opensource.org/licenses/MIT
- */
 trait Width
 {
 	/**


### PR DESCRIPTION
## Description

This PR extracts more properties from field classes and moves them into mixins. This is a first step to create an extensive mixin library, which will be useful for all fields. 

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

- Removed all default values for mixin properties 
- Allowed null for all bool mixin properties 

### ♻️ Refactored

- New Kirby\Form\Mixin\DefaultValue mixin 
- New Kirby\Form\Mixin\Disabled trait
- New Kirby\Form\Mixin\Name trait
- New Kirby\Form\Mixin\Pretty trait
- New Kirby\Form\Mixin\Required mixin
- New Kirby\Form\Mixin\Sortable trait

### 🚨 Breaking changes

- All mixin props no longer define a default value. The default value is now defined by the getter when the property value is null. 
- Setter methods of FieldClass mixins no longer have a default value. The default value is worthless in the constructor, as we never call a setter without argument. It just increases the redundancy in the code. The following `set` methods are affected.
  - `::setAfter()`
  - `::setAutofocus()`
  - `::setBefore()`
  - `::setDefault()`
  - `::setDisabled()`
  - `::setEmpty()`
  - `::setHelp()`
  - `::setIcon()`
  - `::setLabel()`
  - `::setMax()`
  - `::setMin()`
  - `::setName()`
  - `::setPlaceholder()`
  - `::setPretty()`
  - `::setRequired()`
  - `::setSortable()`
  - `::setTranslate()`
  - `::setWhen()`
  - `::setWidth()`
- All translatable properties in FieldClass mixins are no longer translating the value in the setter but in the getter. This is a cleaner approach, where we store the property as untouched as possible and then compute any changes in the getter if needed. This way, we can always access the originally passed value for the property and we can also reduce the amount of computing that is done when the instance is created. The following props are affected:
  - `after`
  - `before`
  - `empty`
  - `help`
  - `label`
  - `placeholder`
- Lower-casing of the name property of the FieldClass has been moved from the setter to the getter. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion