### PR TITLE
(Fields PR) refact!: New ColorField class

### DIFF
--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -73,6 +73,7 @@ export default {
 		app.component("k-writer-field", WriterField);
 
 		// Legacy fields components
+		app.component("k-legacy-color-field", ColorField);
 		app.component("k-legacy-gap-field", GapField);
 		app.component("k-legacy-headline-field", HeadlineField);
 		app.component("k-legacy-info-field", InfoField);

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -11,6 +11,7 @@ use Kirby\Cms\Auth\EmailChallenge;
 use Kirby\Cms\Auth\TotpChallenge;
 use Kirby\Form\Field\BlocksField;
 use Kirby\Form\Field\CheckboxesField;
+use Kirby\Form\Field\ColorField;
 use Kirby\Form\Field\EntriesField;
 use Kirby\Form\Field\GapField;
 use Kirby\Form\Field\HeadlineField;
@@ -231,7 +232,7 @@ class Core
 		return [
 			'blocks'      => BlocksField::class,
 			'checkboxes'  => CheckboxesField::class,
-			'color'       => $this->root . '/fields/color.php',
+			'color'       => ColorField::class,
 			'date'        => $this->root . '/fields/date.php',
 			'email'       => $this->root . '/fields/email.php',
 			'entries'     => EntriesField::class,
@@ -266,6 +267,7 @@ class Core
 			'writer'      => $this->root . '/fields/writer.php',
 
 			'legacy-checkboxes'  => $this->root . '/fields/checkboxes.php',
+			'legacy-color'       => $this->root . '/fields/color.php',
 			'legacy-gap'         => $this->root . '/fields/gap.php',
 			'legacy-headline'    => $this->root . '/fields/headline.php',
 			'legacy-hidden'      => $this->root . '/fields/hidden.php',

--- a/src/Form/Field/ColorField.php
+++ b/src/Form/Field/ColorField.php
@@ -135,25 +135,25 @@ class ColorField extends OptionField
 		return ['hex', 'hsl', 'rgb'];
 	}
 
-	public function isColor(string $value): bool
+	public static function isColor(string $value): bool
 	{
 		return
-			$this->isHex($value) === true ||
-			$this->isRgb($value) === true ||
-			$this->isHsl($value) === true;
+			static::isHex($value) === true ||
+			static::isRgb($value) === true ||
+			static::isHsl($value) === true;
 	}
 
-	public function isHex(string $value): bool
+	public static function isHex(string $value): bool
 	{
 		return preg_match('/^#([\da-f]{3,4}){1,2}$/i', $value) === 1;
 	}
 
-	public function isHsl(string $value): bool
+	public static function isHsl(string $value): bool
 	{
 		return preg_match('/^hsla?\(\s*(\d{1,3}\.?\d*)(deg|rad|grad|turn)?(?:,|\s)+(\d{1,3})%(?:,|\s)+(\d{1,3})%(?:,|\s|\/)*(\d*(?:\.\d+)?)(%?)\s*\)?$/i', $value) === 1;
 	}
 
-	public function isRgb(string $value): bool
+	public static function isRgb(string $value): bool
 	{
 		return preg_match('/^rgba?\(\s*(\d{1,3})(%?)(?:,|\s)+(\d{1,3})(%?)(?:,|\s)+(\d{1,3})(%?)(?:,|\s|\/)*(\d*(?:\.\d+)?)(%?)\s*\)?$/i', $value) === 1;
 	}
@@ -200,7 +200,7 @@ class ColorField extends OptionField
 		$format = $this->format();
 		$method = 'is' . $format;
 
-		if ($this->$method($value) === false) {
+		if (static::$method($value) === false) {
 			throw new InvalidArgumentException(
 				key: 'validation.color',
 				data: ['format' => $format]

--- a/src/Form/Field/ColorField.php
+++ b/src/Form/Field/ColorField.php
@@ -123,16 +123,17 @@ class ColorField extends OptionField
 
 	public function format(): string
 	{
-		if (in_array($this->format, $this->formats(), true) === true) {
+		if ($this->format === null) {
+			return 'hex';
+		}
+
+		if (in_array($this->format, ['hex', 'hsl', 'rgb'], true) === true) {
 			return $this->format;
 		}
 
-		return $this->formats()[0];
-	}
-
-	public function formats(): array
-	{
-		return ['hex', 'hsl', 'rgb'];
+		throw new InvalidArgumentException(
+			message: 'Invalid format "' . $this->format . '" in color field' . ($this->name ? ' "' . $this->name . '"' : null)
+		);
 	}
 
 	public static function isColor(string $value): bool
@@ -160,16 +161,17 @@ class ColorField extends OptionField
 
 	public function mode(): string
 	{
-		if (in_array($this->mode, $this->modes(), true) === true) {
+		if ($this->mode === null) {
+			return 'picker';
+		}
+
+		if (in_array($this->mode, ['picker', 'input', 'options'], true) === true) {
 			return $this->mode;
 		}
 
-		return $this->modes()[0];
-	}
-
-	public function modes(): array
-	{
-		return ['picker', 'input', 'options'];
+		throw new InvalidArgumentException(
+			message: 'Invalid mode "' . $this->mode . '" in color field' . ($this->name ? ' "' . $this->name . '"' : null)
+		);
 	}
 
 	public function props(): array

--- a/src/Form/Field/ColorField.php
+++ b/src/Form/Field/ColorField.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Field\FieldOptions;
+use Kirby\Form\Mixin;
+use Kirby\Toolkit\A;
+
+/**
+ * Color field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class ColorField extends OptionField
+{
+	use Mixin\Icon;
+	use Mixin\Placeholder;
+
+	/**
+	 * Whether to allow alpha transparency in the color
+	 */
+	protected bool|null $alpha;
+
+	/**
+	 * The CSS format (hex, rgb, hsl) to display and store the value
+	 */
+	protected string|null $format;
+
+	/**
+	 * Change mode to disable the color picker (`input`) or to only
+	 * show the `options` as toggles
+	 */
+	protected string|null $mode;
+
+	protected mixed $value = '';
+
+	public function __construct(
+		bool|null $alpha = null,
+		bool|null $autofocus = null,
+		mixed $default = null,
+		bool|null $disabled = null,
+		string|null $format = null,
+		array|string|null $help = null,
+		string|null $icon = null,
+		array|string|null $label = null,
+		string|null $mode = null,
+		string|null $name = null,
+		array|string|null $options = null,
+		array|string|null $placeholder = null,
+		bool|null $required = null,
+		bool|null $translate = null,
+		array|null $when = null,
+		string|null $width = null
+	) {
+		parent::__construct(
+			autofocus: $autofocus,
+			default: $default,
+			disabled: $disabled,
+			help: $help,
+			label: $label,
+			name: $name,
+			options: $options,
+			required: $required,
+			translate: $translate,
+			when: $when,
+			width: $width
+		);
+
+		$this->alpha       = $alpha;
+		$this->format      = $format;
+		$this->icon        = $icon;
+		$this->mode        = $mode;
+		$this->placeholder = $placeholder;
+	}
+
+	public function alpha(): bool
+	{
+		return $this->alpha ?? false;
+	}
+
+	protected function fetchOptions(): array
+	{
+		// resolve options to support manual arrays
+		// alongside api and query options
+		$props   = FieldOptions::polyfill(['options' => $this->options ?? []]);
+		$options = FieldOptions::factory([
+			'text'  => '{{ item.value }}',
+			'value' => '{{ item.key }}',
+			...$props['options']
+		]);
+
+		$options = $options->render($this->model());
+
+		if ($options === []) {
+			return [];
+		}
+
+		if (
+			is_numeric($options[0]['value']) ||
+			$options[0]['value'] === $options[0]['text']
+		) {
+			// simple array of values
+			// or value=text (from Options class)
+			$options = A::map($options, fn ($option) => [
+				'value' => $option['text']
+			]);
+
+		} else {
+			$options = A::map($options, fn ($option) => [
+				'value' => $option['value'],
+				'text'  => $option['text']
+			]);
+		}
+
+		return $options;
+	}
+
+	public function format(): string
+	{
+		if (in_array($this->format, $this->formats(), true) === true) {
+			return $this->format;
+		}
+
+		return $this->formats()[0];
+	}
+
+	public function formats(): array
+	{
+		return ['hex', 'hsl', 'rgb'];
+	}
+
+	public function isColor(string $value): bool
+	{
+		return
+			$this->isHex($value) === true ||
+			$this->isRgb($value) === true ||
+			$this->isHsl($value) === true;
+	}
+
+	public function isHex(string $value): bool
+	{
+		return preg_match('/^#([\da-f]{3,4}){1,2}$/i', $value) === 1;
+	}
+
+	public function isHsl(string $value): bool
+	{
+		return preg_match('/^hsla?\(\s*(\d{1,3}\.?\d*)(deg|rad|grad|turn)?(?:,|\s)+(\d{1,3})%(?:,|\s)+(\d{1,3})%(?:,|\s|\/)*(\d*(?:\.\d+)?)(%?)\s*\)?$/i', $value) === 1;
+	}
+
+	public function isRgb(string $value): bool
+	{
+		return preg_match('/^rgba?\(\s*(\d{1,3})(%?)(?:,|\s)+(\d{1,3})(%?)(?:,|\s)+(\d{1,3})(%?)(?:,|\s|\/)*(\d*(?:\.\d+)?)(%?)\s*\)?$/i', $value) === 1;
+	}
+
+	public function mode(): string
+	{
+		if (in_array($this->mode, $this->modes(), true) === true) {
+			return $this->mode;
+		}
+
+		return $this->modes()[0];
+	}
+
+	public function modes(): array
+	{
+		return ['picker', 'input', 'options'];
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'alpha'       => $this->alpha(),
+			'format'      => $this->format(),
+			'icon'        => $this->icon(),
+			'mode'        => $this->mode(),
+			'placeholder' => $this->placeholder(),
+		];
+	}
+
+	protected function validations(): array
+	{
+		return [
+			'color' => fn ($value) => $this->validateColor($value)
+		];
+	}
+
+	protected function validateColor(string|null $value): void
+	{
+		if ($this->isEmptyValue($value) === true) {
+			return;
+		}
+
+		$format = $this->format();
+		$method = 'is' . $format;
+
+		if ($this->$method($value) === false) {
+			throw new InvalidArgumentException(
+				key: 'validation.color',
+				data: ['format' => $format]
+			);
+		}
+	}
+}

--- a/src/Form/Field/ColorField.php
+++ b/src/Form/Field/ColorField.php
@@ -60,16 +60,16 @@ class ColorField extends OptionField
 	) {
 		parent::__construct(
 			autofocus: $autofocus,
-			default: $default,
-			disabled: $disabled,
-			help: $help,
-			label: $label,
-			name: $name,
-			options: $options,
-			required: $required,
+			default:   $default,
+			disabled:  $disabled,
+			help:      $help,
+			label:     $label,
+			name:      $name,
+			options:   $options,
+			required:  $required,
 			translate: $translate,
-			when: $when,
-			width: $width
+			when:      $when,
+			width:     $width
 		);
 
 		$this->alpha       = $alpha;

--- a/tests/Form/Field/ColorFieldTest.php
+++ b/tests/Form/Field/ColorFieldTest.php
@@ -10,13 +10,33 @@ class ColorFieldTest extends TestCase
 	public function testDefaultProps(): void
 	{
 		$field = $this->field('color');
+		$props = $field->props();
 
-		$this->assertSame('color', $field->type());
-		$this->assertSame('color', $field->name());
-		$this->assertFalse($field->alpha());
-		$this->assertSame('hex', $field->format());
-		$this->assertSame('picker', $field->mode());
-		$this->assertTrue($field->hasValue());
+		ksort($props);
+
+		$expected = [
+			'alpha'       => false,
+			'autofocus'   => false,
+			'default'     => null,
+			'disabled'    => false,
+			'format'      => 'hex',
+			'help'        => null,
+			'hidden'      => false,
+			'icon'        => null,
+			'label'       => 'Color',
+			'mode'        => 'picker',
+			'name'        => 'color',
+			'options'     => [],
+			'placeholder' => null,
+			'required'    => false,
+			'saveable'    => true,
+			'translate'   => true,
+			'type'        => 'color',
+			'when'        => null,
+			'width'       => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
 	}
 
 	public function testEmptyColor(): void
@@ -36,18 +56,6 @@ class ColorFieldTest extends TestCase
 		]);
 
 		$this->assertSame('#fff', $field->default());
-	}
-
-	public function testReset(): void
-	{
-		$field = $this->field('color');
-		$field->fill('#efefef');
-
-		$this->assertSame('#efefef', $field->toFormValue());
-
-		$field->reset();
-
-		$this->assertSame('', $field->toFormValue());
 	}
 
 	public function testFormat(): void
@@ -102,6 +110,21 @@ class ColorFieldTest extends TestCase
 		$this->assertTrue(ColorField::isRgb('rgba(255, 0, 0, 0.6)'));
 
 		$this->assertFalse(ColorField::isRgb('rgp(255, 0, 0,.6)'));
+	}
+
+	public function testIsValid(): void
+	{
+		$field = $this->field('color');
+
+		$this->assertTrue($field->isValid());
+
+		$field->fill('#ddd');
+
+		$this->assertTrue($field->isValid());
+
+		$field->fill('#ödd');
+
+		$this->assertFalse($field->isValid());
 	}
 
 	public function testMode(): void
@@ -187,5 +210,17 @@ class ColorFieldTest extends TestCase
 			['value' => '#bbb', 'text' => 'Color b'],
 			['value' => '#ccc', 'text' => 'Color c']
 		], $field->options());
+	}
+
+	public function testReset(): void
+	{
+		$field = $this->field('color');
+		$field->fill('#efefef');
+
+		$this->assertSame('#efefef', $field->toFormValue());
+
+		$field->reset();
+
+		$this->assertSame('', $field->toFormValue());
 	}
 }

--- a/tests/Form/Field/ColorFieldTest.php
+++ b/tests/Form/Field/ColorFieldTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Form\Field;
 
 use Kirby\Cms\App;
-use Kirby\Exception\InvalidArgumentException;
 
 class ColorFieldTest extends TestCase
 {
@@ -13,11 +12,10 @@ class ColorFieldTest extends TestCase
 
 		$this->assertSame('color', $field->type());
 		$this->assertSame('color', $field->name());
-		$this->assertNull($field->value());
 		$this->assertFalse($field->alpha());
 		$this->assertSame('hex', $field->format());
 		$this->assertSame('picker', $field->mode());
-		$this->assertTrue($field->save());
+		$this->assertTrue($field->hasValue());
 	}
 
 	public function testEmptyColor(): void
@@ -26,8 +24,8 @@ class ColorFieldTest extends TestCase
 			'value' => null
 		]);
 
-		$this->assertNull($field->value());
-		$this->assertNull($field->toString());
+		$this->assertNull($field->toFormValue());
+		$this->assertNull($field->toStoredValue());
 	}
 
 	public function testDefault(): void
@@ -39,28 +37,28 @@ class ColorFieldTest extends TestCase
 		$this->assertSame('#fff', $field->default());
 	}
 
-	public function testFillWithEmptyValue(): void
+	public function testReset(): void
 	{
 		$field = $this->field('color');
 		$field->fill('#efefef');
 
 		$this->assertSame('#efefef', $field->toFormValue());
 
-		$field->fillWithEmptyValue();
+		$field->reset();
 
 		$this->assertSame('', $field->toFormValue());
 	}
 
 	public function testFormatInvalid(): void
 	{
-		$this->expectException(InvalidArgumentException::class);
-		$this->field('color', ['format' => 'foo']);
+		$field = $this->field('color', ['format' => 'foo']);
+		$this->assertSame('hex', $field->format());
 	}
 
 	public function testModeInvalid(): void
 	{
-		$this->expectException(InvalidArgumentException::class);
-		$this->field('color', ['mode' => 'foo']);
+		$field = $this->field('color', ['mode' => 'foo']);
+		$this->assertSame('picker', $field->mode());
 	}
 
 	public function testOptions(): void

--- a/tests/Form/Field/ColorFieldTest.php
+++ b/tests/Form/Field/ColorFieldTest.php
@@ -55,6 +55,45 @@ class ColorFieldTest extends TestCase
 		$this->assertSame('hex', $field->format());
 	}
 
+	public function testIsColor(): void
+	{
+		$this->assertTrue(ColorField::isColor('#f00'));
+		$this->assertTrue(ColorField::isColor('#ff0000'));
+		$this->assertTrue(ColorField::isColor('#ff0000aa'));
+		$this->assertTrue(ColorField::isColor('rgb(255,0,0)'));
+		$this->assertTrue(ColorField::isColor('rgba(255, 0, 0, 0.6)'));
+		$this->assertTrue(ColorField::isColor('hsl(0, 100%, 50%)'));
+		$this->assertTrue(ColorField::isColor('hsla(0, 100%, 50%, .6)'));
+
+		$this->assertFalse(ColorField::isColor('#47'));
+		$this->assertFalse(ColorField::isColor('rgp(255, 0, 0,.6)'));
+	}
+
+	public function testIsHex(): void
+	{
+		$this->assertTrue(ColorField::isHex('#f00'));
+		$this->assertTrue(ColorField::isHex('#ff0000'));
+		$this->assertTrue(ColorField::isHex('#ff0000aa'));
+
+		$this->assertFalse(ColorField::isHex('#47'));
+	}
+
+	public function testIsHsl(): void
+	{
+		$this->assertTrue(ColorField::isHsl('hsl(0, 100%, 50%)'));
+		$this->assertTrue(ColorField::isHsl('hsla(0, 100%, 50%, .6)'));
+
+		$this->assertFalse(ColorField::isColor('hzl(0, 100%, 50%)'));
+	}
+
+	public function testIsRgb(): void
+	{
+		$this->assertTrue(ColorField::isRgb('rgb(255,0,0)'));
+		$this->assertTrue(ColorField::isRgb('rgba(255, 0, 0, 0.6)'));
+
+		$this->assertFalse(ColorField::isRgb('rgp(255, 0, 0,.6)'));
+	}
+
 	public function testModeInvalid(): void
 	{
 		$field = $this->field('color', ['mode' => 'foo']);

--- a/tests/Form/Field/ColorFieldTest.php
+++ b/tests/Form/Field/ColorFieldTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Form\Field;
 
 use Kirby\Cms\App;
+use Kirby\Exception\InvalidArgumentException;
 
 class ColorFieldTest extends TestCase
 {
@@ -49,10 +50,19 @@ class ColorFieldTest extends TestCase
 		$this->assertSame('', $field->toFormValue());
 	}
 
-	public function testFormatInvalid(): void
+	public function testFormat(): void
 	{
-		$field = $this->field('color', ['format' => 'foo']);
+		$field = $this->field('color', ['format' => 'rgb']);
+		$this->assertSame('rgb', $field->format());
+
+		$field = $this->field('color');
 		$this->assertSame('hex', $field->format());
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid format "foo" in color field');
+
+		$field = $this->field('color', ['format' => 'foo']);
+		$field->format();
 	}
 
 	public function testIsColor(): void
@@ -94,10 +104,19 @@ class ColorFieldTest extends TestCase
 		$this->assertFalse(ColorField::isRgb('rgp(255, 0, 0,.6)'));
 	}
 
-	public function testModeInvalid(): void
+	public function testMode(): void
 	{
-		$field = $this->field('color', ['mode' => 'foo']);
+		$field = $this->field('color', ['mode' => 'options']);
+		$this->assertSame('options', $field->mode());
+
+		$field = $this->field('color');
 		$this->assertSame('picker', $field->mode());
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid mode "foo" in color field');
+
+		$field = $this->field('color', ['mode' => 'foo']);
+		$field->mode();
 	}
 
 	public function testOptions(): void


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7696
- [x] https://github.com/getkirby/kirby/pull/7698
- [x] https://github.com/getkirby/kirby/pull/7699
- [x] https://github.com/getkirby/kirby/pull/7700
- [x] https://github.com/getkirby/kirby/pull/7702
- [x] https://github.com/getkirby/kirby/pull/7703
- [x] https://github.com/getkirby/kirby/pull/7704

## Changelog 

### ♻️ Refactored

- New `Kirby\Form\Field\ColorField` class

### 🚨 Breaking changes

- The `api` and `query` options for the multiselect field and other option classes are no longer available. Queries and API calls to fetch options have now to be declared directly in the options property. 
```yaml
fields: 
  myColor:
    type: color
    options: 
      type: query
      query: some.query
```

or 

```yaml
fields: 
  myColor: 
    type: color
    options: 
      type: api
      url: /some/options/api
```

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

- [ ] Remove outdated api and query options from docs. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion