### PR TITLE
(Fields PR) refact: New RangeField class

### DIFF
--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -23,6 +23,7 @@ use Kirby\Form\Field\MultiselectField;
 use Kirby\Form\Field\NumberField;
 use Kirby\Form\Field\ObjectField;
 use Kirby\Form\Field\RadioField;
+use Kirby\Form\Field\RangeField;
 use Kirby\Form\Field\SelectField;
 use Kirby\Form\Field\StatsField;
 use Kirby\Form\Field\StructureField;
@@ -252,7 +253,7 @@ class Core
 			'object'      => ObjectField::class,
 			'pages'       => $this->root . '/fields/pages.php',
 			'radio'       => RadioField::class,
-			'range'       => $this->root . '/fields/range.php',
+			'range'       => RangeField::class,
 			'select'      => SelectField::class,
 			'slug'        => $this->root . '/fields/slug.php',
 			'stats'       => StatsField::class,
@@ -279,6 +280,7 @@ class Core
 			'legacy-number'      => $this->root . '/fields/number.php',
 			'legacy-object'      => $this->root . '/fields/object.php',
 			'legacy-radio'       => $this->root . '/fields/radio.php',
+			'legacy-range'       => $this->root . '/fields/range.php',
 			'legacy-select'      => $this->root . '/fields/select.php',
 			'legacy-structure'   => $this->root . '/fields/structure.php',
 			'legacy-tags'        => $this->root . '/fields/tags.php',

--- a/src/Form/Field/RangeField.php
+++ b/src/Form/Field/RangeField.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+/**
+ * Range field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class RangeField extends NumberField
+{
+	protected array|bool|null $tooltip;
+
+	public function __construct(
+		array|string|null $after = null,
+		bool|null $autofocus = null,
+		array|string|null $before = null,
+		float|string|null $default = null,
+		bool|null $disabled = null,
+		array|string|null $help = null,
+		string|null $icon = null,
+		array|string|null $label = null,
+		array|string|null $placeholder = null,
+		float|null $max = null,
+		float|null $min = null,
+		string|null $name = null,
+		bool|null $required = null,
+		float|string|null $step = null,
+		array|bool|null $tooltip = null,
+		bool|null $translate = null,
+		array|null $when = null,
+		string|null $width = null
+	) {
+		parent::__construct(
+			after: $after,
+			autofocus: $autofocus,
+			before: $before,
+			default: $default,
+			disabled: $disabled,
+			help: $help,
+			icon: $icon,
+			label: $label,
+			max: $max,
+			min: $min,
+			name: $name,
+			placeholder: $placeholder,
+			required: $required,
+			step: $step,
+			translate: $translate,
+			when: $when,
+			width: $width,
+		);
+
+		$this->tooltip = $tooltip;
+	}
+
+	public function max(): float|null
+	{
+		return $this->max ?? 100;
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'tooltip' => $this->tooltip()
+		];
+	}
+
+	public function tooltip(): array|bool
+	{
+		if (is_array($this->tooltip) === true) {
+			return [
+				'after'  => $this->i18n($this->tooltip['after'] ?? null),
+				'before' => $this->i18n($this->tooltip['before'] ?? null)
+			];
+		}
+
+		return $this->tooltip ?? true;
+	}
+}

--- a/tests/Form/Field/RangeFieldTest.php
+++ b/tests/Form/Field/RangeFieldTest.php
@@ -3,22 +3,43 @@
 namespace Kirby\Form\Field;
 
 use Kirby\Toolkit\I18n;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(RangeField::class)]
 class RangeFieldTest extends TestCase
 {
 	public function testDefaultProps(): void
 	{
 		$field = $this->field('range');
+		$props = $field->props();
 
-		$this->assertSame('range', $field->type());
-		$this->assertSame('range', $field->name());
-		$this->assertSame('', $field->value());
-		$this->assertSame('', $field->default());
-		$this->assertNull($field->min());
-		$this->assertSame(100.0, $field->max());
-		$this->assertSame('', $field->step());
-		$this->assertTrue($field->tooltip());
-		$this->assertTrue($field->save());
+		ksort($props);
+
+		$expected = [
+			'after'       => null,
+			'autofocus'   => false,
+			'before'      => null,
+			'default'     => null,
+			'disabled'    => false,
+			'help'        => null,
+			'hidden'      => false,
+			'icon'        => null,
+			'label'       => 'Range',
+			'max'         => 100.0,
+			'min'         => null,
+			'name'        => 'range',
+			'placeholder' => null,
+			'required'    => false,
+			'saveable'    => true,
+			'step'        => null,
+			'tooltip'     => true,
+			'translate'   => true,
+			'type'        => 'range',
+			'when'        => null,
+			'width'       => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
 	}
 
 	public function testMin(): void


### PR DESCRIPTION
## Changelog 

### ♻️ Refactored

- New `Kirby\Form\Field\RangeField` class

### 🚨 Breaking changes

- `RangeField::toNumber()` will now always return null instead of an empty string in case of empty values. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion