### PR TITLE
refact: `$value` prop handling in field classes 

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -51,6 +51,8 @@ class Field extends Component
 	 */
 	public static array $types = [];
 
+	protected mixed $value = null;
+
 	/**
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */

--- a/src/Form/Field/BaseField.php
+++ b/src/Form/Field/BaseField.php
@@ -26,7 +26,6 @@ abstract class BaseField
 	use Mixin\Name;
 	use Mixin\Siblings;
 	use Mixin\Translatable;
-	use Mixin\Value;
 	use Mixin\When;
 	use Mixin\Width;
 
@@ -74,16 +73,15 @@ abstract class BaseField
 			$field->setModel($props['model']);
 		}
 
-		if (array_key_exists('value', $props) === true) {
-			$field->fill($props['value']);
-		}
-
 		return $field;
 	}
 
+	/**
+	 * Checks if the field has a value
+	 */
 	public function hasValue(): bool
 	{
-		return false;
+		return property_exists($this, 'value') === true;
 	}
 
 	public function id(): string

--- a/src/Form/Field/BaseField.php
+++ b/src/Form/Field/BaseField.php
@@ -113,16 +113,6 @@ abstract class BaseField
 	}
 
 	/**
-	 * @since 5.2.0
-	 * @todo Move to `Value` mixin once array-based fields are unsupported
-	 */
-	public function reset(): static
-	{
-		$this->value = $this->emptyValue();
-		return $this;
-	}
-
-	/**
 	 * Parses a string template in the given value
 	 */
 	protected function stringTemplate(string|null $string = null, bool $safe = true): string|null

--- a/src/Form/Field/BaseField.php
+++ b/src/Form/Field/BaseField.php
@@ -73,6 +73,13 @@ abstract class BaseField
 			$field->setModel($props['model']);
 		}
 
+		if (
+			array_key_exists('value', $props) === true &&
+			method_exists(static::class, 'fill') === true
+		) {
+			$field->fill($props['value']);
+		}
+
 		return $field;
 	}
 

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -47,7 +47,7 @@ class BlocksField extends InputField
 	 */
 	protected string|null $group;
 
-	protected mixed $value = [];
+	protected array $value = [];
 
 	public function __construct(
 		bool|null $autofocus = null,

--- a/src/Form/Field/ColorField.php
+++ b/src/Form/Field/ColorField.php
@@ -38,8 +38,6 @@ class ColorField extends OptionField
 	 */
 	protected string|null $mode;
 
-	protected mixed $value = '';
-
 	public function __construct(
 		bool|null $alpha = null,
 		bool|null $autofocus = null,

--- a/src/Form/Field/DateTimeField.php
+++ b/src/Form/Field/DateTimeField.php
@@ -33,10 +33,7 @@ abstract class DateTimeField extends InputField
 	protected string|null $min;
 	protected array|int|string|null $step;
 
-	/**
-	 * @var \Kirby\Toolkit\Date|null
-	 */
-	protected mixed $value = null;
+	protected Date|null $value = null;
 
 	public function __construct(
 		bool|null $autofocus = null,

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -37,7 +37,7 @@ class EntriesField extends InputField
 	protected array|string|null $field;
 
 	protected Form $form;
-	protected mixed $value = [];
+	protected array $value = [];
 
 	public function __construct(
 		bool|null $autofocus = null,

--- a/src/Form/Field/HiddenField.php
+++ b/src/Form/Field/HiddenField.php
@@ -14,6 +14,8 @@ namespace Kirby\Form\Field;
  */
 class HiddenField extends BaseField
 {
+	protected mixed $value = null;
+
 	public function __construct(
 		mixed $default = null,
 		string|null $name = null,

--- a/src/Form/Field/HiddenField.php
+++ b/src/Form/Field/HiddenField.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Form\Field;
 
+use Kirby\Form\Mixin;
+
 /**
  * Hidden field
  *
@@ -12,8 +14,10 @@ namespace Kirby\Form\Field;
  * @license   https://getkirby.com/license
  * @since     6.0.0
  */
-class HiddenField extends BaseField
+class HiddenField extends InputField
 {
+	use Mixin\Value;
+
 	protected mixed $value = null;
 
 	public function __construct(
@@ -27,11 +31,6 @@ class HiddenField extends BaseField
 
 		$this->default   = $default;
 		$this->translate = $translate;
-	}
-
-	public function hasValue(): bool
-	{
-		return true;
 	}
 
 	public function isHidden(): bool

--- a/src/Form/Field/HiddenField.php
+++ b/src/Form/Field/HiddenField.php
@@ -14,7 +14,7 @@ use Kirby\Form\Mixin;
  * @license   https://getkirby.com/license
  * @since     6.0.0
  */
-class HiddenField extends InputField
+class HiddenField extends BaseField
 {
 	use Mixin\Value;
 

--- a/src/Form/Field/InputField.php
+++ b/src/Form/Field/InputField.php
@@ -70,4 +70,14 @@ abstract class InputField extends BaseField
 			'width'     => $this->width(),
 		];
 	}
+
+	/**
+	 * @since 5.2.0
+	 * @todo Move to `Value` mixin once array-based fields are unsupported
+	 */
+	public function reset(): static
+	{
+		$this->value = $this->emptyValue();
+		return $this;
+	}
 }

--- a/src/Form/Field/InputField.php
+++ b/src/Form/Field/InputField.php
@@ -53,26 +53,6 @@ abstract class InputField extends BaseField
 		$this->width     = $width;
 	}
 
-	/**
-	 * Creates a new field instance from a $props array
-	 * @since 6.0.0
-	 */
-	public static function factory(
-		array $props,
-		Fields|null $siblings = null
-	): static {
-		/**
-		 * @var \Kirby\Form\Field\InputField $field
-		 */
-		$field = parent::factory($props, $siblings);
-
-		if (array_key_exists('value', $props) === true) {
-			$field->fill($props['value']);
-		}
-
-		return $field;
-	}
-
 	public function props(): array
 	{
 		return [

--- a/src/Form/Field/InputField.php
+++ b/src/Form/Field/InputField.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Form\Field;
 
+use Kirby\Form\Fields;
 use Kirby\Form\Mixin;
 
 /**
@@ -22,6 +23,7 @@ abstract class InputField extends BaseField
 	use Mixin\Label;
 	use Mixin\Required;
 	use Mixin\Validation;
+	use Mixin\Value;
 	use Mixin\Width;
 
 	public function __construct(
@@ -51,9 +53,24 @@ abstract class InputField extends BaseField
 		$this->width     = $width;
 	}
 
-	public function hasValue(): bool
-	{
-		return true;
+	/**
+	 * Creates a new field instance from a $props array
+	 * @since 6.0.0
+	 */
+	public static function factory(
+		array $props,
+		Fields|null $siblings = null
+	): static {
+		/**
+		 * @var \Kirby\Form\Field\InputField $field
+		 */
+		$field = parent::factory($props, $siblings);
+
+		if (array_key_exists('value', $props) === true) {
+			$field->fill($props['value']);
+		}
+
+		return $field;
 	}
 
 	public function props(): array

--- a/src/Form/Field/LinkField.php
+++ b/src/Form/Field/LinkField.php
@@ -23,7 +23,7 @@ class LinkField extends InputField
 	 */
 	protected array|null $options;
 
-	protected mixed $value = '';
+	protected string $value = '';
 
 	public function __construct(
 		bool|null $autofocus = null,

--- a/src/Form/Field/ModelPickerField.php
+++ b/src/Form/Field/ModelPickerField.php
@@ -80,7 +80,7 @@ abstract class ModelPickerField extends InputField
 	 */
 	protected string|null $text;
 
-	protected mixed $value = [];
+	protected array $value = [];
 
 	public function __construct(
 		bool|null $autofocus = null,

--- a/src/Form/Field/NumberField.php
+++ b/src/Form/Field/NumberField.php
@@ -38,6 +38,8 @@ class NumberField extends InputField
 	 */
 	protected float|string|null $step;
 
+	protected float|null $value = null;
+
 	public function __construct(
 		array|string|null $after = null,
 		bool|null $autofocus = null,

--- a/src/Form/Field/ObjectField.php
+++ b/src/Form/Field/ObjectField.php
@@ -11,7 +11,7 @@ class ObjectField extends InputField
 	use Mixin\EmptyState;
 	use Mixin\Fields;
 
-	protected mixed $value = [];
+	protected array $value = [];
 
 	public function __construct(
 		array|null $default = null,

--- a/src/Form/Field/OptionField.php
+++ b/src/Form/Field/OptionField.php
@@ -18,7 +18,7 @@ abstract class OptionField extends InputField
 {
 	use Mixin\Options;
 
-	protected mixed $value = '';
+	protected string $value = '';
 
 	public function __construct(
 		bool|null $autofocus = null,

--- a/src/Form/Field/OptionsField.php
+++ b/src/Form/Field/OptionsField.php
@@ -20,7 +20,7 @@ abstract class OptionsField extends InputField
 	use Mixin\Min;
 	use Mixin\Options;
 
-	protected mixed $value = [];
+	protected array $value = [];
 
 	public function __construct(
 		bool|null $autofocus = null,

--- a/src/Form/Field/StringField.php
+++ b/src/Form/Field/StringField.php
@@ -25,7 +25,7 @@ abstract class StringField extends InputField
 	use Mixin\Placeholder;
 	use Mixin\Spellcheck;
 
-	protected mixed $value = '';
+	protected string $value = '';
 
 	public function __construct(
 		string|null $autocomplete = null,

--- a/src/Form/Field/StructureField.php
+++ b/src/Form/Field/StructureField.php
@@ -21,7 +21,7 @@ class StructureField extends InputField
 	use Mixin\SortBy;
 	use Mixin\TableColumns;
 
-	protected mixed $value = [];
+	protected array $value = [];
 
 	public function __construct(
 		bool|null $batch = null,

--- a/src/Form/Field/TagsField.php
+++ b/src/Form/Field/TagsField.php
@@ -47,8 +47,6 @@ class TagsField extends OptionsField
 	 */
 	protected bool|null $sort;
 
-	protected mixed $value = [];
-
 	public function __construct(
 		string|null $accept = null,
 		bool|null $autofocus = null,

--- a/src/Form/Field/TextField.php
+++ b/src/Form/Field/TextField.php
@@ -73,9 +73,9 @@ class TextField extends StringField
 		$this->pattern   = $pattern;
 	}
 
-	public function default(): string|null
+	public function default(): string
 	{
-		return $this->convert($this->default);
+		return $this->convert($this->default) ?? '';
 	}
 
 	/**
@@ -85,7 +85,7 @@ class TextField extends StringField
 	public function fill(mixed $value): static
 	{
 		return parent::fill(
-			value: $this->convert($value)
+			value: $this->convert($value) ?? ''
 		);
 	}
 

--- a/src/Form/Field/TextareaField.php
+++ b/src/Form/Field/TextareaField.php
@@ -43,7 +43,7 @@ class TextareaField extends InputField
 	 */
 	protected string|null $size;
 
-	protected mixed $value = '';
+	protected string $value = '';
 
 	public function __construct(
 		bool|null $autofocus = null,

--- a/src/Form/Field/ToggleField.php
+++ b/src/Form/Field/ToggleField.php
@@ -30,6 +30,8 @@ class ToggleField extends InputField
 	 */
 	protected array|string|null $text;
 
+	protected bool|null $value = null;
+
 	public function __construct(
 		array|string|null $after = null,
 		bool|null $autofocus = null,

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -72,11 +72,6 @@ abstract class FieldClass extends InputField
 		throw new NotFoundException(message: 'Method or option "' . $param . '" does not exist for field type "' . $this->type() . '"');
 	}
 
-	public function hasValue(): bool
-	{
-		return true;
-	}
-
 	/**
 	 * Define the props that will be sent to
 	 * the Vue component

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -26,6 +26,8 @@ abstract class FieldClass extends InputField
 	use Mixin\Placeholder;
 	use Mixin\Width;
 
+	protected mixed $value = null;
+
 	public function __construct(
 		array|string|null $after = null,
 		bool|null $autofocus = null,

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -401,7 +401,7 @@ class Fields extends Collection
 	{
 		return $this->toValues(
 			fn ($field) => $field->toStoredValue(),
-			fn ($field) => $field->isStorable($this->language())
+			fn ($field) => $field->hasValue() ? $field->isStorable($this->language()) : false
 		);
 	}
 

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -9,6 +9,7 @@ use Kirby\Cms\ModelWithContent;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Form\Field\BaseField;
+use Kirby\Form\Field\InputField;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Collection;
 use Kirby\Toolkit\Str;
@@ -277,7 +278,7 @@ class Fields extends Collection
 		foreach ($this->data as $field) {
 			if ($field instanceof Field) {
 				$field->fillWithEmptyValue();
-			} else {
+			} elseif ($field instanceof InputField) {
 				$field->reset();
 			}
 		}

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -9,7 +9,6 @@ use Kirby\Cms\ModelWithContent;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Form\Field\BaseField;
-use Kirby\Form\Field\InputField;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Collection;
 use Kirby\Toolkit\Str;
@@ -276,10 +275,12 @@ class Fields extends Collection
 
 		// reset the values of each field
 		foreach ($this->data as $field) {
-			if ($field instanceof Field) {
-				$field->fillWithEmptyValue();
-			} elseif ($field instanceof InputField) {
-				$field->reset();
+			if ($field->hasValue() === true) {
+				if ($field instanceof Field) {
+					$field->fillWithEmptyValue();
+				} else {
+					$field->reset();
+				}
 			}
 		}
 

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -71,7 +71,10 @@ class Form
 		$language = $this->fields->language();
 
 		foreach ($this->fields as $field) {
-			if ($field->isStorable($language) === false) {
+			if (
+				$field->hasValue() === false ||
+				$field->isStorable($language) === false
+			) {
 				if ($includeNulls === true) {
 					$data[$field->name()] = null;
 				}

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -36,19 +36,8 @@ trait Value
 	 */
 	public function fill(mixed $value): static
 	{
-		if (property_exists($this, 'value') === true) {
-			$this->value = $value ?? $this->emptyValue();
-		}
-
+		$this->value = $value ?? $this->emptyValue();
 		return $this;
-	}
-
-	/**
-	 * Checks if the field has a value
-	 */
-	public function hasValue(): bool
-	{
-		return true;
 	}
 
 	/**

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -8,11 +8,6 @@ use ReflectionProperty;
 trait Value
 {
 	/**
-	 * The value of the field
-	 */
-	protected mixed $value = null;
-
-	/**
 	 * @deprecated 5.0.0 Use `::toStoredValue()` instead to receive
 	 * the value in the format that will be needed for content files.
 	 *
@@ -41,7 +36,10 @@ trait Value
 	 */
 	public function fill(mixed $value): static
 	{
-		$this->value = $value;
+		if (property_exists($this, 'value') === true) {
+			$this->value = $value ?? $this->emptyValue();
+		}
+
 		return $this;
 	}
 

--- a/tests/Form/Field/ColorFieldTest.php
+++ b/tests/Form/Field/ColorFieldTest.php
@@ -47,8 +47,8 @@ class ColorFieldTest extends TestCase
 			'value' => null
 		]);
 
-		$this->assertNull($field->toFormValue());
-		$this->assertNull($field->toStoredValue());
+		$this->assertSame('', $field->toFormValue());
+		$this->assertSame('', $field->toStoredValue());
 	}
 
 	public function testDefault(): void

--- a/tests/Form/Field/EmailFieldTest.php
+++ b/tests/Form/Field/EmailFieldTest.php
@@ -21,7 +21,7 @@ class EmailFieldTest extends TestCase
 			'before'       => null,
 			'converter'    => null,
 			'counter'      => false,
-			'default'      => null,
+			'default'      => '',
 			'disabled'     => false,
 			'font'         => 'sans-serif',
 			'help'         => null,

--- a/tests/Form/Field/HeadlineFieldTest.php
+++ b/tests/Form/Field/HeadlineFieldTest.php
@@ -13,9 +13,7 @@ class HeadlineFieldTest extends TestCase
 
 		$this->assertSame('headline', $field->type());
 		$this->assertSame('headline', $field->name());
-		$this->assertNull($field->value());
 		$this->assertSame('Headline', $field->label());
 		$this->assertFalse($field->hasValue());
-		$this->assertFalse($field->save());
 	}
 }

--- a/tests/Form/Field/SlugFieldTest.php
+++ b/tests/Form/Field/SlugFieldTest.php
@@ -22,7 +22,7 @@ class SlugFieldTest extends TestCase
 			'before'       => null,
 			'converter'    => null,
 			'counter'      => false,
-			'default'      => null,
+			'default'      => '',
 			'disabled'     => false,
 			'font'         => 'sans-serif',
 			'help'         => null,

--- a/tests/Form/Field/TelFieldTest.php
+++ b/tests/Form/Field/TelFieldTest.php
@@ -21,7 +21,7 @@ class TelFieldTest extends TestCase
 			'before'       => null,
 			'converter'    => null,
 			'counter'      => false,
-			'default'      => null,
+			'default'      => '',
 			'disabled'     => false,
 			'font'         => 'sans-serif',
 			'help'         => null,

--- a/tests/Form/Field/TextFieldTest.php
+++ b/tests/Form/Field/TextFieldTest.php
@@ -23,7 +23,7 @@ class TextFieldTest extends TestCase
 			'before'       => null,
 			'converter'    => null,
 			'counter'      => true,
-			'default'      => null,
+			'default'      => '',
 			'disabled'     => false,
 			'font'         => 'sans-serif',
 			'help'         => null,
@@ -54,7 +54,7 @@ class TextFieldTest extends TestCase
 			['upper', 'Super nice', 'SUPER NICE'],
 			['lower', 'Super nice', 'super nice'],
 			['ucfirst', 'super nice', 'Super nice'],
-			['upper', null, null],
+			['upper', null, ''],
 			['lower', '', ''],
 		];
 	}

--- a/tests/Form/Field/UrlFieldTest.php
+++ b/tests/Form/Field/UrlFieldTest.php
@@ -21,7 +21,7 @@ class UrlFieldTest extends TestCase
 			'before'       => null,
 			'converter'    => null,
 			'counter'      => false,
-			'default'      => null,
+			'default'      => '',
 			'disabled'     => false,
 			'font'         => 'sans-serif',
 			'help'         => null,

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -880,6 +880,7 @@ class FieldsTest extends TestCase
 			'a' => [
 				'autofocus'  => false,
 				'counter'    => true,
+				'default'    => '',
 				'disabled'   => false,
 				'font'       => 'sans-serif',
 				'hidden'     => false,


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

- Do not define the property in `Mixin\Value` but the field classes so we can type hint it more strictl
- Move `Mixin\Value` to `InputField` as just the base field class should not yet have a value
- For `::hasValue()` check if `$value` property exists
