### PR TITLE
refact: Consistent `parent::fill()` in fields

### DIFF
--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -236,9 +236,7 @@ class BlocksField extends InputField
 	{
 		$value  = BlocksCollection::parse($value);
 		$blocks = BlocksCollection::factory($value)->toArray();
-		$this->value = $this->blocksToValues($blocks);
-
-		return $this;
+		return parent::fill(value: $this->blocksToValues($blocks));
 	}
 
 	public function form(array $fields): Form
@@ -296,9 +294,9 @@ class BlocksField extends InputField
 		] + parent::props();
 	}
 
-	public function toStoredValue(bool $default = false): mixed
+	public function toStoredValue(): mixed
 	{
-		$value  = $this->toFormValue($default);
+		$value  = parent::toStoredValue();
 		$blocks = $this->blocksToValues((array)$value, 'toStoredValues');
 
 		// returns empty string to avoid storing empty array as string `[]`
@@ -316,20 +314,14 @@ class BlocksField extends InputField
 			'blocks' => function ($value) {
 				if ($this->min && count($value) < $this->min) {
 					throw new InvalidArgumentException(
-						key: match ($this->min) {
-							1       => 'blocks.min.singular',
-							default => 'blocks.min.plural'
-						},
+						key: 'blocks.min.' . ($this->min === 1 ? 'singular' : 'plural'),
 						data: ['min' => $this->min]
 					);
 				}
 
 				if ($this->max && count($value) > $this->max) {
 					throw new InvalidArgumentException(
-						key: match ($this->max) {
-							1       => 'blocks.max.singular',
-							default => 'blocks.max.plural'
-						},
+						key: 'blocks.max.' . ($this->max === 1 ? 'singular' : 'plural'),
 						data: ['max' => $this->max]
 					);
 				}

--- a/src/Form/Field/CheckboxesField.php
+++ b/src/Form/Field/CheckboxesField.php
@@ -64,8 +64,9 @@ class CheckboxesField extends OptionsField
 	 */
 	public function fill(mixed $value): static
 	{
-		$this->value = Str::split($value, ',');
-		return $this;
+		return parent::fill(
+			value: Str::split($value, ',')
+		);
 	}
 
 	public function props(): array

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -110,8 +110,9 @@ class EntriesField extends InputField
 	 */
 	public function fill(mixed $value): static
 	{
-		$this->value = Data::decode($value ?? '', 'yaml');
-		return $this;
+		return parent::fill(
+			value: Data::decode($value ?? '', 'yaml')
+		);
 	}
 
 	public function form(): Form

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -325,10 +325,10 @@ class LayoutField extends BlocksField
 		return $this->settingsFieldset ??= Fieldset::factory($settings);
 	}
 
-	public function toStoredValue(bool $default = false): mixed
+	public function toStoredValue(): mixed
 	{
+		$value = $this->toFormValue();
 		$attrs = $this->attrsForm();
-		$value = $this->toFormValue($default);
 		$value = Layouts::factory($value, ['parent' => $this->model()])->toArray();
 
 		// returns empty string to avoid storing empty array as string `[]`

--- a/src/Form/Field/NumberField.php
+++ b/src/Form/Field/NumberField.php
@@ -85,12 +85,16 @@ class NumberField extends InputField
 	 */
 	public function fill(mixed $value): static
 	{
-		return parent::fill(static::toNumber($value));
+		return parent::fill(
+			value: static::toNumber($value)
+		);
 	}
 
 	public function default(): float|null
 	{
-		return static::toNumber(parent::default());
+		return static::toNumber(
+			value: parent::default()
+		);
 	}
 
 	public function max(): float|null

--- a/src/Form/Field/ObjectField.php
+++ b/src/Form/Field/ObjectField.php
@@ -57,8 +57,9 @@ class ObjectField extends InputField
 	 */
 	public function fill(mixed $value): static
 	{
-		$this->value = Data::decode($value, 'yaml');
-		return $this;
+		return parent::fill(
+			value: Data::decode($value, 'yaml')
+		);
 	}
 
 	public function toFormValue(): array

--- a/src/Form/Field/StructureField.php
+++ b/src/Form/Field/StructureField.php
@@ -75,6 +75,17 @@ class StructureField extends InputField
 		return $this->duplicate ?? true;
 	}
 
+	/**
+	 * @psalm-suppress MethodSignatureMismatch
+	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
+	 */
+	public function fill(mixed $value): static
+	{
+		return parent::fill(
+			value: Data::decode($value, 'yaml')
+		);
+	}
+
 	public function props(): array
 	{
 		return [
@@ -91,16 +102,6 @@ class StructureField extends InputField
 			'sortable'  => $this->sortable(),
 			'sortBy'    => $this->sortBy()
 		];
-	}
-
-	/**
-	 * @psalm-suppress MethodSignatureMismatch
-	 * @todo Remove psalm suppress after https://github.com/vimeo/psalm/issues/8673 is fixed
-	 */
-	public function fill(mixed $value): static
-	{
-		$this->value = Data::decode($value, 'yaml');
-		return $this;
 	}
 
 	public function toFormValue(): array

--- a/src/Form/Field/TagsField.php
+++ b/src/Form/Field/TagsField.php
@@ -113,8 +113,9 @@ class TagsField extends OptionsField
 	 */
 	public function fill(mixed $value): static
 	{
-		$this->value = Str::split($value, $this->separator());
-		return $this;
+		return parent::fill(
+			value: Str::split($value, $this->separator())
+		);
 	}
 
 	public function icon(): string
@@ -145,17 +146,9 @@ class TagsField extends OptionsField
 		];
 	}
 
-	public function toFormValue(): array
-	{
-		return $this->value;
-	}
-
 	public function toStoredValue(): string
 	{
-		return A::join(
-			$this->value ?? [],
-			$this->separator() . ' '
-		);
+		return A::join($this->value, $this->separator() . ' ');
 	}
 
 	protected function validations(): array

--- a/src/Form/Field/TextField.php
+++ b/src/Form/Field/TextField.php
@@ -84,8 +84,9 @@ class TextField extends StringField
 	 */
 	public function fill(mixed $value): static
 	{
-		$this->value = $this->convert($value);
-		return $this;
+		return parent::fill(
+			value: $this->convert($value)
+		);
 	}
 
 	public function props(): array

--- a/src/Form/Field/TextareaField.php
+++ b/src/Form/Field/TextareaField.php
@@ -165,7 +165,9 @@ class TextareaField extends InputField
 	 */
 	public function fill(mixed $value): static
 	{
-		return parent::fill(value: trim($value ?? ''));
+		return parent::fill(
+			value: trim($value ?? '')
+		);
 	}
 
 	public function props(): array

--- a/src/Form/Field/ToggleField.php
+++ b/src/Form/Field/ToggleField.php
@@ -71,8 +71,9 @@ class ToggleField extends InputField
 	 */
 	public function fill(mixed $value): static
 	{
-		$this->value = static::toBool($value);
-		return $this;
+		return parent::fill(
+			value: static::toBool($value)
+		);
 	}
 
 	public function props(): array

--- a/src/Form/Field/WriterField.php
+++ b/src/Form/Field/WriterField.php
@@ -106,8 +106,9 @@ class WriterField extends StringField
 		// convert non-breaking spaces to HTML entity
 		// as that's how ProseMirror handles it internally;
 		// will allow comparing saved and current content
-		$this->value = str_replace(' ', '&nbsp;', $value);
-		return $this;
+		$value = str_replace(' ', '&nbsp;', $value);
+
+		return parent::fill($value);
 	}
 
 	public function headings(): array


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

- Use `parent::fill()` (`Mixin\Value::fill()`) in field classes wherever suitable.
- Remove some `$default` parameters from `::toStoredValue()` that have no use anymore