### PR TITLE
(Fields PR) refact!: New TogglesField class

### DIFF
--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -81,5 +81,6 @@ export default {
 		app.component("k-legacy-radio-field", RadioField);
 		app.component("k-legacy-select-field", SelectField);
 		app.component("k-legacy-structure-field", StructureField);
+		app.component("k-legacy-toggles-field", TogglesField);
 	}
 };

--- a/panel/src/components/Forms/Input/TogglesInput.vue
+++ b/panel/src/components/Forms/Input/TogglesInput.vue
@@ -50,7 +50,7 @@ export const props = {
 		grow: Boolean,
 		labels: Boolean,
 		options: Array,
-		reset: Boolean,
+		resettable: Boolean,
 		value: [String, Number, Boolean]
 	}
 };
@@ -71,7 +71,7 @@ export default {
 			)?.focus();
 		},
 		onClick(value) {
-			if (value === this.value && this.reset && !this.required) {
+			if (value === this.value && this.resettable && !this.required) {
 				this.$emit("input", "");
 			}
 		},

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -23,6 +23,7 @@ use Kirby\Form\Field\RadioField;
 use Kirby\Form\Field\SelectField;
 use Kirby\Form\Field\StatsField;
 use Kirby\Form\Field\StructureField;
+use Kirby\Form\Field\TogglesField;
 use Kirby\Panel\Ui\FilePreview\AudioFilePreview;
 use Kirby\Panel\Ui\FilePreview\ImageFilePreview;
 use Kirby\Panel\Ui\FilePreview\PdfFilePreview;
@@ -257,7 +258,7 @@ class Core
 			'textarea'    => $this->root . '/fields/textarea.php',
 			'time'        => $this->root . '/fields/time.php',
 			'toggle'      => $this->root . '/fields/toggle.php',
-			'toggles'     => $this->root . '/fields/toggles.php',
+			'toggles'     => TogglesField::class,
 			'url'         => $this->root . '/fields/url.php',
 			'users'       => $this->root . '/fields/users.php',
 			'writer'      => $this->root . '/fields/writer.php',
@@ -272,6 +273,7 @@ class Core
 			'legacy-radio'      => $this->root . '/fields/radio.php',
 			'legacy-select'     => $this->root . '/fields/select.php',
 			'legacy-structure'  => $this->root . '/fields/structure.php',
+			'legacy-toggles'    => $this->root . '/fields/toggles.php',
 		];
 	}
 

--- a/src/Form/Field/TogglesField.php
+++ b/src/Form/Field/TogglesField.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+/**
+ * Toggles Field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class TogglesField extends OptionField
+{
+	/**
+	 * Toggles will automatically span the full width of the field. With the grow option, you can disable this behaviour for a more compact layout.
+	 */
+	protected bool|null $grow = null;
+
+	/**
+	 * If `false` all labels will be hidden for icon-only toggles.
+	 */
+	protected bool|null $labels = null;
+
+	/**
+	 * A toggle can be deactivated on click. If resettable is `false` deactivating a toggle is no longer possible.
+	 */
+	protected bool|null $resettable = null;
+
+	public function __construct(
+		bool|null $autofocus = null,
+		mixed $default = null,
+		bool|null $disabled = null,
+		bool|null $grow = null,
+		array|string|null $help = null,
+		array|string|null $label = null,
+		bool|null $labels = null,
+		string|null $name = null,
+		array|string|null $options = null,
+		bool|null $required = null,
+		bool|null $resettable = null,
+		bool|null $translate = null,
+		array|null $when = null,
+		string|null $width = null
+	) {
+		parent::__construct(
+			autofocus: $autofocus,
+			default: $default,
+			disabled: $disabled,
+			help: $help,
+			label: $label,
+			name: $name,
+			options: $options,
+			required: $required,
+			translate: $translate,
+			when: $when,
+			width: $width
+		);
+
+		$this->grow       = $grow;
+		$this->labels     = $labels;
+		$this->resettable = $resettable;
+	}
+
+	public function labels(): bool
+	{
+		return $this->labels ?? true;
+	}
+
+	public function grow(): bool
+	{
+		return $this->grow ?? true;
+	}
+
+	public function resettable(): bool
+	{
+		return $this->resettable ?? true;
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'grow'       => $this->grow(),
+			'labels'     => $this->labels(),
+			'resettable' => $this->resettable(),
+		];
+	}
+}

--- a/tests/Form/Field/TogglesFieldTest.php
+++ b/tests/Form/Field/TogglesFieldTest.php
@@ -2,22 +2,36 @@
 
 namespace Kirby\Form\Field;
 
-use PHPUnit\Framework\Attributes\DataProvider;
-
 class TogglesFieldTest extends TestCase
 {
 	public function testDefaultProps(): void
 	{
 		$field = $this->field('toggles');
+		$props = $field->props();
 
-		$this->assertSame('toggles', $field->type());
-		$this->assertSame('toggles', $field->name());
-		$this->assertSame('', $field->value());
-		$this->assertTrue($field->grow());
-		$this->assertTrue($field->labels());
-		$this->assertTrue($field->reset());
-		$this->assertSame([], $field->options());
-		$this->assertTrue($field->save());
+		ksort($props);
+
+		$expected = [
+			'autofocus'  => false,
+			'default'    => null,
+			'disabled'   => false,
+			'grow'       => true,
+			'help'       => null,
+			'hidden'     => false,
+			'label'      => 'Toggles',
+			'labels'     => true,
+			'name'       => 'toggles',
+			'options'    => [],
+			'required'   => false,
+			'resettable' => true,
+			'saveable'   => true,
+			'translate'  => true,
+			'type'       => 'toggles',
+			'when'       => null,
+			'width'      => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
 	}
 
 	public function testGrow(): void
@@ -50,43 +64,18 @@ class TogglesFieldTest extends TestCase
 		$this->assertTrue($field->labels());
 	}
 
-	public function testReset(): void
+	public function testResettable(): void
 	{
 		$field = $this->field('toggles', [
-			'reset' => false
+			'resettable' => false
 		]);
 
-		$this->assertFalse($field->reset());
+		$this->assertFalse($field->resettable());
 
 		$field = $this->field('toggles', [
-			'reset' => true
+			'resettable' => true
 		]);
 
-		$this->assertTrue($field->reset());
-	}
-
-	public static function valueInputProvider(): array
-	{
-		return [
-			['a', 'a'],
-			['b', 'b'],
-			['c', 'c'],
-			['d', '']
-		];
-	}
-
-	#[DataProvider('valueInputProvider')]
-	public function testValue($input, $expected): void
-	{
-		$field = $this->field('toggles', [
-			'options' => [
-				'a',
-				'b',
-				'c'
-			],
-			'value' => $input
-		]);
-
-		$this->assertTrue($expected === $field->value());
+		$this->assertTrue($field->resettable());
 	}
 }


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7696
- [x] https://github.com/getkirby/kirby/pull/7698
- [x] https://github.com/getkirby/kirby/pull/7699
- [x] https://github.com/getkirby/kirby/pull/7700

## Changelog 

### ♻️ Refactored

- New `Kirby\Form\Field\TogglesField` class

### 🚨 Breaking changes

- The `reset` method has been renamed to `resettable` to avoid collissions with the `TogglesField::reset()` method. This also applies to the `<k-toggles-input>` component.
- The toggles field does no longer remove invalid values on submit or fill, but uses the options validator to warn if a value is invalid. This is more in line with what other input fields do in Kirby and has massive performance benefits. It also means that you can deliberately store a non-existing option if you skip validation, which also might be useful in some cases.
- The `api` and `query` options for the toggles field and other option classes are no longer available. Queries and API calls to fetch options have now to be declared directly in the options property. 
```yaml
fields: 
  myToggles:
    type: toggles
    options: 
      type: query
      query: some.query
```

or 

```yaml
fields: 
  myToggles: 
    type: toggles
    options: 
      type: api
      url: /some/options/api
```

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

- [ ] Remove outdated api and query options from docs. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion