### PR TITLE
refact: Remove `panel.vue.compiler` option

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -694,7 +694,6 @@
 	"system.issues.kirby": "The kirby folder seems to be exposed",
 	"system.issues.local": "The site is running locally with relaxed security checks",
 	"system.issues.site": "The site folder seems to be exposed",
-	"system.issues.vue.compiler": "The Vue template compiler is enabled",
 	"system.issues.vulnerability.kirby": "Your installation might be affected by the following vulnerability ({ severity } severity): { description }",
 	"system.issues.vulnerability.plugin": "Your installation might be affected by the following vulnerability in the { plugin } plugin ({ severity } severity): { description }",
 	"system.updateStatus": "Update status",

--- a/panel/src/components/Lab/PlaygroundView.vue
+++ b/panel/src/components/Lab/PlaygroundView.vue
@@ -13,14 +13,9 @@
 		</k-header>
 		<k-tabs :tab="tab" :tabs="tabs" />
 
-		<k-box v-if="compiler === false" theme="info">
-			The Vue template compiler must be enabled to show lab examples
-		</k-box>
-		<template v-else>
-			<component :is="component" v-if="component" v-bind="props" />
-			<!-- eslint-disable-next-line vue/no-v-html, vue/no-v-text-v-html-on-component -->
-			<component :is="'style'" v-if="styles" v-html="styles" />
-		</template>
+		<component :is="component" v-if="component" v-bind="props" />
+		<!-- eslint-disable-next-line vue/no-v-html, vue/no-v-text-v-html-on-component -->
+		<component :is="'style'" v-if="styles" v-html="styles" />
 	</k-panel-inside>
 </template>
 
@@ -38,7 +33,6 @@ import TableCell from "./TableCell.vue";
 export default {
 	props: {
 		buttons: Array,
-		compiler: Boolean,
 		docs: String,
 		examples: [Object, Array],
 		file: String,

--- a/panel/vite.config.mjs
+++ b/panel/vite.config.mjs
@@ -82,10 +82,6 @@ function createPlugins(mode) {
 					{
 						src: "node_modules/vue/dist/vue.esm-browser.prod.js",
 						dest: "js"
-					},
-					{
-						src: "node_modules/vue/dist/vue.runtime.esm-browser.prod.js",
-						dest: "js"
 					}
 				]
 			})

--- a/src/Panel/Assets.php
+++ b/src/Panel/Assets.php
@@ -330,10 +330,6 @@ class Assets
 			return $this->url . '/js/vue.esm-browser.js';
 		}
 
-		if ($this->kirby->option('panel.vue.compiler', true) === true) {
-			return $this->url . '/js/vue.esm-browser.prod.js';
-		}
-
-		return $this->url . '/js/vue.runtime.esm-browser.prod.js';
+		return $this->url . '/js/vue.esm-browser.prod.js';
 	}
 }

--- a/src/Panel/Controller/View/LabExampleViewController.php
+++ b/src/Panel/Controller/View/LabExampleViewController.php
@@ -101,7 +101,6 @@ class LabExampleViewController extends ViewController
 			component: 'k-lab-playground-view',
 			breadcrumb: $this->breadcrumb(),
 			buttons: $this->buttons(),
-			compiler: $this->kirby->option('panel.vue.compiler', true),
 			docs: $this->doc()?->name,
 			examples: $this->example->vue()['examples'],
 			file: $this->example->module(),

--- a/tests/Panel/AssetsTest.php
+++ b/tests/Panel/AssetsTest.php
@@ -456,22 +456,4 @@ class AssetsTest extends TestCase
 
 		$this->assertSame('/media/panel/' . $this->app->versionHash() . '/js/vue.esm-browser.js', $vue);
 	}
-
-	public function testVueWithDisabledTemplateCompiler(): void
-	{
-		$this->app->clone([
-			'options' => [
-				'panel' => [
-					'vue' => [
-						'compiler' => false
-					]
-				]
-			]
-		]);
-
-		$assets = new Assets();
-		$vue    = $assets->vue();
-
-		$this->assertSame('/media/panel/' . $this->app->versionHash() . '/js/vue.runtime.esm-browser.prod.js', $vue);
-	}
 }

--- a/tests/Panel/Controller/View/LabExampleViewControllerTest.php
+++ b/tests/Panel/Controller/View/LabExampleViewControllerTest.php
@@ -61,7 +61,6 @@ class LabExampleViewControllerTest extends TestCase
 		$this->assertSame('k-lab-playground-view', $view->component);
 
 		$props = $view->props();
-		$this->assertTrue($props['compiler']);
 		$this->assertSame('k-button', $props['docs']);
 		$this->assertSame('/lab/components/buttons/1_variants/index.vue', $props['file']);
 		$this->assertSame('https://github.com/getkirby/kirby/tree/main/panel/src/components/Navigation/Button.vue', $props['github']);
@@ -71,22 +70,5 @@ class LabExampleViewControllerTest extends TestCase
 		$this->assertSame('1_variants', $props['tab']);
 		$this->assertIsArray($props['tabs']);
 		$this->assertSame('buttons', $props['title']);
-	}
-
-	public function testLoadWithDisabledCompiler(): void
-	{
-		$this->app = $this->app->clone([
-			'options' => [
-				'panel' => [
-					'vue' => [
-						'compiler' => false
-					]
-				]
-			]
-		]);
-
-		$controller = new LabExampleViewController($this->category, $this->example);
-		$props = $controller->load()->props();
-		$this->assertFalse($props['compiler']);
 	}
 }


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- Removed the `panel.vue.compiler` option. It isn't needed with Vue 3 anymore.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion