### PR TITLE
(Fields PR) refact!: New ObjectField class

### DIFF
--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -77,6 +77,7 @@ export default {
 		app.component("k-legacy-headline-field", HeadlineField);
 		app.component("k-legacy-info-field", InfoField);
 		app.component("k-legacy-line-field", LineField);
+		app.component("k-legacy-object-field", ObjectField);
 		app.component("k-legacy-structure-field", StructureField);
 	}
 };

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -17,6 +17,7 @@ use Kirby\Form\Field\HiddenField;
 use Kirby\Form\Field\InfoField;
 use Kirby\Form\Field\LayoutField;
 use Kirby\Form\Field\LineField;
+use Kirby\Form\Field\ObjectField;
 use Kirby\Form\Field\StatsField;
 use Kirby\Form\Field\StructureField;
 use Kirby\Panel\Ui\FilePreview\AudioFilePreview;
@@ -239,7 +240,7 @@ class Core
 			'list'        => $this->root . '/fields/list.php',
 			'multiselect' => $this->root . '/fields/multiselect.php',
 			'number'      => $this->root . '/fields/number.php',
-			'object'      => $this->root . '/fields/object.php',
+			'object'      => ObjectField::class,
 			'pages'       => $this->root . '/fields/pages.php',
 			'radio'       => $this->root . '/fields/radio.php',
 			'range'       => $this->root . '/fields/range.php',
@@ -263,6 +264,7 @@ class Core
 			'legacy-hidden'    => $this->root . '/fields/hidden.php',
 			'legacy-info'      => $this->root . '/fields/info.php',
 			'legacy-line'      => $this->root . '/fields/line.php',
+			'legacy-object'    => $this->root . '/fields/object.php',
 			'legacy-structure' => $this->root . '/fields/structure.php',
 		];
 	}

--- a/src/Data/Txt.php
+++ b/src/Data/Txt.php
@@ -44,7 +44,7 @@ class Txt extends Handler
 	{
 		// avoid problems with certain values
 		$value = match (true) {
-			is_array($value) => Data::encode($value, 'yaml'),
+			is_array($value) => $value === [] ? '' : Data::encode($value, 'yaml'),
 			is_float($value) => Str::float($value),
 			default          => $value
 		};

--- a/src/Form/Field/ObjectField.php
+++ b/src/Form/Field/ObjectField.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Data\Data;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Form\Mixin;
+
+class ObjectField extends InputField
+{
+	use Mixin\EmptyState;
+	use Mixin\Fields;
+
+	protected mixed $value = [];
+
+	public function __construct(
+		array|null $default = null,
+		bool|null $disabled = null,
+		array|string|null $empty = null,
+		array|null $fields = null,
+		array|string|null $help = null,
+		array|string|null $label = null,
+		string|null $name = null,
+		bool|null $required = null,
+		bool|null $translate = null,
+		array|null $when = null,
+		string|null $width = null,
+	) {
+		parent::__construct(
+			default:   $default,
+			disabled:  $disabled,
+			help:      $help,
+			label:     $label,
+			name:      $name,
+			required:  $required,
+			translate: $translate,
+			when:      $when,
+			width:     $width
+		);
+
+		$this->empty  = $empty;
+		$this->fields = $fields;
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'empty'  => $this->empty(),
+			'fields' => $this->fields(),
+		];
+	}
+
+	/**
+	 * @psalm-suppress MethodSignatureMismatch
+	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
+	 */
+	public function fill(mixed $value): static
+	{
+		$this->value = Data::decode($value, 'yaml');
+		return $this;
+	}
+
+	public function toFormValue(): array
+	{
+		if ($this->isEmptyValue($this->value) === true) {
+			return [];
+		}
+
+		return $this->form()
+			->fill(
+				input: $this->value ?? [],
+				passthrough: true
+			)
+			->toFormValues();
+	}
+
+	public function toStoredValue(): array
+	{
+		if ($this->isEmptyValue($this->value) === true) {
+			return [];
+		}
+
+		$form     = $this->form();
+		$defaults = $form->defaults();
+
+		return $form
+			->fill(
+				input: $defaults,
+			)
+			->submit(
+				input: $this->value,
+				passthrough: true
+			)
+			->toStoredValues();
+	}
+
+	protected function validations(): array
+	{
+		return [
+			'object' => $this->validateObject(...)
+		];
+	}
+
+	protected function validateObject(array|string|null $value): void
+	{
+		if ($this->isEmptyValue($value) === true) {
+			return;
+		}
+
+		$errors = $this->form()->fill($value)->errors();
+
+		if ($errors === []) {
+			return;
+		}
+
+		// use the first error for details
+		$name  = array_key_first($errors);
+		$error = $errors[$name];
+
+		throw new InvalidArgumentException(
+			key: 'object.validation',
+			data: [
+				'label'   => $error['label'] ?? $name,
+				'message' => implode("\n", $error['message'])
+			]
+		);
+	}
+}

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -178,7 +178,7 @@ class BlueprintTest extends TestCase
 					'type'   => 'object',
 					'fields' => [
 						'text' => [
-							'type' => 'object',
+							'type' => 'textarea',
 							'uploads' => [
 								'template' => 'd'
 							]
@@ -191,7 +191,7 @@ class BlueprintTest extends TestCase
 						'text' => [
 							'fields' => [
 								'text' => [
-									'type' => 'object',
+									'type' => 'textarea',
 									'uploads' => [
 										'template' => 'e'
 									]

--- a/tests/Data/TxtTest.php
+++ b/tests/Data/TxtTest.php
@@ -109,7 +109,8 @@ class TxtTest extends TestCase
 		$array = [
 			'title' => 'Title',
 			'text'  => ['a', 'b', 'c'],
-			'text2' => ['a']
+			'text2' => [],
+			'text3' => ['a'],
 		];
 
 		$data = Txt::encode($array);

--- a/tests/Data/fixtures/test.txt
+++ b/tests/Data/fixtures/test.txt
@@ -10,4 +10,8 @@ Text:
 
 ----
 
-Text2: - a
+Text2: 
+
+----
+
+Text3: - a

--- a/tests/Form/Field/ObjectFieldTest.php
+++ b/tests/Form/Field/ObjectFieldTest.php
@@ -4,6 +4,36 @@ namespace Kirby\Form\Field;
 
 class ObjectFieldTest extends TestCase
 {
+	public function testDefaultProps(): void
+	{
+		$field = $this->field('object');
+
+		$props = $field->props();
+
+		// makes it easier to compare the arrays
+		ksort($props);
+
+		$expected = [
+			'autofocus' => false,
+			'default'   => null,
+			'disabled'  => false,
+			'empty'     => null,
+			'fields'    => [],
+			'help'      => null,
+			'hidden'    => false,
+			'label'     => 'Object',
+			'name'      => 'object',
+			'required'  => false,
+			'saveable'  => true,
+			'translate' => true,
+			'type'      => 'object',
+			'when'      => null,
+			'width'     => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
+	}
+
 	public function testData(): void
 	{
 		$field = $this->field('object', [
@@ -30,24 +60,7 @@ class ObjectFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertSame('', $field->data());
-	}
-
-	public function testDefaultProps(): void
-	{
-		$field = $this->field('object', [
-			'fields' => [
-				'text' => [
-					'type' => 'text'
-				]
-			]
-		]);
-
-		$this->assertSame('object', $field->type());
-		$this->assertSame('object', $field->name());
-		$this->assertIsArray($field->fields());
-		$this->assertSame('', $field->value());
-		$this->assertTrue($field->save());
+		$this->assertSame([], $field->data());
 	}
 
 	public function testDefaultValue(): void


### PR DESCRIPTION
## Merge first

- [ ] https://github.com/getkirby/kirby/pull/7696

## Changelog 

### ♻️ Refactored

- New `Kirby\Form\Field\ObjectField` class
- `Kirby\Data\Txt::encode()` stores an empty string when an empty array is passed. Otherwise, our yaml encoder will store `[]` as value, which is technically correct, but can lead to unwanted side-effects, when not running it through `Txt::decode()` in a field method again.

### ☠️ Deprecated
- `legacy-object` field will be removed in an upcoming major version. Please move to class-based fields instead and extend the `ObjectField` class.

### 🚨 Breaking changes
- The `object` field is now implemented as class. When extending in an array-based field, either switch your field to a class as well or extend the deprecated `legacy-object` field for the moment.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion