### PR TITLE
feat: `k-image-frame` to support UUID as src

### DIFF
--- a/panel/lab/components/frames/3_image/index.php
+++ b/panel/lab/components/frames/3_image/index.php
@@ -2,4 +2,5 @@
 
 return [
 	'docs' => 'k-image-frame',
+	'id'   => kirby()->page('sections/files')?->images()->first()?->uuid()?->toString()
 ];

--- a/panel/lab/components/frames/3_image/index.vue
+++ b/panel/lab/components/frames/3_image/index.vue
@@ -17,8 +17,8 @@
 					v-for="ratio in ratios"
 					:key="ratio"
 					:cover="true"
+					:file="id"
 					:ratio="ratio"
-					:src="id"
 					back="pattern"
 				/>
 			</k-grid>

--- a/panel/lab/components/frames/3_image/index.vue
+++ b/panel/lab/components/frames/3_image/index.vue
@@ -1,12 +1,24 @@
 <template>
 	<k-lab-examples>
-		<k-lab-example label="image">
+		<k-lab-example label="External URL">
 			<k-grid style="--columns: 3; gap: var(--spacing-6)">
 				<k-image-frame
 					v-for="ratio in ratios"
 					:key="ratio"
 					:ratio="ratio"
 					:src="`https://picsum.photos/600/850?t=` + $helper.uuid()"
+					back="pattern"
+				/>
+			</k-grid>
+		</k-lab-example>
+		<k-lab-example v-if="id" label="Internal file UUID">
+			<k-grid style="--columns: 3; gap: var(--spacing-6)">
+				<k-image-frame
+					v-for="ratio in ratios"
+					:key="ratio"
+					:cover="true"
+					:ratio="ratio"
+					:src="id"
 					back="pattern"
 				/>
 			</k-grid>
@@ -40,10 +52,13 @@
 
 <script>
 export default {
+	props: {
+		id: String
+	},
 	computed: {
 		ratios() {
 			return ["1/1", "4/3", "16/9"];
-		},
-	},
+		}
+	}
 };
 </script>

--- a/panel/lab/components/frames/4_video/index.vue
+++ b/panel/lab/components/frames/4_video/index.vue
@@ -7,7 +7,7 @@
 			/>
 		</k-lab-example>
 		<k-lab-example v-if="id" label="Internal file UUID">
-			<k-video-frame :url="id" :controls="true" />
+			<k-video-frame :file="id" :controls="true" />
 		</k-lab-example>
 	</k-lab-examples>
 </template>

--- a/panel/src/components/Forms/Blocks/Types/Gallery.vue
+++ b/panel/src/components/Forms/Blocks/Types/Gallery.vue
@@ -19,9 +19,7 @@
 					<k-image-frame
 						:ratio="ratio"
 						:cover="crop"
-						:src="image.url"
-						:srcset="image.image.srcset"
-						:alt="image.alt"
+						:src="image.uuid ?? image.id"
 						class="k-block-type-gallery-frame"
 					/>
 				</li>

--- a/panel/src/components/Forms/Blocks/Types/Gallery.vue
+++ b/panel/src/components/Forms/Blocks/Types/Gallery.vue
@@ -17,9 +17,9 @@
 			<template v-else>
 				<li v-for="image in content.images" :key="image.id">
 					<k-image-frame
-						:ratio="ratio"
 						:cover="crop"
-						:src="image.uuid ?? image.id"
+						:file="image.uuid ?? image.id"
+						:ratio="ratio"
 						class="k-block-type-gallery-frame"
 					/>
 				</li>

--- a/panel/src/components/Forms/Blocks/Types/Image.vue
+++ b/panel/src/components/Forms/Blocks/Types/Image.vue
@@ -10,23 +10,8 @@
 		@open="open"
 		@update="update"
 	>
-		<template v-if="src">
-			<k-image-frame
-				v-if="ratio"
-				:ratio="ratio"
-				:cover="crop"
-				:alt="content.alt"
-				:src="src"
-			/>
-			<img
-				v-else
-				:alt="content.alt"
-				:src="src"
-				class="k-block-type-image-auto"
-			/>
-
-			<k-block-background-dropdown :value="back" @input="onBack" />
-		</template>
+		<k-image-frame :alt="content.alt" :cover="crop" :ratio="ratio" :src="src" />
+		<k-block-background-dropdown :value="back" @input="onBack" />
 	</k-block-figure>
 </template>
 
@@ -55,14 +40,10 @@ export default {
 				return this.content.src;
 			}
 
-			if (this.content.image?.[0]?.url) {
-				return this.content.image[0].url;
-			}
-
-			return false;
+			return this.content.image?.[0]?.uuid ?? this.content.image?.[0]?.id;
 		},
 		ratio() {
-			return this.content.ratio ?? false;
+			return this.content.ratio ?? "";
 		}
 	},
 	methods: {
@@ -96,11 +77,13 @@ export default {
 	padding: var(--spacing-3);
 }
 
-.k-block-type-image-auto {
+/* Ratio: auto */
+.k-block-type-image .k-block-figure-container > img {
 	max-width: 100%;
 	max-height: 30rem;
 	margin-inline: auto;
 }
+
 .k-block-type-image .k-background-dropdown {
 	position: absolute;
 	inset-inline-end: var(--spacing-3);

--- a/panel/src/components/Forms/Blocks/Types/Image.vue
+++ b/panel/src/components/Forms/Blocks/Types/Image.vue
@@ -43,7 +43,7 @@ export default {
 			return this.content.image?.[0]?.uuid ?? this.content.image?.[0]?.id;
 		},
 		ratio() {
-			return this.content.ratio ?? "";
+			return !this.content.ratio ? "auto" : this.content.ratio;
 		}
 	},
 	methods: {
@@ -77,8 +77,7 @@ export default {
 	padding: var(--spacing-3);
 }
 
-/* Ratio: auto */
-.k-block-type-image .k-block-figure-container > img {
+.k-block-type-image .k-image-frame[data-ratio="auto"] img {
 	max-width: 100%;
 	max-height: 30rem;
 	margin-inline: auto;

--- a/panel/src/components/Forms/Blocks/Types/Image.vue
+++ b/panel/src/components/Forms/Blocks/Types/Image.vue
@@ -62,7 +62,7 @@ export default {
 			return undefined;
 		},
 		ratio() {
-			return !this.content.ratio ? "auto" : this.content.ratio;
+			return !this.content.ratio ? false : this.content.ratio;
 		}
 	},
 	methods: {
@@ -96,7 +96,7 @@ export default {
 	padding: var(--spacing-3);
 }
 
-.k-block-type-image .k-image-frame[data-ratio="auto"] img {
+.k-block-type-image .k-image-frame[data-ratio="false"] img {
 	max-width: 100%;
 	max-height: 30rem;
 	margin-inline: auto;

--- a/panel/src/components/Forms/Blocks/Types/Image.vue
+++ b/panel/src/components/Forms/Blocks/Types/Image.vue
@@ -5,12 +5,18 @@
 		:caption-marks="captionMarks"
 		:empty-text="$t('field.blocks.image.placeholder') + ' …'"
 		:disabled="disabled"
-		:is-empty="!src"
+		:is-empty="isEmpty"
 		empty-icon="image"
 		@open="open"
 		@update="update"
 	>
-		<k-image-frame :alt="content.alt" :cover="crop" :ratio="ratio" :src="src" />
+		<k-image-frame
+			:alt="content.alt"
+			:cover="crop"
+			:file="file"
+			:ratio="ratio"
+			:src="src"
+		/>
 		<k-block-background-dropdown :value="back" @input="onBack" />
 	</k-block-figure>
 </template>
@@ -35,12 +41,25 @@ export default {
 		crop() {
 			return this.content.crop ?? false;
 		},
+		file() {
+			if (this.isInternal) {
+				return this.content.image?.[0]?.uuid ?? this.content.image?.[0]?.id;
+			}
+
+			return undefined;
+		},
+		isEmpty() {
+			return this.isInternal ? !this.file : !this.src;
+		},
+		isInternal() {
+			return this.content.location === "kirby";
+		},
 		src() {
-			if (this.content.location === "web") {
+			if (!this.isInternal) {
 				return this.content.src;
 			}
 
-			return this.content.image?.[0]?.uuid ?? this.content.image?.[0]?.id;
+			return undefined;
 		},
 		ratio() {
 			return !this.content.ratio ? "auto" : this.content.ratio;

--- a/panel/src/components/Forms/Blocks/Types/Video.vue
+++ b/panel/src/components/Forms/Blocks/Types/Video.vue
@@ -4,17 +4,17 @@
 		:caption-marks="captionMarks"
 		:disabled="disabled"
 		:empty-text="$t('field.blocks.video.placeholder') + ' …'"
-		:is-empty="!video"
+		:is-empty="isEmpty"
 		empty-icon="video"
 		class="k-block-type-video-figure"
 		@open="open"
 		@update="update"
 	>
 		<k-video-frame
-			v-if="video"
 			:controls="content.controls"
+			:file="file"
 			:poster="poster"
-			:url="video"
+			:url="url"
 			element="div"
 		/>
 	</k-block-figure>
@@ -32,15 +32,28 @@ export default {
 		captionMarks() {
 			return this.field("caption", { marks: true }).marks;
 		},
-		poster() {
-			return this.content.poster?.[0]?.url;
-		},
-		video() {
-			if (this.content.location === "kirby") {
+		file() {
+			if (this.isInternal) {
 				return this.content.video?.[0]?.uuid ?? this.content.video?.[0]?.id;
 			}
 
-			return this.content.url;
+			return undefined;
+		},
+		isEmpty() {
+			return this.isInternal ? !this.file : !this.url;
+		},
+		isInternal() {
+			return this.content.location === "kirby";
+		},
+		poster() {
+			return this.content.poster?.[0]?.url;
+		},
+		url() {
+			if (!this.isInternal) {
+				return this.content.url;
+			}
+
+			return undefined;
 		}
 	}
 };

--- a/panel/src/components/Layout/Frame/Frame.vue
+++ b/panel/src/components/Layout/Frame/Frame.vue
@@ -1,8 +1,8 @@
 <template>
 	<component
 		:is="element"
-		v-if="ratio"
 		:class="['k-frame', $attrs.class]"
+		:data-ratio="ratio"
 		:data-theme="theme"
 		:style="{
 			'--fit': fit ?? (cover ? 'cover' : 'contain'),
@@ -13,7 +13,6 @@
 	>
 		<slot />
 	</component>
-	<slot v-else />
 </template>
 
 <script>
@@ -89,13 +88,14 @@ export default {
 	color: var(--theme-color-text-highlight);
 }
 
-.k-frame *:where(img, video, iframe, button) {
+.k-frame:not([data-ratio="auto"]) *:where(img, video, iframe, button) {
 	position: absolute;
 	inset: 0;
 	height: 100%;
 	width: 100%;
 	object-fit: var(--fit);
 }
+
 .k-frame > * {
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/panel/src/components/Layout/Frame/Frame.vue
+++ b/panel/src/components/Layout/Frame/Frame.vue
@@ -2,7 +2,7 @@
 	<component
 		:is="element"
 		:class="['k-frame', $attrs.class]"
-		:data-ratio="ratio"
+		:data-ratio="String(ratio)"
 		:data-theme="theme"
 		:style="{
 			'--fit': fit ?? (cover ? 'cover' : 'contain'),
@@ -35,7 +35,7 @@ export const props = {
 		 *
 		 *  @values e.g. `1/1`, `16/9` or `4/5`
 		 */
-		ratio: String,
+		ratio: [Boolean, String],
 		/**
 		 * If the content doesn't fit the defined ratio, the component will add additional space around the content. You can change that behavior with the `cover` attribute. If `true`, the image will be cropped to fit the ratio.
 		 */
@@ -88,7 +88,7 @@ export default {
 	color: var(--theme-color-text-highlight);
 }
 
-.k-frame:not([data-ratio="auto"]) *:where(img, video, iframe, button) {
+.k-frame:not([data-ratio="false"]) *:where(img, video, iframe, button) {
 	position: absolute;
 	inset: 0;
 	height: 100%;

--- a/panel/src/components/Layout/Frame/Frame.vue
+++ b/panel/src/components/Layout/Frame/Frame.vue
@@ -1,6 +1,7 @@
 <template>
 	<component
 		:is="element"
+		v-if="ratio"
 		:class="['k-frame', $attrs.class]"
 		:data-theme="theme"
 		:style="{
@@ -12,6 +13,7 @@
 	>
 		<slot />
 	</component>
+	<slot v-else />
 </template>
 
 <script>

--- a/panel/src/components/Layout/Frame/ImageFrame.vue
+++ b/panel/src/components/Layout/Frame/ImageFrame.vue
@@ -85,7 +85,7 @@ export default {
 			const data = await await this.$panel.get("items/files", {
 				query: {
 					items: this.src,
-					layout: "cards",
+					layout: "auto",
 					image: JSON.stringify({
 						ratio: this.ratio,
 						cover: this.cover

--- a/src/Panel/Controller/Request/ModelItemsRequestController.php
+++ b/src/Panel/Controller/Request/ModelItemsRequestController.php
@@ -27,7 +27,7 @@ abstract class ModelItemsRequestController extends RequestController
 			$model,
 			image:  json_decode($this->request->get('image', '{}'), true),
 			info:   $this->request->get('info'),
-			layout: $this->request->get('layout', 'list'),
+			layout: $this->request->get('layout'),
 			text:   $this->request->get('text'),
 		);
 	}

--- a/src/Panel/Controller/Request/ModelItemsRequestController.php
+++ b/src/Panel/Controller/Request/ModelItemsRequestController.php
@@ -25,9 +25,10 @@ abstract class ModelItemsRequestController extends RequestController
 		$class = static::ITEM_CLASS;
 		return new $class(
 			$model,
-			info: $this->request->get('info'),
+			image:  json_decode($this->request->get('image', '{}'), true),
+			info:   $this->request->get('info'),
 			layout: $this->request->get('layout', 'list'),
-			text: $this->request->get('text'),
+			text:   $this->request->get('text'),
 		);
 	}
 

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -234,8 +234,8 @@ abstract class Model
 		// depending on layout type, set different sizes
 		// to have multiple options for the srcset attribute
 		$sizes = match ($layout) {
-			'auto'     => [100, 300, 800, 1500, 2500],
-			'cards'    => [300, 800, 1500],
+			'auto'     => [50, 100, 200, 400, 800, 1200, 1600, 2400],
+			'cards'    => [400, 800, 1600],
 			'cardlets' => [96, 192],
 			default    => [36, 72],
 		};

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -164,6 +164,7 @@ abstract class Model
 				// only create srcsets for resizable files
 				$settings['src']    = static::imagePlaceholder();
 				$settings['srcset'] = $this->imageSrcset($image, $layout, $settings);
+
 			} elseif ($image->isViewable() === true) {
 				$settings['src'] = $image->url();
 			}
@@ -233,59 +234,60 @@ abstract class Model
 		// depending on layout type, set different sizes
 		// to have multiple options for the srcset attribute
 		$sizes = match ($layout) {
-			'cards'    => [352, 864, 1408],
+			'auto'     => [100, 300, 800, 1500, 2500],
+			'cards'    => [300, 800, 1500],
 			'cardlets' => [96, 192],
-			default    => [38, 76]
+			default    => [36, 72],
 		};
 
-		// no additional modfications needed if `cover: false`
-		if (($settings['cover'] ?? false) === false) {
+		$ratio = $settings['ratio'] ?? '1/1';
+
+		// no additional modifications needed if `cover: false`
+		if (
+			($settings['cover'] ?? false) === false ||
+			$ratio === 'auto'
+		) {
 			return $image->srcset($sizes);
 		}
 
-		// for card layouts with `cover: true` provide
-		// crops based on the card ratio
-		if ($layout === 'cards') {
-			$ratio = $settings['ratio'] ?? '1/1';
-
-			if (is_numeric($ratio) === false) {
-				$ratio = explode('/', $ratio);
-				$ratio = $ratio[0] / $ratio[1];
-			}
-
+		// for list, table and cardlets
+		// provide square crops in two resolutions
+		if (
+			$layout === 'list' ||
+			$layout === 'cardlets'  ||
+			$layout === 'table'
+		) {
 			return $image->srcset([
-				$sizes[0] . 'w' => [
+				'1x' => [
 					'width'  => $sizes[0],
-					'height' => round($sizes[0] / $ratio),
+					'height' => $sizes[0],
 					'crop'   => true
 				],
-				$sizes[1] . 'w' => [
+				'2x' => [
 					'width'  => $sizes[1],
-					'height' => round($sizes[1] / $ratio),
-					'crop'   => true
-				],
-				$sizes[2] . 'w' => [
-					'width'  => $sizes[2],
-					'height' => round($sizes[2] / $ratio),
+					'height' => $sizes[1],
 					'crop'   => true
 				]
 			]);
 		}
 
-		// for list and cardlets with `cover: true`
-		// provide square crops in two resolutions
-		return $image->srcset([
-			'1x' => [
-				'width'  => $sizes[0],
-				'height' => $sizes[0],
+		// for all other provide crops based on the card ratio
+		if (is_numeric($ratio) === false) {
+			$ratio = explode('/', $ratio);
+			$ratio = $ratio[0] / $ratio[1];
+		}
+
+		$srcset = [];
+
+		foreach ($sizes as $size) {
+			$srcset[$size . 'w'] = [
+				'width'  => $size,
+				'height' => round($size / $ratio),
 				'crop'   => true
-			],
-			'2x' => [
-				'width'  => $sizes[1],
-				'height' => $sizes[1],
-				'crop'   => true
-			]
-		]);
+			];
+		}
+
+		return $image->srcset($srcset);
 	}
 
 	/**

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -234,10 +234,10 @@ abstract class Model
 		// depending on layout type, set different sizes
 		// to have multiple options for the srcset attribute
 		$sizes = match ($layout) {
-			'auto'     => [50, 100, 200, 400, 800, 1200, 1600, 2400],
+			'auto'     => [96, 192, 400, 800, 1600, 2400],
 			'cards'    => [400, 800, 1600],
 			'cardlets' => [96, 192],
-			default    => [36, 72],
+			default    => [36, 96],
 		};
 
 		$ratio = $settings['ratio'] ?? '1/1';

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -243,10 +243,7 @@ abstract class Model
 		$ratio = $settings['ratio'] ?? '1/1';
 
 		// no additional modifications needed if `cover: false`
-		if (
-			($settings['cover'] ?? false) === false ||
-			$ratio === 'auto'
-		) {
+		if (($settings['cover'] ?? false) === false) {
 			return $image->srcset($sizes);
 		}
 

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -279,7 +279,7 @@ class FileTest extends TestCase
 			'icon'   => 'image',
 			'url'    => '/media/site/' . $hash . '/test.jpg',
 			'src'    => Model::imagePlaceholder(),
-			'srcset' => '/media/site/' . $hash . '/test-36x.jpg 36w, /media/site/' . $hash . '/test-72x.jpg 72w'
+			'srcset' => '/media/site/' . $hash . '/test-36x.jpg 36w, /media/site/' . $hash . '/test-96x.jpg 96w'
 		], $panel->image());
 
 		// cover enabled
@@ -290,7 +290,7 @@ class FileTest extends TestCase
 			'icon'   => 'image',
 			'url'    => '/media/site/' . $hash . '/test.jpg',
 			'src'    => Model::imagePlaceholder(),
-			'srcset' => '/media/site/' . $hash . '/test-36x36-crop.jpg 1x, /media/site/' . $hash . '/test-72x72-crop.jpg 2x'
+			'srcset' => '/media/site/' . $hash . '/test-36x36-crop.jpg 1x, /media/site/' . $hash . '/test-96x96-crop.jpg 2x'
 		], $panel->image(['cover' => true]));
 	}
 

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -273,24 +273,24 @@ class FileTest extends TestCase
 
 		// cover disabled as default
 		$this->assertSame([
-			'back' => 'pattern',
-			'color' => 'orange-500',
-			'cover' => false,
-			'icon' => 'image',
-			'url' => '/media/site/' . $hash . '/test.jpg',
-			'src' => Model::imagePlaceholder(),
-			'srcset' => '/media/site/' . $hash . '/test-38x.jpg 38w, /media/site/' . $hash . '/test-76x.jpg 76w'
+			'back'   => 'pattern',
+			'color'  => 'orange-500',
+			'cover'  => false,
+			'icon'   => 'image',
+			'url'    => '/media/site/' . $hash . '/test.jpg',
+			'src'    => Model::imagePlaceholder(),
+			'srcset' => '/media/site/' . $hash . '/test-36x.jpg 36w, /media/site/' . $hash . '/test-72x.jpg 72w'
 		], $panel->image());
 
 		// cover enabled
 		$this->assertSame([
-			'back' => 'pattern',
-			'color' => 'orange-500',
-			'cover' => true,
-			'icon' => 'image',
-			'url' => '/media/site/' . $hash . '/test.jpg',
-			'src' => Model::imagePlaceholder(),
-			'srcset' => '/media/site/' . $hash . '/test-38x38-crop.jpg 1x, /media/site/' . $hash . '/test-76x76-crop.jpg 2x'
+			'back'   => 'pattern',
+			'color'  => 'orange-500',
+			'cover'  => true,
+			'icon'   => 'image',
+			'url'    => '/media/site/' . $hash . '/test.jpg',
+			'src'    => Model::imagePlaceholder(),
+			'srcset' => '/media/site/' . $hash . '/test-36x36-crop.jpg 1x, /media/site/' . $hash . '/test-72x72-crop.jpg 2x'
 		], $panel->image(['cover' => true]));
 	}
 

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -228,14 +228,14 @@ class ModelTest extends TestCase
 		$this->assertArrayHasKey('src', $image);
 		$this->assertArrayHasKey('srcset', $image);
 		$this->assertArrayNotHasKey('query', $image);
-		$this->assertStringContainsString('test-38x.jpg 38w', $image['srcset']);
-		$this->assertStringContainsString('test-76x.jpg 76w', $image['srcset']);
+		$this->assertStringContainsString('test-36x.jpg 36w', $image['srcset']);
+		$this->assertStringContainsString('test-72x.jpg 72w', $image['srcset']);
 
 		// cards
 		$image = $panel->image('site.image', 'cards');
-		$this->assertStringContainsString('test-352x.jpg 352w', $image['srcset']);
-		$this->assertStringContainsString('test-864x.jpg 864w', $image['srcset']);
-		$this->assertStringContainsString('test-1408x.jpg 1408w', $image['srcset']);
+		$this->assertStringContainsString('test-300x.jpg 300w', $image['srcset']);
+		$this->assertStringContainsString('test-800x.jpg 800w', $image['srcset']);
+		$this->assertStringContainsString('test-1500x.jpg 1500w', $image['srcset']);
 
 		// cardlets
 		$image = $panel->image('site.image', 'cardlets');
@@ -244,23 +244,23 @@ class ModelTest extends TestCase
 
 		// table
 		$image = $panel->image('site.image', 'table');
-		$this->assertStringContainsString('test-38x.jpg 38w', $image['srcset']);
-		$this->assertStringContainsString('test-76x.jpg 76w', $image['srcset']);
+		$this->assertStringContainsString('test-36x.jpg 36w', $image['srcset']);
+		$this->assertStringContainsString('test-72x.jpg 72w', $image['srcset']);
 
 		// full options
 		$image = $panel->image([
-			'cover' => true,
-			'icon'  => $icon = 'heart',
-			'query' => 'site.image',
-			'ratio' => $ratio = '16/9'
+			'cover'  => true,
+			'icon'   => $icon = 'heart',
+			'query'  => 'site.image',
+			'ratio'  => $ratio = '16/9'
 		]);
 		$this->assertArrayHasKey('url', $image);
 		$this->assertArrayHasKey('src', $image);
 		$this->assertArrayHasKey('srcset', $image);
 		$this->assertSame($icon, $image['icon']);
 		$this->assertSame($ratio, $image['ratio']);
-		$this->assertStringContainsString('test-38x38-crop.jpg 1x', $image['srcset']);
-		$this->assertStringContainsString('test-76x76-crop.jpg 2x', $image['srcset']);
+		$this->assertStringContainsString('test-36x36-crop.jpg 1x', $image['srcset']);
+		$this->assertStringContainsString('test-72x72-crop.jpg 2x', $image['srcset']);
 
 		// string ratio
 		$image = $panel->image([
@@ -272,9 +272,9 @@ class ModelTest extends TestCase
 		$this->assertArrayHasKey('src', $image);
 		$this->assertArrayHasKey('srcset', $image);
 		$this->assertSame($ratio, $image['ratio']);
-		$this->assertStringContainsString('test-352x235-crop.jpg 352w', $image['srcset']);
-		$this->assertStringContainsString('test-864x576-crop.jpg 864w', $image['srcset']);
-		$this->assertStringContainsString('test-1408x939-crop.jpg 1408w', $image['srcset']);
+		$this->assertStringContainsString('test-300x200-crop.jpg 300w', $image['srcset']);
+		$this->assertStringContainsString('test-800x533-crop.jpg 800w', $image['srcset']);
+		$this->assertStringContainsString('test-1500x1000-crop.jpg 1500w', $image['srcset']);
 
 		// numeric ratio
 		$image = $panel->image([
@@ -286,9 +286,9 @@ class ModelTest extends TestCase
 		$this->assertArrayHasKey('src', $image);
 		$this->assertArrayHasKey('srcset', $image);
 		$this->assertSame($ratio, $image['ratio']);
-		$this->assertStringContainsString('test-352x235-crop.jpg 352w', $image['srcset']);
-		$this->assertStringContainsString('test-864x576-crop.jpg 864w', $image['srcset']);
-		$this->assertStringContainsString('test-1408x939-crop.jpg 1408w', $image['srcset']);
+		$this->assertStringContainsString('test-300x200-crop.jpg 300w', $image['srcset']);
+		$this->assertStringContainsString('test-800x533-crop.jpg 800w', $image['srcset']);
+		$this->assertStringContainsString('test-1500x1000-crop.jpg 1500w', $image['srcset']);
 	}
 
 	public function testImageWithNonResizableAsset(): void

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -233,9 +233,9 @@ class ModelTest extends TestCase
 
 		// cards
 		$image = $panel->image('site.image', 'cards');
-		$this->assertStringContainsString('test-300x.jpg 300w', $image['srcset']);
+		$this->assertStringContainsString('test-400x.jpg 400w', $image['srcset']);
 		$this->assertStringContainsString('test-800x.jpg 800w', $image['srcset']);
-		$this->assertStringContainsString('test-1500x.jpg 1500w', $image['srcset']);
+		$this->assertStringContainsString('test-1600x.jpg 1600w', $image['srcset']);
 
 		// cardlets
 		$image = $panel->image('site.image', 'cardlets');
@@ -272,9 +272,9 @@ class ModelTest extends TestCase
 		$this->assertArrayHasKey('src', $image);
 		$this->assertArrayHasKey('srcset', $image);
 		$this->assertSame($ratio, $image['ratio']);
-		$this->assertStringContainsString('test-300x200-crop.jpg 300w', $image['srcset']);
+		$this->assertStringContainsString('test-400x267-crop.jpg 400w', $image['srcset']);
 		$this->assertStringContainsString('test-800x533-crop.jpg 800w', $image['srcset']);
-		$this->assertStringContainsString('test-1500x1000-crop.jpg 1500w', $image['srcset']);
+		$this->assertStringContainsString('test-1600x1067-crop.jpg 1600w', $image['srcset']);
 
 		// numeric ratio
 		$image = $panel->image([
@@ -286,9 +286,9 @@ class ModelTest extends TestCase
 		$this->assertArrayHasKey('src', $image);
 		$this->assertArrayHasKey('srcset', $image);
 		$this->assertSame($ratio, $image['ratio']);
-		$this->assertStringContainsString('test-300x200-crop.jpg 300w', $image['srcset']);
+		$this->assertStringContainsString('test-400x267-crop.jpg 400w', $image['srcset']);
 		$this->assertStringContainsString('test-800x533-crop.jpg 800w', $image['srcset']);
-		$this->assertStringContainsString('test-1500x1000-crop.jpg 1500w', $image['srcset']);
+		$this->assertStringContainsString('test-1600x1067-crop.jpg 1600w', $image['srcset']);
 	}
 
 	public function testImageWithNonResizableAsset(): void

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -229,7 +229,7 @@ class ModelTest extends TestCase
 		$this->assertArrayHasKey('srcset', $image);
 		$this->assertArrayNotHasKey('query', $image);
 		$this->assertStringContainsString('test-36x.jpg 36w', $image['srcset']);
-		$this->assertStringContainsString('test-72x.jpg 72w', $image['srcset']);
+		$this->assertStringContainsString('test-96x.jpg 96w', $image['srcset']);
 
 		// cards
 		$image = $panel->image('site.image', 'cards');
@@ -245,7 +245,7 @@ class ModelTest extends TestCase
 		// table
 		$image = $panel->image('site.image', 'table');
 		$this->assertStringContainsString('test-36x.jpg 36w', $image['srcset']);
-		$this->assertStringContainsString('test-72x.jpg 72w', $image['srcset']);
+		$this->assertStringContainsString('test-96x.jpg 96w', $image['srcset']);
 
 		// full options
 		$image = $panel->image([
@@ -260,7 +260,7 @@ class ModelTest extends TestCase
 		$this->assertSame($icon, $image['icon']);
 		$this->assertSame($ratio, $image['ratio']);
 		$this->assertStringContainsString('test-36x36-crop.jpg 1x', $image['srcset']);
-		$this->assertStringContainsString('test-72x72-crop.jpg 2x', $image['srcset']);
+		$this->assertStringContainsString('test-96x96-crop.jpg 2x', $image['srcset']);
 
 		// string ratio
 		$image = $panel->image([

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -262,24 +262,24 @@ class PageTest extends TestCase
 
 		// cover disabled as default
 		$this->assertSame([
-			'back' => 'pattern',
-			'color' => 'gray-500',
-			'cover' => false,
-			'icon' => 'page',
-			'url' => $mediaUrl . '/test.jpg',
-			'src' => Model::imagePlaceholder(),
-			'srcset' => $mediaUrl . '/test-38x.jpg 38w, ' . $mediaUrl . '/test-76x.jpg 76w'
+			'back'   => 'pattern',
+			'color'  => 'gray-500',
+			'cover'  => false,
+			'icon'   => 'page',
+			'url'    => $mediaUrl . '/test.jpg',
+			'src'    => Model::imagePlaceholder(),
+			'srcset' => $mediaUrl . '/test-36x.jpg 36w, ' . $mediaUrl . '/test-72x.jpg 72w'
 		], $panel->image());
 
 		// cover enabled
 		$this->assertSame([
-			'back' => 'pattern',
-			'color' => 'gray-500',
-			'cover' => true,
-			'icon' => 'page',
-			'url' => $mediaUrl . '/test.jpg',
-			'src' => Model::imagePlaceholder(),
-			'srcset' => $mediaUrl . '/test-38x38-crop.jpg 1x, ' . $mediaUrl . '/test-76x76-crop.jpg 2x'
+			'back'   => 'pattern',
+			'color'  => 'gray-500',
+			'cover'  => true,
+			'icon'   => 'page',
+			'url'    => $mediaUrl . '/test.jpg',
+			'src'    => Model::imagePlaceholder(),
+			'srcset' => $mediaUrl . '/test-36x36-crop.jpg 1x, ' . $mediaUrl . '/test-72x72-crop.jpg 2x'
 		], $panel->image(['cover' => true]));
 	}
 

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -268,7 +268,7 @@ class PageTest extends TestCase
 			'icon'   => 'page',
 			'url'    => $mediaUrl . '/test.jpg',
 			'src'    => Model::imagePlaceholder(),
-			'srcset' => $mediaUrl . '/test-36x.jpg 36w, ' . $mediaUrl . '/test-72x.jpg 72w'
+			'srcset' => $mediaUrl . '/test-36x.jpg 36w, ' . $mediaUrl . '/test-96x.jpg 96w'
 		], $panel->image());
 
 		// cover enabled
@@ -279,7 +279,7 @@ class PageTest extends TestCase
 			'icon'   => 'page',
 			'url'    => $mediaUrl . '/test.jpg',
 			'src'    => Model::imagePlaceholder(),
-			'srcset' => $mediaUrl . '/test-36x36-crop.jpg 1x, ' . $mediaUrl . '/test-72x72-crop.jpg 2x'
+			'srcset' => $mediaUrl . '/test-36x36-crop.jpg 1x, ' . $mediaUrl . '/test-96x96-crop.jpg 2x'
 		], $panel->image(['cover' => true]));
 	}
 

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -89,24 +89,24 @@ class SiteTest extends TestCase
 
 		// cover disabled as default
 		$this->assertSame([
-			'back' => 'pattern',
-			'color' => 'gray-500',
-			'cover' => false,
-			'icon' => 'page',
-			'url' => $mediaUrl . '/test.jpg',
-			'src' => Model::imagePlaceholder(),
-			'srcset' => $mediaUrl . '/test-38x.jpg 38w, ' . $mediaUrl . '/test-76x.jpg 76w'
+			'back'   => 'pattern',
+			'color'  => 'gray-500',
+			'cover'  => false,
+			'icon'   => 'page',
+			'url'    => $mediaUrl . '/test.jpg',
+			'src'    => Model::imagePlaceholder(),
+			'srcset' => $mediaUrl . '/test-36x.jpg 36w, ' . $mediaUrl . '/test-72x.jpg 72w'
 		], $panel->image());
 
 		// cover enabled
 		$this->assertSame([
-			'back' => 'pattern',
-			'color' => 'gray-500',
-			'cover' => true,
-			'icon' => 'page',
-			'url' => $mediaUrl . '/test.jpg',
-			'src' => Model::imagePlaceholder(),
-			'srcset' => $mediaUrl . '/test-38x38-crop.jpg 1x, ' . $mediaUrl . '/test-76x76-crop.jpg 2x'
+			'back'   => 'pattern',
+			'color'  => 'gray-500',
+			'cover'  => true,
+			'icon'   => 'page',
+			'url'    => $mediaUrl . '/test.jpg',
+			'src'    => Model::imagePlaceholder(),
+			'srcset' => $mediaUrl . '/test-36x36-crop.jpg 1x, ' . $mediaUrl . '/test-72x72-crop.jpg 2x'
 		], $panel->image(['cover' => true]));
 	}
 

--- a/tests/Panel/SiteTest.php
+++ b/tests/Panel/SiteTest.php
@@ -95,7 +95,7 @@ class SiteTest extends TestCase
 			'icon'   => 'page',
 			'url'    => $mediaUrl . '/test.jpg',
 			'src'    => Model::imagePlaceholder(),
-			'srcset' => $mediaUrl . '/test-36x.jpg 36w, ' . $mediaUrl . '/test-72x.jpg 72w'
+			'srcset' => $mediaUrl . '/test-36x.jpg 36w, ' . $mediaUrl . '/test-96x.jpg 96w'
 		], $panel->image());
 
 		// cover enabled
@@ -106,7 +106,7 @@ class SiteTest extends TestCase
 			'icon'   => 'page',
 			'url'    => $mediaUrl . '/test.jpg',
 			'src'    => Model::imagePlaceholder(),
-			'srcset' => $mediaUrl . '/test-36x36-crop.jpg 1x, ' . $mediaUrl . '/test-72x72-crop.jpg 2x'
+			'srcset' => $mediaUrl . '/test-36x36-crop.jpg 1x, ' . $mediaUrl . '/test-96x96-crop.jpg 2x'
 		], $panel->image(['cover' => true]));
 	}
 

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -186,7 +186,7 @@ class UserTest extends TestCase
 			'ratio'  => '1/1',
 			'url'    => $mediaUrl . '/test.jpg',
 			'src'    => Model::imagePlaceholder(),
-			'srcset' => $mediaUrl . '/test-36x.jpg 36w, ' . $mediaUrl . '/test-72x.jpg 72w'
+			'srcset' => $mediaUrl . '/test-36x.jpg 36w, ' . $mediaUrl . '/test-96x.jpg 96w'
 		], $panel->image());
 
 		// cover enabled
@@ -198,7 +198,7 @@ class UserTest extends TestCase
 			'ratio'  => '1/1',
 			'url'    => $mediaUrl . '/test.jpg',
 			'src'    => Model::imagePlaceholder(),
-			'srcset' => $mediaUrl . '/test-36x36-crop.jpg 1x, ' . $mediaUrl . '/test-72x72-crop.jpg 2x'
+			'srcset' => $mediaUrl . '/test-36x36-crop.jpg 1x, ' . $mediaUrl . '/test-96x96-crop.jpg 2x'
 		], $panel->image(['cover' => true]));
 	}
 

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -179,26 +179,26 @@ class UserTest extends TestCase
 
 		// cover disabled as default
 		$this->assertSame([
-			'back' => 'black',
-			'color' => 'gray-500',
-			'cover' => false,
-			'icon' => 'user',
-			'ratio' => '1/1',
-			'url' => $mediaUrl . '/test.jpg',
-			'src' => Model::imagePlaceholder(),
-			'srcset' => $mediaUrl . '/test-38x.jpg 38w, ' . $mediaUrl . '/test-76x.jpg 76w'
+			'back'   => 'black',
+			'color'  => 'gray-500',
+			'cover'  => false,
+			'icon'   => 'user',
+			'ratio'  => '1/1',
+			'url'    => $mediaUrl . '/test.jpg',
+			'src'    => Model::imagePlaceholder(),
+			'srcset' => $mediaUrl . '/test-36x.jpg 36w, ' . $mediaUrl . '/test-72x.jpg 72w'
 		], $panel->image());
 
 		// cover enabled
 		$this->assertSame([
-			'back' => 'black',
-			'color' => 'gray-500',
-			'cover' => true,
-			'icon' => 'user',
-			'ratio' => '1/1',
-			'url' => $mediaUrl . '/test.jpg',
-			'src' => Model::imagePlaceholder(),
-			'srcset' => $mediaUrl . '/test-38x38-crop.jpg 1x, ' . $mediaUrl . '/test-76x76-crop.jpg 2x'
+			'back'   => 'black',
+			'color'  => 'gray-500',
+			'cover'  => true,
+			'icon'   => 'user',
+			'ratio'  => '1/1',
+			'url'    => $mediaUrl . '/test.jpg',
+			'src'    => Model::imagePlaceholder(),
+			'srcset' => $mediaUrl . '/test-36x36-crop.jpg 1x, ' . $mediaUrl . '/test-72x72-crop.jpg 2x'
 		], $panel->image(['cover' => true]));
 	}
 


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- `image` and `gallery` block previews now load properly sized thumbs that also respect the `cover` and `ratio` settings
- `k-image-frame` can receive a file ID/UUID via new `file` prop


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion