### PR TITLE
[User performance 2] refact: Refactor `Iterator` class

### DIFF
--- a/src/Toolkit/Iterator.php
+++ b/src/Toolkit/Iterator.php
@@ -45,6 +45,8 @@ class Iterator implements Countable, IteratorAggregate
 
 	/**
 	 * Returns the current key
+	 * @deprecated
+	 * @todo Remove in v6
 	 */
 	public function key(): int|string|null
 	{
@@ -61,6 +63,8 @@ class Iterator implements Countable, IteratorAggregate
 
 	/**
 	 * Returns the current element
+	 * @deprecated
+	 * @todo Remove in v6
 	 * @return TValue
 	 */
 	public function current(): mixed
@@ -71,6 +75,8 @@ class Iterator implements Countable, IteratorAggregate
 	/**
 	 * Moves the cursor to the previous element
 	 * and returns it
+	 * @deprecated
+	 * @todo Remove in v6
 	 * @return TValue
 	 */
 	public function prev(): mixed
@@ -81,6 +87,8 @@ class Iterator implements Countable, IteratorAggregate
 	/**
 	 * Moves the cursor to the next element
 	 * and returns it
+	 * @deprecated
+	 * @todo Remove in v6
 	 * @return TValue
 	 */
 	public function next(): mixed
@@ -90,6 +98,8 @@ class Iterator implements Countable, IteratorAggregate
 
 	/**
 	 * Moves the cursor to the first element
+	 * @deprecated
+	 * @todo Remove in v6
 	 */
 	public function rewind(): void
 	{
@@ -98,6 +108,8 @@ class Iterator implements Countable, IteratorAggregate
 
 	/**
 	 * Checks if the current element is valid
+	 * @deprecated
+	 * @todo Remove in v6
 	 */
 	public function valid(): bool
 	{

--- a/src/Toolkit/Iterator.php
+++ b/src/Toolkit/Iterator.php
@@ -4,6 +4,7 @@ namespace Kirby\Toolkit;
 
 use ArrayIterator;
 use Countable;
+use Iterator as PhpIterator;
 use IteratorAggregate;
 
 /**
@@ -34,10 +35,10 @@ class Iterator implements Countable, IteratorAggregate
 	}
 
 	/**
-	 * Get an iterator for the items.
+	 * Returns an iterator for the elements
 	 * @return \ArrayIterator<TKey, TValue>
 	 */
-	public function getIterator(): ArrayIterator
+	public function getIterator(): PhpIterator
 	{
 		return new ArrayIterator($this->data);
 	}

--- a/src/Toolkit/Iterator.php
+++ b/src/Toolkit/Iterator.php
@@ -140,7 +140,7 @@ class Iterator implements Countable, IteratorAggregate
 	 */
 	public function has(mixed $key): bool
 	{
-		return isset($this->data[$key]) === true;
+		return array_key_exists($key, $this->data) === true;
 	}
 
 	/**

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -563,13 +563,6 @@ class CollectionTest extends TestCase
 		$this->assertSame(['a' => 2, 'b' => 4], $collection->data());
 	}
 
-	public function testNextAndPrev(): void
-	{
-		$this->assertSame('My second element', $this->collection->next());
-		$this->assertSame('My third element', $this->collection->next());
-		$this->assertSame('My second element', $this->collection->prev());
-	}
-
 	public function testNotAndWithout(): void
 	{
 		// remove elements

--- a/tests/Toolkit/IteratorTest.php
+++ b/tests/Toolkit/IteratorTest.php
@@ -17,16 +17,6 @@ class IteratorTest extends TestCase
 		$this->assertSame($expected, $iterator->data);
 	}
 
-	public function testKey(): void
-	{
-		$iterator = new Iterator([
-			'one' => 'eins',
-			'two' => 'zwei',
-		]);
-
-		$this->assertSame('one', $iterator->key());
-	}
-
 	public function testKeys(): void
 	{
 		$iterator = new Iterator([
@@ -40,64 +30,6 @@ class IteratorTest extends TestCase
 			'two',
 			'three'
 		], $iterator->keys());
-	}
-
-	public function testCurrent(): void
-	{
-		$iterator = new Iterator([
-			'one' => 'eins',
-			'two' => 'zwei',
-		]);
-
-		$this->assertSame('eins', $iterator->current());
-	}
-
-	public function testPrevNext(): void
-	{
-		$iterator = new Iterator([
-			'one'   => 'eins',
-			'two'   => 'zwei',
-			'three' => 'drei'
-		]);
-
-		$this->assertSame('eins', $iterator->current());
-
-		$iterator->next();
-		$this->assertSame('zwei', $iterator->current());
-
-		$iterator->next();
-		$this->assertSame('drei', $iterator->current());
-
-		$iterator->prev();
-		$this->assertSame('zwei', $iterator->current());
-
-		$iterator->prev();
-		$this->assertSame('eins', $iterator->current());
-	}
-
-	public function testRewind(): void
-	{
-		$iterator = new Iterator([
-			'one'   => 'eins',
-			'two'   => 'zwei',
-			'three' => 'drei'
-		]);
-
-		$iterator->next();
-		$iterator->next();
-		$this->assertSame('drei', $iterator->current());
-
-		$iterator->rewind();
-		$this->assertSame('eins', $iterator->current());
-	}
-
-	public function testValid(): void
-	{
-		$iterator = new Iterator([]);
-		$this->assertFalse($iterator->valid());
-
-		$iterator = new Iterator(['one' => 'eins']);
-		$this->assertTrue($iterator->valid());
 	}
 
 	public function testCount(): void

--- a/tests/Toolkit/IteratorTest.php
+++ b/tests/Toolkit/IteratorTest.php
@@ -17,6 +17,26 @@ class IteratorTest extends TestCase
 		$this->assertSame($expected, $iterator->data);
 	}
 
+	public function testIterate(): void
+	{
+		$iterator = new Iterator([
+			'one' => 'eins',
+			'two' => 'zwei',
+		]);
+
+		$i = 0;
+		$keys = $values = [];
+		foreach ($iterator as $key => $value) {
+			$keys[] = $key;
+			$values[] = $value;
+			$i++;
+		}
+
+		$this->assertSame(2, $i);
+		$this->assertSame(['one', 'two'], $keys);
+		$this->assertSame(['eins', 'zwei'], $values);
+	}
+
 	public function testKeys(): void
 	{
 		$iterator = new Iterator([


### PR DESCRIPTION
## Merge first

- [x] #7837 

## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

This PR combines a few minor refactorings:

- Widening the return value for `getIterator()` is needed as `LazyCollection` (PR 3) needs to return a more general `Iterator`, not an `ArrayIterator`; this change has no effect on code behavior
- Switching from `isset()` to `array_key_exists()` is needed as `LazyCollection` will have elements that are `null` because they are not yet loaded. But they are still valid elements of the collection. IMO it was a bug to use `isset()` here.
- The old iterator methods are a leftover from #2216. Before that PR, we implemented the `Iterator` interface, which requires all these separate methods. We switched to the `IteratorAggregate` interface, which uses `getIterator()` instead. The old methods are not used anywhere and are not useful either because they all depend on the internal array cursor (which is only useful during iteration). So deprecating these cleans up the code.
- Also added another test for iteration while I was at it.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->

- Child classes of `Iterator` (mostly collections) can now implement a custom iterator and are not pinned to `ArrayIterator`

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- `Iterator::has()` and the `has()` method of collections correctly treats an existing but `null` value as a valid collection element

### ☠️ Deprecated
<!-- 
e.g. Deprecate method X. Use method Y instead.
-->

- The following cursor-dependent methods of `Iterator` and collection classes have been deprecated and will be removed in Kirby 6: `key`, `current`, `next`, `prev`, `rewind` and `valid`

### 🧹 Housekeeping
<!-- 
e.g. Update JS dependencies
-->

- Improve `Iterator` PHPUnit tests

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion