### PR TITLE
feat: New stack component

### DIFF
--- a/panel/lab/components/stack/index.php
+++ b/panel/lab/components/stack/index.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'docs' => 'k-stack',
+];

--- a/panel/lab/components/stack/index.vue
+++ b/panel/lab/components/stack/index.vue
@@ -1,0 +1,38 @@
+<template>
+	<k-lab-examples>
+		<k-lab-example label="stack (gap: default)">
+			<k-stack>
+				<k-box theme="white">Test Box</k-box>
+				<k-box theme="white">Test Box</k-box>
+				<k-box theme="white">Test Box</k-box>
+			</k-stack>
+		</k-lab-example>
+		<k-lab-example label="stack (gap: spacing-12)">
+			<k-stack gap="var(--spacing-12)">
+				<k-box theme="white">Test Box</k-box>
+				<k-box theme="white">Test Box</k-box>
+				<k-box theme="white">Test Box</k-box>
+			</k-stack>
+		</k-lab-example>
+		<k-lab-example label="stack (direction: row)">
+			<k-stack direction="row">
+				<k-box theme="white">Test Box</k-box>
+				<k-box theme="white">Test Box</k-box>
+				<k-box theme="white">Test Box</k-box>
+			</k-stack>
+		</k-lab-example>
+		<k-lab-example label="stack (direction: row, justify: space-between)">
+			<k-stack direction="row" justify="space-between">
+				<k-box theme="white" style="width: auto">Test Box</k-box>
+				<k-box theme="white" style="width: auto">Test Box</k-box>
+			</k-stack>
+		</k-lab-example>
+		<k-lab-example label="stack (direction: row, align: center)">
+			<k-stack direction="row" align="center">
+				<k-box theme="white">Line 1<br />Line 2</k-box>
+				<k-box theme="white">Test Box</k-box>
+				<k-box theme="white">Test Box</k-box>
+			</k-stack>
+		</k-lab-example>
+	</k-lab-examples>
+</template>

--- a/panel/src/components/Layout/Stack.vue
+++ b/panel/src/components/Layout/Stack.vue
@@ -1,0 +1,34 @@
+<template>
+	<div
+		class="k-stack"
+		:style="{
+			alignItems: align,
+			flexDirection: direction,
+			gap: gap,
+			justifyContent: justify
+		}"
+	>
+		<slot />
+	</div>
+</template>
+
+<script>
+export default {
+	props: {
+		align: String,
+		direction: String,
+		gap: String,
+		justify: String
+	}
+};
+</script>
+
+<style>
+:where(.k-stack) {
+	display: flex;
+	flex-direction: column;
+	container-type: inline-size;
+	gap: var(--spacing-3);
+	width: 100%;
+}
+</style>

--- a/panel/src/components/Layout/index.js
+++ b/panel/src/components/Layout/index.js
@@ -11,6 +11,7 @@ import Header from "./Header.vue";
 import IconFrame from "./Frame/IconFrame.vue";
 import ImageFrame from "./Frame/ImageFrame.vue";
 import Overlay from "./Overlay.vue";
+import Stack from "./Stack.vue";
 import Stat from "./Stat.vue";
 import Stats from "./Stats.vue";
 import Table from "./Table.vue";
@@ -33,6 +34,7 @@ export default {
 		app.component("k-image-frame", ImageFrame);
 		app.component("k-image", ImageFrame);
 		app.component("k-overlay", Overlay);
+		app.component("k-stack", Stack);
 		app.component("k-stat", Stat);
 		app.component("k-stats", Stats);
 		app.component("k-table", Table);


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features

- New `<k-stack>` component to help with horizontal and vertical layouts. Think of it as a flex layout helper component. It's perfect to create equal gaps between elements in a column or row. E.g. different sections or the gap between the headline and contents of a container. 

<img width="907" height="1001" alt="Screenshot 2025-12-11 at 10 42 02" src="https://github.com/user-attachments/assets/b859f0b6-b513-4ce0-a3ba-653284c297bf" />

You can either use the component as a wrapper (which will create a div): 

```html
<k-stack>
	<k-box theme="white">Test Box</k-box>
	<k-box theme="white">Test Box</k-box>
	<k-box theme="white">Test Box</k-box>
</k-stack>
```

… or use the k-stack class on an existing wrapper element to inherit the basic stack styles: 

```html
<ul class="k-stack">
	<li>Item A</li>
	<li>Item B</li>
	<li>Item C</li>
</ul>
```

Use the attributes `gap`, `direction`, `align` and `justify` to control the layout. 

```html
<k-stack gap="var(--spacing-12)" align="center" direction="row" justify="space-between">
	<k-box theme="white">Test Box</k-box>
	<k-box theme="white">Test Box</k-box>
	<k-box theme="white">Test Box</k-box>
</k-stack>
```

Those are applied as inline styles. If you use the `k-stack` class on a custom element, you need to set the inline styles manually or with the CSS rules for your element. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion