### PR TITLE
(Fields PR) refact!: New TagsField class

### DIFF
--- a/config/fields/multiselect.php
+++ b/config/fields/multiselect.php
@@ -4,7 +4,7 @@ use Kirby\Toolkit\Str;
 use Kirby\Toolkit\V;
 
 return [
-	'extends' => 'tags',
+	'extends' => 'legacy-tags',
 	'props' => [
 		/**
 		 * If set to `all`, any type of input is accepted. If set to `options` only the predefined options are accepted as input.

--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -81,6 +81,7 @@ export default {
 		app.component("k-legacy-radio-field", RadioField);
 		app.component("k-legacy-select-field", SelectField);
 		app.component("k-legacy-structure-field", StructureField);
+		app.component("k-legacy-tags-field", TagsField);
 		app.component("k-legacy-toggles-field", TogglesField);
 	}
 };

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -23,6 +23,7 @@ use Kirby\Form\Field\RadioField;
 use Kirby\Form\Field\SelectField;
 use Kirby\Form\Field\StatsField;
 use Kirby\Form\Field\StructureField;
+use Kirby\Form\Field\TagsField;
 use Kirby\Form\Field\TogglesField;
 use Kirby\Panel\Ui\FilePreview\AudioFilePreview;
 use Kirby\Panel\Ui\FilePreview\ImageFilePreview;
@@ -252,7 +253,7 @@ class Core
 			'slug'        => $this->root . '/fields/slug.php',
 			'stats'       => StatsField::class,
 			'structure'   => StructureField::class,
-			'tags'        => $this->root . '/fields/tags.php',
+			'tags'        => TagsField::class,
 			'tel'         => $this->root . '/fields/tel.php',
 			'text'        => $this->root . '/fields/text.php',
 			'textarea'    => $this->root . '/fields/textarea.php',
@@ -273,6 +274,7 @@ class Core
 			'legacy-radio'      => $this->root . '/fields/radio.php',
 			'legacy-select'     => $this->root . '/fields/select.php',
 			'legacy-structure'  => $this->root . '/fields/structure.php',
+			'legacy-tags'       => $this->root . '/fields/tags.php',
 			'legacy-toggles'    => $this->root . '/fields/toggles.php',
 		];
 	}

--- a/src/Form/Field/OptionsField.php
+++ b/src/Form/Field/OptionsField.php
@@ -60,7 +60,7 @@ abstract class OptionsField extends InputField
 		return [
 			...parent::props(),
 			'max'     => $this->max(),
-			'min'     => $this->max(),
+			'min'     => $this->min(),
 			'options' => $this->options(),
 		];
 	}

--- a/src/Form/Field/OptionsField.php
+++ b/src/Form/Field/OptionsField.php
@@ -59,6 +59,8 @@ abstract class OptionsField extends InputField
 	{
 		return [
 			...parent::props(),
+			'max'     => $this->max(),
+			'min'     => $this->max(),
 			'options' => $this->options(),
 		];
 	}

--- a/src/Form/Field/TagsField.php
+++ b/src/Form/Field/TagsField.php
@@ -72,18 +72,18 @@ class TagsField extends OptionsField
 	) {
 		parent::__construct(
 			autofocus: $autofocus,
-			default: $default,
-			disabled: $disabled,
-			help: $help,
-			label: $label,
-			name: $name,
-			max: $max,
-			min: $min,
-			options: $options,
-			required: $required,
+			default:   $default,
+			disabled:  $disabled,
+			help:      $help,
+			label:     $label,
+			name:      $name,
+			max:       $max,
+			min:       $min,
+			options:   $options,
+			required:  $required,
 			translate: $translate,
-			when: $when,
-			width: $width
+			when:      $when,
+			width:     $width
 		);
 
 		$this->accept    = $accept;
@@ -94,22 +94,17 @@ class TagsField extends OptionsField
 		$this->sort      = $sort;
 	}
 
-	public function default(): array
-	{
-		return parent::default() ?? [];
-	}
-
-	public function icon(): string|null
-	{
-		return $this->icon ?? 'tag';
-	}
-
-	public function accept(): string|null
+	public function accept(): string
 	{
 		return match($this->accept) {
 			'options' => 'options',
 			default   => 'all'
 		};
+	}
+
+	public function default(): array
+	{
+		return parent::default() ?? [];
 	}
 
 	/**
@@ -120,6 +115,11 @@ class TagsField extends OptionsField
 	{
 		$this->value = Str::split($value, $this->separator());
 		return $this;
+	}
+
+	public function icon(): string
+	{
+		return $this->icon ?? 'tag';
 	}
 
 	public function search(): array|bool

--- a/src/Form/Field/TagsField.php
+++ b/src/Form/Field/TagsField.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Form\Mixin;
+use Kirby\Form\Validations;
+use Kirby\Toolkit\A;
+use Kirby\Toolkit\Str;
+
+/**
+ * Tags Field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class TagsField extends OptionsField
+{
+	use Mixin\Icon;
+
+	/**
+	 * If set to `all`, any type of input is accepted. If set to `options` only the predefined options are accepted as input.
+	 */
+	protected string|null $accept = null;
+
+	/**
+	 * Set to `list` to display each tag with 100% width,
+	 * otherwise the tags are displayed inline
+	 */
+	protected string|null $layout = null;
+
+	/**
+	 * Enable/disable the search in the dropdown
+	 * Also limit displayed items (display: 20)
+	 * and set minimum number of characters to search (min: 3)
+	 */
+	protected array|bool|null $search = null;
+
+	/**
+	 * Custom tags separator, which will be used to store tags in the content file
+	 */
+	protected string|null $separator = null;
+
+	/**
+	 * If `true`, selected entries will be sorted
+	 * according to their position in the dropdown
+	 */
+	protected bool|null $sort = null;
+
+	protected mixed $value = [];
+
+	public function __construct(
+		string|null $accept = null,
+		bool|null $autofocus = null,
+		mixed $default = null,
+		bool|null $disabled = null,
+		string|null $icon = null,
+		array|string|null $help = null,
+		array|string|null $label = null,
+		string|null $layout = null,
+		int|null $max = null,
+		int|null $min = null,
+		string|null $name = null,
+		array|string|null $options = null,
+		bool|null $required = null,
+		array|bool|null $search = null,
+		string|null $separator = null,
+		bool|null $sort = null,
+		bool|null $translate = null,
+		array|null $when = null,
+		string|null $width = null
+	) {
+		parent::__construct(
+			autofocus: $autofocus,
+			default: $default,
+			disabled: $disabled,
+			help: $help,
+			label: $label,
+			name: $name,
+			max: $max,
+			min: $min,
+			options: $options,
+			required: $required,
+			translate: $translate,
+			when: $when,
+			width: $width
+		);
+
+		$this->accept    = $accept;
+		$this->icon      = $icon;
+		$this->layout    = $layout;
+		$this->search    = $search;
+		$this->separator = $separator;
+		$this->sort      = $sort;
+	}
+
+	public function default(): array
+	{
+		return parent::default() ?? [];
+	}
+
+	public function icon(): string|null
+	{
+		return $this->icon ?? 'tag';
+	}
+
+	public function accept(): string|null
+	{
+		return match($this->accept) {
+			'options' => 'options',
+			default   => 'all'
+		};
+	}
+
+	/**
+	 * @psalm-suppress MethodSignatureMismatch
+	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
+	 */
+	public function fill(mixed $value): static
+	{
+		$this->value = Str::split($value, $this->separator());
+		return $this;
+	}
+
+	public function layout(): string|null
+	{
+		return $this->layout;
+	}
+
+	public function search(): array|bool
+	{
+		return $this->search ?? true;
+	}
+
+	public function separator(): string
+	{
+		return $this->separator ?? ',';
+	}
+
+	public function sort(): bool
+	{
+		return $this->sort ?? false;
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'accept'    => $this->accept(),
+			'icon'      => $this->icon(),
+			'layout'    => $this->layout(),
+			'search'    => $this->search(),
+			'separator' => $this->separator(),
+			'sort'      => $this->sort(),
+		];
+	}
+
+	public function toFormValue(): array
+	{
+		if (is_array($this->value) === false) {
+			return [];
+		}
+
+		return $this->value;
+	}
+
+	public function toStoredValue(): string
+	{
+		return A::join(
+			$this->value ?? [],
+			$this->separator() . ' '
+		);
+	}
+
+	protected function validations(): array
+	{
+		return [
+			'max',
+			'min',
+			'accepted' => $this->validateAcceptedOptions(...)
+		];
+	}
+
+	protected function validateAcceptedOptions(array $value): void
+	{
+		if ($this->accept() === 'all' || $value === []) {
+			return;
+		}
+
+		Validations::options($this, $value);
+	}
+}

--- a/src/Form/Field/TagsField.php
+++ b/src/Form/Field/TagsField.php
@@ -20,35 +20,31 @@ use Kirby\Toolkit\Str;
 class TagsField extends OptionsField
 {
 	use Mixin\Icon;
+	use Mixin\Separator;
 
 	/**
 	 * If set to `all`, any type of input is accepted. If set to `options` only the predefined options are accepted as input.
 	 */
-	protected string|null $accept = null;
+	protected string|null $accept;
 
 	/**
 	 * Set to `list` to display each tag with 100% width,
 	 * otherwise the tags are displayed inline
 	 */
-	protected string|null $layout = null;
+	protected string|null $layout;
 
 	/**
 	 * Enable/disable the search in the dropdown
 	 * Also limit displayed items (display: 20)
 	 * and set minimum number of characters to search (min: 3)
 	 */
-	protected array|bool|null $search = null;
-
-	/**
-	 * Custom tags separator, which will be used to store tags in the content file
-	 */
-	protected string|null $separator = null;
+	protected array|bool|null $search;
 
 	/**
 	 * If `true`, selected entries will be sorted
 	 * according to their position in the dropdown
 	 */
-	protected bool|null $sort = null;
+	protected bool|null $sort;
 
 	protected mixed $value = [];
 
@@ -133,11 +129,6 @@ class TagsField extends OptionsField
 	public function search(): array|bool
 	{
 		return $this->search ?? true;
-	}
-
-	public function separator(): string
-	{
-		return $this->separator ?? ',';
 	}
 
 	public function sort(): bool

--- a/src/Form/Field/TagsField.php
+++ b/src/Form/Field/TagsField.php
@@ -163,7 +163,7 @@ class TagsField extends OptionsField
 		return [
 			'max',
 			'min',
-			'accepted' => $this->validateAcceptedOptions(...)
+			'accepted' => fn ($value) => $this->validateAcceptedOptions($value)
 		];
 	}
 

--- a/src/Form/Field/TagsField.php
+++ b/src/Form/Field/TagsField.php
@@ -20,6 +20,7 @@ use Kirby\Toolkit\Str;
 class TagsField extends OptionsField
 {
 	use Mixin\Icon;
+	use Mixin\Layout;
 	use Mixin\Separator;
 
 	/**
@@ -119,11 +120,6 @@ class TagsField extends OptionsField
 	{
 		$this->value = Str::split($value, $this->separator());
 		return $this;
-	}
-
-	public function layout(): string|null
-	{
-		return $this->layout;
 	}
 
 	public function search(): array|bool

--- a/src/Form/Field/TagsField.php
+++ b/src/Form/Field/TagsField.php
@@ -147,10 +147,6 @@ class TagsField extends OptionsField
 
 	public function toFormValue(): array
 	{
-		if (is_array($this->value) === false) {
-			return [];
-		}
-
 		return $this->value;
 	}
 

--- a/src/Form/Mixin/Layout.php
+++ b/src/Form/Mixin/Layout.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait Layout
+{
+	/**
+	 * Switch the layout for the field
+	 */
+	protected string|null $layout;
+
+	public function layout(): string|null
+	{
+		return $this->layout;
+	}
+}

--- a/src/Form/Mixin/Separator.php
+++ b/src/Form/Mixin/Separator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Kirby\Form\Mixin;
+
+trait Separator
+{
+	/**
+	 * Custom separator, which will be used to store a list of values in the content file
+	 */
+	protected string|null $separator;
+
+	public function separator(): string
+	{
+		return $this->separator ?? ',';
+	}
+}

--- a/tests/Form/Field/CheckboxesFieldTest.php
+++ b/tests/Form/Field/CheckboxesFieldTest.php
@@ -20,6 +20,8 @@ class CheckboxesFieldTest extends TestCase
 			'help'      => null,
 			'hidden'    => false,
 			'label'     => 'Checkboxes',
+			'max'       => null,
+			'min'       => null,
 			'name'      => 'checkboxes',
 			'options'   => [],
 			'required'  => false,

--- a/tests/Form/Field/TagsFieldTest.php
+++ b/tests/Form/Field/TagsFieldTest.php
@@ -7,29 +7,47 @@ class TagsFieldTest extends TestCase
 	public function testDefaultProps(): void
 	{
 		$field = $this->field('tags');
+		$props = $field->props();
 
-		$this->assertSame('tags', $field->type());
-		$this->assertSame('tags', $field->name());
-		$this->assertSame('all', $field->accept());
-		$this->assertSame([], $field->value());
-		$this->assertSame([], $field->default());
-		$this->assertSame([], $field->options());
-		$this->assertNull($field->min());
-		$this->assertNull($field->max());
-		$this->assertSame(',', $field->separator());
-		$this->assertSame('tag', $field->icon());
-		$this->assertNull($field->counter());
-		$this->assertTrue($field->save());
+		ksort($props);
+
+		$expected = [
+			'accept'    => 'all',
+			'autofocus' => false,
+			'default'   => [],
+			'disabled'  => false,
+			'help'      => null,
+			'hidden'    => false,
+			'icon'      => 'tag',
+			'label'     => 'Tags',
+			'layout'    => null,
+			'max'       => null,
+			'min'       => null,
+			'name'      => 'tags',
+			'options'   => [],
+			'required'  => false,
+			'saveable'  => true,
+			'search'    => true,
+			'separator' => ',',
+			'sort'      => false,
+			'required'  => false,
+			'translate' => true,
+			'type'      => 'tags',
+			'when'      => null,
+			'width'     => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
 	}
 
-	public function testFillWithEmptyValue(): void
+	public function testReset(): void
 	{
 		$field = $this->field('tags');
 		$field->fill($value = ['a', 'b', 'c']);
 
 		$this->assertSame($value, $field->toFormValue());
 
-		$field->fillWithEmptyValue();
+		$field->reset();
 
 		$this->assertSame([], $field->toFormValue());
 	}
@@ -114,16 +132,20 @@ class TagsFieldTest extends TestCase
 
 		$field = $this->field('tags', [
 			'model'   => $app->page('b'),
-			'options' => 'query',
-			'query'   => 'page.siblings.pluck("tags", ",", true)',
+			'options' => [
+				'type'  => 'query',
+				'query' => 'page.siblings.pluck("tags", ",", true)',
+			]
 		]);
 
 		$this->assertSame($expected, $field->options());
 
 		$field = $this->field('tags', [
 			'model'   => $app->file('a/b.jpg'),
-			'options' => 'query',
-			'query'   => 'file.siblings.pluck("tags", ",", true)',
+			'options' => [
+				'type'  => 'query',
+				'query' => 'file.siblings.pluck("tags", ",", true)',
+			],
 		]);
 
 		$this->assertSame($expected, $field->options());
@@ -140,7 +162,7 @@ class TagsFieldTest extends TestCase
 		$this->assertFalse($field->isValid());
 		$this->assertArrayHasKey('min', $field->errors());
 		$this->assertSame(2, $field->min());
-		$this->assertTrue($field->required());
+		$this->assertTrue($field->isRequired());
 	}
 
 	public function testMax(): void


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7696
- [x] https://github.com/getkirby/kirby/pull/7698
- [x] https://github.com/getkirby/kirby/pull/7699
- [x] https://github.com/getkirby/kirby/pull/7700
- [x] https://github.com/getkirby/kirby/pull/7702

## Changelog 

### ♻️ Refactored

- New `Kirby\Form\Field\TagsField` class
- New `Kirby\Form\Mixin\Layout` mixin
- New `Kirby\Form\Mixin\Separator` mixin

### 🚨 Breaking changes

- The `api` and `query` options for the tags field and other option classes are no longer available. Queries and API calls to fetch options have now to be declared directly in the options property. 
```yaml
fields: 
  myTags:
    type: tags
    options: 
      type: query
      query: some.query
```

or 

```yaml
fields: 
  myTags: 
    type: tags
    options: 
      type: api
      url: /some/options/api
```

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

- [ ] Remove outdated api and query options from docs. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion