### PR TITLE
feat: More readable file paths in JSON error responses

### DIFF
--- a/tests/Cms/App/AppErrorsTest.php
+++ b/tests/Cms/App/AppErrorsTest.php
@@ -344,7 +344,7 @@ class AppErrorsTest extends TestCase
 			'details' => [
 				'Some error message'
 			],
-			'file' => basename(__FILE__),
+			'file' => '{kirby}/tests/Cms/App/AppErrorsTest.php',
 			'line' => $exception->getLine()
 		]), $this->_getBufferedContent($handlers[0]));
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements

- More readable file paths in JSON error responses for the Panel. Absolute paths to the kirby folder, site folder and index folder will now be replaced with `{kirby_folder}`, `{site_folder}` and `{index_folder}`. This will keep the responses more readable and easier to debug. It will also disguise the filesystem a bit. Although this is not the main intention, since those paths are only visible in debug mode anyway.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion