### PR TITLE
test: Better locale set/reset

### DIFF
--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -82,6 +82,7 @@ class ApiTest extends TestCase
 
 	public function tearDown(): void
 	{
+		setlocale(LC_ALL, 'C');
 		Dir::remove(static::TMP);
 	}
 
@@ -218,8 +219,6 @@ class ApiTest extends TestCase
 
 	public function testCallLocale(): void
 	{
-		$originalLocale = setlocale(LC_CTYPE, 0);
-
 		$language = 'de';
 
 		$api = new Api([
@@ -236,24 +235,27 @@ class ApiTest extends TestCase
 		]);
 
 		$this->assertSame('something', $api->call('foo'));
+		$this->assertTrue(in_array(setlocale(LC_CTYPE, 0), ['de', 'de_DE', 'de_DE.UTF-8', 'de_DE.UTF8', 'de_DE.ISO8859-1']));
+
 		$this->assertTrue(in_array(setlocale(LC_MONETARY, 0), ['de', 'de_DE', 'de_DE.UTF-8', 'de_DE.UTF8', 'de_DE.ISO8859-1']));
 		$this->assertTrue(in_array(setlocale(LC_NUMERIC, 0), ['de', 'de_DE', 'de_DE.UTF-8', 'de_DE.UTF8', 'de_DE.ISO8859-1']));
 		$this->assertTrue(in_array(setlocale(LC_TIME, 0), ['de', 'de_DE', 'de_DE.UTF-8', 'de_DE.UTF8', 'de_DE.ISO8859-1']));
-		$this->assertSame($originalLocale, setlocale(LC_CTYPE, 0));
 
 		$language = 'pt_BR';
 		$this->assertSame('something', $api->call('foo'));
 		$this->assertTrue(in_array(setlocale(LC_MONETARY, 0), ['pt', 'pt_BR', 'pt_BR.UTF-8', 'pt_BR.UTF8', 'pt_BR.ISO8859-1']));
 		$this->assertTrue(in_array(setlocale(LC_NUMERIC, 0), ['pt', 'pt_BR', 'pt_BR.UTF-8', 'pt_BR.UTF8', 'pt_BR.ISO8859-1']));
 		$this->assertTrue(in_array(setlocale(LC_TIME, 0), ['pt', 'pt_BR', 'pt_BR.UTF-8', 'pt_BR.UTF8', 'pt_BR.ISO8859-1']));
-		$this->assertSame($originalLocale, setlocale(LC_CTYPE, 0));
+
+		// should still be the result from App::setLanguage()
+		// while all above are changed according to the user language
+		// via Api::setLocale()
+		$this->assertTrue(in_array(setlocale(LC_CTYPE, 0), ['de', 'de_DE', 'de_DE.UTF-8', 'de_DE.UTF8', 'de_DE.ISO8859-1']));
 	}
 
 	public function testCallLocaleSingleLang1(): void
 	{
-		setlocale(LC_ALL, 'C');
 		$this->assertSame('C', setlocale(LC_ALL, 0));
-
 		$this->assertSame('something', $this->api->call('foo'));
 		$this->assertSame('de_DE.UTF-8', setlocale(LC_ALL, 0));
 	}

--- a/tests/Cms/App/AppTranslationsTest.php
+++ b/tests/Cms/App/AppTranslationsTest.php
@@ -18,15 +18,7 @@ class AppTranslationsTest extends TestCase
 
 	public function setUp(): void
 	{
-		$constants = [
-			LC_ALL, LC_COLLATE, LC_CTYPE, LC_MONETARY,
-			LC_NUMERIC, LC_TIME, LC_MESSAGES
-		];
-
-		// make a backup of the current locale
-		foreach ($constants as $constant) {
-			$this->locale[$constant] = setlocale($constant, '0');
-		}
+		$this->locale = Locale::get();
 
 		// test which locale suffix the system supports
 		setlocale(LC_ALL, 'de_DE.' . $this->localeSuffix);

--- a/tests/Cms/Sections/FilesSectionTest.php
+++ b/tests/Cms/Sections/FilesSectionTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Exception;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
+use Kirby\Toolkit\Locale;
 
 class FilesSectionTest extends TestCase
 {
@@ -334,7 +335,7 @@ class FilesSectionTest extends TestCase
 	{
 		$this->app->impersonate('kirby');
 
-		$locale = setlocale(LC_ALL, 0);
+		$locale = Locale::get();
 		setlocale(LC_ALL, ['de_DE.ISO8859-1', 'de_DE']);
 
 		$model = new Page([
@@ -391,7 +392,7 @@ class FilesSectionTest extends TestCase
 		$this->assertSame('b.jpg', $section->data()[1]['filename']);
 		$this->assertSame('ä.jpg', $section->data()[2]['filename']);
 
-		setlocale(LC_ALL, $locale);
+		Locale::set($locale);
 	}
 
 	public function testSortable(): void

--- a/tests/Cms/Sections/PagesSectionTest.php
+++ b/tests/Cms/Sections/PagesSectionTest.php
@@ -7,6 +7,7 @@ use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Panel\Model;
 use Kirby\TestCase;
+use Kirby\Toolkit\Locale;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class PagesSectionTest extends TestCase
@@ -315,7 +316,7 @@ class PagesSectionTest extends TestCase
 
 	public function testSortBy(): void
 	{
-		$locale = setlocale(LC_ALL, 0);
+		$locale = Locale::get();
 		setlocale(LC_ALL, ['de_DE.ISO8859-1', 'de_DE']);
 
 		$page = new Page([
@@ -376,7 +377,7 @@ class PagesSectionTest extends TestCase
 		$this->assertSame('B', $section->data()[1]['text']);
 		$this->assertSame('Ä', $section->data()[2]['text']);
 
-		setlocale(LC_ALL, $locale);
+		Locale::set($locale);
 	}
 
 	public function testSortByMultiple(): void

--- a/tests/Data/TxtTest.php
+++ b/tests/Data/TxtTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Data;
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use Kirby\Toolkit\Locale;
 use PHPUnit\Framework\Attributes\CoversClass;
 use stdClass;
 
@@ -143,7 +144,7 @@ class TxtTest extends TestCase
 
 	public function testEncodeFloatWithLocaleSetting(): void
 	{
-		$currentLocale = setlocale(LC_ALL, 0);
+		$currentLocale = Locale::get();
 		setlocale(LC_ALL, 'de_DE');
 
 		$data = Txt::encode([
@@ -152,7 +153,7 @@ class TxtTest extends TestCase
 
 		$this->assertSame('Number: 3.2', $data);
 
-		setlocale(LC_ALL, $currentLocale);
+		Locale::set($currentLocale);
 	}
 
 	public function testDecodeFile(): void

--- a/tests/Data/YamlSymfonyTest.php
+++ b/tests/Data/YamlSymfonyTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Data;
 use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use Kirby\Toolkit\Locale;
 use PHPUnit\Framework\Attributes\CoversClass;
 use stdClass;
 
@@ -72,7 +73,7 @@ class YamlSymfonyTest extends TestCase
 
 	public function testEncodeFloatWithNonUSLocale(): void
 	{
-		$locale = setlocale(LC_ALL, 0);
+		$locale = Locale::get();
 
 		setlocale(LC_ALL, 'de_DE');
 
@@ -82,7 +83,7 @@ class YamlSymfonyTest extends TestCase
 
 		$this->assertSame('number: 3.2' . PHP_EOL, $data);
 
-		setlocale(LC_ALL, $locale);
+		Locale::set($locale);
 	}
 
 	public function testEncodeNodeTypes(): void

--- a/tests/Data/YamlTest.php
+++ b/tests/Data/YamlTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Data;
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
+use Kirby\Toolkit\Locale;
 use PHPUnit\Framework\Attributes\CoversClass;
 use stdClass;
 
@@ -61,8 +62,7 @@ class YamlTest extends TestCase
 
 	public function testEncodeFloatWithNonUSLocale(): void
 	{
-		$locale = setlocale(LC_ALL, 0);
-
+		$locale = Locale::get();
 		setlocale(LC_ALL, 'de_DE');
 
 		$data = Yaml::encode([
@@ -71,7 +71,7 @@ class YamlTest extends TestCase
 
 		$this->assertSame('number: 3.2' . PHP_EOL, $data);
 
-		setlocale(LC_ALL, $locale);
+		Locale::set($locale);
 	}
 
 	public function testEncodeNodeTypes(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,7 @@ use Kirby\PhpUnitExtension;
 error_reporting(E_ALL);
 ini_set('display_errors', 'on');
 ini_set('display_startup_errors', 'on');
+setlocale(LC_ALL, 'C');
 
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/PhpUnitExtension.php';


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

- Set a common locale for tests in boostrap
- Use `Locale::get()` and `Local::set()` to store and restore locale across tests