### PR TITLE
fix: exclude CORS headers from pages cache

### DIFF
--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -986,12 +986,9 @@ class Page extends ModelWithContent
 			// cache the result
 			$response = $kirby->response();
 			if ($cache !== null && $response->cache() === true) {
-				$responseData = $response->toArray();
-				$responseData['headers'] = $response->cacheHeaders($responseData['headers']);
-
 				$cache->set($cacheId, [
 					'html'        => $html,
-					'response'    => $responseData,
+					'response'    => $response->toCacheArray(),
 					'usesAuth'    => $response->usesAuth(),
 					'usesCookies' => $response->usesCookies(),
 				], $response->expires() ?? 0);

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -986,9 +986,12 @@ class Page extends ModelWithContent
 			// cache the result
 			$response = $kirby->response();
 			if ($cache !== null && $response->cache() === true) {
+				$responseData = $response->toArray();
+				$responseData['headers'] = $response->cacheHeaders($responseData['headers']);
+
 				$cache->set($cacheId, [
 					'html'        => $html,
-					'response'    => $response->toArray(),
+					'response'    => $responseData,
 					'usesAuth'    => $response->usesAuth(),
 					'usesCookies' => $response->usesCookies(),
 				], $response->expires() ?? 0);

--- a/src/Cms/Responder.php
+++ b/src/Cms/Responder.php
@@ -407,9 +407,15 @@ class Responder implements Stringable
 
 	/**
 	 * Strips request-dependent headers for safe caching
+	 *
+	 * @since 5.2.0
 	 */
 	public function cacheHeaders(array $headers): array
 	{
+		if ($this->requestDependentHeaders === []) {
+			return $headers;
+		}
+
 		foreach ($this->requestDependentHeaders as $name => $values) {
 			if ($name === 'Vary' && is_array($values) === true) {
 				if (isset($headers['Vary']) === false) {
@@ -482,8 +488,10 @@ class Responder implements Stringable
 	/**
 	 * Marks headers (or header parts) as request-dependent, so they
 	 * can be subtracted before caching a response snapshot
+	 *
+	 * @since 5.2.0
 	 */
-	protected function markRequestDependentHeader(string $name, array|null $values = null): void
+	public function markRequestDependentHeader(string $name, array|null $values = null): void
 	{
 		if ($values === null) {
 			$this->requestDependentHeaders[$name] = null;

--- a/src/Cms/Responder.php
+++ b/src/Cms/Responder.php
@@ -69,7 +69,7 @@ class Responder implements Stringable
 	 * Tracks headers that depend on the request
 	 * and must not be persisted in the cache
 	 */
-	protected array $requestDependentHeaders = [];
+	protected array $volatileHeaders = [];
 
 	/**
 	 * Creates and sends the response
@@ -236,7 +236,7 @@ class Responder implements Stringable
 	 */
 	public function fromArray(array $response): void
 	{
-		$this->requestDependentHeaders = [];
+		$this->volatileHeaders = [];
 		$this->body($response['body'] ?? null);
 		$this->cache($response['cache'] ?? null);
 		$this->code($response['code'] ?? null);
@@ -334,7 +334,7 @@ class Responder implements Stringable
 		}
 
 		$this->headers = $headers;
-		$this->requestDependentHeaders = [];
+		$this->volatileHeaders = [];
 		return $this;
 	}
 
@@ -412,11 +412,11 @@ class Responder implements Stringable
 	 */
 	public function cacheHeaders(array $headers): array
 	{
-		if ($this->requestDependentHeaders === []) {
+		if ($this->volatileHeaders === []) {
 			return $headers;
 		}
 
-		foreach ($this->requestDependentHeaders as $name => $values) {
+		foreach ($this->volatileHeaders as $name => $values) {
 			if ($name === 'Vary' && is_array($values) === true) {
 				if (isset($headers['Vary']) === false) {
 					continue;
@@ -494,11 +494,11 @@ class Responder implements Stringable
 	public function markRequestDependentHeader(string $name, array|null $values = null): void
 	{
 		if ($values === null) {
-			$this->requestDependentHeaders[$name] = null;
+			$this->volatileHeaders[$name] = null;
 			return;
 		}
 
-		if (array_key_exists($name, $this->requestDependentHeaders) === true && $this->requestDependentHeaders[$name] === null) {
+		if (array_key_exists($name, $this->volatileHeaders) === true && $this->volatileHeaders[$name] === null) {
 			return;
 		}
 
@@ -509,8 +509,8 @@ class Responder implements Stringable
 			return;
 		}
 
-		$existing = $this->requestDependentHeaders[$name] ?? [];
-		$this->requestDependentHeaders[$name] = array_values(array_unique([...$existing, ...$values]));
+		$existing = $this->volatileHeaders[$name] ?? [];
+		$this->volatileHeaders[$name] = array_values(array_unique([...$existing, ...$values]));
 	}
 
 	/**

--- a/tests/Cms/CorsTest.php
+++ b/tests/Cms/CorsTest.php
@@ -12,6 +12,17 @@ class CorsTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.Cors';
 
+	public function tearDown(): void
+	{
+		unset($_COOKIE['foo']);
+
+		if (Dir::exists(static::TMP) === true) {
+			Dir::remove(static::TMP);
+		}
+
+		parent::tearDown();
+	}
+
 	public function testDisabled(): void
 	{
 		$this->assertSame([], Cors::headers());
@@ -517,8 +528,6 @@ class CorsTest extends TestCase
 
 		$this->assertSame('https://example.com', $headers['Access-Control-Allow-Origin']);
 		$this->assertSame('no-store, private', $headers['Cache-Control']);
-
-		unset($_COOKIE['foo']);
 	}
 
 	public function testHeadersWithVaryMerging(): void
@@ -627,7 +636,5 @@ class CorsTest extends TestCase
 		$html2 = $app->page('test')->render();
 		$this->assertSame($html1, $html2);
 		$this->assertSame('https://app2.com', $app->response()->headers()['Access-Control-Allow-Origin']);
-
-		Dir::remove(static::TMP);
 	}
 }


### PR DESCRIPTION
@lukasbestle A follow-up to https://github.com/getkirby/kirby/pull/7630.

## Description

Kirby's page cache currently persists the complete response snapshot (headers included). With request-dependent CORS settings (multiple `allowOrigin` entries, reflected request headers, credentials), the first visitor's `Access-Control-*` headers are frozen into the cache entry and leaked to every later visitor using Kirby 5.2.0 RC. That makes per-request CORS unusable whenever the page cache is active.

Rather than trying different ways to skip caching, the responder now keeps doing what it always did – inject request-aware headers when `headers()` is called. But it also records which headers are volatile. Right before a page response is written to cache, `Responder::cacheHeaders()` removes those volatile entries (or trims only the relevant `Vary` parts). When the cached response is reused, the responder re-runs the standard injection and therefore produces the correct CORS headers for the current request. There’s effectively no runtime overhead because the cache layer simply skips the extra array merge when no volatile headers were registered.

(I've added regression coverage for the multi-origin cache scenario and dedicated responder tests to focus on the new "volatile header" semantics.)

## Notes

- By trimming headers before serialization, we keep a single code path: every response (cached or not) goes through `Responder::headers()` to assemble the final header set. Cached entries simply store less data (no volatile headers), so when they're rehydrated, the exact same header injection logic runs again for the current request.
- Yes, it adds bookkeeping (tracking volatile headers, normalization helpers), but that's the minimum needed to keep caching generic. I haven't found a simpler way to manage this, maybe @lukasbestle you have another idea? 
- We no longer encode CORS-specific behavior into the cache layer; if another feature adds dynamic headers later, it only needs to call `markRequestDependentHeader()` and trimming continues to work automatically.

## Changelog 

### ✨ Enhancements
- Track request-dependent (volatile) response headers in `Responder`, enabling Kirby to regenerate them per request without special-case cache handling.

### 🐛 Bug fixes (from 5.2.0-RC1)
- Prevent cached pages from leaking `Access-Control-*` headers between different origins; the HTML stays cached, while CORS headers are recalculated on every request.

### For review team
- [ ] Add lab and/or sandbox examples (wherever helpful)  
- [ ] Add changes & docs to release notes draft in Notion