### PR TITLE
feat: Buttons field

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -9,7 +9,11 @@
 	"alpha": "Alpha",
 	"author": "Author",
 	"avatar": "Profile picture",
+
 	"back": "Back",
+
+	"buttons.empty": "No buttons",
+
 	"cancel": "Cancel",
 	"change": "Change",
 	"close": "Close",

--- a/panel/src/components/Forms/Field/ButtonsField.vue
+++ b/panel/src/components/Forms/Field/ButtonsField.vue
@@ -48,10 +48,10 @@ export default {
 	--button-align: start;
 	--button-height: var(--input-height);
 	--button-width: 100%;
-	box-shadow: var(--item-shadow);
 }
 .k-buttons-field .k-button:not([data-theme]) {
 	--button-color-back: var(--item-color-back);
+	box-shadow: var(--shadow);
 }
 .k-buttons-field .k-button .k-button-arrow {
 	margin-inline-start: auto;

--- a/panel/src/components/Forms/Field/ButtonsField.vue
+++ b/panel/src/components/Forms/Field/ButtonsField.vue
@@ -1,0 +1,60 @@
+<template>
+	<k-field
+		:id="id"
+		:help="help"
+		:input="false"
+		:label="label"
+		:name="name"
+		type="buttons"
+		class="k-buttons-field"
+	>
+		<k-button-group v-if="buttons.length > 0">
+			<k-button
+				v-for="button in buttons"
+				:key="button.link ?? button.dialog ?? button.drawer"
+				v-bind="button"
+				:dropdown="true"
+				variant="filled"
+			/>
+		</k-button-group>
+
+		<k-empty v-else icon="bars">{{ $t("buttons.empty") }}</k-empty>
+	</k-field>
+</template>
+
+<script>
+import { help, id, label, name } from "@/mixins/props.js";
+
+/**
+ * @since 6.0.0
+ * @example <k-buttons-field label="Buttons" :buttons="buttons" />
+ */
+export default {
+	mixins: [help, id, label, name],
+	props: {
+		buttons: {
+			type: Array,
+			default: () => []
+		}
+	}
+};
+</script>
+
+<style>
+.k-buttons-field .k-button-group {
+	gap: var(--spacing-1);
+}
+.k-buttons-field .k-button {
+	--button-align: start;
+	--button-height: var(--input-height);
+	--button-width: 100%;
+	box-shadow: var(--item-shadow);
+}
+.k-buttons-field .k-button:not([data-theme]) {
+	--button-color-back: var(--item-color-back);
+}
+.k-buttons-field .k-button .k-button-arrow {
+	margin-inline-start: auto;
+	transform: rotate(-90deg);
+}
+</style>

--- a/panel/src/components/Forms/Field/ButtonsField.vue
+++ b/panel/src/components/Forms/Field/ButtonsField.vue
@@ -42,7 +42,7 @@ export default {
 
 <style>
 .k-buttons-field .k-button-group {
-	gap: var(--spacing-1);
+	gap: 2px;
 }
 .k-buttons-field .k-button {
 	--button-align: start;

--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -1,4 +1,5 @@
 import BlocksField from "./BlocksField.vue";
+import ButtonsField from "./ButtonsField.vue";
 import CheckboxesField from "./CheckboxesField.vue";
 import ColorField from "./ColorField.vue";
 import DateField from "./DateField.vue";
@@ -43,6 +44,7 @@ import LegacyUsersField from "./LegacyUsersField.vue";
 export default {
 	install(app) {
 		app.component("k-blocks-field", BlocksField);
+		app.component("k-buttons-field", ButtonsField);
 		app.component("k-checkboxes-field", CheckboxesField);
 		app.component("k-color-field", ColorField);
 		app.component("k-date-field", DateField);

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -10,6 +10,7 @@ use Kirby\Cache\RedisCache;
 use Kirby\Cms\Auth\EmailChallenge;
 use Kirby\Cms\Auth\TotpChallenge;
 use Kirby\Form\Field\BlocksField;
+use Kirby\Form\Field\ButtonsField;
 use Kirby\Form\Field\CheckboxesField;
 use Kirby\Form\Field\ColorField;
 use Kirby\Form\Field\DateField;
@@ -248,6 +249,7 @@ class Core
 	{
 		return [
 			'blocks'      => BlocksField::class,
+			'buttons'     => ButtonsField::class,
 			'checkboxes'  => CheckboxesField::class,
 			'color'       => ColorField::class,
 			'date'        => DateField::class,

--- a/src/Form/Field/ButtonsField.php
+++ b/src/Form/Field/ButtonsField.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+/**
+ * Buttons field
+ *
+ * @package   Kirby Field
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class ButtonsField extends DisplayField
+{
+	/**
+	 * Array or query string for buttons
+	 */
+	protected array|string|null $buttons;
+
+	public function __construct(
+		array|string|null $label = null,
+		array|string|null $help = null,
+		string|null $name = null,
+		array|string|null $buttons = null,
+		array|null $when = null,
+		string|null $width = null
+	) {
+		parent::__construct(
+			label: $label,
+			help:  $help,
+			name:  $name,
+			when:  $when,
+			width: $width
+		);
+
+		$this->buttons = $buttons;
+	}
+
+	public function buttons(): array
+	{
+		if (is_string($this->buttons) === true) {
+			return $this->model()->query($this->buttons);
+		}
+
+		return $this->buttons ?? [];
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'buttons' => $this->buttons()
+		];
+	}
+}

--- a/tests/Form/Field/ButtonsFieldTest.php
+++ b/tests/Form/Field/ButtonsFieldTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Cms\Page;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+class MockPageForButtonsField extends Page
+{
+	public function buttons(): array
+	{
+		return [
+			['text' => 'Button A']
+		];
+	}
+}
+
+#[CoversClass(ButtonsField::class)]
+class ButtonsFieldTest extends TestCase
+{
+	public function testProps(): void
+	{
+		$field = $this->field('buttons');
+
+		$this->assertSame('buttons', $field->type());
+		$this->assertSame('buttons', $field->name());
+		$this->assertSame('Buttons', $field->label());
+		$this->assertSame([], $field->buttons());
+		$this->assertFalse($field->hasValue());
+
+		$props = $field->props();
+		$this->assertSame('Buttons', $props['label']);
+		$this->assertSame('buttons', $props['name']);
+		$this->assertSame('buttons', $props['type']);
+		$this->assertSame([], $props['buttons']);
+	}
+
+	public function testButtons(): void
+	{
+		$field = $this->field('buttons', [
+			'buttons' => $expected = [['text' => 'Button A']]
+		]);
+
+		$this->assertSame($expected, $field->buttons());
+
+		// as query
+		$field = $this->field('buttons', [
+			'model'   => new MockPageForButtonsField(['slug' => 'test']),
+			'buttons' => 'page.buttons'
+		]);
+
+		$this->assertSame($expected, $field->buttons());
+	}
+}


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features
<!-- 
e.g. New feature X which helps users to …
-->
- New `buttons` field to display (a list of) buttons to open a link, dialog or drawer

<img width="477" height="356" alt="Screenshot 2025-12-29 at 13 08 16" src="https://github.com/user-attachments/assets/5b535736-1ab3-46c9-9d49-07a5851943fe" />


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

```yaml
simple:
  type: buttons
  buttons:
    - text: Button A
      link: https://getkirby.com
    - text: Button B
      link: https://getkirby.com
    - text: Button C
      link: https://getkirby.com

icons:
  type: buttons
  buttons:
    - text: Button A
      icon: heart
      link: https://getkirby.com
    - text: Button B
      icon: star
      link: https://getkirby.com
    - text: Button C
      icon: badge
      link: https://getkirby.com
```


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
  - on the `feat/v6` branch of the sandbox
- [x] Add changes & docs to release notes draft in Notion