### PR TITLE
fix: Dialogs/Drawers routes for block subfields

### DIFF
--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -16,6 +16,8 @@ use Kirby\Form\Form;
 use Kirby\Form\Mixin\EmptyState;
 use Kirby\Form\Mixin\Max;
 use Kirby\Form\Mixin\Min;
+use Kirby\Panel\Controller\Dialog\FieldDialogController;
+use Kirby\Panel\Controller\Drawer\FieldDrawerController;
 use Kirby\Toolkit\Str;
 use Throwable;
 
@@ -70,6 +72,44 @@ class BlocksField extends FieldClass
 		}
 
 		return $result;
+	}
+
+	public function dialogs(): array
+	{
+		return [
+			[
+				'pattern' => 'fieldsets/(:any)/fields/(:any)/(:all?)',
+				'method'  => 'ALL',
+				'action'  => function (
+					string $fieldsetType,
+					string $fieldName,
+					string|null $path = null
+				) {
+					$fields = $this->fields($fieldsetType);
+					$field  = $this->form($fields)->field($fieldName);
+					return new FieldDialogController($field, $path);
+				}
+			],
+		];
+	}
+
+	public function drawers(): array
+	{
+		return [
+			[
+				'pattern' => 'fieldsets/(:any)/fields/(:any)/(:all?)',
+				'method'  => 'ALL',
+				'action'  => function (
+					string $fieldsetType,
+					string $fieldName,
+					string|null $path = null
+				) {
+					$fields = $this->fields($fieldsetType);
+					$field  = $this->form($fields)->field($fieldName);
+					return new FieldDrawerController($field, $path);
+				}
+			],
+		];
 	}
 
 	public function fields(string $type): array
@@ -222,21 +262,25 @@ class BlocksField extends FieldClass
 					string $fieldName,
 					string|null $path = null
 				) use ($field) {
+					/**
+					 * @var \Kirby\Cms\Api $api
+					 */
+					$api    = $this;
 					$fields = $field->fields($fieldsetType);
 					$field  = $field->form($fields)->field($fieldName);
 
-					$fieldApi = $this->clone([
+					$fieldApi = $api->clone([
 						'routes' => $field->api(),
 						'data'   => [
-							...$this->data(),
+							...$api->data(),
 							'field' => $field
 						]
 					]);
 
 					return $fieldApi->call(
 						$path,
-						$this->requestMethod(),
-						$this->requestData()
+						$api->requestMethod(),
+						$api->requestData()
 					);
 				}
 			],

--- a/tests/Form/Field/BlocksFieldTest.php
+++ b/tests/Form/Field/BlocksFieldTest.php
@@ -6,7 +6,10 @@ use Kirby\Cms\App;
 use Kirby\Cms\Fieldsets;
 use Kirby\Cms\Page;
 use Kirby\Exception\NotFoundException;
+use Kirby\Form\Field;
 use Kirby\Form\Fields;
+use Kirby\Panel\Controller\Dialog\FieldDialogController;
+use Kirby\Panel\Controller\Drawer\FieldDrawerController;
 
 class BlocksFieldTest extends TestCase
 {
@@ -20,6 +23,30 @@ class BlocksFieldTest extends TestCase
 		$this->assertInstanceOf(Fieldsets::class, $field->fieldsets());
 		$this->assertSame([], $field->value());
 		$this->assertTrue($field->save());
+	}
+
+	public function testDialogs(): void
+	{
+		$field = $this->field('blocks', []);
+
+		$result = $field->dialogs()[0]['action']('text', 'text', 'test-path');
+
+		$this->assertInstanceOf(FieldDialogController::class, $result);
+		$this->assertInstanceOf(Field::class, $result->field);
+		$this->assertSame('text', $result->field->name());
+		$this->assertSame('test-path', $result->path);
+	}
+
+	public function testDrawers(): void
+	{
+		$field = $this->field('blocks', []);
+
+		$result = $field->drawers()[0]['action']('text', 'text', 'test-path');
+
+		$this->assertInstanceOf(FieldDrawerController::class, $result);
+		$this->assertInstanceOf(Field::class, $result->field);
+		$this->assertSame('text', $result->field->name());
+		$this->assertSame('test-path', $result->path);
 	}
 
 	public function testGroups(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Adds dialog/drawer sub routes for blocks field subfields.
Was overlooked when adding earlier  FieldDialogController/FieldDrawerController to `v6/develop`.

@bastianallgeier If you have an idea how to write tests for this. I tried but failed.