### PR TITLE
fix: Cropping with Imagick

### DIFF
--- a/src/Image/Darkroom/GdLib.php
+++ b/src/Image/Darkroom/GdLib.php
@@ -45,17 +45,9 @@ class GdLib extends Darkroom
 	 */
 	protected function resize(SimpleImage $image, array $options): SimpleImage
 	{
-		// just resize, no crop
-		if ($options['crop'] === false) {
-			return $image->resize($options['width'], $options['height']);
-		}
-
-		// crop based on focus point
-		if ($options['crop'] !== null) {
-			// get crop coords for focal point:
-			// if image needs to be cropped, crop before resizing
+		if ($crop = $options['crop'] ?? null) {
 			if ($focus = Focus::coords(
-				$options['crop'],
+				$crop,
 				$options['sourceWidth'],
 				$options['sourceHeight'],
 				$options['width'],
@@ -72,7 +64,8 @@ class GdLib extends Darkroom
 			return $image->thumbnail($options['width'], $options['height']);
 		}
 
-		return $image;
+
+		return $image->resize($options['width'], $options['height']);
 	}
 
 	/**

--- a/src/Image/Darkroom/GdLib.php
+++ b/src/Image/Darkroom/GdLib.php
@@ -51,7 +51,7 @@ class GdLib extends Darkroom
 		}
 
 		// crop based on focus point
-		if (Focus::isFocalPoint($options['crop']) === true) {
+		if ($options['crop'] !== null) {
 			// get crop coords for focal point:
 			// if image needs to be cropped, crop before resizing
 			if ($focus = Focus::coords(
@@ -72,12 +72,7 @@ class GdLib extends Darkroom
 			return $image->thumbnail($options['width'], $options['height']);
 		}
 
-		// normal crop with crop anchor
-		return $image->thumbnail(
-			$options['width'],
-			$options['height'] ?? $options['width'],
-			$options['crop']
-		);
+		return $image;
 	}
 
 	/**

--- a/src/Image/Darkroom/ImageMagick.php
+++ b/src/Image/Darkroom/ImageMagick.php
@@ -166,7 +166,7 @@ class ImageMagick extends Darkroom
 		}
 
 		// crop based on focus point
-		if (Focus::isFocalPoint($options['crop']) === true) {
+		if ($options['crop'] !== null) {
 			if ($focus = Focus::coords(
 				$options['crop'],
 				$options['sourceWidth'],
@@ -175,7 +175,7 @@ class ImageMagick extends Darkroom
 				$options['height']
 			)) {
 				return sprintf(
-					'-crop %sx%s+%s+%s -resize %sx%s^',
+					'-crop %sx%s+%s+%s -thumbnail %sx%s^',
 					$focus['width'],
 					$focus['height'],
 					$focus['x1'],
@@ -186,24 +186,7 @@ class ImageMagick extends Darkroom
 			}
 		}
 
-		// translate the gravity option into something imagemagick understands
-		$gravity = match ($options['crop'] ?? null) {
-			'top left'     => 'NorthWest',
-			'top'          => 'North',
-			'top right'    => 'NorthEast',
-			'left'         => 'West',
-			'right'        => 'East',
-			'bottom left'  => 'SouthWest',
-			'bottom'       => 'South',
-			'bottom right' => 'SouthEast',
-			default        => 'Center'
-		};
-
-		$command  = '-thumbnail ' . escapeshellarg(sprintf('%sx%s^', $options['width'], $options['height']));
-		$command .= ' -gravity ' . escapeshellarg($gravity);
-		$command .= ' -crop ' . escapeshellarg(sprintf('%sx%s+0+0', $options['width'], $options['height']));
-
-		return $command;
+		return '-thumbnail ' . escapeshellarg(sprintf('%sx%s^', $options['width'], $options['height']));
 	}
 
 	/**

--- a/src/Image/Darkroom/ImageMagick.php
+++ b/src/Image/Darkroom/ImageMagick.php
@@ -160,15 +160,9 @@ class ImageMagick extends Darkroom
 	 */
 	protected function resize(string $file, array $options): string
 	{
-		// simple resize
-		if ($options['crop'] === false) {
-			return '-thumbnail ' . escapeshellarg(sprintf('%sx%s!', $options['width'], $options['height']));
-		}
-
-		// crop based on focus point
-		if ($options['crop'] !== null) {
+		if ($crop = $options['crop'] ?? null) {
 			if ($focus = Focus::coords(
-				$options['crop'],
+				$crop,
 				$options['sourceWidth'],
 				$options['sourceHeight'],
 				$options['width'],

--- a/src/Image/Darkroom/Imagick.php
+++ b/src/Image/Darkroom/Imagick.php
@@ -175,7 +175,7 @@ class Imagick extends Darkroom
 		}
 
 		// crop based on focus point
-		if (Focus::isFocalPoint($options['crop']) === true) {
+		if ($options['crop'] !== null) {
 			if ($focus = Focus::coords(
 				$options['crop'],
 				$options['sourceWidth'],
@@ -199,30 +199,6 @@ class Imagick extends Darkroom
 				return $image;
 			}
 		}
-
-		// translate the gravity option into something imagemagick understands
-		$gravity = match ($options['crop'] ?? null) {
-			'top left'     => Image::GRAVITY_NORTHWEST,
-			'top'          => Image::GRAVITY_NORTH,
-			'top right'    => Image::GRAVITY_NORTHEAST,
-			'left'         => Image::GRAVITY_WEST,
-			'right'        => Image::GRAVITY_EAST,
-			'bottom left'  => Image::GRAVITY_SOUTHWEST,
-			'bottom'       => Image::GRAVITY_SOUTH,
-			'bottom right' => Image::GRAVITY_SOUTHEAST,
-			default        => Image::GRAVITY_CENTER
-		};
-
-		$landscape = $options['width'] >= $options['height'];
-
-		$image->thumbnailImage(
-			$landscape ? $options['width'] : $image->getImageWidth(),
-			$landscape ? $image->getImageHeight() : $options['height'],
-			true
-		);
-
-		$image->setGravity($gravity);
-		$image->cropImage($options['width'], $options['height'], 0, 0);
 
 		return $image;
 	}

--- a/src/Image/Darkroom/Imagick.php
+++ b/src/Image/Darkroom/Imagick.php
@@ -163,21 +163,9 @@ class Imagick extends Darkroom
 	 */
 	protected function resize(Image $image, array $options): Image
 	{
-		// simple resize
-		if ($options['crop'] === false) {
-			$image->thumbnailImage(
-				$options['width'],
-				$options['height'],
-				true
-			);
-
-			return $image;
-		}
-
-		// crop based on focus point
-		if ($options['crop'] !== null) {
+		if ($crop = $options['crop'] ?? null) {
 			if ($focus = Focus::coords(
-				$options['crop'],
+				$crop,
 				$options['sourceWidth'],
 				$options['sourceHeight'],
 				$options['width'],
@@ -190,15 +178,14 @@ class Imagick extends Darkroom
 					$focus['y1']
 				);
 
-				$image->thumbnailImage(
-					$options['width'],
-					$options['height'],
-					true
-				);
-
-				return $image;
 			}
 		}
+
+		$image->thumbnailImage(
+			$options['width'],
+			$options['height'],
+			true
+		);
 
 		return $image;
 	}

--- a/src/Image/Focus.php
+++ b/src/Image/Focus.php
@@ -24,6 +24,7 @@ class Focus
 		int $width,
 		int $height
 	): array|null {
+		$crop = static::normalize($crop);
 		[$x, $y] = static::parse($crop);
 
 		// determine aspect ratios
@@ -76,18 +77,29 @@ class Focus
 		return Str::contains($value, '%') === true;
 	}
 
+	public static function normalize(string $value): string
+	{
+		// support for former Focus plugin
+		if (Str::startsWith($value, '{') === true) {
+			$focus = json_decode($value);
+			$x     = round(100 * $focus->x);
+			$y     = round(100 * $focus->y);
+			return "$x% $y%";
+		}
+
+		if (static::isFocalPoint($value) === false) {
+			return Gravity::from($value)->toPercentageString();
+		}
+
+		return $value;
+	}
+
 	/**
 	 * Transforms the focal point's string value (from content field)
 	 * to a [x, y] array (values 0.0-1.0)
 	 */
 	public static function parse(string $value): array
 	{
-		// support for former Focus plugin
-		if (Str::startsWith($value, '{') === true) {
-			$focus = json_decode($value);
-			return [$focus->x, $focus->y];
-		}
-
 		preg_match_all("/(\d{1,3}\.?\d*)[%|,|\s]*/", $value, $points);
 
 		return A::map(

--- a/src/Image/Gravity.php
+++ b/src/Image/Gravity.php
@@ -27,14 +27,14 @@ enum Gravity: string
 	public function toPercentageString(): string
 	{
 		return match ($this) {
-			static::TOP          => '0% 50%',
+			static::TOP          => '50% 0%',
 			static::TOP_LEFT     => '0% 0%',
-			static::TOP_RIGHT    => '0% 100%',
-			static::LEFT         => '50% 0%',
+			static::TOP_RIGHT    => '100% 0%',
+			static::LEFT         => '0% 50%',
 			static::CENTER       => '50% 50%',
-			static::RIGHT        => '50% 100%',
-			static::BOTTOM       => '100% 50%',
-			static::BOTTOM_LEFT  => '100% 0%',
+			static::RIGHT        => '100% 50%',
+			static::BOTTOM       => '50% 100%',
+			static::BOTTOM_LEFT  => '0% 100%',
 			static::BOTTOM_RIGHT => '100% 100%',
 		};
 	}

--- a/src/Image/Gravity.php
+++ b/src/Image/Gravity.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Kirby\Image;
+
+/**
+ * @package   Kirby Image
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ * @since     5.2.0
+ */
+enum Gravity: string
+{
+	case TOP = 'top';
+	case TOP_LEFT = 'top left';
+	case TOP_RIGHT = 'top right';
+
+	case LEFT = 'left';
+	case CENTER = 'center';
+	case RIGHT = 'right';
+
+	case BOTTOM = 'bottom';
+	case BOTTOM_LEFT = 'bottom left';
+	case BOTTOM_RIGHT = 'bottom right';
+
+	public function toPercentageString(): string
+	{
+		return match ($this) {
+			static::TOP          => '0% 50%',
+			static::TOP_LEFT     => '0% 0%',
+			static::TOP_RIGHT    => '0% 100%',
+			static::LEFT         => '50% 0%',
+			static::CENTER       => '50% 50%',
+			static::RIGHT        => '50% 100%',
+			static::BOTTOM       => '100% 50%',
+			static::BOTTOM_LEFT  => '100% 0%',
+			static::BOTTOM_RIGHT => '100% 100%',
+		};
+	}
+}

--- a/tests/Image/Darkroom/ImagickTest.php
+++ b/tests/Image/Darkroom/ImagickTest.php
@@ -283,38 +283,6 @@ class ImagickTest extends TestCase
 		$this->assertEquals(150, $image->getImageHeight());
 	}
 
-	public static function resizeGravityProvider(): array
-	{
-		return [
-			['top left', Image::GRAVITY_NORTHWEST],
-			['top', Image::GRAVITY_NORTH],
-			['top right', Image::GRAVITY_NORTHEAST],
-			['left', Image::GRAVITY_WEST],
-			['right', Image::GRAVITY_EAST],
-			['bottom left', Image::GRAVITY_SOUTHWEST],
-			['bottom', Image::GRAVITY_SOUTH],
-			['bottom right', Image::GRAVITY_SOUTHEAST],
-			['center', Image::GRAVITY_CENTER]
-		];
-	}
-
-	#[DataProvider('resizeGravityProvider')]
-	public function testResizeGravity(
-		string $crop,
-		int $gravity
-	): void {
-		$image = $this->createMock(Image::class);
-		$image->method('getImageGravity')->willReturn($gravity);
-		$image->expects($this->once())->method('setGravity')->with($gravity);
-
-		$imagick = new Imagick();
-		$this->call($imagick, 'resize', $image, [
-			'crop'   => $crop,
-			'width'  => 200,
-			'height' => 150
-		]);
-	}
-
 	public function testSaveWithFormat(): void
 	{
 		$imagick = new Imagick(['format' => 'webp']);

--- a/tests/Image/FocusTest.php
+++ b/tests/Image/FocusTest.php
@@ -108,6 +108,15 @@ class FocusTest extends TestCase
 		$this->assertNull(Focus::coords(...$options));
 	}
 
+	public function testNormalize(): void
+	{
+		$this->assertSame('70% 30%', Focus::normalize('70% 30%'));
+		$this->assertSame('50% 100%', Focus::normalize('right'));
+		$this->assertSame('100% 50%', Focus::normalize('bottom'));
+		$this->assertSame('100% 0%', Focus::normalize('bottom left'));
+		$this->assertSame('70% 30%', Focus::normalize('{"x":0.7,"y":0.3}'));
+	}
+
 	public function testParse(): void
 	{
 		$this->assertSame([0.7, 0.3], Focus::parse('70%, 30%'));

--- a/tests/Image/FocusTest.php
+++ b/tests/Image/FocusTest.php
@@ -111,9 +111,9 @@ class FocusTest extends TestCase
 	public function testNormalize(): void
 	{
 		$this->assertSame('70% 30%', Focus::normalize('70% 30%'));
-		$this->assertSame('50% 100%', Focus::normalize('right'));
-		$this->assertSame('100% 50%', Focus::normalize('bottom'));
-		$this->assertSame('100% 0%', Focus::normalize('bottom left'));
+		$this->assertSame('100% 50%', Focus::normalize('right'));
+		$this->assertSame('50% 100%', Focus::normalize('bottom'));
+		$this->assertSame('0% 100%', Focus::normalize('bottom left'));
 		$this->assertSame('70% 30%', Focus::normalize('{"x":0.7,"y":0.3}'));
 	}
 


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

I tried a version where I refactored a lot of code to include the focus crop logic also in the Dimensions class. I still think this should be our goal but it got very messy and I realized that it would be too big of a change for v5.2.

Maybe I can give it another try for v6.

However, this smaller fix should align the cropping across all three darkroom drivers.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- New `Kirby\Image\Gravity` enum

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Fixed cropping with `imagick` thumb driver 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion