### PR TITLE
fix: No badge for current changes on languages btn

### DIFF
--- a/panel/src/components/View/Buttons/LanguagesDropdown.vue
+++ b/panel/src/components/View/Buttons/LanguagesDropdown.vue
@@ -57,11 +57,7 @@ export default {
 	},
 	computed: {
 		changesBadge() {
-			// `hasDiff` provides the state for all other than the current
-			// translation from the backend; for the current translation we need to
-			// check `content.diff` as this state can change dynamically without
-			// any other backend request that would update `hasDiff`
-			if (this.hasDiff || this.$panel.content.hasDiff()) {
+			if (this.hasDiff) {
 				return {
 					theme: this.$panel.content.isLocked() ? "red" : "orange"
 				};


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

It looks a bit weird to have the form controls, tab badges AND also a badge on the languages button. To me it would make more sense to only show the badge on the languages button if any other language has changes.