### PR TITLE
fix: Accept empty string as valid group key

### DIFF
--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -521,7 +521,7 @@ class Collection extends Iterator implements Stringable
 				$value = $field($item);
 
 				// make sure that there's always a proper value to group by
-				if (!$value) {
+				if ($value === null || $value === false) {
 					throw new Exception(
 						message: 'Invalid grouping value for key: ' . $key
 					);

--- a/tests/Cms/Collections/CollectionTest.php
+++ b/tests/Cms/Collections/CollectionTest.php
@@ -241,6 +241,19 @@ class CollectionTest extends TestCase
 		$this->assertCount(1, $groupB);
 	}
 
+	public function testGroupWithCallableEmptyString(): void
+	{
+		$collection = new Collection([
+			new MockObject(['id' => 'a', 'group' => '']),
+			new MockObject(['id' => 'b', 'group' => 'test']),
+		]);
+
+		$groups = $collection->group(fn ($item) => $item->group());
+
+		$this->assertCount(2, $groups);
+		$this->assertTrue($groups->has(''));
+	}
+
 	public function testIndexOfWithObject(): void
 	{
 		$collection = new Collection([


### PR DESCRIPTION
## Description

The group() method was throwing an exception when a callable returned an empty string, even though empty strings are valid array keys in PHP. This was inconsistent with grouping by field name, which already accepted empty strings.

Changed the validation to only reject null values, allowing empty strings, zero, and other falsy but valid values to be used as group keys.

Fixes #7733

## Changelog 

### 🐛 Bug fixes

- `$collection->group(callable)` should accept empty string result as key #7733

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion