### PR TITLE
(Fields PR) refact!: New RadioField class

### DIFF
--- a/config/fields/select.php
+++ b/config/fields/select.php
@@ -4,7 +4,7 @@ use Kirby\Field\FieldOptions;
 use Kirby\Toolkit\I18n;
 
 return [
-	'extends' => 'radio',
+	'extends' => 'legacy-radio',
 	'props' => [
 		/**
 		 * Unset inherited props

--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -78,6 +78,7 @@ export default {
 		app.component("k-legacy-info-field", InfoField);
 		app.component("k-legacy-line-field", LineField);
 		app.component("k-legacy-object-field", ObjectField);
+		app.component("k-legacy-radio-field", RadioField);
 		app.component("k-legacy-structure-field", StructureField);
 	}
 };

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -18,6 +18,7 @@ use Kirby\Form\Field\InfoField;
 use Kirby\Form\Field\LayoutField;
 use Kirby\Form\Field\LineField;
 use Kirby\Form\Field\ObjectField;
+use Kirby\Form\Field\RadioField;
 use Kirby\Form\Field\StatsField;
 use Kirby\Form\Field\StructureField;
 use Kirby\Panel\Ui\FilePreview\AudioFilePreview;
@@ -242,7 +243,7 @@ class Core
 			'number'      => $this->root . '/fields/number.php',
 			'object'      => ObjectField::class,
 			'pages'       => $this->root . '/fields/pages.php',
-			'radio'       => $this->root . '/fields/radio.php',
+			'radio'       => RadioField::class,
 			'range'       => $this->root . '/fields/range.php',
 			'select'      => $this->root . '/fields/select.php',
 			'slug'        => $this->root . '/fields/slug.php',
@@ -265,6 +266,7 @@ class Core
 			'legacy-info'      => $this->root . '/fields/info.php',
 			'legacy-line'      => $this->root . '/fields/line.php',
 			'legacy-object'    => $this->root . '/fields/object.php',
+			'legacy-radio'     => $this->root . '/fields/radio.php',
 			'legacy-structure' => $this->root . '/fields/structure.php',
 		];
 	}

--- a/src/Form/Field/OptionField.php
+++ b/src/Form/Field/OptionField.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Form\Mixin;
+
+/**
+ * Option Field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+abstract class OptionField extends InputField
+{
+	use Mixin\Options;
+
+	protected mixed $value = '';
+
+	public function __construct(
+		bool|null $autofocus = null,
+		mixed $default = null,
+		bool|null $disabled = null,
+		array|string|null $help = null,
+		array|string|null $label = null,
+		string|null $name = null,
+		array|string|null $options = null,
+		bool|null $required = null,
+		bool|null $translate = null,
+		array|null $when = null,
+		string|null $width = null
+	) {
+		parent::__construct(
+			autofocus: $autofocus,
+			default: $default,
+			disabled: $disabled,
+			help: $help,
+			label: $label,
+			name: $name,
+			required: $required,
+			translate: $translate,
+			when: $when,
+			width: $width
+		);
+
+		$this->options = $options;
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'options' => $this->options(),
+		];
+	}
+
+	protected function validations(): array
+	{
+		return [
+			'option'
+		];
+	}
+}

--- a/src/Form/Field/RadioField.php
+++ b/src/Form/Field/RadioField.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Form\Mixin;
+
+/**
+ * Radio Field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class RadioField extends OptionField
+{
+	use Mixin\Columns;
+
+	public function __construct(
+		bool|null $autofocus = null,
+		int|null $columns = null,
+		mixed $default = null,
+		bool|null $disabled = null,
+		array|string|null $help = null,
+		array|string|null $label = null,
+		string|null $name = null,
+		array|string|null $options = null,
+		bool|null $required = null,
+		bool|null $translate = null,
+		array|null $when = null,
+		string|null $width = null
+	) {
+		parent::__construct(
+			autofocus: $autofocus,
+			default: $default,
+			disabled: $disabled,
+			help: $help,
+			label: $label,
+			name: $name,
+			options: $options,
+			required: $required,
+			translate: $translate,
+			when: $when,
+			width: $width
+		);
+
+		$this->columns = $columns;
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'columns' => $this->columns(),
+		];
+	}
+}

--- a/src/Form/Mixin/Columns.php
+++ b/src/Form/Mixin/Columns.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait Columns
+{
+	/**
+	 * Arranges the inputs in the given number of columns
+	 */
+	protected int|null $columns;
+
+	public function columns(): int
+	{
+		return $this->columns ?? 1;
+	}
+}

--- a/src/Form/Mixin/Options.php
+++ b/src/Form/Mixin/Options.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+use Kirby\Field\FieldOptions;
+
+trait Options
+{
+	/**
+	 * An array with options
+	 */
+	protected array|string|null $options;
+	protected array $optionsCache;
+
+	protected function fetchOptions(): array
+	{
+		$props   = FieldOptions::polyfill(['options' => $this->options ?? []]);
+		$options = FieldOptions::factory($props['options']);
+		return $options->render($this->model());
+	}
+
+	public function options(): array
+	{
+		return $this->optionsCache ??= $this->fetchOptions();
+	}
+}

--- a/tests/Form/Field/RadioFieldTest.php
+++ b/tests/Form/Field/RadioFieldTest.php
@@ -2,8 +2,6 @@
 
 namespace Kirby\Form\Field;
 
-use PHPUnit\Framework\Attributes\DataProvider;
-
 class RadioFieldTest extends TestCase
 {
 	public function testDefaultProps(): void
@@ -13,33 +11,7 @@ class RadioFieldTest extends TestCase
 		$this->assertSame('radio', $field->type());
 		$this->assertSame('radio', $field->name());
 		$this->assertSame('', $field->value());
-		$this->assertNull($field->icon());
 		$this->assertSame([], $field->options());
-		$this->assertTrue($field->save());
-	}
-
-	public static function valueInputProvider(): array
-	{
-		return [
-			['a', 'a'],
-			['b', 'b'],
-			['c', 'c'],
-			['d', '']
-		];
-	}
-
-	#[DataProvider('valueInputProvider')]
-	public function testValue($input, $expected): void
-	{
-		$field = $this->field('radio', [
-			'options' => [
-				'a',
-				'b',
-				'c'
-			],
-			'value' => $input
-		]);
-
-		$this->assertTrue($expected === $field->value());
+		$this->assertTrue($field->hasValue());
 	}
 }


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7696

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored

- New `Kirby\Form\Field\OptionField` abstract class
- New `Kirby\Form\Field\RadioField` class
- New `Kirby\Form\Mixin\Options` mixin
- New `Kirby\Form\Mixin\Columns` mixin

### 🚨 Breaking changes

- The radio field does no longer remove invalid values on submit or fill, but uses the option validator to warn if a value is invalid. This is more in line with what other input fields do in Kirby and has massive performance benefits. It also means that you can deliberately store a non-existing option if you skip validation, which also might be useful in some cases.
- The `api` and `query` options for the radio and other option classes are no longer available. Queries and API calls to fetch options have now to be declared directly in the options property. 
```yaml
fields: 
  myRadio: 
    type: radio
    options: 
      type: query
      query: some.query
```

or 

```yaml
fields: 
  myRadio: 
    type: radio
    options: 
      type: api
      url: /some/options/api
```

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

- [ ] Remove outdated api and query options from docs. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion