### PR TITLE
feat: `$visitor->ip(hash: true)`

### DIFF
--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -351,6 +351,7 @@ class Auth
 	/**
 	 * Returns the hashed ip of the visitor
 	 * which is used to track invalid logins
+	 * @deprecated 5.3.0 Use `$visitor->ip(hash: true)` instead. Will be removed in Kirby 6.
 	 */
 	public function ipHash(): string
 	{
@@ -365,7 +366,7 @@ class Auth
 	 */
 	public function isBlocked(string $email): bool
 	{
-		$ip     = $this->ipHash();
+		$ip     = $this->kirby->visitor()->ip(hash: true);
 		$log    = $this->log();
 		$trials = $this->kirby->option('auth.trials', 10);
 
@@ -669,7 +670,7 @@ class Auth
 			$this->kirby->trigger('user.login:failed', compact('email'));
 		}
 
-		$ip   = $this->ipHash();
+		$ip   = $this->kirby->visitor()->ip(hash: true);
 		$log  = $this->log();
 		$time = time();
 

--- a/src/Http/Visitor.php
+++ b/src/Http/Visitor.php
@@ -158,6 +158,31 @@ class Visitor
 	}
 
 	/**
+	 * Sets the ip address if provided
+	 * or returns the ip of the current
+	 * visitor otherwise
+	 *
+	 * @return $this|string|null
+	 */
+	public function ip(
+		string|null $ip = null,
+		bool $hash = false
+	): static|string|null {
+		if ($ip === null) {
+			if ($hash === true) {
+				// only use the first 50 chars to ensure privacy
+				$hash = hash('sha256', $this->ip);
+				return substr($hash, 0, 50);
+			}
+
+			return $this->ip;
+		}
+
+		$this->ip = $ip;
+		return $this;
+	}
+
+	/**
 	 * Returns the MIME type from the provided list that
 	 * is most accepted (= preferred) by the visitor
 	 * @since 3.3.0
@@ -193,23 +218,6 @@ class Visitor
 	{
 		$preferred = $this->preferredMimeType('application/json', 'text/html');
 		return $preferred === 'application/json';
-	}
-
-	/**
-	 * Sets the ip address if provided
-	 * or returns the ip of the current
-	 * visitor otherwise
-	 *
-	 * @return $this|string|null
-	 */
-	public function ip(string|null $ip = null): static|string|null
-	{
-		if ($ip === null) {
-			return $this->ip;
-		}
-
-		$this->ip = $ip;
-		return $this;
 	}
 
 	/**

--- a/tests/Http/VisitorTest.php
+++ b/tests/Http/VisitorTest.php
@@ -47,6 +47,14 @@ class VisitorTest extends TestCase
 		$this->assertSame('192.168.1.1', $visitor->ip());
 	}
 
+	public function testIpHash(): void
+	{
+		$visitor = new Visitor();
+		$visitor->ip('192.168.1.1');
+		$this->assertSame('192.168.1.1', $visitor->ip());
+		$this->assertSame('c5eb5a4cc76a5cdb16e79864b9ccd26c3553f0c396d0a21baf', $visitor->ip(hash: true));
+	}
+
 	public function testUserAgent(): void
 	{
 		$visitor = new Visitor();


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

We want to use this in the Hub as well, so ;et's move it out of the `Auth` class and turn it into a regular `Visitor` class feature.

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- `$visitor->ip()` supports new `$hash` parameter to retrieve a 50 char long hash of the visitor's IP

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion