### PR TITLE
fix(slug-field): Apply language rules on initial value

### DIFF
--- a/panel/src/components/Forms/Input/SlugInput.vue
+++ b/panel/src/components/Forms/Input/SlugInput.vue
@@ -76,13 +76,16 @@ export default {
 			deep: true,
 			immediate: true
 		},
-		value(newValue) {
-			newValue = this.sluggify(newValue);
+		value: {
+			handler(newValue) {
+				newValue = this.sluggify(newValue);
 
-			if (newValue !== this.slug) {
-				this.slug = newValue;
-				this.$emit("input", this.slug);
-			}
+				if (newValue !== this.slug) {
+					this.slug = newValue;
+					this.$emit("input", this.slug);
+				}
+			},
+			immediate: true
 		}
 	},
 	methods: {


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

The slug field wasn't converting special characters (ä→ae, ü→ue) when initialized with a default value. It only worked when typing manually.

The issue was that sluggify() was called in data() before this.slugs was available. The value watcher now runs immediately on component mount to ensure slugs are generated with proper language rules.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Filename field bug in upload dialog #7662

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion