### PR TITLE
fix: `k-page-tree` loading spinner

### DIFF
--- a/panel/src/components/Navigation/PageTree.vue
+++ b/panel/src/components/Navigation/PageTree.vue
@@ -30,6 +30,9 @@ export default {
 		if (this.items) {
 			this.state = this.items;
 		} else {
+			// temporarily add an item to show loading spinner
+			this.state = [{ icon: "loader" }];
+
 			// load top-level items (e.g. only site)
 			const items = await this.load(null);
 			await this.open(items[0]);


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Within the constraints of the page tree component, this seems to be a fair compromise to show any indication that loading is happening:

<img width="554" height="248" alt="Screenshot 2025-12-22 at 22 45 40" src="https://github.com/user-attachments/assets/42ec9eb5-eaa2-4adb-b0e9-9f775a82ac05" />

One could also do

```js
this.state = [{ icon: "blank", hasChildren: true, loading: true }];
```

but then the spinner is tiny

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Page move dialog: show spinner while loading
https://feedback.getkirby.com/652

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion