### PR TITLE
[User performance 1] perf: Only load user credentials file once

### DIFF
--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -82,6 +82,10 @@ class User extends ModelWithContent
 		$this->password = $props['password'] ?? null;
 		$this->role     = $set('role', fn ($role) => Str::lower(trim($role)));
 
+		if (isset($props['credentials'])) {
+			$this->credentials = $props['credentials'];
+		}
+
 		// Set blueprint before setting content
 		// or translations in the parent constructor.
 		// Otherwise, the blueprint definition cannot be

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -145,8 +145,9 @@ class Users extends Collection
 
 			// create user model based on role
 			$user = User::factory([
-				'id'    => $userDirectory,
-				'model' => $credentials['role'] ?? null
+				'id'          => $userDirectory,
+				'model'       => $credentials['role'] ?? null,
+				'credentials' => is_array($credentials ?? null) ? $credentials : null
 			] + $inject);
 
 			$users->set($user->id(), $user);

--- a/tests/Cms/User/UserTest.php
+++ b/tests/Cms/User/UserTest.php
@@ -18,6 +18,17 @@ class UserTest extends ModelTestCase
 		$this->assertNull($user->avatar());
 	}
 
+	public function testCredentials(): void
+	{
+		$user = new User([
+			'credentials' => $credentials = [
+				'role' => 'editor'
+			]
+		]);
+
+		$this->assertSame($credentials, $user->credentials());
+	}
+
 	public function testId(): void
 	{
 		$user = new User([


### PR DESCRIPTION
## Performance

> All tested on my Mac mini M2 with PHP 8.4
> Timing values are TTFB measured using `h2load`:
> 296.49ms / 3.42s means "296 ms mean TTFB for 10 sequential requests, 3.42 s mean TTFB under load with 20 requests in parallel, 100 requests total" (numbers under load are better to compare because they fluctuate less during test executions)

### Frontend render using `$kirby->user()`

```
Baseline with 1 user:
23 ms

With 20000 users:
296.49ms / 3.42s @ Kirby 5.2.1
293.58ms / 3.10s @ PR 1 (Only load user credentials once)
```

### Starterkit site view

```
Baseline with 1 user:
75 ms

With 20000 users:
255.04ms / 2.79s @ Kirby 5.2.1
237.86ms / 2.73s @ PR 1 (Only load user credentials once)
```

### Users view

```
Baseline with 1 user:
65 ms

With 20000 users:
435.88ms / 4.88s @ Kirby 5.2.1
312.80ms / 3.30s @ PR 1 (Only load user credentials once)
```

### Account view (admin)

```
Baseline with 1 user:
70 ms

With 20000 users:
459.64ms / 5.38s @ Kirby 5.2.1
363.35ms / 4.34s @ PR 1 (Only load user credentials once)
```

### Account view (non-admin)

```
Baseline with 2 users:
75 ms

With 20000 users:
392.59ms / 4.79s @ Kirby 5.2.1
324.36ms / 3.67s @ PR 1 (Only load user credentials once)
```

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ⚡Performance
<!-- 
e.g. Improve a11y of feature X
-->

- User credentials (main data from `index.php`) are only loaded once when the user object is first created, improving system performance with many user accounts.

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

None

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion