### PR TITLE
refact: `k-button` apply all `aria-` attributes

### DIFF
--- a/panel/src/components/Navigation/Button.vue
+++ b/panel/src/components/Navigation/Button.vue
@@ -147,10 +147,7 @@ export default {
 		attrs() {
 			// Shared
 			const attrs = {
-				"aria-current": this.current,
-				"aria-disabled": this.disabled,
 				"aria-label": this.text ?? this.title,
-				"aria-selected": this.selected,
 				"data-responsive": this.responsive,
 				"data-size": this.size,
 				"data-theme": this.theme,
@@ -159,6 +156,25 @@ export default {
 				tabindex: this.tabindex,
 				title: this.title
 			};
+
+			if (this.current) {
+				attrs["aria-current"] = this.current;
+			}
+
+			if (this.disabled) {
+				attrs["aria-disabled"] = this.disabled;
+			}
+
+			if (this.selected) {
+				attrs["aria-selected"] = this.selected;
+			}
+
+			// support all aria- attributes
+			for (const attr of Object.keys(this.$attrs)) {
+				if (attr.startsWith("aria-") && this.$attrs[attr]) {
+					attrs[attr] = this.$attrs[attr];
+				}
+			}
 
 			if (this.component === "k-link") {
 				// For `<a>`/`<k-link>` element:


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

- Vue 3 renders also attributes with `false` (Vue 2 did not), so I think it makes sense here to just apply certain attributes if needed, instead of applying everywhere `aria-current="false"`.
- I have the use case for `aria-checked`, but I thought it could get too much if we continue adding props for every aria attribute. So I thought about getting any aria- attribute from the $attrs and applying it.