### PR TITLE
refact!: Boolean prev/next for structure drawer

### DIFF
--- a/panel/src/components/Drawers/StructureDrawer.vue
+++ b/panel/src/components/Drawers/StructureDrawer.vue
@@ -33,12 +33,8 @@ import { props as FieldsProps } from "./Elements/Fields.vue";
 
 export const props = {
 	props: {
-		next: {
-			type: Object
-		},
-		prev: {
-			type: Object
-		}
+		next: Boolean,
+		prev: Boolean
 	}
 };
 

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -428,9 +428,9 @@ export default {
 				id: this.id,
 				props: {
 					disabled: this.disabled,
-					icon: this.icon ?? "list-bullet",
-					next: this.items[index + 1],
-					prev: this.items[index - 1],
+					icon: "list-bullet",
+					next: index < this.items.length - 1,
+					prev: index > 0,
 					tabs: {
 						content: {
 							fields: this.form(field)
@@ -445,8 +445,9 @@ export default {
 						const index = this.findIndex(item);
 
 						// update the prev/next navigation
-						this.$panel.drawer.props.next = this.items[index + 1];
-						this.$panel.drawer.props.prev = this.items[index - 1];
+						// in case the updated input changed its sorting position
+						this.$panel.drawer.props.next = index < this.items.length - 1;
+						this.$panel.drawer.props.prev = index > 0;
 
 						this.items[index] = value;
 						this.save();


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- `<k-structure-drawer>`: `prev`/`next` need a boolean as value, not an object anymore


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion