### PR TITLE
deprecate: `Kirby\Http\Url::to()`

### DIFF
--- a/src/Http/Url.php
+++ b/src/Http/Url.php
@@ -241,6 +241,7 @@ class Url
 
 	/**
 	 * Smart resolver for internal and external urls
+	 * @deprecated 5.3.0 Use `Kirby\Cms\Url::to()` instead
 	 */
 	public static function to(
 		string|null $path = null,


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

If we really want to merge `Kirby\Cms\Url` into `Kirby\Http\Url` eventually, this method name currently clashes. Looking across our own code, it seems like we are exclusively using `Kirby\Cms\Url::to()`. So maybe we should start deprecating the other one, so we can eventually replace it/merge the classes.

What do you think?

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ☠️ Deprecated
<!-- 
e.g. Deprecate method X. Use method Y instead.
-->
- `Kirby\Http\Url::to()` has been deprecated. Use `Kirby\Cms\Url::to()`  instead

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion