### PR TITLE
feat: Responsive mode for the table

### DIFF
--- a/panel/lab/components/tables/4_component/index.vue
+++ b/panel/lab/components/tables/4_component/index.vue
@@ -3,6 +3,14 @@
 		<k-lab-example label="Default">
 			<k-table :columns="columns" :options="options" :rows="rows"></k-table>
 		</k-lab-example>
+		<k-lab-example label="Responsive: false">
+			<k-table
+				:columns="columns"
+				:options="options"
+				:responsive="false"
+				:rows="rows"
+			></k-table>
+		</k-lab-example>
 		<k-lab-example label="Sortable">
 			<k-table
 				:columns="columns"
@@ -28,7 +36,8 @@ export default {
 		columns() {
 			return {
 				title: {
-					label: "Title"
+					label: "Title",
+					mobile: true
 				},
 				date: {
 					label: "Date"

--- a/panel/src/components/Layout/Table.vue
+++ b/panel/src/components/Layout/Table.vue
@@ -2,6 +2,7 @@
 	<div
 		:aria-disabled="disabled"
 		:class="['k-table', $attrs.class]"
+		:data-responsive="responsive"
 		:style="$attrs.style"
 	>
 		<table
@@ -227,6 +228,10 @@ export default {
 		 * Optional pagination settings
 		 */
 		pagination: [Object, Boolean],
+		responsive: {
+			type: Boolean,
+			default: true
+		},
 		/**
 		 * Whether the table is in select mode
 		 */
@@ -596,20 +601,20 @@ export default {
 
 /* Mobile */
 @container (max-width: 40rem) {
-	.k-table {
+	.k-table[data-responsive="true"] {
 		overflow-x: auto;
 	}
-	.k-table thead th {
+	.k-table[data-responsive="true"] thead th {
 		position: static;
 	}
 
 	/** Make sure that the option toggle does not create huge row heights **/
-	.k-table .k-options-dropdown-toggle {
+	.k-table[data-responsive="true"] .k-options-dropdown-toggle {
 		aspect-ratio: auto !important;
 	}
 
 	/**	Reset any custom column widths **/
-	.k-table
+	.k-table[data-responsive="true"]
 		:where(th, td):not(
 			.k-table-index-column,
 			.k-table-options-column,
@@ -619,7 +624,7 @@ export default {
 		width: auto !important;
 	}
 
-	.k-table :where(th, td):not([data-mobile="true"]) {
+	.k-table[data-responsive="true"] :where(th, td):not([data-mobile="true"]) {
 		display: none;
 	}
 }


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements

- The `<k-table>` component has a new `responsive` prop, which is set to `true` by default. Switching the responsive mode off will no longer hide columns that are not marked with `data-mobile="true"`. This gives more control over custom responsive behaviors for tables and also helps to improve the usability in narrow widths. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion