### PR TITLE
fix: `Str::short()` to consider appendix length

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1070,8 +1070,8 @@ class Str
 	 * ```
 	 *
 	 * @param string $string The string to be shortened
-	 * @param int $length The final number of characters the
-	 *                    string should have
+	 * @param int $length Final number of characters
+	 *                    the string (excl. appendix) should have
 	 * @param string $appendix The element, which should be added if the
 	 *                         string is too long. Ellipsis is the default.
 	 * @return string The shortened string


### PR DESCRIPTION
@getkirby/backend Not sure if this is the "right" fix or if we just should adapt documentation.

Having less of the original string based on the length of the appendix also felt a little counterintuitive. At the same time, this fix does ensure that the string really ends up at the requested length.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- `Str::short()` now considers length of appendix to always produce a string of the provided length
https://github.com/getkirby/kirby/issues/7722

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion