### PR TITLE
feat: New request error dialog

### DIFF
--- a/panel/lab/components/dialogs/13_request-error/index.php
+++ b/panel/lab/components/dialogs/13_request-error/index.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'docs' => 'k-request-error-dialog',
+];

--- a/panel/lab/components/dialogs/13_request-error/index.vue
+++ b/panel/lab/components/dialogs/13_request-error/index.vue
@@ -1,0 +1,115 @@
+<template>
+	<k-lab-examples>
+		<k-lab-example label="Request Error">
+			<k-button
+				icon="open"
+				variant="filled"
+				@click="
+					$panel.dialog.open({
+						component: 'k-request-error-dialog',
+						props: {
+							message: 'The request failed',
+							request: {
+								url: '/example/request',
+								method: 'POST'
+							},
+							response: {
+								status: 400
+							},
+							exception: {
+								file: '/site/templates/default.php',
+								line: 22,
+								type: 'Kirby\\Exception\\InvalidArgumentException',
+								url: 'vscode://'
+							}
+						}
+					})
+				"
+			>
+				Open
+			</k-button>
+		</k-lab-example>
+
+		<k-lab-example label="Request Error with details">
+			<k-button
+				icon="open"
+				variant="filled"
+				@click="
+					$panel.dialog.open({
+						component: 'k-request-error-dialog',
+						props: {
+							message: 'The request failed',
+							request: {
+								url: '/example/request',
+								method: 'POST'
+							},
+							response: {
+								status: 400
+							},
+							exception: {
+								file: '/site/templates/default.php',
+								line: 22,
+								type: 'Kirby\\Exception\\InvalidArgumentException',
+								url: 'vscode://'
+							},
+							details: {
+								foo: 'bar'
+							}
+						}
+					})
+				"
+			>
+				Open
+			</k-button>
+		</k-lab-example>
+
+		<k-lab-example label="Request Error with details and PHP Trace">
+			<k-button
+				icon="open"
+				variant="filled"
+				@click="
+					$panel.dialog.open({
+						component: 'k-request-error-dialog',
+						props: {
+							message: 'The request failed',
+							request: {
+								url: '/example/request',
+								method: 'POST'
+							},
+							response: {
+								status: 400
+							},
+							exception: {
+								file: '/site/templates/default.php',
+								line: 22,
+								type: 'Kirby\\Exception\\InvalidArgumentException',
+								url: 'vscode://'
+							},
+							details: {
+								foo: 'bar'
+							},
+							trace: [
+								{
+									file: '{kirby}/src/Cms/Page.php',
+									line: 22,
+									class: 'Kirby\\Cms\\Page',
+									type: '->',
+									function: 'update'
+								},
+								{
+									file: '{kirby}/src/Cms/Page.php',
+									line: 22,
+									class: 'Kirby\\Cms\\Page',
+									type: '->',
+									function: 'update'
+								}
+							]
+						}
+					})
+				"
+			>
+				Open
+			</k-button>
+		</k-lab-example>
+	</k-lab-examples>
+</template>

--- a/panel/lab/internals/errors/index.vue
+++ b/panel/lab/internals/errors/index.vue
@@ -35,16 +35,25 @@
 			<br />
 			<br />
 			<k-button-group>
-				<k-button variant="filled" @click="$panel.view.open('/lab/errors')">
+				<k-button
+					variant="filled"
+					@click="$panel.view.open('/lab/errors?foo=bar')"
+				>
 					View
 				</k-button>
-				<k-button variant="filled" @click="$panel.dialog.open('/lab/errors')">
+				<k-button
+					variant="filled"
+					@click="$panel.dialog.open('/lab/errors?foo=bar')"
+				>
 					Dialog
 				</k-button>
-				<k-button variant="filled" @click="$panel.drawer.open('/lab/errors')">
+				<k-button
+					variant="filled"
+					@click="$panel.drawer.open('/lab/errors?foo=bar')"
+				>
 					Drawer
 				</k-button>
-				<k-button variant="filled" @click="request('/lab/errors')">
+				<k-button variant="filled" @click="request('/lab/errors?foo=bar')">
 					Request
 				</k-button>
 			</k-button-group>

--- a/panel/src/components/Dialogs/RequestErrorDialog.vue
+++ b/panel/src/components/Dialogs/RequestErrorDialog.vue
@@ -70,7 +70,6 @@
 
 <script>
 import Dialog from "@/mixins/dialog.js";
-import RequestError from "@/errors/RequestError.js";
 
 export default {
 	mixins: [Dialog],

--- a/panel/src/components/Dialogs/RequestErrorDialog.vue
+++ b/panel/src/components/Dialogs/RequestErrorDialog.vue
@@ -1,0 +1,97 @@
+<template>
+	<k-dialog
+		ref="dialog"
+		:cancel-button="false"
+		:submit-button="false"
+		:visible="visible"
+		class="k-request-error-dialog"
+		size="large"
+		@cancel="$emit('cancel')"
+	>
+		<k-stack gap="var(--spacing-6)">
+			<k-box icon="alert" theme="negative">{{ message }}</k-box>
+
+			<k-stack gap="var(--spacing-3)">
+				<k-stack direction="row" justify="space-between" align="center">
+					<k-headline>{{ $t("error") }}</k-headline>
+					<k-button
+						v-if="exception.url"
+						:link="exception.url"
+						icon="open"
+						size="xs"
+						variant="filled"
+					/>
+				</k-stack>
+				<k-definitions>
+					<k-definition term="URL">
+						<k-code-token type="black">
+							{{ request.url }}
+						</k-code-token>
+					</k-definition>
+
+					<k-definition term="Method">
+						<k-code-token type="black">
+							{{ request.method }}
+						</k-code-token>
+					</k-definition>
+
+					<k-definition term="Code">
+						<k-code-token type="blue">
+							{{ response.status }}
+						</k-code-token>
+					</k-definition>
+
+					<k-definition v-if="exception.type" term="Type">
+						<k-code-token type="object">{{ exception.type }}</k-code-token>
+					</k-definition>
+
+					<k-definition v-if="exception.file" term="File">
+						<k-code-token type="black">{{ exception.file }}</k-code-token>
+					</k-definition>
+
+					<k-definition v-if="exception.line" term="Line">
+						<k-code-token type="purple">{{ exception.line }}</k-code-token>
+					</k-definition>
+				</k-definitions>
+			</k-stack>
+
+			<k-stack v-if="details" gap="var(--spacing-3)">
+				<k-headline>Details</k-headline>
+				<k-code language="js">{{ details }}</k-code>
+			</k-stack>
+
+			<k-stack v-if="$panel.debug && trace" gap="var(--spacing-3)">
+				<k-headline>Trace</k-headline>
+				<k-error-trace :trace="trace" />
+			</k-stack>
+		</k-stack>
+	</k-dialog>
+</template>
+
+<script>
+import Dialog from "@/mixins/dialog.js";
+import RequestError from "@/errors/RequestError.js";
+
+export default {
+	mixins: [Dialog],
+	props: {
+		details: [Array, Object],
+		exception: Object,
+		message: String,
+		request: Object,
+		response: Object,
+		trace: Array
+	},
+	emits: ["cancel"]
+};
+</script>
+
+<style>
+.k-request-error-dialog .k-definitions {
+	font-family: var(--font-mono);
+}
+.k-request-error-dialog .k-definitions dt,
+.k-request-error-dialog .k-code {
+	font-size: var(--text-xs);
+}
+</style>

--- a/panel/src/components/Dialogs/RequestErrorDialog.vue
+++ b/panel/src/components/Dialogs/RequestErrorDialog.vue
@@ -9,24 +9,20 @@
 		@cancel="$emit('cancel')"
 	>
 		<k-stack gap="var(--spacing-6)">
-			<k-box icon="alert" theme="negative">{{ message }}</k-box>
+			<k-stack gap="var(--spacing-3)">
+				<k-headline>Error</k-headline>
+				<k-box icon="alert" theme="negative">{{ message }}</k-box>
+			</k-stack>
 
 			<k-stack gap="var(--spacing-3)">
-				<k-stack direction="row" justify="space-between" align="center">
-					<k-headline>{{ $t("error") }}</k-headline>
-					<k-button
-						v-if="exception.url"
-						:link="exception.url"
-						icon="open"
-						size="xs"
-						variant="filled"
-					/>
-				</k-stack>
+				<k-headline>Request</k-headline>
 				<k-definitions>
-					<k-definition term="URL">
-						<k-code-token type="black">
-							{{ request.url }}
-						</k-code-token>
+					<k-definition term="Path">
+						<span>{{ url.pathname }}</span>
+					</k-definition>
+
+					<k-definition v-if="url.search" term="Query">
+						<span>{{ url.search }}</span>
 					</k-definition>
 
 					<k-definition term="Method">
@@ -40,13 +36,27 @@
 							{{ response.status }}
 						</k-code-token>
 					</k-definition>
+				</k-definitions>
+			</k-stack>
 
+			<k-stack gap="var(--spacing-3)">
+				<k-stack direction="row" justify="space-between" align="center">
+					<k-headline>Exception</k-headline>
+					<k-button
+						v-if="exception.url"
+						:link="exception.url"
+						icon="open"
+						size="xs"
+						variant="filled"
+					/>
+				</k-stack>
+				<k-definitions>
 					<k-definition v-if="exception.type" term="Type">
 						<k-code-token type="object">{{ exception.type }}</k-code-token>
 					</k-definition>
 
 					<k-definition v-if="exception.file" term="File">
-						<k-code-token type="black">{{ exception.file }}</k-code-token>
+						{{ exception.file }}
 					</k-definition>
 
 					<k-definition v-if="exception.line" term="Line">
@@ -55,14 +65,16 @@
 				</k-definitions>
 			</k-stack>
 
-			<k-stack v-if="details" gap="var(--spacing-3)">
+			<k-stack v-if="hasDetails" gap="var(--spacing-3)">
 				<k-headline>Details</k-headline>
 				<k-code language="js">{{ details }}</k-code>
 			</k-stack>
 
 			<k-stack v-if="$panel.debug && trace" gap="var(--spacing-3)">
-				<k-headline>Trace</k-headline>
-				<k-error-trace :trace="trace" />
+				<details>
+					<summary>Trace</summary>
+					<k-error-trace :trace="trace" />
+				</details>
 			</k-stack>
 		</k-stack>
 	</k-dialog>
@@ -81,16 +93,53 @@ export default {
 		response: Object,
 		trace: Array
 	},
-	emits: ["cancel"]
+	emits: ["cancel"],
+	computed: {
+		hasDetails() {
+			if (!this.details) {
+				return false;
+			}
+
+			if (Array.isArray(this.details) === true && this.details.length === 0) {
+				return false;
+			}
+
+			return true;
+		},
+		url() {
+			return new URL(this.request.url);
+		}
+	}
 };
 </script>
 
 <style>
 .k-request-error-dialog .k-definitions {
 	font-family: var(--font-mono);
+	font-size: var(--text-xs);
 }
 .k-request-error-dialog .k-definitions dt,
+.k-request-error-dialog .k-definitions code,
 .k-request-error-dialog .k-code {
 	font-size: var(--text-xs);
+}
+.k-request-error-dialog .k-definitions dd {
+	min-width: 0;
+}
+.k-request-error-dialog .k-definitions dd > * {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.k-request-error-dialog summary {
+	font-weight: var(--font-bold);
+	line-height: 1.5em;
+}
+.k-request-error-dialog summary::marker {
+	font-weight: var(--font-normal);
+	color: var(--color-text-dimmed);
+}
+.k-request-error-dialog .k-error-trace {
+	margin-top: var(--spacing-3);
 }
 </style>

--- a/panel/src/components/Dialogs/index.js
+++ b/panel/src/components/Dialogs/index.js
@@ -22,6 +22,7 @@ import PageMoveDialog from "./PageMoveDialog.vue";
 import PagePickerDialog from "./PagePickerDialog.vue";
 import PagesDialog from "./PagesDialog.vue";
 import RemoveDialog from "./RemoveDialog.vue";
+import RequestErrorDialog from "./RequestErrorDialog.vue";
 import SearchDialog from "./SearchDialog.vue";
 import TextDialog from "./TextDialog.vue";
 import TotpDialog from "./TotpDialog.vue";
@@ -53,6 +54,7 @@ export default {
 		app.component("k-page-picker-dialog", PagePickerDialog);
 		app.component("k-pages-dialog", PagesDialog);
 		app.component("k-remove-dialog", RemoveDialog);
+		app.component("k-request-error-dialog", RequestErrorDialog);
 		app.component("k-search-dialog", SearchDialog);
 		app.component("k-text-dialog", TextDialog);
 		app.component("k-totp-dialog", TotpDialog);

--- a/panel/src/errors/RequestError.js
+++ b/panel/src/errors/RequestError.js
@@ -32,7 +32,8 @@ export default class RequestError extends Error {
 					type: state.exception,
 					url: state.editor
 				},
-				details: state.details
+				details: state.details,
+				trace: state.trace
 			}
 		};
 	}

--- a/panel/src/errors/RequestError.js
+++ b/panel/src/errors/RequestError.js
@@ -12,6 +12,30 @@ export default class RequestError extends Error {
 		this.details = response.json.details;
 	}
 
+	dialog() {
+		const state = this.state();
+
+		return {
+			component: "k-request-error-dialog",
+			props: {
+				message: this.message,
+				request: {
+					url: this.request.url,
+					method: this.request.method
+				},
+				response: {
+					status: this.response.status
+				},
+				exception: {
+					file: state.file,
+					line: state.line,
+					type: state.exception
+				},
+				details: state.details
+			}
+		};
+	}
+
 	state() {
 		return this.response.json;
 	}

--- a/panel/src/errors/RequestError.js
+++ b/panel/src/errors/RequestError.js
@@ -29,7 +29,8 @@ export default class RequestError extends Error {
 				exception: {
 					file: state.file,
 					line: state.line,
-					type: state.exception
+					type: state.exception,
+					url: state.editor
 				},
 				details: state.details
 			}

--- a/panel/src/panel/notification.js
+++ b/panel/src/panel/notification.js
@@ -90,10 +90,14 @@ export default (panel = {}) => {
 
 			// open the error dialog in views
 			if (panel.context === "view") {
-				panel.dialog.open({
-					component: "k-error-dialog",
-					props: error
-				});
+				if (error instanceof RequestError) {
+					panel.dialog.open(error.dialog());
+				} else {
+					panel.dialog.open({
+						component: "k-error-dialog",
+						props: error
+					});
+				}
 			}
 
 			// show the error notification bar

--- a/panel/src/panel/notification.js
+++ b/panel/src/panel/notification.js
@@ -76,17 +76,16 @@ export default (panel = {}) => {
 
 			// convert strings to full error objects
 			if (typeof error === "string") {
-				error = {
-					message: error
-				};
+				error = new Error(error);
 			}
 
-			// turn instances into basic object and
-			// fill in some fallback defaults
-			error = {
-				message: error.message ?? "Something went wrong",
-				details: error.details ?? {}
-			};
+			// turn objects into error instances
+			if (error instanceof Error === false) {
+				const message = error.message ?? "Something went wrong";
+				const details = error.details ?? {};
+				error = new Error(message);
+				error.details = details;
+			}
 
 			// open the error dialog in views
 			if (panel.context === "view") {

--- a/panel/src/panel/notification.js
+++ b/panel/src/panel/notification.js
@@ -74,21 +74,6 @@ export default (panel = {}) => {
 				return this.fatal(error);
 			}
 
-			if (error instanceof RequestError) {
-				// get the broken element in the response json that
-				// has an error message. This can be deprecated later
-				// when the server always sends back a simple error
-				// response without nesting it in dropdown, dialog, etc.
-				const broken = Object.values(error.response.json).find(
-					(element) => typeof element?.error === "string"
-				);
-
-				if (broken) {
-					error.message = broken.error;
-					error.details = broken.details;
-				}
-			}
-
 			// convert strings to full error objects
 			if (typeof error === "string") {
 				error = {

--- a/src/Cms/AppErrors.php
+++ b/src/Cms/AppErrors.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Closure;
 use Kirby\Exception\Exception;
 use Kirby\Http\Response;
+use Kirby\Http\Url;
 use Kirby\Toolkit\I18n;
 use Throwable;
 use Whoops\Handler\CallbackHandler;
@@ -168,8 +169,9 @@ trait AppErrors
 					'code'      => $code,
 					'message'   => $exception->getMessage(),
 					'details'   => $details,
-					'file'      => $this->disguiseFilePath($exception->getFile()),
-					'line'      => $exception->getLine(),
+					'file'      => $this->disguiseFilePath($file = $exception->getFile()),
+					'line'      => $line = $exception->getLine(),
+					'editor'    => Url::editor($this->option('editor', false), $file, $line),
 				], $httpCode);
 			} else {
 				echo Response::json([

--- a/tests/Cms/App/AppErrorsTest.php
+++ b/tests/Cms/App/AppErrorsTest.php
@@ -336,6 +336,14 @@ class AppErrorsTest extends TestCase
 		$this->assertCount(2, $handlers);
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[0]);
 
+		// expose the trace method to make it testable in the output below
+		$tracer = new class () extends App {
+			public function publicTrace(Exception $exception, string|false $editor): array
+			{
+				return $this->trace($exception, $editor);
+			}
+		};
+
 		$this->assertSame(json_encode([
 			'status'    => 'error',
 			'exception' => Exception::class,
@@ -347,6 +355,7 @@ class AppErrorsTest extends TestCase
 			'file'   => '{kirby}/tests/Cms/App/AppErrorsTest.php',
 			'line'   => $exception->getLine(),
 			'editor' => null,
+			'trace'  => $tracer->publicTrace($exception, false),
 		]), $this->_getBufferedContent($handlers[0]));
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 	}

--- a/tests/Cms/App/AppErrorsTest.php
+++ b/tests/Cms/App/AppErrorsTest.php
@@ -337,15 +337,16 @@ class AppErrorsTest extends TestCase
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[0]);
 
 		$this->assertSame(json_encode([
-			'status' => 'error',
+			'status'    => 'error',
 			'exception' => Exception::class,
-			'code' => 'error.general',
-			'message' => 'An error occurred',
-			'details' => [
+			'code'      => 'error.general',
+			'message'   => 'An error occurred',
+			'details'   => [
 				'Some error message'
 			],
-			'file' => '{kirby}/tests/Cms/App/AppErrorsTest.php',
-			'line' => $exception->getLine()
+			'file'   => '{kirby}/tests/Cms/App/AppErrorsTest.php',
+			'line'   => $exception->getLine(),
+			'editor' => null,
 		]), $this->_getBufferedContent($handlers[0]));
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
 	}


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features

- New `k-request-error-dialog` component

<img width="686" height="829" alt="Screenshot 2025-12-16 at 13 08 00" src="https://github.com/user-attachments/assets/5b67fa3c-19df-4eac-94fd-5826dab3f60d" />

### ✨ Enhancements

- New `RequestError.dialog()` method to create all props for the request error dialog according to the details from the error object. 
- All errors are now converted to Error objects in `panel.notification.error()`
- Error responses from the backend now include the `editor` URL if the editor is set up in the config.php and debug mode is one. 
- New protected `AppErrors::trace()` method to return a stack trace for PHP errors in JSON responses when debug mode is enabled. 

### 🚨 Breaking changes

- `panel.notification.error()` no longer resolves nested errors in the state. Always throw Exceptions instead to create first-level error responses. 

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful) (Lab > Dialogs > Request Error Dialog) 
- [x] Add changes & docs to release notes draft in Notion