### PR TITLE
(Fields PR) refact!: New SelectField class 

### DIFF
--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -79,6 +79,7 @@ export default {
 		app.component("k-legacy-line-field", LineField);
 		app.component("k-legacy-object-field", ObjectField);
 		app.component("k-legacy-radio-field", RadioField);
+		app.component("k-legacy-select-field", SelectField);
 		app.component("k-legacy-structure-field", StructureField);
 	}
 };

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -19,6 +19,7 @@ use Kirby\Form\Field\LayoutField;
 use Kirby\Form\Field\LineField;
 use Kirby\Form\Field\ObjectField;
 use Kirby\Form\Field\RadioField;
+use Kirby\Form\Field\SelectField;
 use Kirby\Form\Field\StatsField;
 use Kirby\Form\Field\StructureField;
 use Kirby\Panel\Ui\FilePreview\AudioFilePreview;
@@ -245,7 +246,7 @@ class Core
 			'pages'       => $this->root . '/fields/pages.php',
 			'radio'       => RadioField::class,
 			'range'       => $this->root . '/fields/range.php',
-			'select'      => $this->root . '/fields/select.php',
+			'select'      => SelectField::class,
 			'slug'        => $this->root . '/fields/slug.php',
 			'stats'       => StatsField::class,
 			'structure'   => StructureField::class,
@@ -267,6 +268,7 @@ class Core
 			'legacy-line'      => $this->root . '/fields/line.php',
 			'legacy-object'    => $this->root . '/fields/object.php',
 			'legacy-radio'     => $this->root . '/fields/radio.php',
+			'legacy-select'    => $this->root . '/fields/select.php',
 			'legacy-structure' => $this->root . '/fields/structure.php',
 		];
 	}

--- a/src/Form/Field/SelectField.php
+++ b/src/Form/Field/SelectField.php
@@ -37,16 +37,16 @@ class SelectField extends OptionField
 	) {
 		parent::__construct(
 			autofocus: $autofocus,
-			default: $default,
-			disabled: $disabled,
-			help: $help,
-			label: $label,
-			name: $name,
-			options: $options,
-			required: $required,
+			default:   $default,
+			disabled:  $disabled,
+			help:      $help,
+			label:     $label,
+			name:      $name,
+			options:   $options,
+			required:  $required,
 			translate: $translate,
-			when: $when,
-			width: $width
+			when:      $when,
+			width:     $width
 		);
 
 		$this->icon        = $icon;

--- a/src/Form/Field/SelectField.php
+++ b/src/Form/Field/SelectField.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Field\FieldOptions;
+use Kirby\Form\Mixin;
+
+/**
+ * Select Field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class SelectField extends OptionField
+{
+	use Mixin\Icon;
+	use Mixin\Placeholder;
+
+	public function __construct(
+		bool|null $autofocus = null,
+		mixed $default = null,
+		bool|null $disabled = null,
+		array|string|null $help = null,
+		string|null $icon = null,
+		array|string|null $label = null,
+		string|null $name = null,
+		array|string|null $options = null,
+		array|string|null $placeholder = null,
+		bool|null $required = null,
+		bool|null $translate = null,
+		array|null $when = null,
+		string|null $width = null
+	) {
+		parent::__construct(
+			autofocus: $autofocus,
+			default: $default,
+			disabled: $disabled,
+			help: $help,
+			label: $label,
+			name: $name,
+			options: $options,
+			required: $required,
+			translate: $translate,
+			when: $when,
+			width: $width
+		);
+
+		$this->icon        = $icon;
+		$this->placeholder = $placeholder;
+	}
+
+	protected function fetchOptions(): array
+	{
+		$props = FieldOptions::polyfill(['options' => $this->options ?? []]);
+
+		// disable safe mode as the select field does not
+		// render HTML for the option text
+		$options = FieldOptions::factory($props['options'], false);
+
+		return $options->render($this->model());
+	}
+
+	public function placeholder(): string|null
+	{
+		return $this->stringTemplate($this->i18n($this->placeholder)) ?? '—';
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'icon'        => $this->icon(),
+			'placeholder' => $this->placeholder(),
+		];
+	}
+}

--- a/tests/Form/Field/EntriesFieldTest.php
+++ b/tests/Form/Field/EntriesFieldTest.php
@@ -340,7 +340,16 @@ class EntriesFieldTest extends TestCase
 
 			['number', 1, true],
 
-			['select', 'web', true],
+			['select', 'web', false],
+
+			[
+				[
+					'type'    => 'select',
+					'options' => ['web', 'print'],
+				],
+				'web',
+				true
+			],
 
 			['slug', 'page-slug', true],
 

--- a/tests/Form/Field/SelectFieldTest.php
+++ b/tests/Form/Field/SelectFieldTest.php
@@ -2,8 +2,6 @@
 
 namespace Kirby\Form\Field;
 
-use PHPUnit\Framework\Attributes\DataProvider;
-
 class SelectFieldTest extends TestCase
 {
 	public function testDefaultProps(): void
@@ -99,16 +97,20 @@ class SelectFieldTest extends TestCase
 
 		$field = $this->field('select', [
 			'model'   => $app->page('b'),
-			'options' => 'query',
-			'query'   => 'page.siblings.pluck("tags", ",", true)',
+			'options' => [
+				'type'  => 'query',
+				'query' => 'page.siblings.pluck("tags", ",", true)',
+			],
 		]);
 
 		$this->assertSame($expected, $field->options());
 
 		$field = $this->field('select', [
 			'model'   => $app->file('a/b.jpg'),
-			'options' => 'query',
-			'query'   => 'file.siblings.pluck("tags", ",", true)',
+			'options' => [
+				'type'  => 'query',
+				'query' => 'file.siblings.pluck("tags", ",", true)',
+			],
 		]);
 
 		$this->assertSame($expected, $field->options());
@@ -183,35 +185,5 @@ class SelectFieldTest extends TestCase
 		]);
 
 		$this->assertSame($expected, $field->options());
-	}
-
-	public static function valueInputProvider(): array
-	{
-		return [
-			['a', 'a'],
-			['b', 'b'],
-			['c', 'c'],
-			['d', ''],
-			['1', '1'],
-			['2', '2'],
-			['3', '']
-		];
-	}
-
-	#[DataProvider('valueInputProvider')]
-	public function testValue($input, $expected): void
-	{
-		$field = $this->field('select', [
-			'options' => [
-				'a',
-				'b',
-				'c',
-				1,
-				2
-			],
-			'value' => $input
-		]);
-
-		$this->assertSame($expected, $field->value());
 	}
 }


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7696
- [x] https://github.com/getkirby/kirby/pull/7698

## Changelog 

### ♻️ Refactored

- New `Kirby\Form\Field\SelectField` class

### 🚨 Breaking changes

- The select field does no longer remove invalid values on submit or fill, but uses the option validator to warn if a value is invalid. This is more in line with what other input fields do in Kirby and has massive performance benefits. It also means that you can deliberately store a non-existing option if you skip validation, which also might be useful in some cases.
- The `api` and `query` options for the select field are no longer available. Queries and API calls to fetch options have now to be declared directly in the options property. 
```yaml
fields: 
  mySelect: 
    type: select
    options: 
      type: query
      query: some.query
```

or 

```yaml
fields: 
  mySelect: 
    type: select
    options: 
      type: api
      url: /some/options/api
```

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

- [ ] Remove outdated api and query options from docs. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion