### PR TITLE
fix: Handle race conditions in `Dir::remove()`

### DIFF
--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -6,6 +6,7 @@ use Kirby\Exception\Exception;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\Str;
+use Throwable;
 
 /**
  * File System Cache Driver
@@ -214,13 +215,10 @@ class FileCache extends Cache
 	 */
 	public function flush(): bool
 	{
-		if (
-			Dir::remove($this->root) === true &&
-			Dir::make($this->root) === true
-		) {
-			return true;
+		try {
+			return Dir::remove($this->root) && Dir::make($this->root);
+		} catch (Throwable) {
+			return false;
 		}
-
-		return false; // @codeCoverageIgnore
 	}
 }

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -588,7 +588,11 @@ class Dir
 			}
 		}
 
-		return rmdir($dir);
+		return Helpers::handleErrors(
+			fn (): bool => rmdir($dir),
+			fn (int $errno, string $errstr) => true,
+			fn (): never => throw new Exception('The directory could not be deleted'),
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description

Wrap rmdir() call in Helpers::handleErrors() to gracefully handle race conditions where files are written to a directory between the scandir() and rmdir() calls. This can occur when concurrent processes (e.g., cron jobs and web requests) operate on the same cache directory simultaneously.

`FileCache::flush()` now catches the exception and returns false instead of failing fatally.

I've been trying to write a unit test about race conditions but I haven't succeeded. I'd appreciate any ideas you have.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Flush cache generates a "Directory not empty" error
https://forum.getkirby.com/t/flush-cache-generates-a-directory-not-empty-error/35063/3
#6266 

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion