### PR TITLE
(Fields PR) refact: New BaseField::stringTemplateI18n method 

### DIFF
--- a/src/Form/Field/BaseField.php
+++ b/src/Form/Field/BaseField.php
@@ -136,6 +136,14 @@ abstract class BaseField
 			false => $this->model()->toString($string)
 		};
 	}
+
+	protected function stringTemplateI18n(array|string|null $string = null, bool $safe = true): string|null
+	{
+		if ($string === null) {
+			return null;
+		}
+
+		return $this->stringTemplate($this->i18n($string), $safe);
 	}
 
 	/**

--- a/src/Form/Field/BaseField.php
+++ b/src/Form/Field/BaseField.php
@@ -125,13 +125,17 @@ abstract class BaseField
 	/**
 	 * Parses a string template in the given value
 	 */
-	protected function stringTemplate(string|null $string = null): string|null
+	protected function stringTemplate(string|null $string = null, bool $safe = true): string|null
 	{
-		if ($string !== null) {
-			return $this->model()->toString($string);
+		if ($string === null) {
+			return null;
 		}
 
-		return null;
+		return match ($safe) {
+			true  => $this->model()->toSafeString($string),
+			false => $this->model()->toString($string)
+		};
+	}
 	}
 
 	/**

--- a/src/Form/Field/BaseField.php
+++ b/src/Form/Field/BaseField.php
@@ -127,8 +127,8 @@ abstract class BaseField
 	 */
 	protected function stringTemplate(string|null $string = null, bool $safe = true): string|null
 	{
-		if ($string === null) {
-			return null;
+		if ($string === null || $string === '') {
+			return $string;
 		}
 
 		return match ($safe) {
@@ -139,8 +139,8 @@ abstract class BaseField
 
 	protected function stringTemplateI18n(array|string|null $string = null, bool $safe = true): string|null
 	{
-		if ($string === null) {
-			return null;
+		if ($string === null || $string === '') {
+			return $string;
 		}
 
 		return $this->stringTemplate($this->i18n($string), $safe);

--- a/src/Form/Field/SelectField.php
+++ b/src/Form/Field/SelectField.php
@@ -66,7 +66,7 @@ class SelectField extends OptionField
 
 	public function placeholder(): string|null
 	{
-		return $this->stringTemplate($this->i18n($this->placeholder)) ?? '—';
+		return $this->stringTemplateI18n($this->placeholder) ?? '—';
 	}
 
 	public function props(): array

--- a/src/Form/Mixin/After.php
+++ b/src/Form/Mixin/After.php
@@ -11,6 +11,6 @@ trait After
 
 	public function after(): string|null
 	{
-		return $this->stringTemplate($this->i18n($this->after));
+		return $this->stringTemplateI18n($this->after);
 	}
 }

--- a/src/Form/Mixin/Before.php
+++ b/src/Form/Mixin/Before.php
@@ -11,6 +11,6 @@ trait Before
 
 	public function before(): string|null
 	{
-		return $this->stringTemplate($this->i18n($this->before));
+		return $this->stringTemplateI18n($this->before);
 	}
 }

--- a/src/Form/Mixin/EmptyState.php
+++ b/src/Form/Mixin/EmptyState.php
@@ -11,6 +11,6 @@ trait EmptyState
 
 	public function empty(): string|null
 	{
-		return $this->stringTemplate($this->i18n($this->empty));
+		return $this->stringTemplateI18n($this->empty);
 	}
 }

--- a/src/Form/Mixin/Help.php
+++ b/src/Form/Mixin/Help.php
@@ -12,8 +12,7 @@ trait Help
 	public function help(): string|null
 	{
 		if ($this->help !== null && $this->help !== [] && $this->help !== '') {
-			$help = $this->i18n($this->help);
-			$help = $this->stringTemplate($help);
+			$help = $this->stringTemplateI18n($this->help);
 			$help = $this->kirby()->kirbytext($help);
 			return $help;
 		}

--- a/src/Form/Mixin/Label.php
+++ b/src/Form/Mixin/Label.php
@@ -17,6 +17,6 @@ trait Label
 			return Str::ucfirst($this->name());
 		}
 
-		return $this->stringTemplate($this->i18n($this->label));
+		return $this->stringTemplateI18n($this->label);
 	}
 }

--- a/src/Form/Mixin/Placeholder.php
+++ b/src/Form/Mixin/Placeholder.php
@@ -11,6 +11,6 @@ trait Placeholder
 
 	public function placeholder(): string|null
 	{
-		return $this->stringTemplate($this->i18n($this->placeholder));
+		return $this->stringTemplateI18n($this->placeholder);
 	}
 }

--- a/src/Form/Mixin/Text.php
+++ b/src/Form/Mixin/Text.php
@@ -12,8 +12,7 @@ trait Text
 	public function text(): string|null
 	{
 		if ($this->text !== null && $this->text !== [] && $this->text !== '') {
-			$text = $this->i18n($this->text);
-			$text = $this->stringTemplate($text);
+			$text = $this->stringTemplateI18n($this->text);
 			$text = $this->kirby()->kirbytext($text);
 			return $text;
 		}

--- a/tests/Form/Field/BaseFieldTest.php
+++ b/tests/Form/Field/BaseFieldTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(BaseField::class)]
+class BaseFieldTest extends TestCase
+{
+	public function testStringTemplateWithEmptyValue(): void
+	{
+		$testClass = new class () extends BaseField {
+			public function stringTemplateTest($value)
+			{
+				return $this->stringTemplate($value);
+			}
+		};
+
+		$this->assertNull($testClass->stringTemplateTest(null));
+		$this->assertSame('', $testClass->stringTemplateTest(''));
+	}
+
+	public function testStringTemplateI18nWithEmptyValue(): void
+	{
+		$testClass = new class () extends BaseField {
+			public function stringTemplateI18nTest($value)
+			{
+				return $this->stringTemplateI18n($value);
+			}
+		};
+
+		$this->assertNull($testClass->stringTemplateI18nTest(null));
+		$this->assertSame('', $testClass->stringTemplateI18nTest(''));
+	}
+}


### PR DESCRIPTION
## Changelog 

### ✨ Enhancements

- New `Kirby\Form\Field\BaseField::stringTemplateI18n` method to simplify string templates that need to run through translation first. 

### 🐛 Bug fixes

- `Kirby\Form\Field\BaseField::stringTemplate` now uses `ModelWithContent::toSafeString()` by default and introduces a new `$safe` argument, which can switch to the unsafe method. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion