### PR TITLE
fix: Sort blocks by position before merging

### DIFF
--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -429,7 +429,10 @@ export default {
 		},
 		async merge() {
 			if (this.isMergable) {
-				const blocks = this.selected.map((id) => this.find(id));
+				// sort blocks by their position in the list, not by selection order
+				const blocks = this.selected
+					.map((id) => this.find(id))
+					.sort((a, b) => this.findIndex(a.id) - this.findIndex(b.id));
 
 				// top selected block handles merging
 				// (will update its own content with merged content)


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Blocks are now merged based on their position in the list rather than selection order. Previously, selecting blocks 1-3-2 would merge them in that order. Now they merge as 1-2-3.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->
### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Merge blocks: order of selection is applied #7711

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion