### PR TITLE
refact: Freeze legacy models fields Vue components

### DIFF
--- a/panel/src/components/Dialogs/FilesDialog.vue
+++ b/panel/src/components/Dialogs/FilesDialog.vue
@@ -10,6 +10,9 @@
 import Dialog from "@/mixins/dialog.js";
 import { props as ModelsDialogProps } from "./ModelsDialog.vue";
 
+/**
+ * @deprecated 6.0.0 Use `k-file-picker-dialog` instead
+ */
 export default {
 	mixins: [Dialog, ModelsDialogProps],
 	props: {

--- a/panel/src/components/Dialogs/ModelsDialog.vue
+++ b/panel/src/components/Dialogs/ModelsDialog.vue
@@ -69,6 +69,9 @@ export const props = {
 	}
 };
 
+/**
+ * @deprecated 6.0.0 Use `k-model-picker-dialog` instead
+ */
 export default {
 	mixins: [Dialog, Search, props],
 	emits: ["cancel", "fetched", "submit"],

--- a/panel/src/components/Dialogs/PagesDialog.vue
+++ b/panel/src/components/Dialogs/PagesDialog.vue
@@ -34,6 +34,9 @@
 import Dialog from "@/mixins/dialog.js";
 import { props as ModelsDialogProps } from "./ModelsDialog.vue";
 
+/**
+ * @deprecated 6.0.0 Use `k-page-picker-dialog` instead
+ */
 export default {
 	mixins: [Dialog, ModelsDialogProps],
 	props: {

--- a/panel/src/components/Dialogs/UsersDialog.vue
+++ b/panel/src/components/Dialogs/UsersDialog.vue
@@ -10,6 +10,9 @@
 import Dialog from "@/mixins/dialog.js";
 import { props as ModelsDialogProps } from "./ModelsDialog.vue";
 
+/**
+ * @deprecated 6.0.0 Use `k-user-picker-dialog` instead
+ */
 export default {
 	mixins: [Dialog, ModelsDialogProps],
 	props: {

--- a/panel/src/components/Dialogs/index.js
+++ b/panel/src/components/Dialogs/index.js
@@ -8,18 +8,15 @@ import ChangesDialog from "./ChangesDialog.vue";
 import EmailDialog from "./EmailDialog.vue";
 import ErrorDialog from "./ErrorDialog.vue";
 import StateDialog from "./StateDialog.vue";
-import FilesDialog from "./FilesDialog.vue";
 import FilesPickerDialog from "./FilesPickerDialog.vue";
 import FormDialog from "./FormDialog.vue";
 import LanguageDialog from "./LanguageDialog.vue";
 import LicenseDialog from "./LicenseDialog.vue";
 import LockAlertDialog from "./LockAlertDialog.vue";
 import LinkDialog from "./LinkDialog.vue";
-import ModelsDialog from "./ModelsDialog.vue";
 import ModelsPickerDialog from "./ModelsPickerDialog.vue";
 import PageCreateDialog from "./PageCreateDialog.vue";
 import PageMoveDialog from "./PageMoveDialog.vue";
-import PagesDialog from "./PagesDialog.vue";
 import PagesPickerDialog from "./PagesPickerDialog.vue";
 import RemoveDialog from "./RemoveDialog.vue";
 import SearchDialog from "./SearchDialog.vue";
@@ -27,8 +24,13 @@ import TextDialog from "./TextDialog.vue";
 import TotpDialog from "./TotpDialog.vue";
 import UploadDialog from "./UploadDialog.vue";
 import UploadReplaceDialog from "./UploadReplaceDialog.vue";
-import UsersDialog from "./UsersDialog.vue";
 import UsersPickerDialog from "./UsersPickerDialog.vue";
+
+// @deprecated
+import ModelsDialog from "./ModelsDialog.vue";
+import FilesDialog from "./FilesDialog.vue";
+import PagesDialog from "./PagesDialog.vue";
+import UsersDialog from "./UsersDialog.vue";
 
 export default {
 	install(app) {
@@ -39,18 +41,15 @@ export default {
 		app.component("k-email-dialog", EmailDialog);
 		app.component("k-error-dialog", ErrorDialog);
 		app.component("k-state-dialog", StateDialog);
-		app.component("k-files-dialog", FilesDialog);
 		app.component("k-files-picker-dialog", FilesPickerDialog);
 		app.component("k-form-dialog", FormDialog);
 		app.component("k-license-dialog", LicenseDialog);
 		app.component("k-link-dialog", LinkDialog);
 		app.component("k-lock-alert-dialog", LockAlertDialog);
 		app.component("k-language-dialog", LanguageDialog);
-		app.component("k-models-dialog", ModelsDialog);
 		app.component("k-models-picker-dialog", ModelsPickerDialog);
 		app.component("k-page-create-dialog", PageCreateDialog);
 		app.component("k-page-move-dialog", PageMoveDialog);
-		app.component("k-pages-dialog", PagesDialog);
 		app.component("k-pages-picker-dialog", PagesPickerDialog);
 		app.component("k-remove-dialog", RemoveDialog);
 		app.component("k-search-dialog", SearchDialog);
@@ -58,7 +57,12 @@ export default {
 		app.component("k-totp-dialog", TotpDialog);
 		app.component("k-upload-dialog", UploadDialog);
 		app.component("k-upload-replace-dialog", UploadReplaceDialog);
-		app.component("k-users-dialog", UsersDialog);
 		app.component("k-users-picker-dialog", UsersPickerDialog);
+
+		// @deprecated
+		app.component("k-files-dialog", FilesDialog);
+		app.component("k-models-dialog", ModelsDialog);
+		app.component("k-pages-dialog", PagesDialog);
+		app.component("k-users-dialog", UsersDialog);
 	}
 };

--- a/panel/src/components/Forms/Field/LegacyFilesField.vue
+++ b/panel/src/components/Forms/Field/LegacyFilesField.vue
@@ -1,0 +1,89 @@
+<script>
+import ModelsField from "./LegacyModelsField.vue";
+
+/**
+ * @deprecated 6.0.0 Use `k-files-field` instead
+ */
+export default {
+	extends: ModelsField,
+	type: "files",
+	props: {
+		uploads: [Boolean, Object, Array]
+	},
+	computed: {
+		buttons() {
+			const buttons = ModelsField.computed.buttons.call(this);
+
+			if (this.hasDropzone) {
+				buttons.unshift({
+					autofocus: this.autofocus,
+					text: this.$t("upload"),
+					responsive: true,
+					icon: "upload",
+					click: () => this.$panel.upload.pick(this.uploadOptions)
+				});
+			}
+
+			return buttons;
+		},
+		emptyProps() {
+			return {
+				icon: "image",
+				text:
+					this.empty ??
+					(this.multiple && this.max !== 1
+						? this.$t("field.files.empty")
+						: this.$t("field.files.empty.single"))
+			};
+		},
+		hasDropzone() {
+			return !this.disabled && this.more && this.uploads;
+		},
+		uploadOptions() {
+			return {
+				accept: this.uploads.accept,
+				max: this.max,
+				multiple: this.multiple,
+				preview: this.uploads.preview,
+				url: this.$panel.urls.api + "/" + this.endpoints.field + "/upload",
+				on: {
+					done: async (files) => {
+						if (this.multiple === false) {
+							this.selected = [];
+						}
+
+						for (const file of files) {
+							if (this.selected.find((f) => f.id === file.id) === undefined) {
+								this.selected.push(file);
+							}
+						}
+
+						// send the input event
+						// the content object gets updated
+						this.onInput();
+
+						// the `$panel.content.update()` event sends
+						// the updated form value object to the server
+						await this.$panel.content.update();
+					}
+				}
+			};
+		}
+	},
+	mounted() {
+		this.$events.on("file.delete", this.removeById);
+	},
+	unmounted() {
+		this.$events.off("file.delete", this.removeById);
+	},
+	methods: {
+		drop(files) {
+			if (this.uploads === false) {
+				return false;
+			}
+
+			return this.$panel.upload.open(files, this.uploadOptions);
+		}
+	}
+};
+</script>

--- a/panel/src/components/Forms/Field/LegacyModelsField.vue
+++ b/panel/src/components/Forms/Field/LegacyModelsField.vue
@@ -1,0 +1,173 @@
+<template>
+	<k-field
+		v-bind="$props"
+		:class="['k-models-field', `k-${$options.type}-field`, $attrs.class]"
+		:input="false"
+		:style="$attrs.style"
+	>
+		<template v-if="!disabled" #options>
+			<k-button-group
+				ref="buttons"
+				:buttons="buttons"
+				layout="collapsed"
+				size="xs"
+				variant="filled"
+				class="k-field-options"
+			/>
+		</template>
+
+		<k-dropzone :disabled="!hasDropzone" @drop="drop">
+			<k-input-validator
+				v-bind="{ min, max, required }"
+				:value="JSON.stringify(value)"
+			>
+				<k-collection
+					v-bind="collection"
+					v-on="!disabled ? { empty: open } : {}"
+					@sort="onInput"
+					@sort-change="$emit('change', $event)"
+				>
+					<template v-if="!disabled" #options="{ index }">
+						<k-button
+							:title="$t('remove')"
+							icon="remove"
+							@click="remove(index)"
+						/>
+					</template>
+				</k-collection>
+			</k-input-validator>
+		</k-dropzone>
+	</k-field>
+</template>
+
+<script>
+import { props as FieldProps } from "@/components/Forms/Field.vue";
+import { autofocus, layout } from "@/mixins/props.js";
+
+/**
+ * @deprecated 6.0.0 Use `k-models-field` instead
+ */
+export default {
+	type: "model",
+	mixins: [FieldProps, autofocus, layout],
+	inheritAttrs: false,
+	props: {
+		empty: String,
+		info: String,
+		link: Boolean,
+		max: Number,
+		min: Number,
+		/**
+		 * If false, only a single item can be selected
+		 */
+		multiple: Boolean,
+		parent: String,
+		search: Boolean,
+		size: String,
+		text: String,
+		value: {
+			type: Array,
+			default: () => []
+		}
+	},
+	emits: ["change", "input"],
+	data() {
+		return {
+			selected: this.value
+		};
+	},
+	computed: {
+		buttons() {
+			return [
+				{
+					autofocus: this.autofocus,
+					text: this.$t("select"),
+					icon: "checklist",
+					responsive: true,
+					click: () => this.open()
+				}
+			];
+		},
+		collection() {
+			return {
+				empty: this.emptyProps,
+				items: this.selected,
+				layout: this.layout,
+				link: this.link,
+				size: this.size,
+				sortable: !this.disabled && this.selected.length > 1,
+				theme: this.disabled ? "disabled" : null
+			};
+		},
+		hasDropzone() {
+			return false;
+		},
+		more() {
+			return !this.max || this.max > this.selected.length;
+		}
+	},
+	watch: {
+		value(value) {
+			this.selected = value;
+		}
+	},
+	methods: {
+		drop() {},
+		focus() {},
+		onInput() {
+			this.$emit("input", this.selected);
+		},
+		open() {
+			if (this.disabled) {
+				return false;
+			}
+
+			this.$panel.dialog.open({
+				component: `k-${this.$options.type}-dialog`,
+				props: {
+					endpoint: this.endpoints.field,
+					hasSearch: this.search,
+					max: this.max,
+					multiple: this.multiple,
+					value: this.selected.map((model) => model.id)
+				},
+				on: {
+					submit: (models) => {
+						this.select(models);
+						this.$panel.dialog.close();
+					}
+				}
+			});
+		},
+		remove(index) {
+			this.selected.splice(index, 1);
+			this.onInput();
+		},
+		removeById(id) {
+			this.selected = this.selected.filter((item) => item.id !== id);
+			this.onInput();
+		},
+		select(items) {
+			if (items.length === 0) {
+				this.selected = [];
+				this.onInput();
+				return;
+			}
+
+			// remove all items that are no longer selected
+			this.selected = this.selected.filter((selected) =>
+				items.find((item) => item.id === selected.id)
+			);
+
+			// add items that are not yet in the selected list
+			for (const item of items) {
+				if (!this.selected.find((selected) => item.id === selected.id)) {
+					this.selected.push(item);
+				}
+			}
+
+			this.onInput();
+		}
+	}
+};
+</script>

--- a/panel/src/components/Forms/Field/LegacyPagesField.vue
+++ b/panel/src/components/Forms/Field/LegacyPagesField.vue
@@ -1,0 +1,23 @@
+<script>
+import ModelsField from "./LegacyModelsField.vue";
+
+/**
+ * @deprecated 6.0.0 Use `k-pages-field` instead
+ */
+export default {
+	extends: ModelsField,
+	type: "pages",
+	computed: {
+		emptyProps() {
+			return {
+				icon: "page",
+				text:
+					this.empty ??
+					(this.multiple && this.max !== 1
+						? this.$t("field.pages.empty")
+						: this.$t("field.pages.empty.single"))
+			};
+		}
+	}
+};
+</script>

--- a/panel/src/components/Forms/Field/LegacyUsersField.vue
+++ b/panel/src/components/Forms/Field/LegacyUsersField.vue
@@ -1,0 +1,23 @@
+<script>
+import ModelsField from "./LegacyModelsField.vue";
+
+/**
+ * @deprecated 6.0.0 Use `k-users-field` instead
+ */
+export default {
+	extends: ModelsField,
+	type: "users",
+	computed: {
+		emptyProps() {
+			return {
+				icon: "users",
+				text:
+					this.empty ??
+					(this.multiple && this.max !== 1
+						? this.$t("field.users.empty")
+						: this.$t("field.users.empty.single"))
+			};
+		}
+	}
+};
+</script>

--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -34,6 +34,12 @@ import UrlField from "./UrlField.vue";
 import UserPickerField from "./UserPickerField.vue";
 import WriterField from "./WriterField.vue";
 
+// @deprecated
+import LegacyFilesField from "./LegacyFilesField.vue";
+import LegacyModelsField from "./LegacyModelsField.vue";
+import LegacyPagesField from "./LegacyPagesField.vue";
+import LegacyUsersField from "./LegacyUsersField.vue";
+
 export default {
 	install(app) {
 		app.component("k-blocks-field", BlocksField);
@@ -73,11 +79,12 @@ export default {
 		app.component("k-writer-field", WriterField);
 
 		// Legacy fields components
+		// @deprecated
 		app.component("k-legacy-checkboxes-field", CheckboxesField);
 		app.component("k-legacy-color-field", ColorField);
 		app.component("k-legacy-date-field", DateField);
 		app.component("k-legacy-email-field", EmailField);
-		app.component("k-legacy-files-field", FilePickerField);
+		app.component("k-legacy-files-field", LegacyFilesField);
 		app.component("k-legacy-gap-field", GapField);
 		app.component("k-legacy-headline-field", HeadlineField);
 		app.component("k-legacy-info-field", InfoField);
@@ -85,9 +92,10 @@ export default {
 		app.component("k-legacy-link-field", LinkField);
 		app.component("k-legacy-list-field", ListField);
 		app.component("k-legacy-object-field", ObjectField);
+		app.component("k-legacy-models-field", LegacyModelsField);
 		app.component("k-legacy-multiselect-field", MultiselectField);
 		app.component("k-legacy-number-field", NumberField);
-		app.component("k-legacy-pages-field", PagePickerField);
+		app.component("k-legacy-pages-field", LegacyPagesField);
 		app.component("k-legacy-radio-field", RadioField);
 		app.component("k-legacy-select-field", SelectField);
 		app.component("k-legacy-slug-field", SlugField);
@@ -100,7 +108,7 @@ export default {
 		app.component("k-legacy-toggle-field", ToggleField);
 		app.component("k-legacy-toggles-field", TogglesField);
 		app.component("k-legacy-url-field", UrlField);
-		app.component("k-legacy-users-field", UserPickerField);
+		app.component("k-legacy-users-field", LegacyUsersField);
 		app.component("k-legacy-writer-field", WriterField);
 	}
 };

--- a/src/Cms/FilePicker.php
+++ b/src/Cms/FilePicker.php
@@ -14,6 +14,7 @@ use Kirby\Exception\InvalidArgumentException;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ * @deprecated 6.0.0 Use `Kirby\Panel\Controller\Dialog\FilePickerDialogController` instead
  */
 class FilePicker extends Picker
 {

--- a/src/Cms/PagePicker.php
+++ b/src/Cms/PagePicker.php
@@ -15,6 +15,7 @@ use Kirby\Exception\InvalidArgumentException;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ * @deprecated 6.0.0 Use `Kirby\Panel\Controller\Dialog\PagePickerDialogController` instead
  */
 class PagePicker extends Picker
 {

--- a/src/Cms/Picker.php
+++ b/src/Cms/Picker.php
@@ -11,6 +11,7 @@ namespace Kirby\Cms;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ * @deprecated 6.0.0 Use `Kirby\Panel\Controller\Dialog\ModelPickerDialogController` instead
  */
 abstract class Picker
 {

--- a/src/Cms/UserPicker.php
+++ b/src/Cms/UserPicker.php
@@ -14,6 +14,7 @@ use Kirby\Exception\InvalidArgumentException;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ * @deprecated 6.0.0 Use `Kirby\Panel\Controller\Dialog\UserPickerDialogController` instead
  */
 class UserPicker extends Picker
 {


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Duplicated the models field components for their legacy versions as in the next step we will start modifying the pick fields components, so that the legacy versions need to be freezed at their current state to function with the legacy backend array-based fields.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ☠️ Deprecated
<!-- 
e.g. Deprecate method X. Use method Y instead.
-->
- `Kirby\Cms\Picker`, `Kirby\Cms\PagePicker`, `Kirby\Cms\FilePicker` and `Kirby\Cms\UserPicker` have been deprecated. Use `Kirby\Panel\Controller\Dialog\ModelPickerDialogController`, `Kirby\Panel\Controller\Dialog\PagePickerDialogController`, `Kirby\Panel\Controller\Dialog\FilePickerDialogController` and `Kirby\Panel\Controller\Dialog\UserPickerDialogController` instead.
- `k-models-dialog`, `k-pages-dialog`, `k-files-dialog` and `k-users-dialog` have been deprecated. Use `k-model-picker-dialog`, `k-page-picker-dialog`, `k-file-picker-dialog`, `k-user-picker-dialog` instead.


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to the `v6/fields` PR