### PR TITLE
[License 2] feat: `License::register()` for free licenses

### DIFF
--- a/src/Cms/License.php
+++ b/src/Cms/License.php
@@ -449,7 +449,10 @@ class License
 	{
 		// @codeCoverageIgnoreStart
 		$response = Remote::get(static::hub() . '/' . $path, [
-			'data' => $data
+			'data'    => $data,
+			'headers' => [
+				'Kirby-Version' => $this->kirby->version()
+			]
 		]);
 
 		// handle request errors

--- a/src/Cms/License.php
+++ b/src/Cms/License.php
@@ -54,7 +54,7 @@ class License
 		}
 
 		if ($code === LicenseType::Free->prefix()) {
-			$this->email ??= 'mail@getkirby.com';
+			$this->email ??= 'licensing@getkirby.com';
 		}
 
 		$this->kirby = App::instance();

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -390,8 +390,10 @@ class System
 	 * @throws \Kirby\Exception\Exception
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
-	public function register(string|null $license = null, string|null $email = null): bool
-	{
+	public function register(
+		string|null $license = null,
+		string|null $email = null
+	): bool {
 		$license = new License(
 			code: $license,
 			domain: $this->indexUrl(),

--- a/tests/Cms/System/LicenseTest.php
+++ b/tests/Cms/System/LicenseTest.php
@@ -56,6 +56,12 @@ class LicenseTest extends TestCase
 
 		$this->assertSame($code, $license->code());
 		$this->assertSame('K-ENT-1234XXXXXXXXXXXXXXXXXXXXXX', $license->code(true));
+
+		$license = new License(
+			code: $code = LicenseType::Free->prefix()
+		);
+
+		$this->assertNUll($license->code());
 	}
 
 	public function testContent(): void
@@ -153,6 +159,56 @@ class LicenseTest extends TestCase
 		$this->assertTrue($license->isComplete());
 	}
 
+	public function testIsFree(): void
+	{
+		$license = new License(
+			code: $this->code(LicenseType::Basic),
+		);
+
+		$this->assertFalse($license->isFree());
+
+		$license = new License(
+			code: LicenseType::Free->prefix()
+		);
+
+		$this->assertTrue($license->isFree());
+	}
+
+	public function testIsFreeAndLocal(): void
+	{
+		// local
+		$this->app->clone([
+			'server' => [
+				'REMOTE_ADDR' => '127.0.0.1',
+			]
+		]);
+
+		$license = new License(
+			code: LicenseType::Free->prefix()
+		);
+
+		$this->assertTrue($license->isFreeAndLocal());
+
+		$license = new License(
+			code: $this->code(LicenseType::Basic)
+		);
+
+		$this->assertFalse($license->isFreeAndLocal());
+
+		// not local
+		$this->app->clone([
+			'server' => [
+				'REMOTE_ADDR' => '1.2.3.4',
+			]
+		]);
+
+		$license = new License(
+			code: LicenseType::Free->prefix()
+		);
+
+		$this->assertFalse($license->isFreeAndLocal());
+	}
+
 	public function testIsInactive(): void
 	{
 		MockTime::$time = strtotime('now');
@@ -236,6 +292,21 @@ class LicenseTest extends TestCase
 		$this->assertTrue($license->isOnCorrectDomain());
 	}
 
+	public function testIsSignedFreeAndLocal(): void
+	{
+		$this->app->clone([
+			'server' => [
+				'REMOTE_ADDR' => '127.0.0.1',
+			]
+		]);
+
+		$license = new License(
+			code: LicenseType::Free->prefix()
+		);
+
+		$this->assertTrue($license->isSigned());
+	}
+
 	public function testLabel(): void
 	{
 		$license = new License();
@@ -313,6 +384,33 @@ class LicenseTest extends TestCase
 
 		$license = License::read();
 		$this->assertNull($license->code());
+	}
+
+	public function testRegisterFreeAndLocal(): void
+	{
+		$this->app->clone([
+			'options' => [
+				'url' => 'https://sandbox.test',
+			],
+			'server' => [
+				'REMOTE_ADDR' => '127.0.0.1',
+			]
+		]);
+
+		$license = new License(
+			code:   LicenseType::Free->prefix(),
+			domain: 'sandbox.test'
+		);
+
+		$license->register();
+
+		$system  = new System($this->app);
+		$license = $system->license();
+
+		$this->assertSame('sandbox.test', $license->domain());
+		$this->assertSame(LicenseStatus::Acknowledged, $license->status());
+		$this->assertSame(LicenseType::Free, $license->type());
+		$this->assertTrue($license->isComplete());
 	}
 
 	public function testRegisterWithInvalidDomain(): void
@@ -398,6 +496,15 @@ class LicenseTest extends TestCase
 	{
 		$license = new License();
 		$this->assertSame(LicenseStatus::Missing, $license->status());
+	}
+
+	public function testTypeFree(): void
+	{
+		$license = new License(
+			code: 'FREE'
+		);
+
+		$this->assertSame(LicenseType::Free, $license->type());
 	}
 
 	public function testTypeKirby3(): void

--- a/tests/Cms/System/LicenseTest.php
+++ b/tests/Cms/System/LicenseTest.php
@@ -292,21 +292,6 @@ class LicenseTest extends TestCase
 		$this->assertTrue($license->isOnCorrectDomain());
 	}
 
-	public function testIsSignedFreeAndLocal(): void
-	{
-		$this->app->clone([
-			'server' => [
-				'REMOTE_ADDR' => '127.0.0.1',
-			]
-		]);
-
-		$license = new License(
-			code: LicenseType::Free->prefix()
-		);
-
-		$this->assertTrue($license->isSigned());
-	}
-
 	public function testLabel(): void
 	{
 		$license = new License();

--- a/tests/Cms/System/UpdateStatusTest.php
+++ b/tests/Cms/System/UpdateStatusTest.php
@@ -12,7 +12,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionProperty;
 
 #[CoversClass(UpdateStatus::class)]
-#[CoversClass(UpdateStatus::class)]
 class UpdateStatusTest extends TestCase
 {
 	public const FIXTURES = __DIR__ . '/fixtures/UpdateStatusTest';


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

- Create unsigned local license file if free license and system is local (do not require a signature in this case)
- Get payload from Hub for free license otherwise (depends https://github.com/getkirby/hub.getkirby.com/pull/113 on the Hub end - but that depends on the other PR we merged, we should consider if we want to patch in the `LicenseStatus` and `LicenseType` changes to the Hub already ahead of 5.3 release to be able to merge the Hub PRs)
- Send the Kirby version to the Hub with the register request

### Merge first

- [x] https://github.com/getkirby/kirby/pull/7819