### PR TITLE
(Fields PR) refact!: New CheckboxesField class 

### DIFF
--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -10,6 +10,7 @@ use Kirby\Cache\RedisCache;
 use Kirby\Cms\Auth\EmailChallenge;
 use Kirby\Cms\Auth\TotpChallenge;
 use Kirby\Form\Field\BlocksField;
+use Kirby\Form\Field\CheckboxesField;
 use Kirby\Form\Field\EntriesField;
 use Kirby\Form\Field\GapField;
 use Kirby\Form\Field\HeadlineField;
@@ -226,7 +227,7 @@ class Core
 	{
 		return [
 			'blocks'      => BlocksField::class,
-			'checkboxes'  => $this->root . '/fields/checkboxes.php',
+			'checkboxes'  => CheckboxesField::class,
 			'color'       => $this->root . '/fields/color.php',
 			'date'        => $this->root . '/fields/date.php',
 			'email'       => $this->root . '/fields/email.php',
@@ -261,15 +262,16 @@ class Core
 			'users'       => $this->root . '/fields/users.php',
 			'writer'      => $this->root . '/fields/writer.php',
 
-			'legacy-gap'       => $this->root . '/fields/gap.php',
-			'legacy-headline'  => $this->root . '/fields/headline.php',
-			'legacy-hidden'    => $this->root . '/fields/hidden.php',
-			'legacy-info'      => $this->root . '/fields/info.php',
-			'legacy-line'      => $this->root . '/fields/line.php',
-			'legacy-object'    => $this->root . '/fields/object.php',
-			'legacy-radio'     => $this->root . '/fields/radio.php',
-			'legacy-select'    => $this->root . '/fields/select.php',
-			'legacy-structure' => $this->root . '/fields/structure.php',
+			'legacy-checkboxes' => $this->root . '/fields/checkboxes.php',
+			'legacy-gap'        => $this->root . '/fields/gap.php',
+			'legacy-headline'   => $this->root . '/fields/headline.php',
+			'legacy-hidden'     => $this->root . '/fields/hidden.php',
+			'legacy-info'       => $this->root . '/fields/info.php',
+			'legacy-line'       => $this->root . '/fields/line.php',
+			'legacy-object'     => $this->root . '/fields/object.php',
+			'legacy-radio'      => $this->root . '/fields/radio.php',
+			'legacy-select'     => $this->root . '/fields/select.php',
+			'legacy-structure'  => $this->root . '/fields/structure.php',
 		];
 	}
 

--- a/src/Form/Field/CheckboxesField.php
+++ b/src/Form/Field/CheckboxesField.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Form\Mixin;
+use Kirby\Toolkit\A;
+use Kirby\Toolkit\Str;
+
+/**
+ * Checkboxes Field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class CheckboxesField extends OptionsField
+{
+	use Mixin\Batch;
+	use Mixin\Columns;
+
+	public function __construct(
+		bool|null $autofocus = null,
+		bool|null $batch = null,
+		int|null $columns = null,
+		mixed $default = null,
+		bool|null $disabled = null,
+		array|string|null $help = null,
+		array|string|null $label = null,
+		int|null $max = null,
+		int|null $min = null,
+		string|null $name = null,
+		array|string|null $options = null,
+		bool|null $required = null,
+		bool|null $translate = null,
+		array|null $when = null,
+		string|null $width = null
+	) {
+		parent::__construct(
+			autofocus: $autofocus,
+			default: $default,
+			disabled: $disabled,
+			help: $help,
+			label: $label,
+			max: $max,
+			min: $min,
+			name: $name,
+			options: $options,
+			required: $required,
+			translate: $translate,
+			when: $when,
+			width: $width
+		);
+
+		$this->batch   = $batch;
+		$this->columns = $columns;
+	}
+
+	/**
+	 * @psalm-suppress MethodSignatureMismatch
+	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
+	 */
+	public function fill(mixed $value): static
+	{
+		$this->value = Str::split($value, ',');
+		return $this;
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'batch'   => $this->batch(),
+			'columns' => $this->columns(),
+		];
+	}
+
+	public function toStoredValue(): mixed
+	{
+		return A::join($this->value, ', ');
+	}
+}

--- a/src/Form/Field/CheckboxesField.php
+++ b/src/Form/Field/CheckboxesField.php
@@ -40,18 +40,18 @@ class CheckboxesField extends OptionsField
 	) {
 		parent::__construct(
 			autofocus: $autofocus,
-			default: $default,
-			disabled: $disabled,
-			help: $help,
-			label: $label,
-			max: $max,
-			min: $min,
-			name: $name,
-			options: $options,
-			required: $required,
+			default:   $default,
+			disabled:  $disabled,
+			help:      $help,
+			label:     $label,
+			max:       $max,
+			min:       $min,
+			name:      $name,
+			options:   $options,
+			required:  $required,
 			translate: $translate,
-			when: $when,
-			width: $width
+			when:      $when,
+			width:     $width
 		);
 
 		$this->batch   = $batch;

--- a/src/Form/Field/OptionsField.php
+++ b/src/Form/Field/OptionsField.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Form\Mixin;
+
+/**
+ * Options Field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+abstract class OptionsField extends InputField
+{
+	use Mixin\Max;
+	use Mixin\Min;
+	use Mixin\Options;
+
+	protected mixed $value = [];
+
+	public function __construct(
+		bool|null $autofocus = null,
+		mixed $default = null,
+		bool|null $disabled = null,
+		array|string|null $help = null,
+		array|string|null $label = null,
+		int|null $max = null,
+		int|null $min = null,
+		string|null $name = null,
+		array|string|null $options = null,
+		bool|null $required = null,
+		bool|null $translate = null,
+		array|null $when = null,
+		string|null $width = null
+	) {
+		parent::__construct(
+			autofocus: $autofocus,
+			default: $default,
+			disabled: $disabled,
+			help: $help,
+			label: $label,
+			name: $name,
+			required: $required,
+			translate: $translate,
+			when: $when,
+			width: $width
+		);
+
+		$this->max     = $max;
+		$this->min     = $min;
+		$this->options = $options;
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'options' => $this->options(),
+		];
+	}
+
+	protected function validations(): array
+	{
+		return [
+			'options',
+			'max',
+			'min'
+		];
+	}
+}

--- a/tests/Form/Field/CheckboxesFieldTest.php
+++ b/tests/Form/Field/CheckboxesFieldTest.php
@@ -95,7 +95,7 @@ class CheckboxesFieldTest extends TestCase
 			'value' => 'a, b, d'
 		]);
 
-		$this->assertSame(['a', 'b'], $field->value());
+		$this->assertSame('a, b', $field->toStoredValue());
 	}
 
 	public function testMin(): void

--- a/tests/Form/Field/CheckboxesFieldTest.php
+++ b/tests/Form/Field/CheckboxesFieldTest.php
@@ -7,18 +7,35 @@ class CheckboxesFieldTest extends TestCase
 	public function testDefaultProps(): void
 	{
 		$field = $this->field('checkboxes');
+		$props = $field->props();
 
-		$this->assertSame('checkboxes', $field->type());
-		$this->assertSame('checkboxes', $field->name());
-		$this->assertSame([], $field->value());
-		$this->assertSame([], $field->options());
-		$this->assertTrue($field->save());
+		ksort($props);
+
+		$expected = [
+			'autofocus' => false,
+			'batch'     => false,
+			'columns'   => 1,
+			'default'   => null,
+			'disabled'  => false,
+			'help'      => null,
+			'hidden'    => false,
+			'label'     => 'Checkboxes',
+			'name'      => 'checkboxes',
+			'options'   => [],
+			'required'  => false,
+			'saveable'  => true,
+			'translate' => true,
+			'type'      => 'checkboxes',
+			'when'      => null,
+			'width'     => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
 	}
 
 	public function testValue(): void
 	{
 		$field = $this->field('checkboxes', [
-			'value'   => 'a,b,c',
 			'options' => $expected = [
 				'a',
 				'b',
@@ -26,32 +43,17 @@ class CheckboxesFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertSame($expected, $field->value());
+		$field->fill('a, b, c');
+		$this->assertSame($expected, $field->toFormValue());
 	}
 
 	public function testEmptyValue(): void
 	{
 		$field = $this->field('checkboxes');
-
-		$this->assertSame([], $field->value());
+		$this->assertSame([], $field->toFormValue());
 	}
 
-	public function testDefaultValueWithInvalidOptions(): void
-	{
-		$field = $this->field('checkboxes', [
-			'default' => 'a,b,d',
-			'options' => [
-				'a',
-				'b',
-				'c'
-			],
-		]);
-
-		$this->assertSame(['a', 'b'], $field->default());
-		$this->assertSame('a, b', $field->data(true));
-	}
-
-	public function testFillWithEmptyValue(): void
+	public function testReset(): void
 	{
 		$field = $this->field('checkboxes', [
 			'options' => [
@@ -65,37 +67,18 @@ class CheckboxesFieldTest extends TestCase
 
 		$this->assertSame(['a', 'b'], $field->toFormValue());
 
-		$field->fillWithEmptyValue();
+		$field->reset();
 
 		$this->assertSame([], $field->toFormValue());
 	}
 
-	public function testStringConversion(): void
+	public function testToStoredValue(): void
 	{
-		$field = $this->field('checkboxes', [
-			'options' => [
-				'a',
-				'b',
-				'c'
-			],
-			'value' => 'a,b,c,d'
-		]);
+		$field = $this->field('checkboxes');
 
-		$this->assertSame('a, b, c', $field->data());
-	}
+		$field->fill(['a', 'b', 'c']);
 
-	public function testIgnoreInvalidOptions(): void
-	{
-		$field = $this->field('checkboxes', [
-			'options' => [
-				'a',
-				'b',
-				'c'
-			],
-			'value' => 'a, b, d'
-		]);
-
-		$this->assertSame('a, b', $field->toStoredValue());
+		$this->assertSame('a, b, c', $field->toStoredvalue());
 	}
 
 	public function testMin(): void
@@ -106,7 +89,7 @@ class CheckboxesFieldTest extends TestCase
 			'min'     => 2
 		]);
 
-		$this->assertTrue($field->required());
+		$this->assertTrue($field->isRequired());
 		$this->assertFalse($field->isValid());
 		$this->assertArrayHasKey('min', $field->errors());
 	}
@@ -121,6 +104,21 @@ class CheckboxesFieldTest extends TestCase
 
 		$this->assertFalse($field->isValid());
 		$this->assertArrayHasKey('max', $field->errors());
+	}
+
+	public function testFillWithInvalidOption(): void
+	{
+		$field = $this->field('checkboxes', [
+			'options'  => ['a', 'b', 'c']
+		]);
+
+		$field->fill('c');
+
+		$this->assertTrue($field->isValid());
+
+		$field->fill('d');
+
+		$this->assertFalse($field->isValid());
 	}
 
 	public function testRequiredProps(): void


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7696
- [x] https://github.com/getkirby/kirby/pull/7698
- [x] https://github.com/getkirby/kirby/pull/7699

## Changelog 

### ♻️ Refactored

- New `Kirby\Form\Field\OptionsField` abstract class
- New `Kirby\Form\Field\CheckboxesField` class

### 🚨 Breaking changes

- The checkboxes field does no longer remove invalid values on submit or fill, but uses the options validator to warn if a value is invalid. This is more in line with what other input fields do in Kirby and has massive performance benefits. It also means that you can deliberately store a non-existing option if you skip validation, which also might be useful in some cases.
- The `api` and `query` options for the checkboxes field and other option classes are no longer available. Queries and API calls to fetch options have now to be declared directly in the options property. 
```yaml
fields: 
  myCheckboxes: 
    type: checkboxes
    options: 
      type: query
      query: some.query
```

or 

```yaml
fields: 
  myCheckboxes: 
    type: checkboxes
    options: 
      type: api
      url: /some/options/api
```

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

- [ ] Remove outdated api and query options from docs. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion