### PR TITLE
lab: `css('@snippets')`

### DIFF
--- a/src/Cms/Url.php
+++ b/src/Cms/Url.php
@@ -4,6 +4,8 @@ namespace Kirby\Cms;
 
 use Kirby\Filesystem\F;
 use Kirby\Http\Url as BaseUrl;
+use Kirby\Template\Snippet;
+use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
 
 /**
@@ -50,6 +52,25 @@ class Url extends BaseUrl
 	): string {
 		$maxlength = App::instance()->option('slugs.maxlength', 255);
 		return Str::slug($string, $separator, $allowed, $maxlength);
+	}
+
+	public static function toSnippetsAssets(
+		string $assetPath,
+		string $extension
+	): array {
+		$kirby    = App::instance();
+		$snippets = A::map(
+			array_keys(Snippet::$cache),
+			function (string $snippet) use ($assetPath, $extension, $kirby) {
+				var_dump($assetPath . '/' . $snippet . '.' . $extension);
+				$path  = $assetPath . '/' . $snippet . '.' . $extension;
+				$file  = $kirby->root('assets') . '/' . $path;
+				$url   = $kirby->url('assets') . '/' . $path;
+				return file_exists($file) === true ? $url : null;
+			}
+		);
+
+		return array_filter($snippets);
 	}
 
 	/**


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

I need your opinions on this one:
It has been requested a few times to have something like `css('@auto')` but for snippets, not just templates (https://feedback.getkirby.com/535).

This PR kind of achieves this by introducing a new `css('@snippets')`. And the first draft seems to work relatively well without too much code overhead. 

However, it only works when placed at the bottom of the template. Or to phrase it differently: It can only automatically include assets for a snippet that has already been called before the `css('@snippets')` call. It isn't aware of snippets that follow after it. Which for JS is less relevant as that most often gets placed right before the `</body>` tag, but for CSS it would mean that a second call (aside from the usual one inside `<head>`) would have to be placed there as well if one wants to use this feature.

Given the, I am not so sure about the usefulness of this feature. It's a little quirky. Then again, especially for block snippets that could be quite relevant.