### PR TITLE
fix: `k-item` selected to also wirk with UUIDs

### DIFF
--- a/panel/src/components/Collection/Items.vue
+++ b/panel/src/components/Collection/Items.vue
@@ -185,7 +185,7 @@ export default {
 	methods: {
 		findSelectedIndex(item) {
 			return this.selected.findIndex(
-				(selected) => selected === (item._id ?? item.id)
+				(selected) => selected === (item._id ?? item.uuid ?? item.id)
 			);
 		},
 		isSelected(item) {
@@ -199,7 +199,7 @@ export default {
 		},
 		onSelect(item) {
 			if (this.selectmode === "single") {
-				return this.$emit("select", [item._id ?? item.id]);
+				return this.$emit("select", [item._id ?? item.uuid ?? item.id]);
 			}
 
 			const index = this.findSelectedIndex(item);
@@ -208,7 +208,10 @@ export default {
 				return this.$emit("select", this.selected.toSpliced(index, 1));
 			}
 
-			return this.$emit("select", [...this.selected, item._id ?? item.id]);
+			return this.$emit("select", [
+				...this.selected,
+				item._id ?? item.uuid ?? item.id
+			]);
 		},
 		imageOptions(item) {
 			let globalOptions = this.image;


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

`k-items` should not just pass around `_id` or `id` but also `uuid` if present.
In order `_id`, falls back to `uuid`, then `id` (as I think the use cases with `_id` are the most extraordinaire). 