### PR TITLE
refact: Don’t set default values for field properties

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -25,6 +25,7 @@ class Field extends Component
 {
 	use HasSiblings;
 	use Mixin\Api;
+	use Mixin\DefaultValue;
 	use Mixin\Model;
 	use Mixin\Required;
 	use Mixin\Translatable;
@@ -186,7 +187,7 @@ class Field extends Component
 				},
 				'default' => function () {
 					/** @var \Kirby\Form\Field $this */
-					if ($this->default === null) {
+					if (isset($this->default) === false) {
 						return;
 					}
 

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -26,6 +26,7 @@ class Field extends Component
 	use HasSiblings;
 	use Mixin\Api;
 	use Mixin\Model;
+	use Mixin\Required;
 	use Mixin\Translatable;
 	use Mixin\Validation;
 	use Mixin\When;

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -57,7 +57,7 @@ abstract class FieldClass
 		$this->setPlaceholder($params['placeholder'] ?? null);
 		$this->setRequired($params['required'] ?? false);
 		$this->setSiblings($params['siblings'] ?? null);
-		$this->setTranslate($params['translate'] ?? true);
+		$this->setTranslate($params['translate'] ?? null);
 		$this->setWhen($params['when'] ?? null);
 		$this->setWidth($params['width'] ?? null);
 

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -45,7 +45,7 @@ abstract class FieldClass
 		protected array $params = []
 	) {
 		$this->setAfter($params['after'] ?? null);
-		$this->setAutofocus($params['autofocus'] ?? false);
+		$this->setAutofocus($params['autofocus'] ?? null);
 		$this->setBefore($params['before'] ?? null);
 		$this->setDefault($params['default'] ?? null);
 		$this->setDisabled($params['disabled'] ?? false);

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -33,6 +33,7 @@ abstract class FieldClass
 	use Mixin\Model;
 	use Mixin\Name;
 	use Mixin\Placeholder;
+	use Mixin\Required;
 	use Mixin\Translatable;
 	use Mixin\Validation;
 	use Mixin\Value;

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -26,6 +26,7 @@ abstract class FieldClass
 	use Mixin\Api;
 	use Mixin\Autofocus;
 	use Mixin\Before;
+	use Mixin\DefaultValue;
 	use Mixin\Disabled;
 	use Mixin\Help;
 	use Mixin\Icon;

--- a/src/Form/Mixin/After.php
+++ b/src/Form/Mixin/After.php
@@ -7,7 +7,7 @@ trait After
 	/**
 	 * Optional text that will be shown after the input
 	 */
-	protected array|string|null $after = null;
+	protected array|string|null $after;
 
 	public function after(): string|null
 	{

--- a/src/Form/Mixin/Autofocus.php
+++ b/src/Form/Mixin/Autofocus.php
@@ -7,14 +7,14 @@ trait Autofocus
 	/**
 	 * Sets the focus on this field when the form loads. Only the first field with this label gets
 	 */
-	protected bool $autofocus = false;
+	protected bool|null $autofocus;
 
 	public function autofocus(): bool
 	{
-		return $this->autofocus;
+		return $this->autofocus ?? false;
 	}
 
-	protected function setAutofocus(bool $autofocus): void
+	protected function setAutofocus(bool|null $autofocus): void
 	{
 		$this->autofocus = $autofocus;
 	}

--- a/src/Form/Mixin/Before.php
+++ b/src/Form/Mixin/Before.php
@@ -7,7 +7,7 @@ trait Before
 	/**
 	 * Optional text that will be shown before the input
 	 */
-	protected array|string|null $before = null;
+	protected array|string|null $before;
 
 	public function before(): string|null
 	{

--- a/src/Form/Mixin/DefaultValue.php
+++ b/src/Form/Mixin/DefaultValue.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait DefaultValue
+{
+	/**
+	 * Default value for the field, which will be used when a page/file/user is created
+	 */
+	protected mixed $default;
+
+	/**
+	 * Returns the default value of the field
+	 */
+	public function default(): mixed
+	{
+		if (isset($this->default) === false) {
+			return null;
+		}
+
+		if (is_string($this->default) === false) {
+			return $this->default;
+		}
+
+		return $this->model()->toString($this->default);
+	}
+
+	protected function setDefault(mixed $default): void
+	{
+		$this->default = $default;
+	}
+}

--- a/src/Form/Mixin/Disabled.php
+++ b/src/Form/Mixin/Disabled.php
@@ -7,19 +7,19 @@ trait Disabled
 	/**
 	 * If `true`, the field is no longer editable and will not be saved
 	 */
-	protected bool $disabled = false;
+	protected bool|null $disabled;
 
 	public function disabled(): bool
 	{
-		return $this->disabled;
+		return $this->disabled ?? false;
 	}
 
 	public function isDisabled(): bool
 	{
-		return $this->disabled;
+		return $this->disabled();
 	}
 
-	protected function setDisabled(bool $disabled): void
+	protected function setDisabled(bool|null $disabled): void
 	{
 		$this->disabled = $disabled;
 	}

--- a/src/Form/Mixin/EmptyState.php
+++ b/src/Form/Mixin/EmptyState.php
@@ -7,7 +7,7 @@ trait EmptyState
 	/**
 	 * Sets the text for the empty state box
 	 */
-	protected array|string|null $empty = null;
+	protected array|string|null $empty;
 
 	public function empty(): string|null
 	{

--- a/src/Form/Mixin/Help.php
+++ b/src/Form/Mixin/Help.php
@@ -7,7 +7,7 @@ trait Help
 	/**
 	 * Optional help text below the field
 	 */
-	protected array|string|null $help = null;
+	protected array|string|null $help;
 
 	public function help(): string|null
 	{

--- a/src/Form/Mixin/Icon.php
+++ b/src/Form/Mixin/Icon.php
@@ -7,7 +7,7 @@ trait Icon
 	/**
 	 * Optional icon that will be shown at the end of the field
 	 */
-	protected string|null $icon = null;
+	protected string|null $icon;
 
 	public function icon(): string|null
 	{

--- a/src/Form/Mixin/Label.php
+++ b/src/Form/Mixin/Label.php
@@ -9,7 +9,7 @@ trait Label
 	/**
 	 * The field label can be set as string or associative array with translations
 	 */
-	protected array|string|null $label = null;
+	protected array|string|null $label;
 
 	public function label(): string|null
 	{

--- a/src/Form/Mixin/Max.php
+++ b/src/Form/Mixin/Max.php
@@ -7,11 +7,11 @@ trait Max
 	/**
 	 * Sets the maximum number of allowed items in the field
 	 */
-	protected int|null $max = null;
+	protected int|null $max;
 
 	public function max(): int|null
 	{
-		return $this->max;
+		return $this->max ?? null;
 	}
 
 	protected function setMax(int|null $max): void

--- a/src/Form/Mixin/Min.php
+++ b/src/Form/Mixin/Min.php
@@ -7,7 +7,7 @@ trait Min
 	/**
 	 * Sets the minimum number of required items in the field
 	 */
-	protected int|null $min = null;
+	protected int|null $min;
 
 	public function min(): int|null
 	{
@@ -16,7 +16,7 @@ trait Min
 			return $this->min ?? 1;
 		}
 
-		return $this->min;
+		return $this->min ?? null;
 	}
 
 	protected function setMin(int|null $min): void

--- a/src/Form/Mixin/Name.php
+++ b/src/Form/Mixin/Name.php
@@ -4,7 +4,7 @@ namespace Kirby\Form\Mixin;
 
 trait Name
 {
-	protected string|null $name = null;
+	protected string|null $name;
 
 	public function name(): string
 	{

--- a/src/Form/Mixin/Placeholder.php
+++ b/src/Form/Mixin/Placeholder.php
@@ -7,7 +7,7 @@ trait Placeholder
 	/**
 	 * Optional placeholder value that will be shown when the field is empty
 	 */
-	protected array|string|null $placeholder = null;
+	protected array|string|null $placeholder;
 
 	public function placeholder(): string|null
 	{

--- a/src/Form/Mixin/Pretty.php
+++ b/src/Form/Mixin/Pretty.php
@@ -7,14 +7,14 @@ trait Pretty
 	/**
 	 * Saves pretty printed JSON in text files
 	 */
-	protected bool $pretty = false;
+	protected bool|null $pretty;
 
 	public function pretty(): bool
 	{
-		return $this->pretty;
+		return $this->pretty ?? false;
 	}
 
-	protected function setPretty(bool $pretty): void
+	protected function setPretty(bool|null $pretty): void
 	{
 		$this->pretty = $pretty;
 	}

--- a/src/Form/Mixin/Required.php
+++ b/src/Form/Mixin/Required.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait Required
+{
+	/**
+	 * If `true`, the field has to be filled in correctly to be saved.
+	 */
+	protected bool|null $required;
+
+	/**
+	 * Checks if the field is required
+	 */
+	public function isRequired(): bool
+	{
+		return $this->required();
+	}
+
+	public function required(): bool
+	{
+		return $this->required ?? false;
+	}
+
+	protected function setRequired(bool|null $required): void
+	{
+		$this->required = $required;
+	}
+}

--- a/src/Form/Mixin/Sortable.php
+++ b/src/Form/Mixin/Sortable.php
@@ -7,14 +7,14 @@ trait Sortable
 	/**
 	 * If `true`, entries are sortable via drag & drop
 	 */
-	protected bool $sortable = true;
+	protected bool|null $sortable;
 
 	public function sortable(): bool
 	{
-		return $this->sortable;
+		return $this->sortable ?? true;
 	}
 
-	protected function setSortable(bool $sortable): void
+	protected function setSortable(bool|null $sortable): void
 	{
 		$this->sortable = $sortable;
 	}

--- a/src/Form/Mixin/Translatable.php
+++ b/src/Form/Mixin/Translatable.php
@@ -9,7 +9,7 @@ trait Translatable
 	/**
 	 * Should the field be translatable?
 	 */
-	protected bool $translate = true;
+	protected bool|null $translate;
 
 	/**
 	 * Should the field be translatable into the given language?
@@ -25,13 +25,13 @@ trait Translatable
 		return true;
 	}
 
-	protected function setTranslate(bool $translate): void
+	protected function setTranslate(bool|null $translate): void
 	{
 		$this->translate = $translate;
 	}
 
 	public function translate(): bool
 	{
-		return $this->translate;
+		return $this->translate ?? true;
 	}
 }

--- a/src/Form/Mixin/Validation.php
+++ b/src/Form/Mixin/Validation.php
@@ -12,11 +12,6 @@ use Kirby\Toolkit\V;
 trait Validation
 {
 	/**
-	 * If `true`, the field has to be filled in correctly to be saved.
-	 */
-	protected bool $required = false;
-
-	/**
 	 * Runs all validations and returns an array of
 	 * error messages
 	 */
@@ -67,14 +62,6 @@ trait Validation
 	}
 
 	/**
-	 * Checks if the field is required
-	 */
-	public function isRequired(): bool
-	{
-		return $this->required;
-	}
-
-	/**
 	 * Checks if the field is invalid
 	 */
 	public function isInvalid(): bool
@@ -88,16 +75,6 @@ trait Validation
 	public function isValid(): bool
 	{
 		return $this->errors() === [];
-	}
-
-	public function required(): bool
-	{
-		return $this->required;
-	}
-
-	protected function setRequired(bool $required): void
-	{
-		$this->required = $required;
 	}
 
 	/**

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -10,7 +10,7 @@ trait Value
 	/**
 	 * The value of the field
 	 */
-	protected mixed $value;
+	protected mixed $value = null;
 
 	/**
 	 * @deprecated 5.0.0 Use `::toStoredValue()` instead to receive

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -8,14 +8,9 @@ use ReflectionProperty;
 trait Value
 {
 	/**
-	 * Default value for the field, which will be used when a page/file/user is created
-	 */
-	protected mixed $default = null;
-
-	/**
 	 * The value of the field
 	 */
-	protected mixed $value = null;
+	protected mixed $value;
 
 	/**
 	 * @deprecated 5.0.0 Use `::toStoredValue()` instead to receive
@@ -31,18 +26,6 @@ trait Value
 		}
 
 		return $this->toStoredValue();
-	}
-
-	/**
-	 * Returns the default value of the field
-	 */
-	public function default(): mixed
-	{
-		if (is_string($this->default) === false) {
-			return $this->default;
-		}
-
-		return $this->model->toString($this->default);
 	}
 
 	/**
@@ -159,11 +142,6 @@ trait Value
 		return $this->hasValue();
 	}
 
-	protected function setDefault(mixed $default): void
-	{
-		$this->default = $default;
-	}
-
 	/**
 	 * Submits a new value for the field.
 	 * Fields can overwrite this method to provide custom
@@ -188,7 +166,7 @@ trait Value
 			return null;
 		}
 
-		return $this->value;
+		return $this->value ?? null;
 	}
 
 	/**

--- a/src/Form/Mixin/When.php
+++ b/src/Form/Mixin/When.php
@@ -9,7 +9,7 @@ trait When
 	 *
 	 * @since 3.1.0
 	 */
-	protected array|null $when = null;
+	protected array|null $when;
 
 	/**
 	 * Checks if the field is currently active
@@ -17,13 +17,15 @@ trait When
 	 */
 	public function isActive(): bool
 	{
-		if ($this->when === null || $this->when === []) {
+		$when = $this->when();
+
+		if ($when === null || $when === []) {
 			return true;
 		}
 
 		$siblings = $this->siblings();
 
-		foreach ($this->when as $field => $value) {
+		foreach ($when as $field => $value) {
 			$field = $siblings->get($field);
 			$input = $field?->value() ?? '';
 
@@ -45,6 +47,6 @@ trait When
 
 	public function when(): array|null
 	{
-		return $this->when;
+		return $this->when ?? null;
 	}
 }

--- a/src/Form/Mixin/Width.php
+++ b/src/Form/Mixin/Width.php
@@ -8,7 +8,7 @@ trait Width
 	 * The width of the field in the field grid.
 	 * Available widths: `1/1`, `1/2`, `1/3`, `1/4`, `2/3`, `3/4`
 	 */
-	protected string|null $width = null;
+	protected string|null $width;
 
 	protected function setWidth(string|null $width): void
 	{


### PR DESCRIPTION
## Refactoring

- New Kirby\Form\Mixin\Required mixin
- New Kirby\Form\Mixin\DefaultValue mixin 
- Removed all default values for mixin properties 
- Allowed null for all bool mixin properties 