### PR TITLE
(Fields PR) refact!: New EmailField class

### DIFF
--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -76,6 +76,7 @@ export default {
 		app.component("k-legacy-checkboxes-field", CheckboxesField);
 		app.component("k-legacy-color-field", ColorField);
 		app.component("k-legacy-date-field", DateField);
+		app.component("k-legacy-email-field", EmailField);
 		app.component("k-legacy-gap-field", GapField);
 		app.component("k-legacy-headline-field", HeadlineField);
 		app.component("k-legacy-info-field", InfoField);

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -13,6 +13,7 @@ use Kirby\Form\Field\BlocksField;
 use Kirby\Form\Field\CheckboxesField;
 use Kirby\Form\Field\ColorField;
 use Kirby\Form\Field\DateField;
+use Kirby\Form\Field\EmailField;
 use Kirby\Form\Field\EntriesField;
 use Kirby\Form\Field\GapField;
 use Kirby\Form\Field\HeadlineField;
@@ -240,7 +241,7 @@ class Core
 			'checkboxes'  => CheckboxesField::class,
 			'color'       => ColorField::class,
 			'date'        => DateField::class,
-			'email'       => $this->root . '/fields/email.php',
+			'email'       => EmailField::class,
 			'entries'     => EntriesField::class,
 			'files'       => $this->root . '/fields/files.php',
 			'gap'         => GapField::class,
@@ -275,6 +276,7 @@ class Core
 			'legacy-checkboxes'  => $this->root . '/fields/checkboxes.php',
 			'legacy-color'       => $this->root . '/fields/color.php',
 			'legacy-date'        => $this->root . '/fields/date.php',
+			'legacy-email'       => $this->root . '/fields/email.php',
 			'legacy-gap'         => $this->root . '/fields/gap.php',
 			'legacy-headline'    => $this->root . '/fields/headline.php',
 			'legacy-hidden'      => $this->root . '/fields/hidden.php',

--- a/src/Form/Field/EmailField.php
+++ b/src/Form/Field/EmailField.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+/**
+ * Email Field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class EmailField extends TextField
+{
+	public function __construct(
+		array|string|null $after = null,
+		bool|null $autocomplete = null,
+		bool|null $autofocus = null,
+		array|string|null $before = null,
+		string|null $converter = null,
+		bool|null $counter = null,
+		mixed $default = null,
+		bool|null $disabled = null,
+		array|string|null $help = null,
+		string|null $font = null,
+		string|null $icon = null,
+		array|string|null $label = null,
+		int|null $maxlength = null,
+		int|null $minlength = null,
+		string|null $name = null,
+		string|null $pattern = null,
+		array|string|null $placeholder = null,
+		bool|null $required = null,
+		bool|null $spellcheck = null,
+		bool|null $translate = null,
+		array|null $when = null,
+		string|null $width = null
+	) {
+		parent::__construct(
+			after: $after,
+			autocomplete: $autocomplete,
+			autofocus: $autofocus,
+			before: $before,
+			converter: $converter,
+			counter: $counter,
+			default: $default,
+			disabled: $disabled,
+			font: $font,
+			help: $help,
+			icon: $icon,
+			label: $label,
+			name: $name,
+			maxlength: $maxlength,
+			minlength: $minlength,
+			pattern: $pattern,
+			placeholder: $placeholder,
+			required: $required,
+			spellcheck: $spellcheck,
+			translate: $translate,
+			when: $when,
+			width: $width
+		);
+	}
+
+	public function autocomplete(): string
+	{
+		return $this->autocomplete ?? 'email';
+	}
+
+	public function counter(): bool
+	{
+		return $this->counter ?? false;
+	}
+
+	public function icon(): string
+	{
+		return $this->icon ?? 'email';
+	}
+
+	public function placeholder(): string
+	{
+		return $this->placeholder ?? $this->i18n('email.placeholder');
+	}
+
+	protected function validations(): array
+	{
+		return [
+			...parent::validations(),
+			'email'
+		];
+	}
+}

--- a/src/Form/Mixin/Spellcheck.php
+++ b/src/Form/Mixin/Spellcheck.php
@@ -9,8 +9,8 @@ trait Spellcheck
 	 */
 	protected bool|null $spellcheck;
 
-	public function spellcheck(): bool
+	public function spellcheck(): bool|null
 	{
-		return $this->spellcheck ?? true;
+		return $this->spellcheck;
 	}
 }

--- a/tests/Form/Field/EmailFieldTest.php
+++ b/tests/Form/Field/EmailFieldTest.php
@@ -7,15 +7,39 @@ class EmailFieldTest extends TestCase
 	public function testDefaultProps(): void
 	{
 		$field = $this->field('email');
+		$props = $field->props();
 
-		$this->assertSame('email', $field->type());
-		$this->assertSame('email', $field->name());
-		$this->assertSame('', $field->value());
-		$this->assertSame('email', $field->icon());
-		$this->assertSame('mail@example.com', $field->placeholder());
-		$this->assertFalse($field->counter());
-		$this->assertSame('email', $field->autocomplete());
-		$this->assertTrue($field->hasValue());
+		ksort($props);
+
+		$expected = [
+			'after'        => null,
+			'autocomplete' => 'email',
+			'autofocus'    => false,
+			'before'       => null,
+			'converter'    => null,
+			'counter'      => false,
+			'default'      => null,
+			'disabled'     => false,
+			'font'         => 'sans-serif',
+			'help'         => null,
+			'hidden'       => false,
+			'icon'         => 'email',
+			'label'        => 'Email',
+			'maxlength'    => null,
+			'minlength'    => null,
+			'name'         => 'email',
+			'pattern'      => null,
+			'placeholder'  => 'mail@example.com',
+			'required'     => false,
+			'saveable'     => true,
+			'spellcheck'   => null,
+			'translate'    => true,
+			'type'         => 'email',
+			'when'         => null,
+			'width'        => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
 	}
 
 	public function testEmailValidation(): void

--- a/tests/Form/Field/EmailFieldTest.php
+++ b/tests/Form/Field/EmailFieldTest.php
@@ -13,9 +13,9 @@ class EmailFieldTest extends TestCase
 		$this->assertSame('', $field->value());
 		$this->assertSame('email', $field->icon());
 		$this->assertSame('mail@example.com', $field->placeholder());
-		$this->assertNull($field->counter());
+		$this->assertFalse($field->counter());
 		$this->assertSame('email', $field->autocomplete());
-		$this->assertTrue($field->save());
+		$this->assertTrue($field->hasValue());
 	}
 
 	public function testEmailValidation(): void

--- a/tests/Form/Field/EntriesFieldTest.php
+++ b/tests/Form/Field/EntriesFieldTest.php
@@ -52,7 +52,6 @@ class EntriesFieldTest extends TestCase
 		$this->assertSame('0', $fieldProps['name']);
 		$this->assertFalse($fieldProps['required']);
 		$this->assertTrue($fieldProps['saveable']);
-		$this->assertTrue($fieldProps['spellcheck']);
 		$this->assertTrue($fieldProps['translate']);
 		$this->assertSame('text', $fieldProps['type']);
 		$this->assertSame('1/1', $fieldProps['width']);

--- a/tests/Form/Field/TextFieldTest.php
+++ b/tests/Form/Field/TextFieldTest.php
@@ -37,7 +37,7 @@ class TextFieldTest extends TestCase
 			'placeholder'  => null,
 			'required'     => false,
 			'saveable'     => true,
-			'spellcheck'   => true,
+			'spellcheck'   => null,
 			'translate'    => true,
 			'type'         => 'text',
 			'when'         => null,

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -887,7 +887,6 @@ class FieldsTest extends TestCase
 				'name'       => 'a',
 				'required'   => false,
 				'saveable'   => true,
-				'spellcheck' => true,
 				'translate'  => true,
 				'type'       => 'text',
 				'width'      => '1/1',


### PR DESCRIPTION
## Merge first

- [x] https://github.com/getkirby/kirby/pull/7712

## Changelog 

### ♻️ Refactored

- New `Kirby\Form\Field\EmailField` class
- `spellcheck` is now set to null by default for all `StringField` extensions. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion