### PR TITLE
refact: Show empty blueprint info only in debug

### DIFF
--- a/panel/src/components/Sections/Sections.vue
+++ b/panel/src/components/Sections/Sections.vue
@@ -1,6 +1,6 @@
 <template>
 	<k-box
-		v-if="tab.columns.length === 0"
+		v-if="tab.columns.length === 0 && empty"
 		:html="true"
 		:text="empty"
 		theme="info"

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -43,7 +43,11 @@
 		<k-sections
 			:blueprint="blueprint"
 			:content="content"
-			:empty="$t('file.blueprint', { blueprint: $esc(blueprint) })"
+			:empty="
+				$panel.config.debug
+					? $t('file.blueprint', { blueprint: $esc(blueprint) })
+					: null
+			"
 			:lock="lock"
 			:parent="api"
 			:tab="tab"

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -36,7 +36,11 @@
 		<k-sections
 			:blueprint="blueprint"
 			:content="content"
-			:empty="$t('page.blueprint', { blueprint: $esc(blueprint) })"
+			:empty="
+				$panel.config.debug
+					? $t('page.blueprint', { blueprint: $esc(blueprint) })
+					: null
+			"
 			:lock="lock"
 			:parent="api"
 			:tab="tab"

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -40,7 +40,7 @@
 		<k-sections
 			:blueprint="blueprint"
 			:content="content"
-			:empty="$t('site.blueprint')"
+			:empty="$panel.config.debug ? $t('site.blueprint') : null"
 			:lock="lock"
 			:tab="tab"
 			parent="site"

--- a/panel/src/components/Views/Preview/PreviewForm.vue
+++ b/panel/src/components/Views/Preview/PreviewForm.vue
@@ -24,7 +24,11 @@
 			<k-sections
 				:blueprint="blueprint"
 				:content="content"
-				:empty="$t('page.blueprint', { blueprint: $esc(blueprint) })"
+				:empty="
+					$panel.config.debug
+						? $t('page.blueprint', { blueprint: $esc(blueprint) })
+						: null
+				"
 				:lock="lock"
 				:parent="api"
 				:tab="tab"

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -57,7 +57,11 @@
 		<k-sections
 			:blueprint="blueprint"
 			:content="content"
-			:empty="$t('user.blueprint', { blueprint: $esc(blueprint) })"
+			:empty="
+				$panel.config.debug
+					? $t('user.blueprint', { blueprint: $esc(blueprint) })
+					: null
+			"
 			:lock="lock"
 			:parent="api"
 			:tab="tab"


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- Panel only shows missing blueprint info when debug mode is active 
https://feedback.getkirby.com/392



## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion