### PR TITLE
feat: Remove `legacy` query runner as default

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -25,6 +25,7 @@ use Kirby\Http\Router;
 use Kirby\Http\Uri;
 use Kirby\Http\Visitor;
 use Kirby\Panel\Panel;
+use Kirby\Query\Query;
 use Kirby\Session\AutoSession;
 use Kirby\Session\Session;
 use Kirby\Template\Snippet;
@@ -108,6 +109,9 @@ class App
 		// start with a fresh snippet and version cache
 		Snippet::$cache = [];
 		VersionCache::reset();
+
+		// start with a fresh Query runner option
+		Query::$runner = null;
 
 		// register all roots to be able to load stuff afterwards
 		$this->bakeRoots($props['roots'] ?? []);

--- a/src/Query/Argument.php
+++ b/src/Query/Argument.php
@@ -14,8 +14,7 @@ use Kirby\Toolkit\Str;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
- *
- * @todo Deprecate in v6
+ * @deprecated 6.0.0 Will be removed in Kirby 7
  */
 class Argument
 {

--- a/src/Query/Arguments.php
+++ b/src/Query/Arguments.php
@@ -14,8 +14,7 @@ use Kirby\Toolkit\Collection;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
- *
- * @todo Deprecate in v6
+ * @deprecated 6.0.0 Will be removed in Kirby 7
  *
  * @extends \Kirby\Toolkit\Collection<\Kirby\Query\Argument>
  */

--- a/src/Query/Expression.php
+++ b/src/Query/Expression.php
@@ -14,8 +14,7 @@ use Kirby\Toolkit\A;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
- *
- * @todo Deprecate in v6
+ * @deprecated 6.0.0 Will be removed in Kirby 7
  */
 class Expression
 {

--- a/src/Query/Segment.php
+++ b/src/Query/Segment.php
@@ -16,8 +16,7 @@ use Kirby\Toolkit\Str;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
- *
- * @todo Deprecate in v6
+ * @deprecated 6.0.0 Will be removed in Kirby 7
  */
 class Segment
 {

--- a/src/Query/Segments.php
+++ b/src/Query/Segments.php
@@ -14,8 +14,7 @@ use Kirby\Toolkit\Collection;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
- *
- * @todo Deprecate in v6
+ * @deprecated 6.0.0 Will be removed in Kirby 7
  *
  * @extends \Kirby\Toolkit\Collection<\Kirby\Query\Segment>
  */

--- a/tests/Query/QueryTest.php
+++ b/tests/Query/QueryTest.php
@@ -13,29 +13,19 @@ use PHPUnit\Framework\Attributes\DataProvider;
 #[CoversClass(Query::class)]
 class QueryTest extends TestCase
 {
-	protected function setUp(): void
-	{
-		new App([
-			'options' => [
-				'query' => [
-					'runner' => DefaultRunner::class
-				]
-			]
-		]);
-	}
-
 	protected function tearDown(): void
 	{
 		App::destroy();
+		Query::$runner = null;
 	}
 
 	public function test__Construct(): void
 	{
 		$query = new Query('');
-		$this->assertInstanceOf(DefaultRunner::class, $query->runner);
+		$this->assertInstanceOf(DefaultRunner::class, $query::$runner);
 	}
 
-	public function test__ConstructWithoutConfig(): void
+	public function test__ConstructWitoutConfig(): void
 	{
 		new App([
 			'options' => [
@@ -46,7 +36,21 @@ class QueryTest extends TestCase
 		]);
 
 		$query = new Query('');
-		$this->assertSame('legacy', $query->runner);
+		$this->assertInstanceOf(DefaultRunner::class, $query::$runner);
+	}
+
+	public function test__ConstructWitLegacyConfig(): void
+	{
+		new App([
+			'options' => [
+				'query' => [
+					'runner' => 'legacy'
+				]
+			]
+		]);
+
+		$query = new Query('');
+		$this->assertSame('legacy', $query::$runner);
 	}
 
 	public function test__ConstructWithInvalidConfig(): void
@@ -60,7 +64,7 @@ class QueryTest extends TestCase
 		]);
 
 		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('Query runner foo must extend Kirby\Query\Runners\Runner');
+		$this->expectExceptionMessage('Query runner "foo" must extend Kirby\Query\Runners\Runner');
 
 		new Query('');
 	}


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ☠️ Deprecated
<!-- 
e.g. Deprecate method X. Use method Y instead.
-->
- `legacy` query runner has been deprecated and removed as default. Use `Kirby\Query\Runners\DefaultRunner` instead.
- `Kirby\Query\Argument`, `Kirby\Query\Arguments`, `Kirby\Query\Expression`, `Kirby\Query\Segment`, `Kirby\Query\Segments` have been deprecated and will be removed in Kirby 7.


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion