### PR TITLE
fix: Populate UUID cache on model actions

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -90,6 +90,8 @@ trait FileActions
 			$newFile->parent()->files()->remove($oldFile->id());
 			$newFile->parent()->files()->set($newFile->id(), $newFile);
 
+			$newFile->uuid()?->populate();
+
 			return $newFile;
 		});
 	}
@@ -189,6 +191,7 @@ trait FileActions
 		// overwrite with new UUID (remove old, add new)
 		if (Uuids::enabled() === true) {
 			$copy = $copy->save(['uuid' => Uuid::generate()]);
+			$copy->uuid()->populate();
 		}
 
 		return $copy;
@@ -291,6 +294,8 @@ trait FileActions
 
 			// store the content if necessary
 			$file->changeStorage($storage);
+
+			$file->uuid()?->populate();
 
 			// return a fresh clone
 			return $file->clone();

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -119,7 +119,7 @@ trait PageActions
 			]);
 
 			// clear UUID cache recursively (for children and files as well)
-			$oldPage->uuid()?->clear(true);
+			$oldPage->uuid()?->clear(recursive: true);
 
 			if ($oldPage->exists() === true) {
 				// actually move stuff on disk
@@ -141,6 +141,8 @@ trait PageActions
 
 				Dir::remove($oldPage->mediaRoot());
 			}
+
+			$newPage->uuid()?->populate(recursive: true);
 
 			return $newPage;
 		});
@@ -422,6 +424,8 @@ trait PageActions
 			parent: $parentModel
 		);
 
+		$copy->uuid()?->populate(recursive: true);
+
 		return $copy;
 	}
 
@@ -486,6 +490,8 @@ trait PageActions
 		if (isset($props['num']) === true) {
 			$page = $page->changeStatus('listed', $props['num']);
 		}
+
+		$page->uuid()?->populate();
 
 		return $page;
 	}
@@ -583,7 +589,7 @@ trait PageActions
 			$page->changeStorage(ImmutableMemoryStorage::class);
 
 			// clear UUID cache
-			$page->uuid()?->clear();
+			$page->uuid()?->clear(recursive: true);
 
 			// Explanation: The two while loops below are only
 			// necessary because our property caches result in
@@ -696,6 +702,8 @@ trait PageActions
 					key: 'page.move.notFound'
 				);
 			}
+
+			$newPage->uuid()?->populate(recursive: true);
 
 			return $newPage;
 		});

--- a/src/Uuid/PageUuid.php
+++ b/src/Uuid/PageUuid.php
@@ -26,6 +26,25 @@ class PageUuid extends ModelUuid
 	public Identifiable|null $model = null;
 
 	/**
+	 * Removes the current UUID from cache,
+	 * recursively including all children if needed
+	 */
+	public function clear(bool $recursive = false): bool
+	{
+		/**
+		 * If $recursive, also clear UUIDs from cache for all children
+		 * @var \Kirby\Cms\Page $model
+		 */
+		if ($recursive === true && $model = $this->model()) {
+			foreach ($model->children() as $child) {
+				$child->uuid()->clear(true);
+			}
+		}
+
+		return parent::clear();
+	}
+
+	/**
 	 * Looks up UUID in cache and resolves
 	 * to page object
 	 */
@@ -53,6 +72,27 @@ class PageUuid extends ModelUuid
 			yield $page;
 			yield from static::index($page);
 		}
+	}
+
+	/**
+	 * Feeds the UUID for the page (and optionally
+	 * its children) into the cache
+	 */
+	public function populate(
+		bool $force = false,
+		bool $recursive = false
+	): bool {
+		/**
+		 * If $recursive, also populate UUIDs for all children
+		 * @var \Kirby\Cms\Page $model
+		 */
+		if ($recursive === true && $model = $this->model()) {
+			foreach ($model->children() as $child) {
+				$child->uuid()->populate($force, true);
+			}
+		}
+
+		return parent::populate($force);
 	}
 
 	/**

--- a/src/Uuid/Uuid.php
+++ b/src/Uuid/Uuid.php
@@ -100,18 +100,8 @@ abstract class Uuid implements Stringable
 	 * Removes the current UUID from cache,
 	 * recursively including all children if needed
 	 */
-	public function clear(bool $recursive = false): bool
+	public function clear(): bool
 	{
-		// For all models with children: if $recursive,
-		// also clear UUIDs from cache for all children
-		if ($recursive === true && $model = $this->model()) {
-			if (method_exists($model, 'children') === true) {
-				foreach ($model->children() as $child) {
-					$child->uuid()->clear(true);
-				}
-			}
-		}
-
 		if ($key = $this->key()) {
 			return Uuids::cache()->remove($key);
 		}

--- a/tests/Uuid/IdentifiableModelActionsTest.php
+++ b/tests/Uuid/IdentifiableModelActionsTest.php
@@ -42,7 +42,7 @@ class IdentifiableModelActionsTest extends TestCase
 
 		$this->app->impersonate('kirby');
 		$page->changeSlug('page-c');
-		$this->assertFalse($uuid->isCached());
+		$this->assertTrue($uuid->isCached());
 	}
 
 	public function testPageDelete(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

- [x] Unit tests

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- UUID cache gets populated on model actions (e.g. page creation)
https://github.com/getkirby/kirby/issues/7682


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion