### PR TITLE
(Fields PR) refact!: New NumberField class

### DIFF
--- a/config/fields/range.php
+++ b/config/fields/range.php
@@ -3,7 +3,7 @@
 use Kirby\Toolkit\I18n;
 
 return [
-	'extends' => 'number',
+	'extends' => 'legacy-number',
 	'props' => [
 		/**
 		 * Unset inherited props

--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -81,6 +81,7 @@ export default {
 		app.component("k-legacy-line-field", LineField);
 		app.component("k-legacy-object-field", ObjectField);
 		app.component("k-legacy-multiselect-field", MultiselectField);
+		app.component("k-legacy-number-field", NumberField);
 		app.component("k-legacy-radio-field", RadioField);
 		app.component("k-legacy-select-field", SelectField);
 		app.component("k-legacy-structure-field", StructureField);

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -20,6 +20,7 @@ use Kirby\Form\Field\InfoField;
 use Kirby\Form\Field\LayoutField;
 use Kirby\Form\Field\LineField;
 use Kirby\Form\Field\MultiselectField;
+use Kirby\Form\Field\NumberField;
 use Kirby\Form\Field\ObjectField;
 use Kirby\Form\Field\RadioField;
 use Kirby\Form\Field\SelectField;
@@ -247,7 +248,7 @@ class Core
 			'link'        => $this->root . '/fields/link.php',
 			'list'        => $this->root . '/fields/list.php',
 			'multiselect' => MultiselectField::class,
-			'number'      => $this->root . '/fields/number.php',
+			'number'      => NumberField::class,
 			'object'      => ObjectField::class,
 			'pages'       => $this->root . '/fields/pages.php',
 			'radio'       => RadioField::class,
@@ -275,6 +276,7 @@ class Core
 			'legacy-info'        => $this->root . '/fields/info.php',
 			'legacy-line'        => $this->root . '/fields/line.php',
 			'legacy-multiselect' => $this->root . '/fields/multiselect.php',
+			'legacy-number'      => $this->root . '/fields/number.php',
 			'legacy-object'      => $this->root . '/fields/object.php',
 			'legacy-radio'       => $this->root . '/fields/radio.php',
 			'legacy-select'      => $this->root . '/fields/select.php',

--- a/src/Form/Field/NumberField.php
+++ b/src/Form/Field/NumberField.php
@@ -59,15 +59,15 @@ class NumberField extends InputField
 	) {
 		parent::__construct(
 			autofocus: $autofocus,
-			default: $default,
-			disabled: $disabled,
-			help: $help,
-			label: $label,
-			name: $name,
-			required: $required,
+			default:   $default,
+			disabled:  $disabled,
+			help:      $help,
+			label:     $label,
+			name:      $name,
+			required:  $required,
 			translate: $translate,
-			when: $when,
-			width: $width,
+			when:      $when,
+			width:     $width,
 		);
 
 		$this->after       = $after;

--- a/src/Form/Field/NumberField.php
+++ b/src/Form/Field/NumberField.php
@@ -90,13 +90,7 @@ class NumberField extends InputField
 
 	public function default(): float|null
 	{
-		$default = $this->default;
-
-		if (is_string($default) === true) {
-			$default = $this->stringTemplate($default);
-		}
-
-		return static::toNumber($default);
+		return static::toNumber(parent::default());
 	}
 
 	public function max(): float|null

--- a/src/Form/Field/NumberField.php
+++ b/src/Form/Field/NumberField.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Form\Mixin;
+use Kirby\Toolkit\Str;
+
+/**
+ * Number field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class NumberField extends InputField
+{
+	use Mixin\After;
+	use Mixin\Before;
+	use Mixin\Icon;
+	use Mixin\Placeholder;
+
+	/**
+	 * The highest allowed number
+	 */
+	protected float|null $max;
+
+	/**
+	 * The lowest allowed number
+	 */
+	protected float|null $min;
+
+	/**
+	 * Allowed incremental steps between numbers (i.e `0.5`)
+	 * Use `any` to allow any decimal value.
+	 */
+	protected float|string|null $step;
+
+	public function __construct(
+		array|string|null $after = null,
+		bool|null $autofocus = null,
+		array|string|null $before = null,
+		float|string|null $default = null,
+		bool|null $disabled = null,
+		array|string|null $help = null,
+		string|null $icon = null,
+		array|string|null $label = null,
+		array|string|null $placeholder = null,
+		float|null $max = null,
+		float|null $min = null,
+		string|null $name = null,
+		bool|null $required = null,
+		float|string|null $step = null,
+		bool|null $translate = null,
+		array|null $when = null,
+		string|null $width = null
+	) {
+		parent::__construct(
+			autofocus: $autofocus,
+			default: $default,
+			disabled: $disabled,
+			help: $help,
+			label: $label,
+			name: $name,
+			required: $required,
+			translate: $translate,
+			when: $when,
+			width: $width,
+		);
+
+		$this->after       = $after;
+		$this->before      = $before;
+		$this->icon        = $icon;
+		$this->max         = $max;
+		$this->min         = $min;
+		$this->placeholder = $placeholder;
+		$this->step        = $step;
+	}
+
+	/**
+	 * @psalm-suppress MethodSignatureMismatch
+	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
+	 */
+	public function fill(mixed $value): static
+	{
+		return parent::fill(static::toNumber($value));
+	}
+
+	public function default(): float|null
+	{
+		$default = $this->default;
+
+		if (is_string($default) === true) {
+			$default = $this->stringTemplate($default);
+		}
+
+		return static::toNumber($default);
+	}
+
+	public function max(): float|null
+	{
+		return $this->max;
+	}
+
+	public function min(): float|null
+	{
+		return $this->min;
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'after'       => $this->after(),
+			'before'      => $this->before(),
+			'icon'        => $this->icon(),
+			'max'         => $this->max(),
+			'min'         => $this->min(),
+			'placeholder' => $this->placeholder(),
+			'step'        => $this->step(),
+		];
+	}
+
+	public function step(): float|string|null
+	{
+		return match ($this->step) {
+			'any'   => 'any',
+			default => static::toNumber($this->step)
+		};
+	}
+
+	public static function toNumber(mixed $value): float|null
+	{
+		return match(true) {
+			$value === ''     => null,
+			is_null($value)   => $value,
+			is_bool($value)   => $value,
+			is_float($value)  => $value,
+			is_int($value)    => $value,
+			default           => (float)Str::float($value),
+		};
+	}
+
+	protected function validations(): array
+	{
+		return [
+			'min',
+			'max'
+		];
+	}
+}

--- a/tests/Form/Field/NumberFieldTest.php
+++ b/tests/Form/Field/NumberFieldTest.php
@@ -2,29 +2,50 @@
 
 namespace Kirby\Form\Field;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversClass(NumberField::class)]
 class NumberFieldTest extends TestCase
 {
 	public function testDefaultProps(): void
 	{
 		$field = $this->field('number');
+		$props = $field->props();
 
-		$this->assertSame('number', $field->type());
-		$this->assertSame('number', $field->name());
-		$this->assertSame('', $field->value());
-		$this->assertSame('', $field->default());
-		$this->assertNull($field->min());
-		$this->assertNull($field->max());
-		$this->assertSame('', $field->step());
-		$this->assertTrue($field->save());
+		ksort($props);
+
+		$expected = [
+			'after'       => null,
+			'autofocus'   => false,
+			'before'      => null,
+			'default'     => null,
+			'disabled'    => false,
+			'help'        => null,
+			'hidden'      => false,
+			'icon'        => null,
+			'label'       => 'Number',
+			'max'         => null,
+			'min'         => null,
+			'name'        => 'number',
+			'placeholder' => null,
+			'required'    => false,
+			'saveable'    => true,
+			'step'        => null,
+			'translate'   => true,
+			'type'        => 'number',
+			'when'        => null,
+			'width'       => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
 	}
 
 	public static function valueProvider(): array
 	{
 		return [
-			[null, ''],
-			['', ''],
+			[null, null],
+			['', null],
 			[false, (float)0],
 			[0, (float)0],
 			['0', (float)0],
@@ -47,7 +68,7 @@ class NumberFieldTest extends TestCase
 			'step'    => $input
 		]);
 
-		$this->assertSame($expected, $field->value());
+		$this->assertSame($expected, $field->toFormValue());
 		$this->assertSame($expected, $field->default());
 		$this->assertSame($expected, $field->step());
 	}
@@ -80,6 +101,6 @@ class NumberFieldTest extends TestCase
 			'value' => 1000
 		]);
 
-		$this->assertSame(1000.0, $field->value());
+		$this->assertSame(1000.0, $field->toFormValue());
 	}
 }


### PR DESCRIPTION
## Changelog 

### ♻️ Refactored

- New `Kirby\Form\Field\NumberField` class

### 🚨 Breaking changes

- `NumberField::toNumber()` will now always return null instead of an empty string in case of empty values. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion