### PR TITLE
feat: New Url::editor() method

### DIFF
--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -67,6 +67,7 @@ class Url
 	/**
 	 * Use Whoops to create an editor URL to open
 	 * a file at the given line number
+	 * @since 5.3.0
 	 */
 	public static function editor(string|false $editor, string|null $file, int $line = 0): string|null
 	{

--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -3,6 +3,7 @@
 namespace Kirby\Http;
 
 use Kirby\Toolkit\Str;
+use Whoops\Handler\PrettyPageHandler;
 
 /**
  * Static URL tools
@@ -61,6 +62,22 @@ class Url
 	public static function currentDir(): string
 	{
 		return dirname(static::current());
+	}
+
+	/**
+	 * Use Whoops to create an editor URL to open
+	 * a file at the given line number
+	 */
+	public static function editor(string|false $editor, string|null $file, int $line = 0): string|null
+	{
+		if ($editor === false || $file === null) {
+			return null;
+		}
+
+		$handler = new PrettyPageHandler();
+		$handler->setEditor($editor);
+
+		return $handler->getEditorHref($file, $line);
 	}
 
 	/**

--- a/tests/Http/UrlTest.php
+++ b/tests/Http/UrlTest.php
@@ -36,6 +36,19 @@ class UrlTest extends TestCase
 		$this->assertSame('https://www.youtube.com', Url::currentDir());
 	}
 
+	public function testEditor(): void
+	{
+		$file = '/test/index.php';
+
+		$this->assertSame(
+			'vscode://file/%2Ftest%2Findex.php:23',
+			Url::editor(editor: 'vscode', file: $file, line: 23)
+		);
+
+		$this->assertNull(Url::editor(editor: false, file: $file, line: 23));
+		$this->assertNull(Url::editor(editor: 'vscode', file: null, line: 23));
+	}
+
 	public function testHome(): void
 	{
 		$this->assertSame('/', Url::home());


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features

New `Kirby\Http\Url::editor($editor, $file, $line)` method, to create local editor URLs to open files in a code editor at the given line. 
```php
<a href="<?= Url::editor('vscode', '/my/local/file.php', 12) ?>">Open in VSCode</a>
```

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion