### PR TITLE
fix: Improve error reporting in the Panel

### DIFF
--- a/src/Panel/Response/ViewDocumentResponse.php
+++ b/src/Panel/Response/ViewDocumentResponse.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel\Response;
 
 use Kirby\Cms\App;
+use Kirby\Exception\NotFoundException;
 use Kirby\Http\Response;
 use Kirby\Http\Uri;
 use Kirby\Panel\Assets;
@@ -73,6 +74,23 @@ class ViewDocumentResponse extends ViewResponse
 	public function data(bool $globals = true): array
 	{
 		return parent::data($globals);
+	}
+
+	/**
+	 * Renders the main panel view either as
+	 * full HTML document based on the request
+	 * header or query params
+	 */
+	public static function from(mixed $data): Response
+	{
+		// Create an error view for any route that throws a not found exception.
+		// This will make sure that users can navigate to such views and will get a
+		// useful response instead of the debugger or the fatal screen.
+		if ($data instanceof NotFoundException) {
+			return static::error($data->getMessage());
+		}
+
+		return parent::from($data);
 	}
 
 	public function headers(): array

--- a/src/Panel/Response/ViewDocumentResponse.php
+++ b/src/Panel/Response/ViewDocumentResponse.php
@@ -70,9 +70,9 @@ class ViewDocumentResponse extends ViewResponse
 	/**
 	 * Returns the full state data object
 	 */
-	public function data(): array
+	public function data(bool $globals = true): array
 	{
-		return $this->state()->toArray(globals: true);
+		return parent::data($globals);
 	}
 
 	public function headers(): array

--- a/src/Panel/Response/ViewResponse.php
+++ b/src/Panel/Response/ViewResponse.php
@@ -50,9 +50,18 @@ class ViewResponse extends JsonResponse
 	/**
 	 * Returns the full state data object
 	 */
-	public function data(): array
+	public function data(bool $globals = false): array
 	{
-		return $this->state()->toArray(globals: false);
+		$data = $this->state()->toArray(globals: $globals);
+
+		// make sure that the context is added
+		// correctly to the view object
+		$data['view']['code']     ??= $this->code();
+		$data['view']['path']     ??= $this->path();
+		$data['view']['query']    ??= $this->query();
+		$data['view']['referrer'] ??= $this->referrer();
+
+		return $data;
 	}
 
 	/**
@@ -91,7 +100,7 @@ class ViewResponse extends JsonResponse
 	{
 		return new State(
 			area: $this->area,
-			view: $this->view,
+			view: $this->view(),
 		);
 	}
 

--- a/src/Panel/Response/ViewResponse.php
+++ b/src/Panel/Response/ViewResponse.php
@@ -110,13 +110,6 @@ class ViewResponse extends JsonResponse
 	 */
 	public static function from(mixed $data): Response
 	{
-		// Create an error view for any route that throws a not found exception.
-		// This will make sure that users can navigate to such views and will get a
-		// useful response instead of the debugger or the fatal screen.
-		if ($data instanceof NotFoundException) {
-			return static::error($data->getMessage());
-		}
-
 		// handle redirects
 		if ($data instanceof Redirect) {
 			// if the redirect is a refresh, return a refresh response

--- a/src/Panel/Response/ViewResponse.php
+++ b/src/Panel/Response/ViewResponse.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel\Response;
 
 use Kirby\Cms\App;
 use Kirby\Data\Json;
+use Kirby\Exception\NotFoundException;
 use Kirby\Http\Response;
 use Kirby\Panel\Redirect;
 use Kirby\Panel\State;
@@ -101,6 +102,13 @@ class ViewResponse extends JsonResponse
 	 */
 	public static function from(mixed $data): Response
 	{
+		// Create an error view for any route that throws a not found exception.
+		// This will make sure that users can navigate to such views and will get a
+		// useful response instead of the debugger or the fatal screen.
+		if ($data instanceof NotFoundException) {
+			return static::error($data->getMessage());
+		}
+
 		// handle redirects
 		if ($data instanceof Redirect) {
 			// if the redirect is a refresh, return a refresh response

--- a/src/Panel/Response/ViewResponse.php
+++ b/src/Panel/Response/ViewResponse.php
@@ -4,7 +4,6 @@ namespace Kirby\Panel\Response;
 
 use Kirby\Cms\App;
 use Kirby\Data\Json;
-use Kirby\Exception\NotFoundException;
 use Kirby\Http\Response;
 use Kirby\Panel\Redirect;
 use Kirby\Panel\State;

--- a/src/Panel/Router.php
+++ b/src/Panel/Router.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel;
 
 use Kirby\Api\Upload;
 use Kirby\Cms\App;
+use Kirby\Exception\NotFoundException;
 use Kirby\Http\Response;
 use Kirby\Http\Router as BaseRouter;
 use Kirby\Panel\Response\DialogResponse;
@@ -189,7 +190,7 @@ class Router
 		// catch all route
 		$routes[] = [
 			'pattern' => '(:all)',
-			'action'  => fn (string $pattern) => 'Could not find Panel view for route: ' . $pattern
+			'action'  => fn (string $pattern) => throw new NotFoundException('Could not find Panel view for route: ' . $pattern)
 		];
 
 		return $routes;

--- a/tests/Panel/Areas/AreaTestCase.php
+++ b/tests/Panel/Areas/AreaTestCase.php
@@ -5,6 +5,7 @@ namespace Kirby\Panel\Areas;
 use Kirby\Cms\App;
 use Kirby\Cms\Blueprint;
 use Kirby\Cms\User;
+use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Http\Response;
 use Kirby\TestCase;
@@ -58,9 +59,10 @@ abstract class AreaTestCase extends TestCase
 
 	protected function assertErrorView(string $path, string $message): void
 	{
-		$view = $this->view($path);
-		$this->assertSame('k-error-view', $view['component']);
-		$this->assertSame($message, $view['props']['error']);
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage($message);
+
+		$this->view($path);
 	}
 
 	protected function assertFormDialog(array $dialog): void

--- a/tests/Panel/Areas/PluginTest.php
+++ b/tests/Panel/Areas/PluginTest.php
@@ -61,7 +61,6 @@ class PluginTest extends AreaTestCase
 		$view = $this->view('foo');
 		$this->assertSame('k-foo-view', $view['component']);
 
-		$view = $this->view('bar');
-		$this->assertSame('k-error-view', $view['component']);
+		$this->assertErrorView('bar', 'Could not find Panel view for route: bar');
 	}
 }

--- a/tests/Panel/Response/JsonResponseTest.php
+++ b/tests/Panel/Response/JsonResponseTest.php
@@ -5,6 +5,8 @@ namespace Kirby\Panel\Response;
 use Exception;
 use Kirby\Data\Json;
 use Kirby\Exception\Exception as KirbyException;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\NotFoundException;
 use Kirby\Panel\Redirect;
 use Kirby\Panel\TestCase;
 use Kirby\Panel\Ui\Button;
@@ -115,18 +117,18 @@ class JsonResponseTest extends TestCase
 
 	public function testFromKirbyException(): void
 	{
-		$input  = new KirbyException('Error message');
-		$output = JsonResponse::from($input);
+		$this->expectException(KirbyException::class);
+		$this->expectExceptionMessage('Error message');
 
-		$this->assertSame('Error message', $output->data()['error']);
+		JsonResponse::from(new KirbyException('Error message'));
 	}
 
 	public function testFromException(): void
 	{
-		$input  = new Exception('Error message');
-		$output = JsonResponse::from($input);
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Error message');
 
-		$this->assertSame('Error message', $output->data()['error']);
+		JsonResponse::from(new Exception('Error message'));
 	}
 
 	public function testFromUiComponent(): void
@@ -139,11 +141,10 @@ class JsonResponseTest extends TestCase
 
 	public function testFromString(): void
 	{
-		$input  = 'test';
-		$output = JsonResponse::from($input);
+		$this->expectException(KirbyException::class);
+		$this->expectExceptionMessage('test');
 
-		$this->assertSame(500, $output->code());
-		$this->assertSame('test', $output->data()['error']);
+		JsonResponse::from('test');
 	}
 
 	public function testFromArray(): void
@@ -156,27 +157,26 @@ class JsonResponseTest extends TestCase
 
 	public function testFromEmptyArray(): void
 	{
-		$input  = [];
-		$output = JsonResponse::from($input);
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('The response is empty');
 
-		$this->assertSame(404, $output->code());
-		$this->assertSame('The response is empty', $output->data()['error']);
+		JsonResponse::from([]);
 	}
 
 	public function testFromNull(): void
 	{
-		$output = JsonResponse::from(null);
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('The data could not be found');
 
-		$this->assertSame(404, $output->code());
-		$this->assertSame('The data could not be found', $output->data()['error']);
+		JsonResponse::from(null);
 	}
 
 	public function testFromInvalid(): void
 	{
-		$output = JsonResponse::from(5);
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid response');
 
-		$this->assertSame(500, $output->code());
-		$this->assertSame('Invalid response', $output->data()['error']);
+		JsonResponse::from(5);
 	}
 
 	public function testHeaders(): void

--- a/tests/Panel/Response/ViewDocumentResponseTest.php
+++ b/tests/Panel/Response/ViewDocumentResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Panel\Response;
 
+use Kirby\Exception\NotFoundException;
 use Kirby\Panel\State;
 use Kirby\Panel\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -60,6 +61,14 @@ class ViewDocumentResponseTest extends TestCase
 	{
 		$response = new ViewDocumentResponse();
 		$this->assertInstanceOf(State::class, $response->state());
+	}
+
+	public function testFromNotFoundException(): void
+	{
+		$response = ViewDocumentResponse::from(new NotFoundException('test'));
+
+		$this->assertSame(404, $response->code());
+		$this->assertSame('test', $response->state()->view()['error']);
 	}
 
 	public function testHeaders(): void


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features
<!-- 
e.g. New feature X which helps users to …
-->

### ✨ Enhancements

- Exceptions are no longer intercepted by our Response classes but handled by our regular error handler. This will improve the JSON error responses drastically and expose more details in debug mode. One exception (pun intended) are NotFoundExceptions for views, which will still create a full error view with error message, to make sure that navigation to  non-existing routes still works.

### 🐛 Bug fixes

- Important context data (path, referrer, query, code) is always added to the view response object again. This is important to make sure that the view URL for error views are correct. Otherwise, the frontend will create some weird side-effects, such as redirects to /panel/null. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion