### PR TITLE
Fix focus loss in entries field

### DIFF
--- a/panel/src/components/Forms/Field/EntriesField.vue
+++ b/panel/src/components/Forms/Field/EntriesField.vue
@@ -237,8 +237,9 @@ export default {
 			handler(entries) {
 				entries ??= [];
 
-				// no need to add ids again if the values are the same
-				if (entries === this.values) {
+				// Prevent unnecessary re-creation of entries that causes focus loss
+				// when typing in input fields by comparing actual values
+				if (JSON.stringify(entries) === JSON.stringify(this.values)) {
 					return;
 				}
 


### PR DESCRIPTION
## Description

Every time you type a character:
1. The watcher sees a new array reference coming in
2. It recreates all entries with brand new IDs
3. Vue sees different IDs and remounts everything
4. Focus is lost

The problem was this check wasn't working:
```js
if (entries === this.values) {
  return;
}
```

Because `this.values` is a computed property that returns a new array each time, so `===` always returns false.

Added a proper value comparison using `JSON.stringify()` to check if the actual content has changed before recreating entries. Not the most elegant solution but it works and is simple enough.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Entries field: can only type one letter before field looses focus #7779

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion