### PR TITLE
feat: New Definitions components

### DIFF
--- a/panel/lab/components/definitions/1_definitions/index.php
+++ b/panel/lab/components/definitions/1_definitions/index.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'docs' => 'k-definitions',
+];

--- a/panel/lab/components/definitions/1_definitions/index.vue
+++ b/panel/lab/components/definitions/1_definitions/index.vue
@@ -1,0 +1,11 @@
+<template>
+	<k-lab-examples>
+		<k-lab-example label="Definitions">
+			<k-definitions>
+				<k-definition term="Term" description="Description" />
+				<k-definition term="Term" description="Description" />
+				<k-definition term="Term" description="Description" />
+			</k-definitions>
+		</k-lab-example>
+	</k-lab-examples>
+</template>

--- a/panel/lab/components/definitions/2_definition/index.php
+++ b/panel/lab/components/definitions/2_definition/index.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'docs' => 'k-definition',
+];

--- a/panel/lab/components/definitions/2_definition/index.vue
+++ b/panel/lab/components/definitions/2_definition/index.vue
@@ -1,0 +1,65 @@
+<template>
+	<k-lab-examples>
+		<k-lab-example label="Props">
+			<k-definitions>
+				<k-definition term="Term" description="Description" />
+				<k-definition term="Term" description="Description" />
+				<k-definition term="Term" description="Description" />
+			</k-definitions>
+		</k-lab-example>
+		<k-lab-example label="Slots">
+			<k-definitions>
+				<k-definition>
+					<template #term><em>Term</em></template>
+					<p class="k-text">
+						<a href="https://getkirby.com">Description</a>
+					</p>
+				</k-definition>
+				<k-definition>
+					<template #term><em>Term</em></template>
+					<p class="k-text">
+						<a href="https://getkirby.com">Description</a>
+					</p>
+				</k-definition>
+				<k-definition>
+					<template #term><em>Term</em></template>
+					<p class="k-text">
+						<a href="https://getkirby.com">Description</a>
+					</p>
+				</k-definition>
+			</k-definitions>
+		</k-lab-example>
+		<k-lab-example label="Slots & Props">
+			<k-definitions>
+				<k-definition term="Term">
+					<p class="k-text">
+						<a href="https://getkirby.com">Description</a>
+					</p>
+				</k-definition>
+				<k-definition term="Term">
+					<p class="k-text">
+						<a href="https://getkirby.com">Description</a>
+					</p>
+				</k-definition>
+				<k-definition term="Term">
+					<p class="k-text">
+						<a href="https://getkirby.com">Description</a>
+					</p>
+				</k-definition>
+			</k-definitions>
+		</k-lab-example>
+		<k-lab-example label="Term width">
+			<k-definitions style="--definition-term-width: 33%">
+				<k-definition term="Longer Term" description="Description" />
+			</k-definitions>
+		</k-lab-example>
+		<k-lab-example label="Definition height">
+			<k-definitions
+				style="--definition-height: 10rem; --definition-align: start"
+			>
+				<k-definition term="Longer Term" description="Description" />
+				<k-definition term="Longer Term" description="Description" />
+			</k-definitions>
+		</k-lab-example>
+	</k-lab-examples>
+</template>

--- a/panel/src/components/Layout/Definition.vue
+++ b/panel/src/components/Layout/Definition.vue
@@ -1,0 +1,49 @@
+<template>
+	<div class="k-definition">
+		<dt>
+			<slot name="term">{{ term }}</slot>
+		</dt>
+		<dd>
+			<slot>{{ description }}</slot>
+		</dd>
+	</div>
+</template>
+
+<script>
+export default {
+	props: {
+		description: String,
+		term: String
+	}
+};
+</script>
+
+<style>
+:root {
+	--definition-align: center;
+	--definition-height: var(--table-row-height);
+	--definition-term-width: clamp(5rem, 100%, 20%);
+}
+
+.k-definition {
+	display: grid;
+	grid-template-columns: var(--definition-term-width) 1fr;
+}
+.k-definition dt,
+.k-definition dd {
+	padding-block: var(--spacing-2);
+	padding-inline: var(--table-cell-padding);
+	height: var(--definition-height);
+	min-height: var(--table-row-height);
+	display: flex;
+	align-items: var(--definition-align);
+}
+.k-definition:not(:last-child) dt,
+.k-definition:not(:last-child) dd {
+	border-block-end: 1px solid var(--table-color-border);
+}
+.k-definition dt {
+	background: var(--table-color-th-back);
+	border-inline-end: 1px solid var(--table-color-border);
+}
+</style>

--- a/panel/src/components/Layout/Definitions.vue
+++ b/panel/src/components/Layout/Definitions.vue
@@ -1,0 +1,16 @@
+<template>
+	<dl class="k-definitions">
+		<slot />
+	</dl>
+</template>
+
+<style>
+.k-definitions {
+	background: var(--table-color-back);
+	box-shadow: var(--shadow);
+	border-radius: var(--rounded);
+	overflow: hidden;
+	line-height: 1.25;
+	container-type: inline-size;
+}
+</style>

--- a/panel/src/components/Layout/index.js
+++ b/panel/src/components/Layout/index.js
@@ -4,6 +4,8 @@ import Bubble from "./Bubble.vue";
 import Bubbles from "./Bubbles.vue";
 import Column from "./Column.vue";
 import ColorFrame from "./Frame/ColorFrame.vue";
+import Definition from "./Definition.vue";
+import Definitions from "./Definitions.vue";
 import Dropzone from "./Dropzone.vue";
 import Frame from "./Frame/Frame.vue";
 import Grid from "./Grid.vue";
@@ -25,6 +27,8 @@ export default {
 		app.component("k-bubbles", Bubbles);
 		app.component("k-color-frame", ColorFrame);
 		app.component("k-column", Column);
+		app.component("k-definition", Definition);
+		app.component("k-definitions", Definitions);
 		app.component("k-dropzone", Dropzone);
 		app.component("k-frame", Frame);
 		app.component("k-grid", Grid);


### PR DESCRIPTION

### 🎉 Features

- New `<k-definitions>` and `<k-definition>` components to build definition lists in the style of our tables. This is particularly useful to show any kind of information in a semantic way. We will use this for our new error dialogs. 

<img width="999" height="321" alt="Screenshot 2025-12-11 at 12 50 07" src="https://github.com/user-attachments/assets/a8606aa9-5a33-4263-abf7-2fb5d0e9bc6e" />

```html
<k-definitions>
	<k-definition term="Term" description="Description" />
	<k-definition term="Term" description="Description" />
	<k-definition term="Term" description="Description" />
</k-definitions>
```

Definition items can also be created with custom slots: 

```html
<k-definitions>
	<k-definition>
		<template #term><em>Term</em></template>
		<p class="k-text">
			<a href="https://getkirby.com">Description</a>
		</p>
	</k-definition>
	<k-definition>
		<template #term><em>Term</em></template>
		<p class="k-text">
			<a href="https://getkirby.com">Description</a>
		</p>
	</k-definition>
	<k-definition>
		<template #term><em>Term</em></template>
		<p class="k-text">
			<a href="https://getkirby.com">Description</a>
		</p>
	</k-definition>
</k-definitions>
```

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion