### PR TITLE
feat: New k-error-trace component

### DIFF
--- a/panel/lab/components/errors/error-trace/index.php
+++ b/panel/lab/components/errors/error-trace/index.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'docs' => 'k-error-trace',
+];

--- a/panel/lab/components/errors/error-trace/index.vue
+++ b/panel/lab/components/errors/error-trace/index.vue
@@ -1,0 +1,41 @@
+<template>
+	<k-lab-examples>
+		<k-lab-example label="Trace">
+			<k-error-trace
+				:trace="[
+					{
+						file: '/some/test/file.php'
+					},
+					{
+						file: '/some/test/file.php',
+						line: 22
+					},
+					{
+						file: '/some/test/file.php',
+						line: 22,
+						function: 'foo'
+					},
+					{
+						file: '/some/test/file.php',
+						line: 22,
+						class: 'SomeClass',
+						function: 'foo'
+					},
+					{
+						file: '/some/test/file.php',
+						url: 'vscode://',
+						line: 22,
+						class: 'SomeClass',
+						type: '->',
+						function: 'foo'
+					},
+					{
+						class: 'SomeClass',
+						type: '->',
+						function: 'foo'
+					}
+				]"
+			/>
+		</k-lab-example>
+	</k-lab-examples>
+</template>

--- a/panel/src/components/Errors/ErrorTrace.vue
+++ b/panel/src/components/Errors/ErrorTrace.vue
@@ -1,0 +1,72 @@
+<template>
+	<div class="k-error-trace">
+		<ol class="k-stack">
+			<li v-for="(item, index) in trace" :key="'trace-' + index">
+				<a :href="item.url ? item.url : null">
+					<p v-if="item.file">
+						<span style="color: var(--color-gray-200)">{{ item.file }}</span>
+						<template v-if="item.line">
+							<span>:</span>
+							<span style="color: var(--color-purple-400)">{{
+								item.line
+							}}</span>
+						</template>
+					</p>
+					<p v-else>Internal</p>
+					<p v-if="item.function">
+						<template v-if="item.class">
+							<span style="color: var(--color-yellow-400)">
+								{{ item.class }}
+							</span>
+							<span>
+								{{ item.type ?? "::" }}
+							</span>
+						</template>
+						<span style="color: var(--color-blue-400)">
+							{{ item.function }}
+						</span>
+						<span>()</span>
+					</p>
+				</a>
+			</li>
+		</ol>
+	</div>
+</template>
+
+<script>
+export default {
+	props: {
+		trace: Array
+	}
+};
+</script>
+
+<style>
+.k-error-trace {
+	line-height: 1.5;
+	background: var(--color-black);
+	border-radius: var(--rounded);
+	font-size: 0.7rem;
+	font-family: var(--font-mono);
+	overflow-x: auto;
+	overflow-y: hidden;
+	padding: var(--spacing-3);
+}
+.k-error-trace ol {
+	gap: var(--spacing-3);
+	list-style: numeric;
+	margin-left: 5ch;
+}
+.k-error-trace li::marker {
+	color: var(--color-gray-600);
+}
+.k-error-trace li a {
+	display: block;
+}
+.k-error-trace p {
+	color: var(--color-gray-600);
+	display: flex;
+	white-space: nowrap;
+	min-width: 0;
+}
+</style>

--- a/panel/src/components/Errors/ErrorTrace.vue
+++ b/panel/src/components/Errors/ErrorTrace.vue
@@ -34,6 +34,9 @@
 </template>
 
 <script>
+/**
+ * @since 6.0.0
+ */
 export default {
 	props: {
 		trace: Array

--- a/panel/src/components/Errors/index.js
+++ b/panel/src/components/Errors/index.js
@@ -1,0 +1,7 @@
+import ErrorTrace from "./ErrorTrace.vue";
+
+export default {
+	install(app) {
+		app.component("k-error-trace", ErrorTrace);
+	}
+};

--- a/panel/src/components/index.js
+++ b/panel/src/components/index.js
@@ -2,6 +2,7 @@ import Collection from "@/components/Collection/index.js";
 import Dialogs from "@/components/Dialogs/index.js";
 import Drawers from "@/components/Drawers/index.js";
 import Dropdowns from "@/components/Dropdowns/index.js";
+import Errors from "@/components/Errors/index.js";
 import Forms from "@/components/Forms/index.js";
 import Lab from "@/components/Lab/index.js";
 import Layout from "@/components/Layout/index.js";
@@ -19,6 +20,7 @@ export default {
 		app.use(Dialogs);
 		app.use(Drawers);
 		app.use(Dropdowns);
+		app.use(Errors);
 		app.use(Forms);
 		app.use(Lab);
 		app.use(Layout);


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features

- New `<k-error-trace>` component to display PHP stack traces. We will use it for PHP error stacks in error dialogs, but it's universal enough to also be used in other places or for JS traces. 
<img width="543" height="463" alt="Screenshot 2025-12-12 at 11 29 24" src="https://github.com/user-attachments/assets/4d97cb3f-d514-4ead-8ce7-12f3da2d8123" />

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion