### PR TITLE
(Fields PR) refact!: Remove all setter methods from field classes

### DIFF
--- a/src/Form/Field/BaseField.php
+++ b/src/Form/Field/BaseField.php
@@ -35,9 +35,9 @@ abstract class BaseField
 		array|null $when = null,
 		string|null $width = null
 	) {
-		$this->setName($name);
-		$this->setWhen($when);
-		$this->setWidth($width);
+		$this->name  = $name;
+		$this->when  = $when;
+		$this->width = $width;
 	}
 
 	/**

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -78,12 +78,12 @@ class BlocksField extends InputField
 			width:     $width
 		);
 
-		$this->setEmpty($empty);
-		$this->setFieldsets($fieldsets);
-		$this->setGroup($group);
-		$this->setMax($max);
-		$this->setMin($min);
-		$this->setPretty($pretty);
+		$this->empty     = $empty;
+		$this->fieldsets = $fieldsets;
+		$this->group     = $group;
+		$this->max       = $max;
+		$this->min       = $min;
+		$this->pretty    = $pretty;
 	}
 
 	public function blocksToValues(
@@ -109,6 +109,22 @@ class BlocksField extends InputField
 		}
 
 		return $result;
+	}
+
+	public function default(): mixed
+	{
+		$default = $this->default;
+
+		if (is_array($default) === false) {
+			return null;
+		}
+
+		// set id for blocks if not exists
+		array_walk($default, function (&$block) {
+			$block['id'] ??= Str::uuid();
+		});
+
+		return $default;
 	}
 
 	public function fields(string $type): array
@@ -278,28 +294,6 @@ class BlocksField extends InputField
 				}
 			],
 		];
-	}
-
-	protected function setDefault(mixed $default): void
-	{
-		// set id for blocks if not exists
-		if (is_array($default) === true) {
-			array_walk($default, function (&$block) {
-				$block['id'] ??= Str::uuid();
-			});
-		}
-
-		parent::setDefault($default);
-	}
-
-	protected function setFieldsets(array|null $fieldsets): void
-	{
-		$this->fieldsets = $fieldsets;
-	}
-
-	protected function setGroup(string|null $group): void
-	{
-		$this->group = $group;
 	}
 
 	public function toStoredValue(bool $default = false): mixed

--- a/src/Form/Field/DisplayField.php
+++ b/src/Form/Field/DisplayField.php
@@ -32,9 +32,9 @@ abstract class DisplayField extends BaseField
 			when: $when
 		);
 
-		$this->setHelp($help);
-		$this->setLabel($label);
-		$this->setWidth($width);
+		$this->help  = $help;
+		$this->label = $label;
+		$this->width = $width;
 	}
 
 	public function props(): array

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -69,11 +69,11 @@ class EntriesField extends InputField
 			width:     $width
 		);
 
-		$this->setEmpty($empty);
-		$this->setField($field);
-		$this->setMax($max);
-		$this->setMin($min);
-		$this->setSortable($sortable);
+		$this->empty    = $empty;
+		$this->field    = $field;
+		$this->max      = $max;
+		$this->min      = $min;
+		$this->sortable = $sortable;
 	}
 
 	public function field(): array

--- a/src/Form/Field/HiddenField.php
+++ b/src/Form/Field/HiddenField.php
@@ -23,8 +23,8 @@ class HiddenField extends BaseField
 			name: $name
 		);
 
-		$this->setDefault($default);
-		$this->setTranslate($translate);
+		$this->default   = $default;
+		$this->translate = $translate;
 	}
 
 	public function hasValue(): bool

--- a/src/Form/Field/InfoField.php
+++ b/src/Form/Field/InfoField.php
@@ -38,9 +38,9 @@ class InfoField extends DisplayField
 			width: $width
 		);
 
-		$this->setIcon($icon);
-		$this->setText($text);
-		$this->setTheme($theme);
+		$this->icon  = $icon;
+		$this->text  = $text;
+		$this->theme = $theme;
 	}
 
 	public function props(): array

--- a/src/Form/Field/InputField.php
+++ b/src/Form/Field/InputField.php
@@ -41,14 +41,14 @@ abstract class InputField extends BaseField
 			when: $when
 		);
 
-		$this->setAutofocus($autofocus);
-		$this->setDefault($default);
-		$this->setDisabled($disabled);
-		$this->setHelp($help);
-		$this->setLabel($label);
-		$this->setRequired($required);
-		$this->setTranslate($translate);
-		$this->setWidth($width);
+		$this->autofocus = $autofocus;
+		$this->default   = $default;
+		$this->disabled  = $disabled;
+		$this->help      = $help;
+		$this->label     = $label;
+		$this->required  = $required;
+		$this->translate = $translate;
+		$this->width     = $width;
 	}
 
 	public function hasValue(): bool

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -75,10 +75,10 @@ class LayoutField extends BlocksField
 			width:     $width
 		);
 
-		$this->setDefault($default);
-		$this->setLayouts($layouts);
-		$this->setSelector($selector);
-		$this->setSettings($settings);
+		$this->default  = $default;
+		$this->layouts  = $layouts;
+		$this->selector = $selector;
+		$this->settings = $settings;
 	}
 
 	public function default(): mixed

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -55,10 +55,10 @@ abstract class FieldClass extends InputField
 			width: $width
 		);
 
-		$this->setAfter($after);
-		$this->setBefore($before);
-		$this->setIcon($icon);
-		$this->setPlaceholder($placeholder);
+		$this->after       = $after;
+		$this->before      = $before;
+		$this->icon        = $icon;
+		$this->placeholder = $placeholder;
 	}
 
 	public function __call(string $param, array $args): mixed

--- a/src/Form/Mixin/After.php
+++ b/src/Form/Mixin/After.php
@@ -13,9 +13,4 @@ trait After
 	{
 		return $this->stringTemplate($this->i18n($this->after));
 	}
-
-	protected function setAfter(array|string|null $after): void
-	{
-		$this->after = $after;
-	}
 }

--- a/src/Form/Mixin/Autocomplete.php
+++ b/src/Form/Mixin/Autocomplete.php
@@ -13,9 +13,4 @@ trait Autocomplete
 	{
 		return $this->autocomplete;
 	}
-
-	protected function setAutocomplete(string|null $autocomplete): void
-	{
-		$this->autocomplete = $autocomplete;
-	}
 }

--- a/src/Form/Mixin/Autofocus.php
+++ b/src/Form/Mixin/Autofocus.php
@@ -13,9 +13,4 @@ trait Autofocus
 	{
 		return $this->autofocus ?? false;
 	}
-
-	protected function setAutofocus(bool|null $autofocus): void
-	{
-		$this->autofocus = $autofocus;
-	}
 }

--- a/src/Form/Mixin/Batch.php
+++ b/src/Form/Mixin/Batch.php
@@ -13,9 +13,4 @@ trait Batch
 	{
 		return $this->batch ?? false;
 	}
-
-	protected function setBatch(bool|null $batch): void
-	{
-		$this->batch = $batch;
-	}
 }

--- a/src/Form/Mixin/Before.php
+++ b/src/Form/Mixin/Before.php
@@ -13,9 +13,4 @@ trait Before
 	{
 		return $this->stringTemplate($this->i18n($this->before));
 	}
-
-	protected function setBefore(array|string|null $before): void
-	{
-		$this->before = $before;
-	}
 }

--- a/src/Form/Mixin/Counter.php
+++ b/src/Form/Mixin/Counter.php
@@ -13,9 +13,4 @@ trait Counter
 	{
 		return $this->counter ?? true;
 	}
-
-	protected function setCounter(bool|null $counter): void
-	{
-		$this->counter = $counter;
-	}
 }

--- a/src/Form/Mixin/DefaultValue.php
+++ b/src/Form/Mixin/DefaultValue.php
@@ -24,9 +24,4 @@ trait DefaultValue
 
 		return $this->model()->toString($this->default);
 	}
-
-	protected function setDefault(mixed $default): void
-	{
-		$this->default = $default;
-	}
 }

--- a/src/Form/Mixin/Disabled.php
+++ b/src/Form/Mixin/Disabled.php
@@ -18,9 +18,4 @@ trait Disabled
 	{
 		return $this->disabled();
 	}
-
-	protected function setDisabled(bool|null $disabled): void
-	{
-		$this->disabled = $disabled;
-	}
 }

--- a/src/Form/Mixin/EmptyState.php
+++ b/src/Form/Mixin/EmptyState.php
@@ -13,9 +13,4 @@ trait EmptyState
 	{
 		return $this->stringTemplate($this->i18n($this->empty));
 	}
-
-	protected function setEmpty(array|string|null $empty): void
-	{
-		$this->empty = $empty;
-	}
 }

--- a/src/Form/Mixin/Font.php
+++ b/src/Form/Mixin/Font.php
@@ -16,9 +16,4 @@ trait Font
 			default             => 'sans-serif'
 		};
 	}
-
-	protected function setFont(string|null $font): void
-	{
-		$this->font = $font;
-	}
 }

--- a/src/Form/Mixin/Help.php
+++ b/src/Form/Mixin/Help.php
@@ -20,9 +20,4 @@ trait Help
 
 		return null;
 	}
-
-	protected function setHelp(array|string|null $help): void
-	{
-		$this->help = $help;
-	}
 }

--- a/src/Form/Mixin/Icon.php
+++ b/src/Form/Mixin/Icon.php
@@ -13,9 +13,4 @@ trait Icon
 	{
 		return $this->icon;
 	}
-
-	protected function setIcon(string|null $icon): void
-	{
-		$this->icon = $icon;
-	}
 }

--- a/src/Form/Mixin/Label.php
+++ b/src/Form/Mixin/Label.php
@@ -19,9 +19,4 @@ trait Label
 
 		return $this->stringTemplate($this->i18n($this->label));
 	}
-
-	protected function setLabel(array|string|null $label): void
-	{
-		$this->label = $label;
-	}
 }

--- a/src/Form/Mixin/Max.php
+++ b/src/Form/Mixin/Max.php
@@ -13,9 +13,4 @@ trait Max
 	{
 		return $this->max;
 	}
-
-	protected function setMax(int|null $max): void
-	{
-		$this->max = $max;
-	}
 }

--- a/src/Form/Mixin/Maxlength.php
+++ b/src/Form/Mixin/Maxlength.php
@@ -13,9 +13,4 @@ trait Maxlength
 	{
 		return $this->maxlength;
 	}
-
-	protected function setMaxlength(int|null $maxlength): void
-	{
-		$this->maxlength = $maxlength;
-	}
 }

--- a/src/Form/Mixin/Min.php
+++ b/src/Form/Mixin/Min.php
@@ -19,11 +19,6 @@ trait Min
 		return $this->min;
 	}
 
-	protected function setMin(int|null $min): void
-	{
-		$this->min = $min;
-	}
-
 	public function isRequired(): bool
 	{
 		// set required to true if min is set

--- a/src/Form/Mixin/Minlength.php
+++ b/src/Form/Mixin/Minlength.php
@@ -13,9 +13,4 @@ trait Minlength
 	{
 		return $this->minlength;
 	}
-
-	protected function setMinlength(int|null $minlength): void
-	{
-		$this->minlength = $minlength;
-	}
 }

--- a/src/Form/Mixin/Name.php
+++ b/src/Form/Mixin/Name.php
@@ -10,9 +10,4 @@ trait Name
 	{
 		return strtolower($this->name ?? $this->type());
 	}
-
-	protected function setName(string|null $name): void
-	{
-		$this->name = $name;
-	}
 }

--- a/src/Form/Mixin/Pattern.php
+++ b/src/Form/Mixin/Pattern.php
@@ -13,9 +13,4 @@ trait Pattern
 	{
 		return $this->pattern;
 	}
-
-	protected function setPattern(string|null $pattern): void
-	{
-		$this->pattern = $pattern;
-	}
 }

--- a/src/Form/Mixin/Placeholder.php
+++ b/src/Form/Mixin/Placeholder.php
@@ -13,9 +13,4 @@ trait Placeholder
 	{
 		return $this->stringTemplate($this->i18n($this->placeholder));
 	}
-
-	protected function setPlaceholder(array|string|null $placeholder): void
-	{
-		$this->placeholder = $placeholder;
-	}
 }

--- a/src/Form/Mixin/Pretty.php
+++ b/src/Form/Mixin/Pretty.php
@@ -13,9 +13,4 @@ trait Pretty
 	{
 		return $this->pretty ?? false;
 	}
-
-	protected function setPretty(bool|null $pretty): void
-	{
-		$this->pretty = $pretty;
-	}
 }

--- a/src/Form/Mixin/Required.php
+++ b/src/Form/Mixin/Required.php
@@ -21,9 +21,4 @@ trait Required
 	{
 		return $this->required ?? false;
 	}
-
-	protected function setRequired(bool|null $required): void
-	{
-		$this->required = $required;
-	}
 }

--- a/src/Form/Mixin/Sortable.php
+++ b/src/Form/Mixin/Sortable.php
@@ -13,9 +13,4 @@ trait Sortable
 	{
 		return $this->sortable ?? true;
 	}
-
-	protected function setSortable(bool|null $sortable): void
-	{
-		$this->sortable = $sortable;
-	}
 }

--- a/src/Form/Mixin/Spellcheck.php
+++ b/src/Form/Mixin/Spellcheck.php
@@ -13,9 +13,4 @@ trait Spellcheck
 	{
 		return $this->spellcheck ?? true;
 	}
-
-	protected function setSpellcheck(bool|null $spellcheck): void
-	{
-		$this->spellcheck = $spellcheck;
-	}
 }

--- a/src/Form/Mixin/Text.php
+++ b/src/Form/Mixin/Text.php
@@ -20,9 +20,4 @@ trait Text
 
 		return null;
 	}
-
-	protected function setText(array|string|null $text): void
-	{
-		$this->text = $text;
-	}
 }

--- a/src/Form/Mixin/Theme.php
+++ b/src/Form/Mixin/Theme.php
@@ -13,9 +13,4 @@ trait Theme
 	{
 		return $this->theme;
 	}
-
-	protected function setTheme(string|null $theme): void
-	{
-		$this->theme = $theme;
-	}
 }

--- a/src/Form/Mixin/Translatable.php
+++ b/src/Form/Mixin/Translatable.php
@@ -25,11 +25,6 @@ trait Translatable
 		return true;
 	}
 
-	protected function setTranslate(bool|null $translate): void
-	{
-		$this->translate = $translate;
-	}
-
 	public function translate(): bool
 	{
 		return $this->translate ?? true;

--- a/src/Form/Mixin/When.php
+++ b/src/Form/Mixin/When.php
@@ -40,11 +40,6 @@ trait When
 		return true;
 	}
 
-	protected function setWhen(array|null $when): void
-	{
-		$this->when = $when;
-	}
-
 	public function when(): array|null
 	{
 		return $this->when;

--- a/src/Form/Mixin/Width.php
+++ b/src/Form/Mixin/Width.php
@@ -10,11 +10,6 @@ trait Width
 	 */
 	protected string|null $width;
 
-	protected function setWidth(string|null $width): void
-	{
-		$this->width = $width;
-	}
-
 	public function width(): string
 	{
 		return $this->width ?? '1/1';


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🚨 Breaking changes

- All setter Methods from Field classes and Field Mixins have been removed. Set class properties directly instead. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion