### PR TITLE
refact: Replace `::routes()` with `::api()`

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -84,6 +84,11 @@ class Field extends Component
 		$this->siblings = $siblings ?? new Fields([$this]);
 	}
 
+	public function api(): array
+	{
+		return $this->routes();
+	}
+
 	/**
 	 * Default props and computed of the field
 	 */
@@ -381,7 +386,7 @@ class Field extends Component
 	}
 
 	/**
-	 * Returns field api routes
+	 * Returns field API routes
 	 */
 	public function routes(): array
 	{

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -86,6 +86,72 @@ class BlocksField extends InputField
 		$this->pretty    = $pretty;
 	}
 
+	public function api(): array
+	{
+		$field = $this;
+
+		return [
+			[
+				'pattern' => 'uuid',
+				'action'  => fn (): array => ['uuid' => Str::uuid()]
+			],
+			[
+				'pattern' => 'paste',
+				'method'  => 'POST',
+				'action'  => function () use ($field): array {
+					$request = App::instance()->request();
+					$value   = BlocksCollection::parse($request->get('html'));
+					$blocks  = BlocksCollection::factory($value);
+
+					return $field->pasteBlocks($blocks->toArray());
+				}
+			],
+			[
+				'pattern' => 'fieldsets/(:any)',
+				'method'  => 'GET',
+				'action'  => function (
+					string $fieldsetType
+				) use ($field): array {
+					$fields = $field->fields($fieldsetType);
+					$form   = $field->form($fields);
+
+					$form->fill(input: $form->defaults());
+
+					return Block::factory([
+						'content' => $form->toFormValues(),
+						'type'    => $fieldsetType
+					])->toArray();
+				}
+			],
+			[
+				'pattern' => 'fieldsets/(:any)/fields/(:any)/(:all?)',
+				'method'  => 'ALL',
+				'action'  => function (
+					string $fieldsetType,
+					string $fieldName,
+					string|null $path = null
+				) use ($field) {
+					$fields = $field->fields($fieldsetType);
+					$field  = $field->form($fields)->field($fieldName);
+
+					$fieldApi = $this->clone([
+						'routes' => $field->api(),
+						'data'   => [
+							...$this->data(),
+							'field' => $field
+						]
+					]);
+
+					return $fieldApi->call(
+						$path,
+						$this->requestMethod(),
+						$this->requestData()
+					);
+				}
+			],
+		];
+	}
+
 	public function blocksToValues(
 		array $blocks,
 		string $to = 'toFormValues'
@@ -228,72 +294,6 @@ class BlocksField extends InputField
 			'max'            => $this->max(),
 			'min'            => $this->min(),
 		] + parent::props();
-	}
-
-	public function routes(): array
-	{
-		$field = $this;
-
-		return [
-			[
-				'pattern' => 'uuid',
-				'action'  => fn (): array => ['uuid' => Str::uuid()]
-			],
-			[
-				'pattern' => 'paste',
-				'method'  => 'POST',
-				'action'  => function () use ($field): array {
-					$request = App::instance()->request();
-					$value   = BlocksCollection::parse($request->get('html'));
-					$blocks  = BlocksCollection::factory($value);
-
-					return $field->pasteBlocks($blocks->toArray());
-				}
-			],
-			[
-				'pattern' => 'fieldsets/(:any)',
-				'method'  => 'GET',
-				'action'  => function (
-					string $fieldsetType
-				) use ($field): array {
-					$fields = $field->fields($fieldsetType);
-					$form   = $field->form($fields);
-
-					$form->fill(input: $form->defaults());
-
-					return Block::factory([
-						'content' => $form->toFormValues(),
-						'type'    => $fieldsetType
-					])->toArray();
-				}
-			],
-			[
-				'pattern' => 'fieldsets/(:any)/fields/(:any)/(:all?)',
-				'method'  => 'ALL',
-				'action'  => function (
-					string $fieldsetType,
-					string $fieldName,
-					string|null $path = null
-				) use ($field) {
-					$fields = $field->fields($fieldsetType);
-					$field  = $field->form($fields)->field($fieldName);
-
-					$fieldApi = $this->clone([
-						'routes' => $field->api(),
-						'data'   => [
-							...$this->data(),
-							'field' => $field
-						]
-					]);
-
-					return $fieldApi->call(
-						$path,
-						$this->requestMethod(),
-						$this->requestData()
-					);
-				}
-			],
-		];
 	}
 
 	public function toStoredValue(bool $default = false): mixed

--- a/src/Form/Mixin/Api.php
+++ b/src/Form/Mixin/Api.php
@@ -4,15 +4,10 @@ namespace Kirby\Form\Mixin;
 
 trait Api
 {
-	public function api(): array
-	{
-		return $this->routes();
-	}
-
 	/**
 	 * Routes for the field API
 	 */
-	public function routes(): array
+	public function api(): array
 	{
 		return [];
 	}

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -595,12 +595,6 @@ class FieldClassTest extends TestCase
 		], $field->props());
 	}
 
-	public function testRoutes(): void
-	{
-		$field = new TestField();
-		$this->assertSame([], $field->routes());
-	}
-
 	public function testSave(): void
 	{
 		$field = new TestField();


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

In conjunction with `::dialogs()` and `::drawers()`, I think it's better to use `::api()` for API endpoints than `::routes()` as that name could also refer to dialog routes etc.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- `FieldClass` based fields need to define API routes in `::api()`, not `::routes()`


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion