### PR TITLE
(Fields PR) refact: New LineField class

### DIFF
--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -75,5 +75,6 @@ export default {
 		// Legacy fields components
 		app.component("k-legacy-headline-field", HeadlineField);
 		app.component("k-legacy-info-field", InfoField);
+		app.component("k-legacy-line-field", LineField);
 	}
 };

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -14,6 +14,7 @@ use Kirby\Form\Field\EntriesField;
 use Kirby\Form\Field\HeadlineField;
 use Kirby\Form\Field\InfoField;
 use Kirby\Form\Field\LayoutField;
+use Kirby\Form\Field\LineField;
 use Kirby\Form\Field\StatsField;
 use Kirby\Panel\Ui\FilePreview\AudioFilePreview;
 use Kirby\Panel\Ui\FilePreview\ImageFilePreview;
@@ -230,7 +231,7 @@ class Core
 			'hidden'      => $this->root . '/fields/hidden.php',
 			'info'        => InfoField::class,
 			'layout'      => LayoutField::class,
-			'line'        => $this->root . '/fields/line.php',
+			'line'        => LineField::class,
 			'link'        => $this->root . '/fields/link.php',
 			'list'        => $this->root . '/fields/list.php',
 			'multiselect' => $this->root . '/fields/multiselect.php',
@@ -256,6 +257,7 @@ class Core
 
 			'legacy-headline' => $this->root . '/fields/headline.php',
 			'legacy-info'     => $this->root . '/fields/info.php',
+			'legacy-line'     => $this->root . '/fields/line.php',
 		];
 	}
 

--- a/src/Form/Field/LineField.php
+++ b/src/Form/Field/LineField.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Form\Mixin;
+
+/**
+ * Line field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class LineField extends BaseField
+{
+	use Mixin\Width;
+
+	public function __construct(
+		string|null $name = null,
+		array|null $when = null,
+		string|null $width = null
+	) {
+		parent::__construct(
+			name:  $name,
+			when:  $when,
+		);
+
+		$this->setWidth($width);
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'width' => $this->width()
+		];
+	}
+}

--- a/tests/Form/Field/LineFieldTest.php
+++ b/tests/Form/Field/LineFieldTest.php
@@ -7,9 +7,19 @@ class LineFieldTest extends TestCase
 	public function testDefaultProps(): void
 	{
 		$field = $this->field('line');
+		$props = $field->props();
 
-		$this->assertSame('line', $field->type());
-		$this->assertSame('line', $field->name());
-		$this->assertFalse($field->save());
+		ksort($props);
+
+		$expected = [
+			'hidden'   => false,
+			'name'     => 'line',
+			'saveable' => false,
+			'type'     => 'line',
+			'when'     => null,
+			'width'    => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
 	}
 }


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7691
- [x] https://github.com/getkirby/kirby/pull/7692

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- Refactored `line` field as class

### ☠️ Deprecated
<!-- 
e.g. Deprecate method X. Use method Y instead.
-->
- `legacy-line` field will be removed in an upcoming major version. Please move to class-based fields instead and extend the `LineField` class.

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- The `line` field is now implemented as class. When extending in an array-based field, either switch your field to a class as well or extend the deprecated `legacy-line` field for the moment.
