### PR TITLE
refact: Model tabs reload view instead link

### DIFF
--- a/panel/src/components/Navigation/ModelTabs.vue
+++ b/panel/src/components/Navigation/ModelTabs.vue
@@ -8,7 +8,10 @@
  */
 export default {
 	props: {
-		diff: Object,
+		diff: {
+			type: Object,
+			default: () => ({})
+		},
 		tab: String,
 		tabs: {
 			type: Array,
@@ -39,10 +42,19 @@ export default {
 					changes.includes(field.toLowerCase())
 				).length;
 
-				return {
-					...tab,
-					badge: changesInTab > 0 ? { text: changesInTab } : null
+				if (changesInTab > 0) {
+					tab.badge = { text: changesInTab };
+				}
+
+				// remove link to rather use $panel.view.reload with the tab name
+				delete tab.link;
+
+				tab.click = (e) => {
+					e?.preventDefault();
+					this.$panel.view.reload({ query: { tab: tab.name } });
 				};
+
+				return tab;
 			});
 		}
 	}


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

I think it would be advantageous for the model tabs to not use the `link` of the tab, but rather reload the view with the new tab name. I don't think for model tabs there is any other use case for the link but to point to the same URL with a different tab. By ignoring the link, this will allow us to use model tabs in other views, e.g. preview view, where the URL would not match but reloading with new tab name still works.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### Breaking changes
<!-- 
e.g. Rename method X to method Y.
-->
- `k-model-tabs` ignores `tab.link` but reloads the view with the tab as query

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion