### PR TITLE
test: Use ParaTest to run PHP unit tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -3,7 +3,7 @@
 name: CI - Backend
 
 env:
-  OS: &os ubuntu-22.04
+  OS: &os ubuntu-24.04
   TIMEOUT: &timeout 5
 
   # run job only under the following conditions:
@@ -73,7 +73,7 @@ jobs:
           fetch-depth: 2
 
       - name: Install system locales
-        run: sudo apt-get update && sudo apt-get install -y locales-all
+        run: sudo apt-get update && sudo apt-get install -y locales-all imagemagick
 
       - name: Setup PHP environment
         uses: ./.github/actions/setup-php
@@ -81,22 +81,23 @@ jobs:
           php: ${{ matrix.php }}
           ini: apc.enabled=1, apc.enable_cli=1, pcov.directory=., "pcov.exclude=\"~(vendor|tests)~\""
           coverage: pcov
-          tools: phpunit:12.4.4
+          tools: phpunit:12.5.4, brianium/paratest:7.16.1
 
       - name: Check Composer platform requirements
         run: composer check-platform-reqs
 
       - name: Run PHPUnit tests
-        run: phpunit -c phpunit.ci.xml --coverage-clover ${{ github.workspace }}/clover.xml
+        run: paratest -c phpunit.ci.xml --coverage-clover ${{ github.workspace }}/clover.xml --exclude-source-from-xml-coverage
 
       - name: Upload coverage results to Codecov
         if: matrix.php == '8.4'
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           # for better reliability if the GitHub API is down
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           files: ${{ github.workspace }}/clover.xml
+          disable_search: true
           flags: backend
           env_vars: PHP
         env:
@@ -155,7 +156,7 @@ jobs:
 
       - name: Upload code scanning results to GitHub
         if: github.repository == 'getkirby/kirby' && steps.psalm.outcome == 'success'
-        uses: github/codeql-action/upload-sarif@497990dfed22177a82ba1bbab381bc8f6d27058f # v3
+        uses: github/codeql-action/upload-sarif@45c373516f557556c15d420e3f5e0aa3d64366bc # v3
         with:
           sarif_file: sarif
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -3,7 +3,7 @@
 name: CI - Frontend
 
 env:
-  OS: &os ubuntu-22.04
+  OS: &os ubuntu-24.04
   TIMEOUT: &timeout 5
 
   # run job only under the following conditions:

--- a/composer.json
+++ b/composer.json
@@ -98,8 +98,8 @@
 			"@test"
 		],
 		"fix": "php-cs-fixer fix",
-		"test": "phpunit",
-		"test:coverage": "XDEBUG_MODE=coverage phpunit --coverage-html=tests/coverage",
+		"test": "paratest",
+		"test:coverage": "XDEBUG_MODE=coverage paratest --coverage-html=tests/coverage",
 		"zip": "composer archive --format=zip --file=dist"
 	}
 }

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -16,6 +16,8 @@ class FieldTest extends TestCase
 
 	public function setUp(): void
 	{
+		parent::setUp();
+
 		new App([
 			'roots' => [
 				'index' => '/dev/null'
@@ -30,8 +32,9 @@ class FieldTest extends TestCase
 
 	public function tearDown(): void
 	{
-		Field::$types = [];
+		parent::tearDown();
 
+		Field::$types = [];
 		Field::$mixins = $this->originalMixins;
 	}
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,17 +2,73 @@
 
 namespace Kirby;
 
+use Closure;
 use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Cms\User;
+use Kirby\Data\Data;
 use Kirby\Filesystem\Dir;
+use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Locale;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
 	protected App $app;
+
+	protected string|Closure|null $i18nLocale;
+	protected string|array|Closure|null $i18nFallback;
+	protected Closure|null $i18nLoad;
+	protected array $i18nTranslations;
+	protected array|string $localeBackup;
+
+	public function setUp(): void
+	{
+		App::destroy();
+
+		$translationRoot = dirname(__DIR__) . '/i18n/translations';
+
+		$this->localeBackup = Locale::get();
+		Locale::set('C');
+
+		$this->i18nLocale = I18n::$locale;
+		$this->i18nFallback = I18n::$fallback;
+		$this->i18nLoad = I18n::$load;
+		$this->i18nTranslations = I18n::$translations;
+
+		I18n::$locale = 'en';
+		I18n::$fallback = 'en';
+		I18n::$load = function (string $locale) use ($translationRoot): array {
+			$file = $translationRoot . '/' . basename($locale) . '.json';
+			return Data::read($file, fail: false);
+		};
+		I18n::$translations = [];
+	}
+
+	public function tearDown(): void
+	{
+		if (isset($this->localeBackup) === true) {
+			Locale::set($this->localeBackup);
+		}
+
+		if (isset($this->i18nLocale) === true) {
+			I18n::$locale = $this->i18nLocale;
+		}
+
+		if (isset($this->i18nFallback) === true) {
+			I18n::$fallback = $this->i18nFallback;
+		}
+
+		if (isset($this->i18nLoad) === true) {
+			I18n::$load = $this->i18nLoad;
+		}
+
+		if (isset($this->i18nTranslations) === true) {
+			I18n::$translations = $this->i18nTranslations;
+		}
+	}
 
 	/**
 	 * Whether $actual is a File object

--- a/tests/Toolkit/HasI18nTest.php
+++ b/tests/Toolkit/HasI18nTest.php
@@ -2,29 +2,10 @@
 
 namespace Kirby\Toolkit;
 
-use Closure;
 use Kirby\TestCase;
 
 class HasI18nTest extends TestCase
 {
-	protected string|Closure $localeBackup;
-
-	public function setUp(): void
-	{
-		$this->localeBackup = I18n::$locale;
-		I18n::$locale = 'foo';
-		I18n::$translations['foo'] = [
-			'my.key'   => 'My translation',
-			'my.count' => 'All {count} things'
-		];
-	}
-
-	public function tearDown(): void
-	{
-		unset(I18n::$translations['foo']);
-		I18n::$locale = $this->localeBackup;
-	}
-
 	public function testI18n(): void
 	{
 		$class = new class () {
@@ -35,6 +16,12 @@ class HasI18nTest extends TestCase
 				return $this->i18n($key, $data);
 			}
 		};
+
+		// set up custom i18n strings for test
+		I18n::$translations['en'] = [
+			'my.key'   => 'My translation',
+			'my.count' => 'All {count} things'
+		];
 
 		$this->assertNull($class->translate(null));
 		$this->assertSame('Hello', $class->translate('Hello'));

--- a/tests/Toolkit/VTest.php
+++ b/tests/Toolkit/VTest.php
@@ -33,8 +33,8 @@ class VTest extends TestCase
 {
 	public function tearDown(): void
 	{
+		parent::tearDown();
 		V::$validators = [];
-		App::destroy();
 	}
 
 	public function testCallCustomValidator(): void
@@ -249,20 +249,21 @@ class VTest extends TestCase
 
 	public function testErrors(): void
 	{
+		// set up custom i18n strings for test
+		I18n::$translations['en'] = [
+			'error.validation.same' => 'Error message for same: {other}'
+		];
+
 		$result = V::errors('test@getkirby.com', [
 			'email',
 			'maxLength' => 17,
 			'minLength' => 17
 		]);
-
 		$this->assertSame([], $result);
 
-		$result = V::errors('a', [
-			'same' => 'b'
-		]);
-
+		$result = V::errors('a', ['same' => 'b']);
 		$this->assertSame([
-			'same' => 'Please enter "b"',
+			'same' => 'Error message for same: b',
 		], $result);
 	}
 
@@ -568,8 +569,13 @@ class VTest extends TestCase
 
 	public function testMessage(): void
 	{
+		// set up custom i18n strings for test
+		I18n::$translations['en'] = [
+			'error.validation.same' => 'Error message for same: {other}'
+		];
+
 		$message = V::message('same', 'a', 'b');
-		$this->assertSame('Please enter "b"', $message);
+		$this->assertSame('Error message for same: b', $message);
 	}
 
 	public function testMessageInvalidValidator(): void
@@ -902,22 +908,28 @@ class VTest extends TestCase
 
 	public function testValueFails(): void
 	{
-		// load the translation strings
-		new App();
+		// set up custom i18n strings for test
+		I18n::$translations['en'] = [
+			'error.validation.same' => 'Error message for same: {other}'
+		];
 
 		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('Please enter "b"');
+		$this->expectExceptionMessage('Error message for same');
 
-		V::value('a', [
-			'same' => 'b'
-		]);
+		V::value('a', ['same' => 'b']);
 	}
 
 	public function testValueFailsNotThrowing(): void
 	{
+		// set up custom i18n strings for test
+		I18n::$translations['en'] = [
+			'error.validation.same' => 'Error message for same: {other}'
+		];
+
 		$result = V::value('a', ['same' => 'b'], fail: false);
+
 		$this->assertSame([
-			'same' => 'Please enter "b"'
+			'same' => 'Error message for same: b'
 		], $result);
 	}
 }


### PR DESCRIPTION
## Description

- Make sure to install paratest 7.16.1 before testing locally

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🧹 Housekeeping
<!-- 
e.g. Update JS dependencies
-->
- Using ParaTest to run PHPUnit tests in parallel


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion