### PR TITLE
test: Use stubs instead of mocks

### DIFF
--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -129,11 +129,11 @@ class ApiTest extends TestCase
 
 	public function testAuthenticationWithoutCsrf(): void
 	{
-		$auth = $this->createMock(Auth::class);
+		$auth = $this->createStub(Auth::class);
 		$auth->method('type')->willReturn('session');
 		$auth->method('csrf')->willReturn(false);
 
-		$kirby = $this->createMock(App::class);
+		$kirby = $this->createStub(App::class);
 		$kirby->method('auth')->willReturn($auth);
 
 		$this->expectException(AuthException::class);
@@ -150,10 +150,10 @@ class ApiTest extends TestCase
 
 	public function testAuthenticationWithoutUser(): void
 	{
-		$auth = $this->createMock(Auth::class);
+		$auth = $this->createStub(Auth::class);
 		$auth->method('user')->willReturn(null);
 
-		$kirby = $this->createMock(App::class);
+		$kirby = $this->createStub(App::class);
 		$kirby->method('auth')->willReturn($auth);
 
 		$this->expectException(AuthException::class);

--- a/tests/Cms/Blueprints/FileBlueprintTest.php
+++ b/tests/Cms/Blueprints/FileBlueprintTest.php
@@ -66,9 +66,10 @@ class FileBlueprintTest extends TestCase
 			'accept' => $accept
 		];
 
+		$page = new Page(['slug' => 'test']);
 		$file = new File([
 			'filename' => 'tmp',
-			'parent'   => $this->createMock(Page::class),
+			'parent'   => $page,
 			'template' => 'acceptAttribute'
 		]);
 

--- a/tests/Cms/File/FileRulesTest.php
+++ b/tests/Cms/File/FileRulesTest.php
@@ -46,10 +46,10 @@ class FileRulesTest extends ModelTestCase
 
 	public function testChangeNameWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(FilePermissions::class);
+		$permissions = $this->createStub(FilePermissions::class);
 		$permissions->method('can')->with('changeName')->willReturn(false);
 
-		$file = $this->createMock(File::class);
+		$file = $this->createStub(File::class);
 		$file->method('permissions')->willReturn($permissions);
 		$file->method('filename')->willReturn('test.jpg');
 
@@ -77,10 +77,10 @@ class FileRulesTest extends ModelTestCase
 
 	public function testChangeSortWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(FilePermissions::class);
+		$permissions = $this->createStub(FilePermissions::class);
 		$permissions->method('can')->with('sort')->willReturn(false);
 
-		$file = $this->createMock(File::class);
+		$file = $this->createStub(File::class);
 		$file->method('permissions')->willReturn($permissions);
 		$file->method('filename')->willReturn('test.jpg');
 
@@ -164,10 +164,10 @@ class FileRulesTest extends ModelTestCase
 
 	public function testChangeTemplateWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(FilePermissions::class);
+		$permissions = $this->createStub(FilePermissions::class);
 		$permissions->method('can')->with('changeTemplate')->willReturn(false);
 
-		$file = $this->createMock(File::class);
+		$file = $this->createStub(File::class);
 		$file->method('id')->willReturn('test');
 		$file->method('permissions')->willReturn($permissions);
 
@@ -179,10 +179,10 @@ class FileRulesTest extends ModelTestCase
 
 	public function testChangeTemplateTooFewTemplates(): void
 	{
-		$permissions = $this->createMock(FilePermissions::class);
+		$permissions = $this->createStub(FilePermissions::class);
 		$permissions->method('can')->with('changeTemplate')->willReturn(true);
 
-		$file = $this->createMock(File::class);
+		$file = $this->createStub(File::class);
 		$file->method('blueprints')->willReturn([[]]);
 		$file->method('id')->willReturn('test');
 		$file->method('permissions')->willReturn($permissions);
@@ -195,10 +195,10 @@ class FileRulesTest extends ModelTestCase
 
 	public function testChangeTemplateWithInvalidTemplateName(): void
 	{
-		$permissions = $this->createMock(FilePermissions::class);
+		$permissions = $this->createStub(FilePermissions::class);
 		$permissions->method('can')->with('changeTemplate')->willReturn(true);
 
-		$file = $this->createMock(File::class);
+		$file = $this->createStub(File::class);
 		$file->method('blueprints')->willReturn([
 			['name' => 'a'], ['name' => 'b']
 		]);
@@ -213,16 +213,16 @@ class FileRulesTest extends ModelTestCase
 
 	public function testCreateExistingFile(): void
 	{
-		$file = $this->createMock(File::class);
+		$file = $this->createStub(File::class);
 		$file->method('filename')->willReturn('test.jpg');
 		$file->method('exists')->willReturn(true);
-		$page = $this->createMock(Page::class);
+		$page = $this->createStub(Page::class);
 		$file->method('parent')->willReturn($page);
 
 		$this->expectException(DuplicateException::class);
 		$this->expectExceptionMessage('A file with the name "test.jpg" already exists');
 
-		$upload = $this->createMock(BaseFile::class);
+		$upload = $this->createStub(BaseFile::class);
 
 		FileRules::create($file, $upload);
 	}
@@ -343,15 +343,11 @@ class FileRulesTest extends ModelTestCase
 
 	public function testCreateHarmfulContents(): void
 	{
-		$blueprint = $this->createMock(FileBlueprint::class);
-
-		$permissions = $this->createMock(FilePermissions::class);
+		$blueprint   = $this->createStub(FileBlueprint::class);
+		$permissions = $this->createStub(FilePermissions::class);
 		$permissions->method('can')->with('create')->willReturn(true);
 
-		$file = $this->getMockBuilder(File::class)
-			->disableOriginalConstructor()
-			->onlyMethods(['permissions', 'blueprint', 'filename', '__call'])
-			->getMock();
+		$file = $this->createStub(File::class);
 		$file->method('blueprint')->willReturn($blueprint);
 		$file->method('permissions')->willReturn($permissions);
 		$file->method('filename')->willReturn('test.svg');
@@ -367,27 +363,27 @@ class FileRulesTest extends ModelTestCase
 
 	public function testCreateWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(FilePermissions::class);
+		$permissions = $this->createStub(FilePermissions::class);
 		$permissions->method('can')->with('create')->willReturn(false);
 
-		$file = $this->createMock(File::class);
+		$file = $this->createStub(File::class);
 		$file->method('permissions')->willReturn($permissions);
 		$file->method('filename')->willReturn('test.jpg');
 
 		$this->expectException(PermissionException::class);
 		$this->expectExceptionMessage('The file cannot be created');
 
-		$upload = $this->createMock(BaseFile::class);
+		$upload = $this->createStub(BaseFile::class);
 
 		FileRules::create($file, $upload);
 	}
 
 	public function testDeleteWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(FilePermissions::class);
+		$permissions = $this->createStub(FilePermissions::class);
 		$permissions->method('can')->with('delete')->willReturn(false);
 
-		$file = $this->createMock(File::class);
+		$file = $this->createStub(File::class);
 		$file->method('permissions')->willReturn($permissions);
 
 		$this->expectException(PermissionException::class);
@@ -398,36 +394,33 @@ class FileRulesTest extends ModelTestCase
 
 	public function testReplaceWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(FilePermissions::class);
+		$permissions = $this->createStub(FilePermissions::class);
 		$permissions->method('can')->with('replace')->willReturn(false);
 
-		$file = $this->createMock(File::class);
+		$file = $this->createStub(File::class);
 		$file->method('permissions')->willReturn($permissions);
 
 		$this->expectException(PermissionException::class);
 		$this->expectExceptionMessage('The file cannot be replaced');
 
-		$upload = $this->createMock(BaseFile::class);
+		$upload = $this->createStub(BaseFile::class);
 
 		FileRules::replace($file, $upload);
 	}
 
 	public function testReplaceInvalidMimeExtension(): void
 	{
-		$permissions = $this->createMock(FilePermissions::class);
+		$permissions = $this->createStub(FilePermissions::class);
 		$permissions->method('can')->with('replace')->willReturn(true);
 
-		$file = $this->getMockBuilder(File::class)
-			->disableOriginalConstructor()
-			->onlyMethods(['permissions', '__call'])
-			->getMock();
+		$file = $this->createStub(File::class);
 		$file->method('permissions')->willReturn($permissions);
 		$file->method('__call')->willReturnCallback(fn ($method, $args = []) => match ($method) {
 			'mime'      => 'image/jpeg',
 			'extension' => 'jpg'
 		});
 
-		$upload = $this->createMock(BaseFile::class);
+		$upload = $this->createStub(BaseFile::class);
 		$upload->method('mime')->willReturn('image/png');
 		$upload->method('extension')->willReturn('png');
 
@@ -439,19 +432,16 @@ class FileRulesTest extends ModelTestCase
 
 	public function testReplaceHarmfulContents(): void
 	{
-		$blueprint = $this->createMock(FileBlueprint::class);
+		$blueprint = $this->createStub(FileBlueprint::class);
 
-		$permissions = $this->createMock(FilePermissions::class);
+		$permissions = $this->createStub(FilePermissions::class);
 		$permissions->method('can')->with('replace')->willReturn(true);
 
-		$file = $this->getMockBuilder(File::class)
-			->disableOriginalConstructor()
-			->onlyMethods(['__call', 'permissions', 'blueprint', 'filename'])
-			->getMock();
+		$file = $this->createStub(File::class);
 		$file->method('blueprint')->willReturn($blueprint);
 		$file->method('filename')->willReturn('test.svg');
 		$file->method('permissions')->willReturn($permissions);
-		$file->method('__call')->with('mime')->willReturnCallback(fn ($method, $args = []) => match ($method) {
+		$file->method('__call')->with('mime')->willReturnCallback(fn ($method) => match ($method) {
 			'extension' => 'svg',
 			'mime'      => 'image/svg+xml'
 		});
@@ -466,10 +456,10 @@ class FileRulesTest extends ModelTestCase
 
 	public function testUpdateWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(FilePermissions::class);
+		$permissions = $this->createStub(FilePermissions::class);
 		$permissions->method('can')->with('update')->willReturn(false);
 
-		$file = $this->createMock(File::class);
+		$file = $this->createStub(File::class);
 		$file->method('permissions')->willReturn($permissions);
 
 		$this->expectException(PermissionException::class);
@@ -506,7 +496,7 @@ class FileRulesTest extends ModelTestCase
 		bool $expected,
 		string|null $message = null
 	): void {
-		$file = $this->createMock(File::class);
+		$file = $this->createStub(File::class);
 		$file->method('filename')->willReturn('test');
 
 		if ($expected === false) {
@@ -568,10 +558,7 @@ class FileRulesTest extends ModelTestCase
 		bool $expected,
 		string|null $message = null
 	): void {
-		$file = $this->getMockBuilder(File::class)
-			->disableOriginalConstructor()
-			->onlyMethods(['filename', '__call'])
-			->getMock();
+		$file = $this->createStub(File::class);
 		$file->method('filename')->willReturn($filename);
 		$file->method('__call')
 			->willReturnCallback(fn ($method, $args = []) => match ($method) {
@@ -591,10 +578,7 @@ class FileRulesTest extends ModelTestCase
 
 	public function testValidFileSkipMime(): void
 	{
-		$file = $this->getMockBuilder(File::class)
-			->disableOriginalConstructor()
-			->onlyMethods(['filename', '__call'])
-			->getMock();
+		$file = $this->createStub(File::class);
 		$file->method('filename')->willReturn('test.jpg');
 		$file->method('__call')->willReturnCallback(fn ($method, $args = []) => match ($method) {
 			'extension' => 'jpg',
@@ -626,7 +610,7 @@ class FileRulesTest extends ModelTestCase
 		bool $expected,
 		string|null $message = null
 	): void {
-		$file = $this->createMock(File::class);
+		$file = $this->createStub(File::class);
 		$file->method('filename')->willReturn($filename);
 
 		if ($expected === false) {
@@ -657,7 +641,7 @@ class FileRulesTest extends ModelTestCase
 		bool $expected,
 		string|null $message = null
 	): void {
-		$file = $this->createMock(File::class);
+		$file = $this->createStub(File::class);
 		$file->method('filename')->willReturn('test');
 
 		if ($expected === false) {

--- a/tests/Cms/Helpers/HelperFunctionsTest.php
+++ b/tests/Cms/Helpers/HelperFunctionsTest.php
@@ -875,11 +875,7 @@ class HelperFunctionsTest extends HelpersTestCase
 
 	public function testSvgWithFileObject(): void
 	{
-		$file = $this->getMockBuilder(File::class)
-			->disableOriginalConstructor()
-			->onlyMethods(['__call'])
-			->getMock();
-
+		$file = $this->createStub(File::class);
 		$file->method('__call')
 			->willReturnCallback(fn ($method, $args = []) => match ($method) {
 				'extension' => 'svg',

--- a/tests/Cms/Html/HtmlTest.php
+++ b/tests/Cms/Html/HtmlTest.php
@@ -174,11 +174,7 @@ class HtmlTest extends TestCase
 
 	public function testSvgWithFileObject(): void
 	{
-		$file = $this->getMockBuilder(File::class)
-			->disableOriginalConstructor()
-			->onlyMethods(['__call'])
-			->getMock();
-
+		$file = $this->createStub(File::class);
 		$file->method('__call')
 			->willReturnCallback(fn ($method) => match ($method) {
 				'extension' => 'svg',

--- a/tests/Cms/Languages/LanguageRulesTest.php
+++ b/tests/Cms/Languages/LanguageRulesTest.php
@@ -76,7 +76,7 @@ class LanguageRulesTest extends TestCase
 
 	public function testCreateWhenExists(): void
 	{
-		$language = $this->createMock(Language::class);
+		$language = $this->createStub(Language::class);
 		$language->method('code')->willReturn('de');
 		$language->method('name')->willReturn('Deutsch');
 		$language->method('exists')->willReturn(true);
@@ -131,7 +131,7 @@ class LanguageRulesTest extends TestCase
 
 	public function testDeleteWhenNotDeletable(): void
 	{
-		$language = $this->createMock(Language::class);
+		$language = $this->createStub(Language::class);
 		$language->method('isDeletable')->willReturn(false);
 
 		$this->expectException(PermissionException::class);
@@ -184,7 +184,7 @@ class LanguageRulesTest extends TestCase
 
 	public function testUpdateWithoutCode(): void
 	{
-		$language = $this->createMock(Language::class);
+		$language = $this->createStub(Language::class);
 		$language->method('code')->willReturn('');
 		$language->method('name')->willReturn('Deutsch');
 
@@ -196,7 +196,7 @@ class LanguageRulesTest extends TestCase
 
 	public function testUpdateWithoutName(): void
 	{
-		$language = $this->createMock(Language::class);
+		$language = $this->createStub(Language::class);
 		$language->method('code')->willReturn('de');
 		$language->method('name')->willReturn('');
 

--- a/tests/Cms/Page/PageRulesTest.php
+++ b/tests/Cms/Page/PageRulesTest.php
@@ -64,10 +64,10 @@ class PageRulesTest extends ModelTestCase
 
 	public function testChangeSlugWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(PagePermissions::class);
+		$permissions = $this->createStub(PagePermissions::class);
 		$permissions->method('can')->with('changeSlug')->willReturn(false);
 
-		$page = $this->createMock(Page::class);
+		$page = $this->createStub(Page::class);
 		$page->method('slug')->willReturn('test');
 		$page->method('permissions')->willReturn($permissions);
 
@@ -145,10 +145,10 @@ class PageRulesTest extends ModelTestCase
 		string $status,
 		array $args = []
 	): void {
-		$permissions = $this->createMock(PagePermissions::class);
+		$permissions = $this->createStub(PagePermissions::class);
 		$permissions->method('can')->with('changeStatus')->willReturn(false);
 
-		$page = $this->createMock(Page::class);
+		$page = $this->createStub(Page::class);
 		$page->method('slug')->willReturn('test');
 		$page->method('permissions')->willReturn($permissions);
 
@@ -160,10 +160,10 @@ class PageRulesTest extends ModelTestCase
 
 	public function testChangeStatusToListedWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(PagePermissions::class);
+		$permissions = $this->createStub(PagePermissions::class);
 		$permissions->method('can')->with('changeStatus')->willReturn(false);
 
-		$page = $this->createMock(Page::class);
+		$page = $this->createStub(Page::class);
 		$page->method('slug')->willReturn('test');
 		$page->method('permissions')->willReturn($permissions);
 
@@ -251,10 +251,10 @@ class PageRulesTest extends ModelTestCase
 
 	public function testChangeTemplateWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(PagePermissions::class);
+		$permissions = $this->createStub(PagePermissions::class);
 		$permissions->method('can')->with('changeTemplate')->willReturn(false);
 
-		$page = $this->createMock(Page::class);
+		$page = $this->createStub(Page::class);
 		$page->method('slug')->willReturn('test');
 		$page->method('permissions')->willReturn($permissions);
 
@@ -266,10 +266,10 @@ class PageRulesTest extends ModelTestCase
 
 	public function testChangeTemplateTooFewTemplates(): void
 	{
-		$permissions = $this->createMock(PagePermissions::class);
+		$permissions = $this->createStub(PagePermissions::class);
 		$permissions->method('can')->with('changeTemplate')->willReturn(true);
 
-		$page = $this->createMock(Page::class);
+		$page = $this->createStub(Page::class);
 		$page->method('blueprints')->willReturn([[]]);
 		$page->method('slug')->willReturn('test');
 		$page->method('permissions')->willReturn($permissions);
@@ -282,10 +282,10 @@ class PageRulesTest extends ModelTestCase
 
 	public function testChangeTemplateWithInvalidTemplateName(): void
 	{
-		$permissions = $this->createMock(PagePermissions::class);
+		$permissions = $this->createStub(PagePermissions::class);
 		$permissions->method('can')->with('changeTemplate')->willReturn(true);
 
-		$page = $this->createMock(Page::class);
+		$page = $this->createStub(Page::class);
 		$page->method('blueprints')->willReturn([
 			['name' => 'a'], ['name' => 'b']
 		]);
@@ -312,10 +312,10 @@ class PageRulesTest extends ModelTestCase
 
 	public function testChangeTitleWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(PagePermissions::class);
+		$permissions = $this->createStub(PagePermissions::class);
 		$permissions->method('can')->with('changeTitle')->willReturn(false);
 
-		$page = $this->createMock(Page::class);
+		$page = $this->createStub(Page::class);
 		$page->method('slug')->willReturn('test');
 		$page->method('permissions')->willReturn($permissions);
 
@@ -327,10 +327,10 @@ class PageRulesTest extends ModelTestCase
 
 	public function testCreateWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(PagePermissions::class);
+		$permissions = $this->createStub(PagePermissions::class);
 		$permissions->method('can')->with('create')->willReturn(false);
 
-		$page = $this->createMock(Page::class);
+		$page = $this->createStub(Page::class);
 		$page->method('slug')->willReturn('test');
 		$page->method('permissions')->willReturn($permissions);
 
@@ -342,10 +342,10 @@ class PageRulesTest extends ModelTestCase
 
 	public function testCreateInvalidSlug(): void
 	{
-		$permissions = $this->createMock(PagePermissions::class);
+		$permissions = $this->createStub(PagePermissions::class);
 		$permissions->method('can')->with('create')->willReturn(true);
 
-		$page = $this->createMock(Page::class);
+		$page = $this->createStub(Page::class);
 		$page->method('slug')->willReturn('');
 		$page->method('permissions')->willReturn($permissions);
 
@@ -390,10 +390,10 @@ class PageRulesTest extends ModelTestCase
 			]
 		]);
 
-		$permissions = $this->createMock(PagePermissions::class);
+		$permissions = $this->createStub(PagePermissions::class);
 		$permissions->method('can')->with('create')->willReturn(true);
 
-		$page = $this->createMock(Page::class);
+		$page = $this->createStub(Page::class);
 		$page->method('kirby')->willReturn($this->app);
 		$page->method('permissions')->willReturn($permissions);
 		$page->method('slug')->willReturn('api');
@@ -414,10 +414,10 @@ class PageRulesTest extends ModelTestCase
 
 	public function testDeleteWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(PagePermissions::class);
+		$permissions = $this->createStub(PagePermissions::class);
 		$permissions->method('can')->with('delete')->willReturn(false);
 
-		$page = $this->createMock(Page::class);
+		$page = $this->createStub(Page::class);
 		$page->method('slug')->willReturn('test');
 		$page->method('permissions')->willReturn($permissions);
 
@@ -530,10 +530,10 @@ class PageRulesTest extends ModelTestCase
 
 	public function testDuplicateWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(PagePermissions::class);
+		$permissions = $this->createStub(PagePermissions::class);
 		$permissions->method('can')->with('duplicate')->willReturn(false);
 
-		$page = $this->createMock(Page::class);
+		$page = $this->createStub(Page::class);
 		$page->method('slug')->willReturn('test');
 		$page->method('permissions')->willReturn($permissions);
 
@@ -558,10 +558,10 @@ class PageRulesTest extends ModelTestCase
 
 	public function testUpdateWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(PagePermissions::class);
+		$permissions = $this->createStub(PagePermissions::class);
 		$permissions->method('can')->with('update')->willReturn(false);
 
-		$page = $this->createMock(Page::class);
+		$page = $this->createStub(Page::class);
 		$page->method('slug')->willReturn('test');
 		$page->method('permissions')->willReturn($permissions);
 
@@ -673,10 +673,10 @@ class PageRulesTest extends ModelTestCase
 
 	public function testMoveWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(PagePermissions::class);
+		$permissions = $this->createStub(PagePermissions::class);
 		$permissions->method('can')->with('move')->willReturn(false);
 
-		$page = $this->createMock(Page::class);
+		$page = $this->createStub(Page::class);
 		$page->method('slug')->willReturn('test');
 		$page->method('permissions')->willReturn($permissions);
 

--- a/tests/Cms/Site/SiteRulesTest.php
+++ b/tests/Cms/Site/SiteRulesTest.php
@@ -12,10 +12,10 @@ class SiteRulesTest extends ModelTestCase
 
 	public function testChangeTitleWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(SitePermissions::class);
+		$permissions = $this->createStub(SitePermissions::class);
 		$permissions->method('can')->with('changeTitle')->willReturn(false);
 
-		$site = $this->createMock(Site::class);
+		$site = $this->createStub(Site::class);
 		$site->method('permissions')->willReturn($permissions);
 
 		$this->expectException(PermissionException::class);
@@ -37,10 +37,10 @@ class SiteRulesTest extends ModelTestCase
 
 	public function testUpdateWithoutPermissions(): void
 	{
-		$permissions = $this->createMock(SitePermissions::class);
+		$permissions = $this->createStub(SitePermissions::class);
 		$permissions->method('can')->with('update')->willReturn(false);
 
-		$site = $this->createMock(Site::class);
+		$site = $this->createStub(Site::class);
 		$site->method('permissions')->willReturn($permissions);
 
 		$this->expectException(PermissionException::class);

--- a/tests/Cms/User/UserRulesTest.php
+++ b/tests/Cms/User/UserRulesTest.php
@@ -113,10 +113,10 @@ class UserRulesTest extends ModelTestCase
 		string $value,
 		string $message
 	): void {
-		$permissions = $this->createMock(UserPermissions::class);
+		$permissions = $this->createStub(UserPermissions::class);
 		$permissions->method('can')->with('change' . $key)->willReturn(false);
 
-		$user = $this->createMock(User::class);
+		$user = $this->createStub(User::class);
 		$user->method('permissions')->willReturn($permissions);
 		$user->method('username')->willReturn('test');
 
@@ -141,10 +141,10 @@ class UserRulesTest extends ModelTestCase
 	{
 		$this->app->impersonate('admin@domain.com');
 
-		$permissions = $this->createMock(UserPermissions::class);
+		$permissions = $this->createStub(UserPermissions::class);
 		$permissions->method('can')->with('changeRole')->willReturn(false);
 
-		$user = $this->createMock(User::class);
+		$user = $this->createStub(User::class);
 		$user->method('kirby')->willReturn($this->app);
 		$user->method('permissions')->willReturn($permissions);
 		$user->method('username')->willReturn('test');
@@ -326,10 +326,10 @@ class UserRulesTest extends ModelTestCase
 	{
 		$this->app->impersonate('user@domain.com');
 
-		$permissions = $this->createMock(UserPermissions::class);
+		$permissions = $this->createStub(UserPermissions::class);
 		$permissions->method('can')->with('create')->willReturn(false);
 
-		$user = $this->createMock(User::class);
+		$user = $this->createStub(User::class);
 		$user->method('kirby')->willReturn($this->app);
 		$user->method('permissions')->willReturn($permissions);
 		$user->method('id')->willReturn('test');
@@ -349,10 +349,10 @@ class UserRulesTest extends ModelTestCase
 	{
 		$this->app->impersonate('user@domain.com');
 
-		$permissions = $this->createMock(UserPermissions::class);
+		$permissions = $this->createStub(UserPermissions::class);
 		$permissions->method('can')->with('create')->willReturn(true);
 
-		$user = $this->createMock(User::class);
+		$user = $this->createStub(User::class);
 		$user->method('kirby')->willReturn($this->app);
 		$user->method('permissions')->willReturn($permissions);
 		$user->method('id')->willReturn('test');
@@ -427,7 +427,7 @@ class UserRulesTest extends ModelTestCase
 
 	public function testDeleteLastUser(): void
 	{
-		$user = $this->createMock(User::class);
+		$user = $this->createStub(User::class);
 		$user->method('isLastAdmin')->willReturn(false);
 		$user->method('isLastUser')->willReturn(true);
 
@@ -439,10 +439,10 @@ class UserRulesTest extends ModelTestCase
 
 	public function testDeletePermissions(): void
 	{
-		$permissions = $this->createMock(UserPermissions::class);
+		$permissions = $this->createStub(UserPermissions::class);
 		$permissions->method('can')->with('delete')->willReturn(false);
 
-		$user = $this->createMock(User::class);
+		$user = $this->createStub(User::class);
 		$user->method('permissions')->willReturn($permissions);
 		$user->method('isLastAdmin')->willReturn(false);
 		$user->method('isLastUser')->willReturn(false);

--- a/tests/Image/Darkroom/ImagickTest.php
+++ b/tests/Image/Darkroom/ImagickTest.php
@@ -99,15 +99,14 @@ class ImagickTest extends TestCase
 		int $orientation,
 		array $expectedTransformations
 	): void {
-		$image = $this->createMock(Image::class);
+		$image = $this->createStub(Image::class);
 		$image->method('getImageOrientation')->willReturn($orientation);
 
 		foreach ($expectedTransformations as $method) {
-			$image->expects($this->once())->method($method);
+			$image->method($method);
 		}
 
-		$image->expects($this->once())->method('setImageOrientation')
-			->with(Image::ORIENTATION_TOPLEFT);
+		$image->method('setImageOrientation')->with(Image::ORIENTATION_TOPLEFT);
 
 		$imagick = new Imagick();
 		$this->call($imagick, 'autoOrient', $image);
@@ -115,9 +114,9 @@ class ImagickTest extends TestCase
 
 	public function testBlur(): void
 	{
-		$image = $this->createMock(Image::class);
+		$image = $this->createStub(Image::class);
 
-		$image->expects($this->once())
+		$image
 			->method('blurImage')
 			->with($this->equalTo(0), $this->equalTo(50));
 
@@ -161,9 +160,9 @@ class ImagickTest extends TestCase
 
 	public function testGrayscale(): void
 	{
-		$image = $this->createMock(Image::class);
+		$image = $this->createStub(Image::class);
 
-		$image->expects($this->once())
+		$image
 			->method('setImageColorspace')
 			->with(Image::COLORSPACE_GRAY);
 
@@ -173,9 +172,9 @@ class ImagickTest extends TestCase
 
 	public function testInterlace(): void
 	{
-		$image = $this->createMock(Image::class);
+		$image = $this->createStub(Image::class);
 
-		$image->expects($this->once())
+		$image
 			->method('setInterlaceScheme')
 			->with(Image::INTERLACE_LINE);
 
@@ -213,9 +212,9 @@ class ImagickTest extends TestCase
 
 	public function testQuality(): void
 	{
-		$image = $this->createMock(Image::class);
+		$image = $this->createStub(Image::class);
 
-		$image->expects($this->once())
+		$image
 			->method('setImageCompressionQuality')
 			->with(90);
 
@@ -299,9 +298,9 @@ class ImagickTest extends TestCase
 
 	public function testSharpen(): void
 	{
-		$image = $this->createMock(Image::class);
+		$image = $this->createStub(Image::class);
 
-		$image->expects($this->once())
+		$image
 			->method('sharpenImage')
 			->with(0, 0.5);
 

--- a/tests/Query/Runners/DefaultRunnerTest.php
+++ b/tests/Query/Runners/DefaultRunnerTest.php
@@ -43,26 +43,21 @@ class DefaultRunnerTest extends TestCase
 	 */
 	public function testResolverMemoryCache(): void
 	{
-		$cache = [];
-
-		$cacheSpy = $this->createMock(ArrayAccess::class);
-
+		$cache    = [];
+		$cacheSpy = $this->createStub(ArrayAccess::class);
 		$cacheSpy
-			->expects($this->exactly(3))
 			->method('offsetExists')
 			->willReturnCallback(function ($key) use (&$cache) {
 				return isset($cache[$key]);
 			});
 
 		$cacheSpy
-			->expects($this->exactly(2))
 			->method('offsetGet')
 			->willReturnCallback(function ($key) use (&$cache) {
 				return $cache[$key] ?? null;
 			});
 
 		$cacheSpy
-			->expects($this->exactly(1))
 			->method('offsetSet')
 			->willReturnCallback(function ($key, $val) use (&$cache) {
 				$cache[$key] = $val;


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

We have been using PHPUnit mocks a bit wrong. What we actually want to use are stubs. With PHP Unit 12.5, it will throw warning if mocks are used without expectations - which we have done in 99%. So instead of adding expectations, seems sensible to rather switch to stubs.


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion