### PR TITLE
test: Upgrade to PHPUnit 12

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -104,7 +104,7 @@ jobs:
           extensions: ${{ env.extensions }}
           ini-values: ${{ env.ini }}
           coverage: pcov
-          tools: phpunit:11.5.44, psalm:6.13.1
+          tools: phpunit:12.4.4, psalm:6.13.1
 
       - name: Setup problem matchers
         run: |

--- a/phpunit.ci.xml
+++ b/phpunit.ci.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.4/phpunit.xsd"
 	beStrictAboutOutputDuringTests="true"
 	bootstrap="tests/bootstrap.php"
 	cacheDirectory=".phpunit.cache"

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.4/phpunit.xsd"
 	beStrictAboutOutputDuringTests="true"
 	bootstrap="tests/bootstrap.php"
 	cacheDirectory=".phpunit.cache"
 	colors="true"
 	controlGarbageCollector="true"
 	displayDetailsOnIncompleteTests="true"
+	displayDetailsOnPhpunitDeprecations="true"
 	displayDetailsOnTestsThatTriggerDeprecations="true"
 	displayDetailsOnTestsThatTriggerErrors="true"
 	displayDetailsOnTestsThatTriggerNotices="true"

--- a/tests/Cms/App/AppErrorsTest.php
+++ b/tests/Cms/App/AppErrorsTest.php
@@ -9,7 +9,7 @@ use ReflectionMethod;
 use Whoops\Handler\CallbackHandler;
 use Whoops\Handler\PlainTextHandler;
 
-#[CoversClass(AppErrors::class)]
+#[CoversClass(App::class)]
 class AppErrorsTest extends TestCase
 {
 	protected App|null $originalApp;

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -887,24 +887,16 @@ class AppPluginsTest extends TestCase
 			],
 			'hooks' => [
 				'system.loadPlugins:after' => function () use ($phpUnit, &$executed, $tmp) {
-					if (count($this->plugins()) === 2) {
+					$plugins = $this->plugins();
+
+					if (count($plugins) === 2) {
 						$phpUnit->assertSame([
 							'kirby/manual1' => new Plugin('kirby/manual1', []),
 							'kirby/manual2' => new Plugin('kirby/manual2', [])
-						], $this->plugins());
+						], $plugins);
 					} else {
-						// cannot use strict assertion
-						// (test for object contents)
-						$phpUnit->assertEquals([
-							'kirby/test1' => new Plugin('kirby/test1', [
-								'hooks' => [
-									'system.loadPlugins:after' => function () {
-										// just a dummy closure to compare against
-									}
-								],
-								'root' => $tmp . '/site/plugins-loader/test1'
-							])
-						], $this->plugins());
+						$phpUnit->assertInstanceOf(Plugin::class, $plugins['kirby/test1']);
+						$phpUnit->assertSame($tmp . '/site/plugins-loader/test1', $plugins['kirby/test1']->root());
 					}
 
 					$executed++;

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -52,7 +52,7 @@ class DummyFilePreview
 {
 }
 
-#[CoversClass(AppPlugins::class)]
+#[CoversClass(App::class)]
 class AppPluginsTest extends TestCase
 {
 	public const string FIXTURES = __DIR__ . '/fixtures';

--- a/tests/Cms/File/FileModificationsTest.php
+++ b/tests/Cms/File/FileModificationsTest.php
@@ -8,7 +8,7 @@ use Kirby\Filesystem\Asset;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-#[CoversClass(FileModifications::class)]
+#[CoversClass(File::class)]
 class FileModificationsTest extends ModelTestCase
 {
 	public const string TMP = KIRBY_TMP_DIR . '/Cms.FileModifications';

--- a/tests/Cms/File/HasFilesTest.php
+++ b/tests/Cms/File/HasFilesTest.php
@@ -22,7 +22,7 @@ class NewHasFileTraitUser
 	}
 }
 
-#[CoversClass(HasFiles::class)]
+#[CoversClass(Page::class)]
 class NewHasFilesTest extends ModelTestCase
 {
 	public const string TMP = KIRBY_TMP_DIR . '/Cms.NewHasFiles';

--- a/tests/Exception/AuthExceptionTest.php
+++ b/tests/Exception/AuthExceptionTest.php
@@ -5,9 +5,9 @@ namespace Kirby\Exception;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class AuthExceptionTest extends TestCase
 {
-	#[CoversNothing]
 	public function testDefaults(): void
 	{
 		$exception = new AuthException();

--- a/tests/Exception/BadMethodCallExceptionTest.php
+++ b/tests/Exception/BadMethodCallExceptionTest.php
@@ -5,9 +5,9 @@ namespace Kirby\Exception;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class BadMethodCallExceptionTest extends TestCase
 {
-	#[CoversNothing]
 	public function testDefaults(): void
 	{
 		$exception = new BadMethodCallException();
@@ -17,7 +17,6 @@ class BadMethodCallExceptionTest extends TestCase
 		$this->assertSame(['method' => null], $exception->getData());
 	}
 
-	#[CoversNothing]
 	public function testPlaceholders(): void
 	{
 		$exception = new BadMethodCallException(data: [
@@ -27,7 +26,6 @@ class BadMethodCallExceptionTest extends TestCase
 		$this->assertSame(['method' => 'get'], $exception->getData());
 	}
 
-	#[CoversNothing]
 	public function testPlaceholdersWithNamedArguments(): void
 	{
 		$exception = new BadMethodCallException(

--- a/tests/Exception/DuplicateExceptionTest.php
+++ b/tests/Exception/DuplicateExceptionTest.php
@@ -5,9 +5,9 @@ namespace Kirby\Exception;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class DuplicateExceptionTest extends TestCase
 {
-	#[CoversNothing]
 	public function testDefaults(): void
 	{
 		$exception = new DuplicateException();

--- a/tests/Exception/ErrorPageExceptionTest.php
+++ b/tests/Exception/ErrorPageExceptionTest.php
@@ -5,9 +5,9 @@ namespace Kirby\Exception;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class ErrorPageExceptionTest extends TestCase
 {
-	#[CoversNothing]
 	public function testDefaults(): void
 	{
 		$exception = new ErrorPageException();

--- a/tests/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/Exception/InvalidArgumentExceptionTest.php
@@ -5,9 +5,9 @@ namespace Kirby\Exception;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class InvalidArgumentExceptionTest extends TestCase
 {
-	#[CoversNothing]
 	public function testDefaults(): void
 	{
 		$exception = new InvalidArgumentException();
@@ -17,7 +17,6 @@ class InvalidArgumentExceptionTest extends TestCase
 		$this->assertSame(['argument' => null, 'method' => null], $exception->getData());
 	}
 
-	#[CoversNothing]
 	public function testPlaceholders(): void
 	{
 		$exception = new InvalidArgumentException(data: [
@@ -31,7 +30,6 @@ class InvalidArgumentExceptionTest extends TestCase
 		], $exception->getData());
 	}
 
-	#[CoversNothing]
 	public function testPlaceholdersWithNamedArguments(): void
 	{
 		$exception = new InvalidArgumentException(

--- a/tests/Exception/LogicExceptionTest.php
+++ b/tests/Exception/LogicExceptionTest.php
@@ -5,9 +5,9 @@ namespace Kirby\Exception;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class LogicExceptionTest extends TestCase
 {
-	#[CoversNothing]
 	public function testDefaults(): void
 	{
 		$exception = new LogicException();

--- a/tests/Exception/NotFoundExceptionTest.php
+++ b/tests/Exception/NotFoundExceptionTest.php
@@ -5,9 +5,9 @@ namespace Kirby\Exception;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class NotFoundExceptionTest extends TestCase
 {
-	#[CoversNothing]
 	public function testDefaults(): void
 	{
 		$exception = new NotFoundException();

--- a/tests/Exception/PermissionExceptionTest.php
+++ b/tests/Exception/PermissionExceptionTest.php
@@ -5,9 +5,9 @@ namespace Kirby\Exception;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class PermissionExceptionTest extends TestCase
 {
-	#[CoversNothing]
 	public function testDefaults(): void
 	{
 		$exception = new PermissionException();

--- a/tests/Filesystem/IsFileTest.php
+++ b/tests/Filesystem/IsFileTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Filesystem;
 
 use Kirby\Cms\App;
+use Kirby\Cms\File as CmsFile;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\Image\Image;
 use Kirby\TestCase;
@@ -15,7 +16,7 @@ class AFile
 	public string $foo = 'bar';
 }
 
-#[CoversClass(IsFile::class)]
+#[CoversClass(CmsFile::class)]
 class IsFileTest extends TestCase
 {
 	protected function _asset($file = 'blank.pdf')

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -413,7 +413,7 @@ class FieldTest extends TestCase
 	public function testFillWithRestoredState(): void
 	{
 		Field::$types = [
-			'test' => $definition = [
+			'test' => [
 				'computed' => [
 					'options' => fn () => ['a', 'b', 'c']
 				],
@@ -430,15 +430,17 @@ class FieldTest extends TestCase
 			'value' => 'test'
 		]);
 
+		$originalOptions = $field->optionsDebugger();
+
 		$this->assertSame(['a', 'b', 'c'], $field->options());
-		$this->assertEquals(Field::setup('test'), $field->optionsDebugger());
+		$this->assertEquals($originalOptions, $field->optionsDebugger());
 
 		// filling a new value must not break the mandatory
 		// component definition properties
 		$field->fill('test2');
 
 		$this->assertSame(['a', 'b', 'c'], $field->options());
-		$this->assertEquals(Field::setup('test'), $field->optionsDebugger());
+		$this->assertEquals($originalOptions, $field->optionsDebugger());
 	}
 
 	public function testHelp(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

PHPUnit 12 does not support PHP 8.2 which is why we can only upgrade it for v6, not v5.

- PHPUnit does not support anymore `CoversNothing` for methods, only classes
- PHPUnit does not support anymore `CoversClass` with traits

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features
<!-- 
e.g. New feature X which helps users to …
-->

### 🧹 Housekeeping
<!-- 
e.g. Update JS dependencies
-->
- Upgraded to PHPUnit 12

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion