### PR TITLE
fix: Proper fallback for `HasI18n` with data

### DIFF
--- a/src/Toolkit/HasI18n.php
+++ b/src/Toolkit/HasI18n.php
@@ -35,6 +35,6 @@ trait HasI18n
 			return I18n::translate($key, $key);
 		}
 
-		return I18n::template($key, $data);
+		return I18n::template($key, $key, $data);
 	}
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,9 +7,7 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Cms\User;
-use Kirby\Data\Data;
 use Kirby\Filesystem\Dir;
-use Kirby\Toolkit\I18n;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
@@ -92,17 +90,6 @@ class TestCase extends BaseTestCase
 	protected function hasTmp(): bool
 	{
 		return defined(static::class . '::TMP');
-	}
-
-	/**
-	 * Sets up `Toolkit\I18n` loader for the
-	 * specified language code
-	 */
-	protected function setUpI18nLoader(string $code = 'en'): void
-	{
-		// load i18n strings
-		$i18n = dirname(__DIR__) . '/i18n/translations/' . $code . '.json';
-		I18n::$load = fn () => Data::read($i18n, fail: false);
 	}
 
 	/**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,7 +7,9 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Cms\User;
+use Kirby\Data\Data;
 use Kirby\Filesystem\Dir;
+use Kirby\Toolkit\I18n;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
@@ -90,6 +92,17 @@ class TestCase extends BaseTestCase
 	protected function hasTmp(): bool
 	{
 		return defined(static::class . '::TMP');
+	}
+
+	/**
+	 * Sets up `Toolkit\I18n` loader for the
+	 * specified language code
+	 */
+	protected function setUpI18nLoader(string $code = 'en'): void
+	{
+		// load i18n strings
+		$i18n = dirname(__DIR__) . '/i18n/translations/' . $code . '.json';
+		I18n::$load = fn () => Data::read($i18n, fail: false);
 	}
 
 	/**

--- a/tests/Toolkit/HasI18nTest.php
+++ b/tests/Toolkit/HasI18nTest.php
@@ -6,6 +6,11 @@ use Kirby\TestCase;
 
 class HasI18nTest extends TestCase
 {
+	public function setUp(): void
+	{
+		$this->setUpI18nLoader();
+	}
+
 	protected function object(): object
 	{
 		return new class () {

--- a/tests/Toolkit/HasI18nTest.php
+++ b/tests/Toolkit/HasI18nTest.php
@@ -2,18 +2,32 @@
 
 namespace Kirby\Toolkit;
 
+use Closure;
 use Kirby\TestCase;
 
 class HasI18nTest extends TestCase
 {
+	protected string|Closure $localeBackup;
+
 	public function setUp(): void
 	{
-		$this->setUpI18nLoader();
+		$this->localeBackup = I18n::$locale;
+		I18n::$locale = 'foo';
+		I18n::$translations['foo'] = [
+			'my.key'   => 'My translation',
+			'my.count' => 'All {count} things'
+		];
 	}
 
-	protected function object(): object
+	public function tearDown(): void
 	{
-		return new class () {
+		unset(I18n::$translations['foo']);
+		I18n::$locale = $this->localeBackup;
+	}
+
+	public function testI18n(): void
+	{
+		$class = new class () {
 			use HasI18n;
 
 			public function translate($key, $data = null)
@@ -21,19 +35,15 @@ class HasI18nTest extends TestCase
 				return $this->i18n($key, $data);
 			}
 		};
-	}
-
-	public function testI18n(): void
-	{
-		$class = $this->object();
 
 		$this->assertNull($class->translate(null));
 		$this->assertSame('Hello', $class->translate('Hello'));
+		$this->assertSame('Hello', $class->translate('Hello', ['data' => 'data']));
 		$this->assertSame('Hello', $class->translate(fn () => 'Hello'));
 		$this->assertSame('Hello', $class->translate(['Hello']));
 		$this->assertSame('Hello', $class->translate(['Hello', 'World']));
 
-		$this->assertSame('Copy all', $class->translate('copy.all'));
-		$this->assertSame('3 copied!', $class->translate('copy.success.multiple', ['count' => 3]));
+		$this->assertSame('My translation', $class->translate('my.key'));
+		$this->assertSame('All 3 things', $class->translate('my.count', ['count' => 3]));
 	}
 }


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

- Fix: Pass key also as fallback in `HasI18n:: i18n()`
- Make `HasI18nTest ` independent of the unit tests preloading i18n strings
