### PR TITLE
(Fields PR) refact!: New MultiselectField class

### DIFF
--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -78,6 +78,7 @@ export default {
 		app.component("k-legacy-info-field", InfoField);
 		app.component("k-legacy-line-field", LineField);
 		app.component("k-legacy-object-field", ObjectField);
+		app.component("k-legacy-multiselect-field", MultiselectField);
 		app.component("k-legacy-radio-field", RadioField);
 		app.component("k-legacy-select-field", SelectField);
 		app.component("k-legacy-structure-field", StructureField);

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -18,6 +18,7 @@ use Kirby\Form\Field\HiddenField;
 use Kirby\Form\Field\InfoField;
 use Kirby\Form\Field\LayoutField;
 use Kirby\Form\Field\LineField;
+use Kirby\Form\Field\MultiselectField;
 use Kirby\Form\Field\ObjectField;
 use Kirby\Form\Field\RadioField;
 use Kirby\Form\Field\SelectField;
@@ -243,7 +244,7 @@ class Core
 			'line'        => LineField::class,
 			'link'        => $this->root . '/fields/link.php',
 			'list'        => $this->root . '/fields/list.php',
-			'multiselect' => $this->root . '/fields/multiselect.php',
+			'multiselect' => MultiselectField::class,
 			'number'      => $this->root . '/fields/number.php',
 			'object'      => ObjectField::class,
 			'pages'       => $this->root . '/fields/pages.php',
@@ -264,18 +265,19 @@ class Core
 			'users'       => $this->root . '/fields/users.php',
 			'writer'      => $this->root . '/fields/writer.php',
 
-			'legacy-checkboxes' => $this->root . '/fields/checkboxes.php',
-			'legacy-gap'        => $this->root . '/fields/gap.php',
-			'legacy-headline'   => $this->root . '/fields/headline.php',
-			'legacy-hidden'     => $this->root . '/fields/hidden.php',
-			'legacy-info'       => $this->root . '/fields/info.php',
-			'legacy-line'       => $this->root . '/fields/line.php',
-			'legacy-object'     => $this->root . '/fields/object.php',
-			'legacy-radio'      => $this->root . '/fields/radio.php',
-			'legacy-select'     => $this->root . '/fields/select.php',
-			'legacy-structure'  => $this->root . '/fields/structure.php',
-			'legacy-tags'       => $this->root . '/fields/tags.php',
-			'legacy-toggles'    => $this->root . '/fields/toggles.php',
+			'legacy-checkboxes'  => $this->root . '/fields/checkboxes.php',
+			'legacy-gap'         => $this->root . '/fields/gap.php',
+			'legacy-headline'    => $this->root . '/fields/headline.php',
+			'legacy-hidden'      => $this->root . '/fields/hidden.php',
+			'legacy-info'        => $this->root . '/fields/info.php',
+			'legacy-line'        => $this->root . '/fields/line.php',
+			'legacy-multiselect' => $this->root . '/fields/multiselect.php',
+			'legacy-object'      => $this->root . '/fields/object.php',
+			'legacy-radio'       => $this->root . '/fields/radio.php',
+			'legacy-select'      => $this->root . '/fields/select.php',
+			'legacy-structure'   => $this->root . '/fields/structure.php',
+			'legacy-tags'        => $this->root . '/fields/tags.php',
+			'legacy-toggles'     => $this->root . '/fields/toggles.php',
 		];
 	}
 

--- a/src/Form/Field/MultiselectField.php
+++ b/src/Form/Field/MultiselectField.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+/**
+ * Multiselect Field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class MultiselectField extends TagsField
+{
+	public function __construct(
+		string|null $accept = null,
+		bool|null $autofocus = null,
+		mixed $default = null,
+		bool|null $disabled = null,
+		string|null $icon = null,
+		array|string|null $help = null,
+		array|string|null $label = null,
+		string|null $layout = null,
+		int|null $max = null,
+		int|null $min = null,
+		string|null $name = null,
+		array|string|null $options = null,
+		bool|null $required = null,
+		array|bool|null $search = null,
+		string|null $separator = null,
+		bool|null $sort = null,
+		bool|null $translate = null,
+		array|null $when = null,
+		string|null $width = null
+	) {
+		parent::__construct(
+			accept:    $accept,
+			autofocus: $autofocus,
+			default:   $default,
+			disabled:  $disabled,
+			help:      $help,
+			icon:      $icon,
+			label:     $label,
+			layout:    $layout,
+			name:      $name,
+			max:       $max,
+			min:       $min,
+			options:   $options,
+			required:  $required,
+			search:    $search,
+			separator: $separator,
+			sort:      $sort,
+			translate: $translate,
+			when:      $when,
+			width:     $width
+		);
+	}
+
+	public function accept(): string
+	{
+		return match($this->accept) {
+			'all'   => 'all',
+			default => 'options'
+		};
+	}
+
+	public function icon(): string
+	{
+		return $this->icon ?? 'checklist';
+	}
+}

--- a/tests/Form/Field/MultiselectFieldTest.php
+++ b/tests/Form/Field/MultiselectFieldTest.php
@@ -7,20 +7,37 @@ class MultiselectFieldTest extends TestCase
 	public function testDefaultProps(): void
 	{
 		$field = $this->field('multiselect');
+		$props = $field->props();
 
-		$this->assertSame('multiselect', $field->type());
-		$this->assertSame('multiselect', $field->name());
-		$this->assertSame([], $field->value());
-		$this->assertSame([], $field->default());
-		$this->assertSame([], $field->options());
-		$this->assertNull($field->min());
-		$this->assertNull($field->max());
-		$this->assertSame(',', $field->separator());
-		$this->assertSame('checklist', $field->icon());
-		$this->assertNull($field->counter());
-		$this->assertTrue($field->search());
-		$this->assertFalse($field->sort());
-		$this->assertTrue($field->save());
+		ksort($props);
+
+		$expected = [
+			'accept'    => 'options',
+			'autofocus' => false,
+			'default'   => [],
+			'disabled'  => false,
+			'help'      => null,
+			'hidden'    => false,
+			'icon'      => 'checklist',
+			'label'     => 'Multiselect',
+			'layout'    => null,
+			'max'       => null,
+			'min'       => null,
+			'name'      => 'multiselect',
+			'options'   => [],
+			'required'  => false,
+			'saveable'  => true,
+			'search'    => true,
+			'separator' => ',',
+			'sort'      => false,
+			'required'  => false,
+			'translate' => true,
+			'type'      => 'multiselect',
+			'when'      => null,
+			'width'     => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
 	}
 
 	public function testMin(): void
@@ -45,16 +62,5 @@ class MultiselectFieldTest extends TestCase
 
 		$this->assertFalse($field->isValid());
 		$this->assertArrayHasKey('max', $field->errors());
-	}
-
-	public function testSanitizeOptions(): void
-	{
-		$field = $this->field('multiselect', [
-			'value'   => 'a, b',
-			'options' => ['b', 'c'],
-		]);
-
-		$this->assertCount(1, $field->value());
-		$this->assertArrayHasKey(0, $field->value());
 	}
 }


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7696
- [x] https://github.com/getkirby/kirby/pull/7698
- [x] https://github.com/getkirby/kirby/pull/7699
- [x] https://github.com/getkirby/kirby/pull/7700
- [x] https://github.com/getkirby/kirby/pull/7702
- [x] https://github.com/getkirby/kirby/pull/7703

## Changelog 

### ♻️ Refactored

- New `Kirby\Form\Field\MultiselectField` class

### 🚨 Breaking changes

- The `api` and `query` options for the multiselect field and other option classes are no longer available. Queries and API calls to fetch options have now to be declared directly in the options property. 
```yaml
fields: 
  myMultiselect:
    type: multiselect
    options: 
      type: query
      query: some.query
```

or 

```yaml
fields: 
  myMultiselect: 
    type: multiselect
    options: 
      type: api
      url: /some/options/api
```

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

- [ ] Remove outdated api and query options from docs. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion