### PR TITLE
fix: Ensure `Remote::json()` return types

### DIFF
--- a/src/Http/Remote.php
+++ b/src/Http/Remote.php
@@ -310,7 +310,18 @@ class Remote
 	 */
 	public function json(bool $array = true): array|stdClass|null
 	{
-		return json_decode($this->content(), $array);
+		if ($content = $this->content()) {
+			$json = json_decode($content, $array);
+
+			if (
+				is_array($json) === true ||
+				$json instanceof stdClass === true
+			) {
+				return $json;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/tests/Http/RemoteTest.php
+++ b/tests/Http/RemoteTest.php
@@ -7,6 +7,7 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use stdClass;
 
 #[CoversClass(Remote::class)]
 class RemoteTest extends TestCase
@@ -180,6 +181,15 @@ class RemoteTest extends TestCase
 		$options = $request->options();
 		$this->assertSame('different-value', $options['key']);
 		$this->assertFalse($options['body']);
+
+		// reset app options
+		new App(
+			[
+				'options' => [
+					'remote' => []
+				]
+			]
+		);
 	}
 
 	public function testContent(): void
@@ -233,6 +243,26 @@ class RemoteTest extends TestCase
 	{
 		$request = new Remote('https://getkirby.com');
 		$this->assertSame([], $request->info());
+	}
+
+	public function testJson(): void
+	{
+		$request = new Remote('https://getkirby.com');
+		$this->assertNull($request->json());
+
+		$request = new Remote('https://getkirby.com');
+		$request->content = '{"foo":"bar"}';
+		$this->assertSame(['foo' => 'bar'], $request->json(array: true));
+
+		$request = new Remote('https://getkirby.com');
+		$request->content = '{"foo":"bar"}';
+		$json = $request->json(array: false);
+		$this->assertInstanceOf(stdClass::class, $json);
+		$this->assertSame('bar', $json->foo);
+
+		$request = new Remote('https://getkirby.com');
+		$request->content = '5';
+		$this->assertNull($request->json());
 	}
 
 	public function testPatch(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

- Ensure that setting remote options in one unit test doesn't spill over into other tests
- Ensure that `Remote::json()` really always only returns `array|stdClass|null` and no type error


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Prevent error when calling `Remote::json()` with single-value JSON content (e.g. a single string, single int)

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion