### PR TITLE
(Fields PR) refact!: New StructureField class

### DIFF
--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -77,5 +77,6 @@ export default {
 		app.component("k-legacy-headline-field", HeadlineField);
 		app.component("k-legacy-info-field", InfoField);
 		app.component("k-legacy-line-field", LineField);
+		app.component("k-legacy-structure-field", StructureField);
 	}
 };

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -18,6 +18,7 @@ use Kirby\Form\Field\InfoField;
 use Kirby\Form\Field\LayoutField;
 use Kirby\Form\Field\LineField;
 use Kirby\Form\Field\StatsField;
+use Kirby\Form\Field\StructureField;
 use Kirby\Panel\Ui\FilePreview\AudioFilePreview;
 use Kirby\Panel\Ui\FilePreview\ImageFilePreview;
 use Kirby\Panel\Ui\FilePreview\PdfFilePreview;
@@ -245,7 +246,7 @@ class Core
 			'select'      => $this->root . '/fields/select.php',
 			'slug'        => $this->root . '/fields/slug.php',
 			'stats'       => StatsField::class,
-			'structure'   => $this->root . '/fields/structure.php',
+			'structure'   => StructureField::class,
 			'tags'        => $this->root . '/fields/tags.php',
 			'tel'         => $this->root . '/fields/tel.php',
 			'text'        => $this->root . '/fields/text.php',
@@ -257,11 +258,12 @@ class Core
 			'users'       => $this->root . '/fields/users.php',
 			'writer'      => $this->root . '/fields/writer.php',
 
-			'legacy-gap'      => $this->root . '/fields/gap.php',
-			'legacy-headline' => $this->root . '/fields/headline.php',
-			'legacy-hidden'   => $this->root . '/fields/hidden.php',
-			'legacy-info'     => $this->root . '/fields/info.php',
-			'legacy-line'     => $this->root . '/fields/line.php',
+			'legacy-gap'       => $this->root . '/fields/gap.php',
+			'legacy-headline'  => $this->root . '/fields/headline.php',
+			'legacy-hidden'    => $this->root . '/fields/hidden.php',
+			'legacy-info'      => $this->root . '/fields/info.php',
+			'legacy-line'      => $this->root . '/fields/line.php',
+			'legacy-structure' => $this->root . '/fields/structure.php',
 		];
 	}
 

--- a/src/Form/Field/StructureField.php
+++ b/src/Form/Field/StructureField.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Data\Data;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Form\Mixin;
+use Kirby\Toolkit\Str;
+
+class StructureField extends InputField
+{
+	use Mixin\Batch;
+	use Mixin\EmptyState;
+	use Mixin\Fields;
+	use Mixin\Limit;
+	use Mixin\Max;
+	use Mixin\Min;
+	use Mixin\Sortable;
+	use Mixin\SortBy;
+	use Mixin\TableColumns;
+
+	/**
+	 * Toggles duplicating rows for the structure
+	 */
+	protected bool|null $duplicate;
+
+	protected mixed $value = [];
+
+	public function __construct(
+		bool|null $batch = null,
+		array|null $columns = null,
+		array|null $default = null,
+		bool|null $disabled = null,
+		array|null $duplicate = null,
+		array|string|null $empty = null,
+		array|null $fields = null,
+		array|string|null $help = null,
+		array|string|null $label = null,
+		int|null $limit = null,
+		string|null $name = null,
+		int|null $max = null,
+		int|null $min = null,
+		bool|null $required = null,
+		bool|null $sortable = null,
+		string|null $sortBy = null,
+		bool|null $translate = null,
+		array|null $when = null,
+		string|null $width = null,
+	) {
+		parent::__construct(
+			default:   $default,
+			disabled:  $disabled,
+			help:      $help,
+			label:     $label,
+			name:      $name,
+			required:  $required,
+			translate: $translate,
+			when:      $when,
+			width:     $width
+		);
+
+		$this->batch     = $batch;
+		$this->columns   = $columns;
+		$this->duplicate = $duplicate;
+		$this->empty     = $empty;
+		$this->fields    = $fields;
+		$this->limit     = $limit;
+		$this->max       = $max;
+		$this->min       = $min;
+		$this->sortable  = $sortable;
+		$this->sortBy    = $sortBy;
+	}
+
+	public function duplicate(): bool
+	{
+		return $this->duplicate ?? true;
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'batch'     => $this->batch(),
+			'columns'   => $this->columns(),
+			'duplicate' => $this->duplicate(),
+			'empty'     => $this->empty(),
+			'fields'    => $this->fields(),
+			'limit'     => $this->limit(),
+			'max'       => $this->max(),
+			'min'       => $this->min(),
+			'sortable'  => $this->sortable(),
+			'sortBy'    => $this->sortBy()
+		];
+	}
+
+	/**
+	 * @psalm-suppress MethodSignatureMismatch
+	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
+	 */
+	public function fill(mixed $value): static
+	{
+		$this->value = Data::decode($value, 'yaml');
+		return $this;
+	}
+
+	public function toFormValue(): array
+	{
+		$data = [];
+
+		foreach ($this->value as $row) {
+			$data[] = $this->form()
+				->fill(
+					input: $row,
+					passthrough: true
+				)
+				->toFormValues();
+		}
+
+		return $data;
+	}
+
+	public function toStoredValue(): array
+	{
+		$data     = [];
+		$form     = $this->form();
+		$defaults = $form->defaults();
+
+		foreach ($this->value as $row) {
+			$row = $form
+				->reset()
+				->fill(
+					input: $defaults,
+				)
+				->submit(
+					input: $row,
+					passthrough: true
+				)
+				->toStoredValues();
+
+			// remove frontend helper id
+			unset($row['_id']);
+
+			$data[] = $row;
+		}
+
+		return $data;
+	}
+
+	protected function validations(): array
+	{
+		return [
+			'min',
+			'max',
+			'structure' => $this->validateRows(...)
+		];
+	}
+
+	protected function validateRows(array $value): void
+	{
+		if ($value === []) {
+			return;
+		}
+
+		foreach ($this->value as $index => $value) {
+			$form = $this->form()->fill(input: $value);
+
+			foreach ($form->fields() as $field) {
+				$errors = $field->errors();
+
+				if ($errors !== []) {
+					throw new InvalidArgumentException(
+						key: 'structure.validation',
+						data: [
+							'field' => $field->label() ?? Str::ucfirst($field->name()),
+							'index' => $index + 1
+						]
+					);
+				}
+			}
+		}
+	}
+}

--- a/src/Form/Field/StructureField.php
+++ b/src/Form/Field/StructureField.php
@@ -10,19 +10,16 @@ use Kirby\Toolkit\Str;
 class StructureField extends InputField
 {
 	use Mixin\Batch;
+	use Mixin\Duplicate;
 	use Mixin\EmptyState;
 	use Mixin\Fields;
 	use Mixin\Limit;
 	use Mixin\Max;
 	use Mixin\Min;
+	use Mixin\Prepend;
 	use Mixin\Sortable;
 	use Mixin\SortBy;
 	use Mixin\TableColumns;
-
-	/**
-	 * Toggles duplicating rows for the structure
-	 */
-	protected bool|null $duplicate;
 
 	protected mixed $value = [];
 
@@ -31,7 +28,7 @@ class StructureField extends InputField
 		array|null $columns = null,
 		array|null $default = null,
 		bool|null $disabled = null,
-		array|null $duplicate = null,
+		bool|null $duplicate = null,
 		array|string|null $empty = null,
 		array|null $fields = null,
 		array|string|null $help = null,
@@ -40,6 +37,7 @@ class StructureField extends InputField
 		string|null $name = null,
 		int|null $max = null,
 		int|null $min = null,
+		bool|null $prepend = null,
 		bool|null $required = null,
 		bool|null $sortable = null,
 		string|null $sortBy = null,
@@ -67,6 +65,7 @@ class StructureField extends InputField
 		$this->limit     = $limit;
 		$this->max       = $max;
 		$this->min       = $min;
+		$this->prepend   = $prepend;
 		$this->sortable  = $sortable;
 		$this->sortBy    = $sortBy;
 	}

--- a/src/Form/Field/StructureField.php
+++ b/src/Form/Field/StructureField.php
@@ -87,6 +87,7 @@ class StructureField extends InputField
 			'limit'     => $this->limit(),
 			'max'       => $this->max(),
 			'min'       => $this->min(),
+			'prepend'   => $this->prepend(),
 			'sortable'  => $this->sortable(),
 			'sortBy'    => $this->sortBy()
 		];

--- a/src/Form/Mixin/Duplicate.php
+++ b/src/Form/Mixin/Duplicate.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait Duplicate
+{
+	/**
+	 * Allow duplicating items in the field
+	 */
+	protected bool|null $duplicate;
+
+	public function duplicate(): bool
+	{
+		return $this->duplicate ?? true;
+	}
+
+	protected function setDuplicate(bool|null $duplicate): void
+	{
+		$this->duplicate = $duplicate;
+	}
+}

--- a/src/Form/Mixin/Duplicate.php
+++ b/src/Form/Mixin/Duplicate.php
@@ -13,9 +13,4 @@ trait Duplicate
 	{
 		return $this->duplicate ?? true;
 	}
-
-	protected function setDuplicate(bool|null $duplicate): void
-	{
-		$this->duplicate = $duplicate;
-	}
 }

--- a/src/Form/Mixin/Fields.php
+++ b/src/Form/Mixin/Fields.php
@@ -41,9 +41,4 @@ trait Fields
 
 		return $this->form->reset();
 	}
-
-	protected function setFields(array|null $fields): void
-	{
-		$this->fields = $fields;
-	}
 }

--- a/src/Form/Mixin/Fields.php
+++ b/src/Form/Mixin/Fields.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+use Kirby\Form\Form;
+
+trait Fields
+{
+	/**
+	 * Fields setup for the form. Works just like fields in regular forms.
+	 */
+	protected array|null $fields;
+
+	/**
+	 * Cache for the form instance
+	 */
+	protected Form $form;
+
+	/**
+	 * Returns the props for all fields in the form
+	 */
+	public function fields(): array
+	{
+		if ($this->fields === null || $this->fields === []) {
+			return [];
+		}
+
+		return $this->form()->fields()->toProps();
+	}
+
+	/**
+	 * Creates and caches the form instance with all fields
+	 */
+	public function form(): Form
+	{
+		$this->form ??= new Form(
+			fields: $this->fields ?? [],
+			model: $this->model(),
+			language: 'current'
+		);
+
+		return $this->form->reset();
+	}
+
+	protected function setFields(array|null $fields): void
+	{
+		$this->fields = $fields;
+	}
+}

--- a/src/Form/Mixin/Limit.php
+++ b/src/Form/Mixin/Limit.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait Limit
+{
+	/**
+	 * The number of entries that will be displayed on a single page. Afterwards pagination kicks in.
+	 */
+	protected int|null $limit;
+
+	public function limit(): int|null
+	{
+		return $this->limit;
+	}
+
+	protected function setLimit(int|null $limit): void
+	{
+		$this->limit = $limit;
+	}
+}

--- a/src/Form/Mixin/Limit.php
+++ b/src/Form/Mixin/Limit.php
@@ -13,9 +13,4 @@ trait Limit
 	{
 		return $this->limit;
 	}
-
-	protected function setLimit(int|null $limit): void
-	{
-		$this->limit = $limit;
-	}
 }

--- a/src/Form/Mixin/Prepend.php
+++ b/src/Form/Mixin/Prepend.php
@@ -13,9 +13,4 @@ trait Prepend
 	{
 		return $this->prepend ?? false;
 	}
-
-	protected function setPrepend(bool|null $prepend): void
-	{
-		$this->prepend = $prepend;
-	}
 }

--- a/src/Form/Mixin/Prepend.php
+++ b/src/Form/Mixin/Prepend.php
@@ -5,13 +5,13 @@ namespace Kirby\Form\Mixin;
 trait Prepend
 {
 	/**
-     * If activated, new items will be added at the start
+	 * If activated, new items will be added at the start
 	 */
 	protected bool|null $prepend;
 
 	public function prepend(): bool
 	{
-		return $this->prepend ?? true;
+		return $this->prepend ?? false;
 	}
 
 	protected function setPrepend(bool|null $prepend): void

--- a/src/Form/Mixin/Prepend.php
+++ b/src/Form/Mixin/Prepend.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait Prepend
+{
+	/**
+     * If activated, new items will be added at the start
+	 */
+	protected bool|null $prepend;
+
+	public function prepend(): bool
+	{
+		return $this->prepend ?? true;
+	}
+
+	protected function setPrepend(bool|null $prepend): void
+	{
+		$this->prepend = $prepend;
+	}
+}

--- a/src/Form/Mixin/SortBy.php
+++ b/src/Form/Mixin/SortBy.php
@@ -14,9 +14,4 @@ trait SortBy
 	{
 		return $this->sortBy;
 	}
-
-	protected function setSortBy(string|null $sortBy): void
-	{
-		$this->sortBy = $sortBy;
-	}
 }

--- a/src/Form/Mixin/SortBy.php
+++ b/src/Form/Mixin/SortBy.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait SortBy
+{
+	/**
+	 * Sorts the entries by the given field and order (i.e. `title desc`)
+	 * Drag & drop is disabled in this case
+	 */
+	protected string|null $sortBy;
+
+	public function sortBy(): string|null
+	{
+		return $this->sortBy;
+	}
+
+	protected function setSortBy(string|null $sortBy): void
+	{
+		$this->sortBy = $sortBy;
+	}
+}

--- a/src/Form/Mixin/TableColumns.php
+++ b/src/Form/Mixin/TableColumns.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait TableColumns
+{
+	protected array|null $columns = null;
+	protected array $columnsCache;
+
+	public function columns(): array
+	{
+		return $this->columnsCache ??= $this->normalizeColumns(
+			columns: $this->columns ?? [],
+			fields: $this->fields()
+		);
+	}
+
+	protected function columnsFromFields(array $fields): array
+	{
+		// get all field names
+		$columnNames = array_column($fields, 'name');
+
+		// create keys for each name
+		return array_fill_keys($columnNames, true);
+	}
+
+	protected function normalizeColumn(string $name, array|true $column, array|null $field): array|null
+	{
+		// Skip empty and unsaveable fields
+		// They should never be included as column
+		if ($field === null || $field['saveable'] === false || $field['type'] === 'hidden' || $field['hidden'] === true) {
+			return null;
+		}
+
+		if (is_array($column) === false) {
+			$column = [];
+		}
+
+		$column['type']  ??= $field['type'];
+		$column['label'] ??= $field['label'] ?? $name;
+		$column['label']   = $this->i18n($column['label']);
+
+		return $column;
+	}
+
+	protected function normalizeColumns(array $columns, array $fields): array
+	{
+		// lower case all keys, because field names will
+		// be lowercase as well.
+		$columns = array_change_key_case($columns);
+
+		// create auto-columns from fields
+		if ($columns === []) {
+			$columns = $this->columnsFromFields($fields);
+		}
+
+		foreach ($columns as $name => $column) {
+			$columns[$name] = $this->normalizeColumn($name, $column, $fields[$name] ?? null);
+		}
+
+		$columns = array_filter($columns);
+
+		// make the first column visible on mobile
+		// if no other mobile columns are defined
+		if (in_array(true, array_column($columns, 'mobile'), true) === false) {
+			$columns[array_key_first($columns)]['mobile'] = true;
+		}
+
+		return $columns;
+	}
+
+	protected function setColumns(array|null $columns = null): void
+	{
+		$this->columns = $columns;
+	}
+}

--- a/src/Form/Mixin/TableColumns.php
+++ b/src/Form/Mixin/TableColumns.php
@@ -67,6 +67,10 @@ trait TableColumns
 
 		$columns = array_filter($columns);
 
+		if ($columns === []) {
+			return [];
+		}
+
 		// make the first column visible on mobile
 		// if no other mobile columns are defined
 		if (in_array(true, array_column($columns, 'mobile'), true) === false) {

--- a/src/Form/Mixin/TableColumns.php
+++ b/src/Form/Mixin/TableColumns.php
@@ -4,7 +4,14 @@ namespace Kirby\Form\Mixin;
 
 trait TableColumns
 {
+	/**
+	 * Columns definition for the table
+	 */
 	protected array|null $columns = null;
+
+	/**
+	 * Cache for the columns definition
+	 */
 	protected array $columnsCache;
 
 	public function columns(): array

--- a/src/Form/Mixin/TableColumns.php
+++ b/src/Form/Mixin/TableColumns.php
@@ -7,7 +7,7 @@ trait TableColumns
 	/**
 	 * Columns definition for the table
 	 */
-	protected array|null $columns = null;
+	protected array|null $columns;
 
 	/**
 	 * Cache for the columns definition

--- a/src/Form/Mixin/TableColumns.php
+++ b/src/Form/Mixin/TableColumns.php
@@ -75,9 +75,4 @@ trait TableColumns
 
 		return $columns;
 	}
-
-	protected function setColumns(array|null $columns = null): void
-	{
-		$this->columns = $columns;
-	}
 }

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -32,6 +32,7 @@ class StructureFieldTest extends TestCase
 					'mobile' => true
 				]
 			],
+			'default'   => null,
 			'disabled'  => false,
 			'duplicate' => true,
 			'empty'     => null,

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -128,6 +128,30 @@ class StructureFieldTest extends TestCase
 		$this->assertSame($expected, $field->columns());
 	}
 
+	public function testColumnsFromUnsaveableFields(): void
+	{
+		$field = $this->field('structure', [
+			'fields' => [
+				'a' => [
+					'type' => 'text'
+				],
+				'b' => [
+					'type' => 'info'
+				]
+			],
+		]);
+
+		$expected = [
+			'a' => [
+				'type' => 'text',
+				'label' => 'a',
+				'mobile' => true // the first column should be automatically kept on mobile
+			],
+		];
+
+		$this->assertSame($expected, $field->columns());
+	}
+
 	public function testColumnsWithCustomMobileSetup(): void
 	{
 		$field = $this->field('structure', [
@@ -184,6 +208,19 @@ class StructureFieldTest extends TestCase
 		];
 
 		$this->assertSame($expected, $field->columns());
+	}
+
+	public function testDuplicate(): void
+	{
+		$field = $this->field('structure');
+
+		$this->assertTrue($field->duplicate());
+
+		$field = $this->field('structure', [
+			'duplicate' => false
+		]);
+
+		$this->assertFalse($field->duplicate());
 	}
 
 	public function testLowerCaseColumnsNames(): void

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -17,12 +17,45 @@ class StructureFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertSame('structure', $field->type());
-		$this->assertSame('structure', $field->name());
-		$this->assertNull($field->limit());
-		$this->assertIsArray($field->fields());
-		$this->assertSame([], $field->value());
-		$this->assertTrue($field->save());
+		$props = $field->props();
+
+		// makes it easier to compare the arrays
+		ksort($props);
+
+		$expected = [
+			'autofocus' => false,
+			'batch'     => false,
+			'columns'   => [
+				'text' => [
+					'type'   => 'text',
+					'label'  => 'text',
+					'mobile' => true
+				]
+			],
+			'disabled'  => false,
+			'duplicate' => true,
+			'empty'     => null,
+			'fields'    => $props['fields'],
+			'help'      => null,
+			'hidden'    => false,
+			'label'     => 'Structure',
+			'limit'     => null,
+			'max'       => null,
+			'min'       => null,
+			'name'      => 'structure',
+			'required'  => false,
+			'saveable'  => true,
+			'sortBy'    => null,
+			'sortable'  => true,
+			'translate' => true,
+			'type'      => 'structure',
+			'when'      => null,
+			'width'     => '1/1',
+		];
+
+		$this->assertCount(1, $props['fields']);
+		$this->assertArrayHasKey('text', $props['fields']);
+		$this->assertSame($expected, $props);
 	}
 
 	public function testReset(): void

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -25,7 +25,7 @@ class StructureFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
-	public function testFillWithEmptyValue(): void
+	public function testReset(): void
 	{
 		$field = $this->field('structure', [
 			'fields' => [
@@ -46,7 +46,7 @@ class StructureFieldTest extends TestCase
 
 		$this->assertSame($value, $field->toFormValue());
 
-		$field->fillWithEmptyValue();
+		$field->reset();
 
 		$this->assertSame([], $field->toFormValue());
 	}
@@ -197,7 +197,7 @@ class StructureFieldTest extends TestCase
 
 		$this->assertFalse($field->isValid());
 		$this->assertSame(2, $field->min());
-		$this->assertTrue($field->required());
+		$this->assertTrue($field->isRequired());
 		$this->assertArrayHasKey('min', $field->errors());
 	}
 

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -9,13 +9,7 @@ class StructureFieldTest extends TestCase
 {
 	public function testDefaultProps(): void
 	{
-		$field = $this->field('structure', [
-			'fields' => [
-				'text' => [
-					'type' => 'text'
-				]
-			]
-		]);
+		$field = $this->field('structure', []);
 
 		$props = $field->props();
 
@@ -25,18 +19,12 @@ class StructureFieldTest extends TestCase
 		$expected = [
 			'autofocus' => false,
 			'batch'     => false,
-			'columns'   => [
-				'text' => [
-					'type'   => 'text',
-					'label'  => 'text',
-					'mobile' => true
-				]
-			],
+			'columns'   => [],
 			'default'   => null,
 			'disabled'  => false,
 			'duplicate' => true,
 			'empty'     => null,
-			'fields'    => $props['fields'],
+			'fields'    => [],
 			'help'      => null,
 			'hidden'    => false,
 			'label'     => 'Structure',
@@ -55,8 +43,6 @@ class StructureFieldTest extends TestCase
 			'width'     => '1/1',
 		];
 
-		$this->assertCount(1, $props['fields']);
-		$this->assertArrayHasKey('text', $props['fields']);
 		$this->assertSame($expected, $props);
 	}
 

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -44,6 +44,7 @@ class StructureFieldTest extends TestCase
 			'max'       => null,
 			'min'       => null,
 			'name'      => 'structure',
+			'prepend'   => false,
 			'required'  => false,
 			'saveable'  => true,
 			'sortBy'    => null,


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7691
- [x] https://github.com/getkirby/kirby/pull/7692
- [x] https://github.com/getkirby/kirby/pull/7693
- [x] https://github.com/getkirby/kirby/pull/7694
- [x] https://github.com/getkirby/kirby/pull/7695

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- Refactored `structure` field as class
- New `Kirby\Form\Mixin\Duplicate` mixin
- New `Kirby\Form\Mixin\Fields` mixin
- New `Kirby\Form\Mixin\Limit` mixin
- New `Kirby\Form\Mixin\Prepend` mixin
- New `Kirby\Form\Mixin\SortBy` mixin
- New `Kirby\Form\Mixin\TableColumns` mixin

### ☠️ Deprecated
<!-- 
e.g. Deprecate method X. Use method Y instead.
-->
- `legacy-structure` field will be removed in an upcoming major version. Please move to class-based fields instead and extend the `StructureField` class.

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- The `structure` field is now implemented as class. When extending in an array-based field, either switch your field to a class as well or extend the deprecated `legacy-structure` field for the moment.
