### PR TITLE
feat: New k-validation-error-dialog

### DIFF
--- a/panel/lab/components/dialogs/14_validation-error/index.php
+++ b/panel/lab/components/dialogs/14_validation-error/index.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'docs' => 'k-validation-error-dialog',
+];

--- a/panel/lab/components/dialogs/14_validation-error/index.vue
+++ b/panel/lab/components/dialogs/14_validation-error/index.vue
@@ -1,0 +1,37 @@
+<template>
+	<k-lab-examples>
+		<k-lab-example label="Validation Error">
+			<k-button
+				icon="open"
+				variant="filled"
+				@click="
+					$panel.dialog.open({
+						component: 'k-validation-error-dialog',
+						props: {
+							message: 'Your changes could not be saved',
+							fields: {
+								title: {
+									label: 'Title',
+									issues: ['The field is rquired']
+								},
+								text: {
+									label: 'Text',
+									issues: [
+										'The text must not be shorter than 10 characters',
+										'The text must not be longer than 140 characters'
+									]
+								},
+								email: {
+									label: 'Email',
+									issues: ['Enter a valid email address']
+								}
+							}
+						}
+					})
+				"
+			>
+				Open
+			</k-button>
+		</k-lab-example>
+	</k-lab-examples>
+</template>

--- a/panel/lab/internals/errors/index.vue
+++ b/panel/lab/internals/errors/index.vue
@@ -58,11 +58,8 @@
 				</k-button>
 			</k-button-group>
 		</k-lab-example>
-		<k-lab-example label="Backend issues">
-			<k-text>
-				The backend route throws a Kirby exception with details (we use this for
-				form errors for example)
-			</k-text>
+		<k-lab-example label="Backend issues with details">
+			<k-text> The backend route throws a Kirby exception with details</k-text>
 
 			<k-code language="php">{{
 				`throw new Kirby\\Exception\\InvalidArgumentException(
@@ -79,6 +76,66 @@
 			'message' => [
 				'This is the first message for Detail B',
 				'This is the second message for Detail B',
+			],
+		],
+	]
+);`
+			}}</k-code>
+			<br />
+			<br />
+			<k-button-group>
+				<k-button
+					variant="filled"
+					@click="$panel.view.open('/lab/errors/details?foo=bar')"
+				>
+					View
+				</k-button>
+				<k-button
+					variant="filled"
+					@click="$panel.dialog.open('/lab/errors/details?foo=bar')"
+				>
+					Dialog
+				</k-button>
+				<k-button
+					variant="filled"
+					@click="$panel.drawer.open('/lab/errors/details?foo=bar')"
+				>
+					Drawer
+				</k-button>
+				<k-button
+					variant="filled"
+					@click="request('/lab/errors/details?foo=bar')"
+				>
+					Request
+				</k-button>
+			</k-button-group>
+		</k-lab-example>
+		<k-lab-example label="Form validation issues">
+			<k-text>
+				The backend route throws a Kirby Form Validation exception
+			</k-text>
+
+			<k-code language="php">{{
+				`throw new Kirby\\Exception\\FormValidationError(
+	fallback: 'Your changes could not be saved',
+	details: [
+		'title' => [
+			'label'  => 'Title',
+			'issues' => [
+				'The field is required',
+			],
+		],
+		'text' => [
+			'label'  => 'Text',
+			'issues' => [
+				'The text must not be shorter than 10 characters',
+				'The text must not be longer than 140 characters',
+			],
+		],
+		'email' => [
+			'label'  => 'Email',
+			'issues' => [
+				'Enter a valid email address',
 			],
 		],
 	]

--- a/panel/src/components/Dialogs/ValidationErrorDialog.vue
+++ b/panel/src/components/Dialogs/ValidationErrorDialog.vue
@@ -1,0 +1,33 @@
+<template>
+	<k-dialog
+		ref="dialog"
+		:cancel-button="false"
+		:submit-button="false"
+		:visible="visible"
+		class="k-validation-error-dialog"
+		size="large"
+		@cancel="$emit('cancel')"
+	>
+		<k-stack gap="var(--spacing-6)">
+			<k-box icon="alert" theme="notice">{{ message }}</k-box>
+
+			<k-stack>
+				<k-headline>Please, fix the following issues:</k-headline>
+				<k-validation-issues :fields="fields" />
+			</k-stack>
+		</k-stack>
+	</k-dialog>
+</template>
+
+<script>
+import Dialog from "@/mixins/dialog.js";
+
+export default {
+	mixins: [Dialog],
+	props: {
+		fields: Object,
+		message: String
+	},
+	emits: ["cancel"]
+};
+</script>

--- a/panel/src/components/Dialogs/index.js
+++ b/panel/src/components/Dialogs/index.js
@@ -30,6 +30,7 @@ import UploadDialog from "./UploadDialog.vue";
 import UploadReplaceDialog from "./UploadReplaceDialog.vue";
 import UserPickerDialog from "./UserPickerDialog.vue";
 import UsersDialog from "./UsersDialog.vue";
+import ValidationErrorDialog from "./ValidationErrorDialog.vue";
 
 export default {
 	install(app) {
@@ -62,5 +63,6 @@ export default {
 		app.component("k-upload-replace-dialog", UploadReplaceDialog);
 		app.component("k-user-picker-dialog", UserPickerDialog);
 		app.component("k-users-dialog", UsersDialog);
+		app.component("k-validation-error-dialog", ValidationErrorDialog);
 	}
 };

--- a/panel/src/components/Errors/ValidationIssues.vue
+++ b/panel/src/components/Errors/ValidationIssues.vue
@@ -7,7 +7,7 @@
 		>
 			<k-checklist theme="negative">
 				<li
-					v-for="(issue, issueKey) in field.issues"
+					v-for="(issue, issueKey) in field.issues ?? field.message"
 					:key="fieldName + '-issue-' + issueKey"
 				>
 					{{ issue }}

--- a/panel/src/errors/RequestError.js
+++ b/panel/src/errors/RequestError.js
@@ -15,6 +15,16 @@ export default class RequestError extends Error {
 	dialog() {
 		const state = this.state();
 
+		if (state.exception === "Kirby\\Exception\\FormValidationException") {
+			return {
+				component: "k-validation-error-dialog",
+				props: {
+					message: this.message,
+					fields: state.details
+				}
+			};
+		}
+
 		return {
 			component: "k-request-error-dialog",
 			props: {

--- a/src/Panel/Lab/Responses.php
+++ b/src/Panel/Lab/Responses.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel\Lab;
 
 use Exception;
+use Kirby\Exception\FormValidationException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Http\Response;
 
@@ -23,7 +24,31 @@ class Responses
 	public static function errorResponseByType(string|null $type = null): Response|Exception
 	{
 		return match ($type) {
-			'form' => new InvalidArgumentException(
+			'form' => new FormValidationException(
+				fallback: 'Your changes could not be saved',
+				details: [
+					'title' => [
+						'label'  => 'Title',
+						'issues' => [
+							'The field is required',
+						],
+					],
+					'text' => [
+						'label'  => 'Text',
+						'issues' => [
+							'The text must not be shorter than 10 characters',
+							'The text must not be longer than 140 characters',
+						],
+					],
+					'email' => [
+						'label'  => 'Email',
+						'issues' => [
+							'Enter a valid email address',
+						],
+					],
+				]
+			),
+			'details' => new InvalidArgumentException(
 				fallback: 'Exception with details',
 				details: [
 					'a' => [


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features
<!-- 
e.g. New feature X which helps users to …
-->
- New `<k-validation-error-dialog>` to improve the readability of field validation problems.
<img width="695" height="336" alt="Screenshot 2025-12-16 at 14 24 48" src="https://github.com/user-attachments/assets/069ef193-e43d-4d0f-827e-1ed19dabdc86" />

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion