### PR TITLE
(Fields PR) refact: New HiddenField class

### DIFF
--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -13,6 +13,7 @@ use Kirby\Form\Field\BlocksField;
 use Kirby\Form\Field\EntriesField;
 use Kirby\Form\Field\GapField;
 use Kirby\Form\Field\HeadlineField;
+use Kirby\Form\Field\HiddenField;
 use Kirby\Form\Field\InfoField;
 use Kirby\Form\Field\LayoutField;
 use Kirby\Form\Field\LineField;
@@ -229,7 +230,7 @@ class Core
 			'files'       => $this->root . '/fields/files.php',
 			'gap'         => GapField::class,
 			'headline'    => HeadlineField::class,
-			'hidden'      => $this->root . '/fields/hidden.php',
+			'hidden'      => HiddenField::class,
 			'info'        => InfoField::class,
 			'layout'      => LayoutField::class,
 			'line'        => LineField::class,
@@ -258,6 +259,7 @@ class Core
 
 			'legacy-gap'      => $this->root . '/fields/gap.php',
 			'legacy-headline' => $this->root . '/fields/headline.php',
+			'legacy-hidden'   => $this->root . '/fields/hidden.php',
 			'legacy-info'     => $this->root . '/fields/info.php',
 			'legacy-line'     => $this->root . '/fields/line.php',
 		];

--- a/src/Form/Field/HiddenField.php
+++ b/src/Form/Field/HiddenField.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+/**
+ * Hidden field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class HiddenField extends BaseField
+{
+	public function __construct(
+		mixed $default = null,
+		string|null $name = null,
+		bool|null $translate = null,
+		array|null $when = null,
+	) {
+		parent::__construct(
+			name: $name,
+			when: $when,
+		);
+
+		$this->setDefault($default);
+		$this->setTranslate($translate);
+	}
+
+	public function hasValue(): bool
+	{
+		return true;
+	}
+
+	public function isHidden(): bool
+	{
+		return true;
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'default'   => $this->default(),
+			'translate' => $this->translate(),
+		];
+	}
+}

--- a/tests/Form/Field/HiddenFieldTest.php
+++ b/tests/Form/Field/HiddenFieldTest.php
@@ -7,11 +7,28 @@ class HiddenFieldTest extends TestCase
 	public function testDefaultProps(): void
 	{
 		$field = $this->field('hidden');
+		$props = $field->props();
 
-		$this->assertSame('hidden', $field->type());
-		$this->assertSame('hidden', $field->name());
-		$this->assertNull($field->value());
-		$this->assertTrue($field->isHidden());
-		$this->assertTrue($field->save());
+		ksort($props);
+
+		$expected = [
+			'default'   => null,
+			'hidden'    => true,
+			'name'      => 'hidden',
+			'saveable'  => true,
+			'translate' => true,
+			'type'      => 'hidden',
+			'when'      => null,
+		];
+
+		$this->assertSame($expected, $props);
+	}
+
+	public function testFill(): void
+	{
+		$field = $this->field('hidden');
+		$field->fill('test');
+
+		$this->assertSame('test', $field->toFormValue());
 	}
 }


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7691
- [x] https://github.com/getkirby/kirby/pull/7692
- [x] https://github.com/getkirby/kirby/pull/7693
- [x] https://github.com/getkirby/kirby/pull/7694

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- Refactored `hidden` field as class

### ☠️ Deprecated
<!-- 
e.g. Deprecate method X. Use method Y instead.
-->
- `legacy-hidden` field will be removed in an upcoming major version. Please move to class-based fields instead and extend the `HiddenField` class.

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- The `hidden` field is now implemented as class. When extending in an array-based field, either switch your field to a class as well or extend the deprecated `legacy-hidden` field for the moment.
