### PR TITLE
fix: `Dom` for newer libxml versions

### DIFF
--- a/src/Toolkit/Dom.php
+++ b/src/Toolkit/Dom.php
@@ -94,7 +94,7 @@ class Dom
 					($node->nodeType === XML_COMMENT_NODE && strpos($node->data, $xml) !== false)
 				) {
 					static::remove($node);
-					continue;
+					break;
 				}
 			}
 
@@ -683,10 +683,11 @@ class Dom
 		// implementations expand it to the long HTML4 transitional doctype
 		// when saving. Normalize it back to the short `<!DOCTYPE html>`
 		// to keep behavior consistent across environments.
-		if (Str::contains($this->code, '<!DOCTYPE ', true) === true) {
-			if (preg_match('/<!doctype\s+html/i', $this->code) === 1) {
-				$html = preg_replace('/^<!DOCTYPE[^>]*>\s*/i', '<!DOCTYPE html>' . "\n", $html, 1);
-			}
+		if (
+			Str::contains($this->code, '<!DOCTYPE ', true) === true &&
+			preg_match('/<!doctype\s+html/i', $this->code) === 1
+		) {
+			$html = preg_replace('/^<!DOCTYPE[^>]*>\s*/i', '<!DOCTYPE html>' . "\n", $html, 1);
 		}
 
 		return trim($html);

--- a/src/Toolkit/Dom.php
+++ b/src/Toolkit/Dom.php
@@ -51,30 +51,54 @@ class Dom
 		$this->doc  = new DOMDocument();
 		$this->type = strtoupper($type);
 
-		// switch to "user error handling"
+		// Switch libxml into internal error handling mode so warnings
+		// don’t leak into output or interrupt parsing
 		$errors = libxml_use_internal_errors(true);
 
 		if ($this->type === 'HTML') {
-			// ensure proper parsing for HTML snippets
+			// If this is an HTML fragment (no <html> or <body> root),
+			// wrap it in <body> so DOMDocument has a valid container.
 			if (preg_match('/<(html|body)[> ]/i', $code) !== 1) {
 				$code = '<body>' . $code . '</body>';
 			}
 
-			// the loadHTML() method expects ISO-8859-1 by default;
-			// force parsing as UTF-8 by injecting an XML declaration
+			// DOMDocument::loadHTML() historically assumes ISO-8859-1 input.
+			// To force UTF-8 parsing, Kirby injects an XML declaration.
+			// The random ID allows us to reliably identify *our* injected node
+			// later and remove it again.
 			$xml  = 'encoding="UTF-8" id="' . Str::random(10) . '"';
 			$load = $this->doc->loadHTML('<?xml ' . $xml . '>' . $code);
 
-			// remove the injected XML declaration again
-			$pis = $this->query('//processing-instruction()');
 
-			foreach (iterator_to_array($pis, false) as $pi) {
-				if ($pi->data === $xml) {
-					static::remove($pi);
+			// Newer libxml2 versions may not attach the injected XML node
+			// inside <html>. Instead, they may convert it into a top-level
+			// comment node that sits before <html>:
+			//   <!--?xml encoding="UTF-8" id="XYZ"--><html>...
+			//
+			//  XPath queries like //comment() or //processing-instruction()
+			//  often operate relative to the document element (<html>) and
+			//  therefore miss this node entirely.
+			//  To fix this, we must also inspect and clean up the document’s
+			//  top-level child nodes explicitly.
+			//
+			// Walk all top-level nodes of the document and remove
+			// any node that matches the injected XML marker
+			for ($node = $this->doc->firstChild; $node !== null; $node = $next) {
+				$next = $node->nextSibling;
+
+				if (
+					// Case 1: libxml preserved it as a processing instruction
+					($node->nodeType === XML_PI_NODE && $node->data === $xml) ||
+					// Case 2: libxml converted it into a comment node
+					// (<!--?xml encoding="UTF-8" id="..."-->)
+					($node->nodeType === XML_COMMENT_NODE && strpos($node->data, $xml) !== false)
+				) {
+					static::remove($node);
+					continue;
 				}
 			}
 
-			// remove the default doctype
+			// Remove the default doctype
 			if (Str::contains($code, '<!DOCTYPE ', true) === false) {
 				static::remove($this->doc->doctype);
 			}
@@ -654,6 +678,16 @@ class Dom
 		// remove the <meta> tag from the document and from the output
 		static::remove($metaTag);
 		$html = str_replace($this->doc->saveHTML($metaTag), '', $html);
+
+		// if the original input contained an HTML doctype, some libxml
+		// implementations expand it to the long HTML4 transitional doctype
+		// when saving. Normalize it back to the short `<!DOCTYPE html>`
+		// to keep behavior consistent across environments.
+		if (Str::contains($this->code, '<!DOCTYPE ', true) === true) {
+			if (preg_match('/<!doctype\s+html/i', $this->code) === 1) {
+				$html = preg_replace('/^<!DOCTYPE[^>]*>\s*/i', '<!DOCTYPE html>' . "\n", $html, 1);
+			}
+		}
 
 		return trim($html);
 	}


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

I had our unit tests failing because of a newer libxml version (it seems that was the culprit).
Adapting our `Dom` class to handle this as well.


### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Fixed `Kirby\Toolkit\Dom` for newer libxml versions

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion