### PR TITLE
(Fields PR) refact: New GapField class

### DIFF
--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -73,6 +73,7 @@ export default {
 		app.component("k-writer-field", WriterField);
 
 		// Legacy fields components
+		app.component("k-legacy-gap-field", GapField);
 		app.component("k-legacy-headline-field", HeadlineField);
 		app.component("k-legacy-info-field", InfoField);
 		app.component("k-legacy-line-field", LineField);

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -11,6 +11,7 @@ use Kirby\Cms\Auth\EmailChallenge;
 use Kirby\Cms\Auth\TotpChallenge;
 use Kirby\Form\Field\BlocksField;
 use Kirby\Form\Field\EntriesField;
+use Kirby\Form\Field\GapField;
 use Kirby\Form\Field\HeadlineField;
 use Kirby\Form\Field\InfoField;
 use Kirby\Form\Field\LayoutField;
@@ -226,7 +227,7 @@ class Core
 			'email'       => $this->root . '/fields/email.php',
 			'entries'     => EntriesField::class,
 			'files'       => $this->root . '/fields/files.php',
-			'gap'         => $this->root . '/fields/gap.php',
+			'gap'         => GapField::class,
 			'headline'    => HeadlineField::class,
 			'hidden'      => $this->root . '/fields/hidden.php',
 			'info'        => InfoField::class,
@@ -255,6 +256,7 @@ class Core
 			'users'       => $this->root . '/fields/users.php',
 			'writer'      => $this->root . '/fields/writer.php',
 
+			'legacy-gap'      => $this->root . '/fields/gap.php',
 			'legacy-headline' => $this->root . '/fields/headline.php',
 			'legacy-info'     => $this->root . '/fields/info.php',
 			'legacy-line'     => $this->root . '/fields/line.php',

--- a/src/Form/Field/BaseField.php
+++ b/src/Form/Field/BaseField.php
@@ -28,13 +28,16 @@ abstract class BaseField
 	use Mixin\Translatable;
 	use Mixin\Value;
 	use Mixin\When;
+	use Mixin\Width;
 
 	public function __construct(
 		string|null $name = null,
-		array|null $when = null
+		array|null $when = null,
+		string|null $width = null
 	) {
 		$this->setName($name);
 		$this->setWhen($when);
+		$this->setWidth($width);
 	}
 
 	/**
@@ -104,7 +107,8 @@ abstract class BaseField
 			'name'     => $this->name(),
 			'saveable' => $this->hasValue(),
 			'type'     => $this->type(),
-			'when'     => $this->when()
+			'when'     => $this->when(),
+			'width'    => $this->width()
 		];
 	}
 

--- a/src/Form/Field/GapField.php
+++ b/src/Form/Field/GapField.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+/**
+ * Gap field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class GapField extends LineField
+{
+}

--- a/src/Form/Field/GapField.php
+++ b/src/Form/Field/GapField.php
@@ -12,6 +12,6 @@ namespace Kirby\Form\Field;
  * @license   https://getkirby.com/license
  * @since     6.0.0
  */
-class GapField extends LineField
+class GapField extends BaseField
 {
 }

--- a/src/Form/Field/LineField.php
+++ b/src/Form/Field/LineField.php
@@ -2,8 +2,6 @@
 
 namespace Kirby\Form\Field;
 
-use Kirby\Form\Mixin;
-
 /**
  * Line field
  *
@@ -16,26 +14,4 @@ use Kirby\Form\Mixin;
  */
 class LineField extends BaseField
 {
-	use Mixin\Width;
-
-	public function __construct(
-		string|null $name = null,
-		array|null $when = null,
-		string|null $width = null
-	) {
-		parent::__construct(
-			name:  $name,
-			when:  $when,
-		);
-
-		$this->setWidth($width);
-	}
-
-	public function props(): array
-	{
-		return [
-			...parent::props(),
-			'width' => $this->width()
-		];
-	}
 }

--- a/tests/Form/Field/GapFieldTest.php
+++ b/tests/Form/Field/GapFieldTest.php
@@ -7,9 +7,19 @@ class GapFieldTest extends TestCase
 	public function testDefaultProps(): void
 	{
 		$field = $this->field('gap');
+		$props = $field->props();
 
-		$this->assertSame('gap', $field->type());
-		$this->assertSame('gap', $field->name());
-		$this->assertFalse($field->save());
+		ksort($props);
+
+		$expected = [
+			'hidden'   => false,
+			'name'     => 'gap',
+			'saveable' => false,
+			'type'     => 'gap',
+			'when'     => null,
+			'width'    => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
 	}
 }


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7691
- [x] https://github.com/getkirby/kirby/pull/7692
- [x] https://github.com/getkirby/kirby/pull/7693

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- Refactored `gap` field as class

### ☠️ Deprecated
<!-- 
e.g. Deprecate method X. Use method Y instead.
-->
- `legacy-gap` field will be removed in an upcoming major version. Please move to class-based fields instead and extend the `GapField` class.

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- The `gap` field is now implemented as class. When extending in an array-based field, either switch your field to a class as well or extend the deprecated `legacy-gap` field for the moment.
