### PR TITLE
[User performance 3] feat: New `LazyCollection` class

### DIFF
--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -167,7 +167,7 @@ class Collection extends BaseCollection
 		$groups = new self(parent: $this->parent());
 
 		if (is_string($field) === true) {
-			foreach ($this->data as $key => $item) {
+			foreach ($this as $key => $item) {
 				$value = $this->getAttribute($item, $field);
 
 				// make sure that there's always a proper value to group by

--- a/src/Cms/LazyCollection.php
+++ b/src/Cms/LazyCollection.php
@@ -1,0 +1,324 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Closure;
+use Iterator;
+
+/**
+ * The LazyCollection class is a variant of the CMS
+ * Collection that is only initialized with keys for
+ * each collection element. Collection values (= objects)
+ * are loaded and initialized lazily when they are
+ * first used.
+ *
+ * @package   Kirby Cms
+ * @author    Lukas Bestle <lukas@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ *
+ * @template TValue
+ * @extends \Kirby\Cms\Collection<TValue>
+ */
+abstract class LazyCollection extends Collection
+{
+	/**
+	 * Flag that tells whether hydration has been
+	 * completed for all collection elements;
+	 * this is used to increase performance
+	 */
+	protected bool $hydrated = false;
+
+	/**
+	 * Temporary auto-hydration whenever a collection
+	 * method is called; some methods may not need raw
+	 * access to all collection data, so performance
+	 * will be improved if methods call hydration
+	 * themselves only if they need it
+	 * @deprecated
+	 * @todo Remove this in v6
+	 */
+	public function __call(string $key, $arguments)
+	{
+		$this->hydrateAll();
+		return parent::__call($key, $arguments);
+	}
+
+	/**
+	 * Low-level getter for elements
+	 *
+	 * @return TValue|null
+	 */
+	public function __get(string $key)
+	{
+		$element = parent::__get($key);
+
+		// `$element === null` could mean "element does not exist"
+		// or "element found but not hydrated"
+		if ($element === null && array_key_exists($key, $this->data)) {
+			return $this->hydrateElement($key);
+		}
+
+		return $element;
+	}
+
+	/**
+	 * Returns the current element
+	 * @deprecated
+	 * @todo Remove in v6
+	 *
+	 * @return TValue
+	 */
+	public function current(): mixed
+	{
+		$current = parent::current();
+
+		// `$current === null` could mean "empty collection"
+		// or "element found but not hydrated"
+		if ($current === null && $key = $this->key()) {
+			return $this->hydrateElement($key);
+		}
+
+		return $current;
+	}
+
+	/**
+	 * Filters elements by one of the
+	 * predefined filter methods, by a
+	 * custom filter function or an array of filters
+	 */
+	public function filter(string|array|Closure $field, ...$args): static
+	{
+		// to filter through values, we need all values present
+		$this->hydrateAll();
+
+		return parent::filter($field, ...$args);
+	}
+
+	/**
+	 * Returns the first element
+	 *
+	 * @return TValue
+	 */
+	public function first()
+	{
+		$first = parent::first();
+
+		// `$first === null` could mean "empty collection"
+		// or "element found but not hydrated"
+		if ($first === null && $key = array_key_first($this->data)) {
+			return $this->hydrateElement($key);
+		}
+
+		return $first;
+	}
+
+	/**
+	 * Returns an iterator for the elements
+	 * @return \Iterator<TKey, TValue>
+	 */
+	public function getIterator(): Iterator
+	{
+		foreach ($this->data as $key => $value) {
+			if ($value === null) {
+				$value = $this->hydrateElement($key);
+			}
+
+			yield $key => $value;
+		}
+	}
+
+	/**
+	 * Ensures that all collection elements are loaded,
+	 * essentially converting the lazy collection into a
+	 * normal collection
+	 */
+	public function hydrateAll(): void
+	{
+		// skip another hydration loop if no longer needed
+		if ($this->hydrated === true) {
+			return;
+		}
+
+		foreach ($this->data as $key => $value) {
+			if ($value === null) {
+				$this->hydrateElement($key);
+			}
+		}
+
+		$this->hydrated = true;
+	}
+
+	/**
+	 * Loads a collection element, sets it in `$this->data[$key]`
+	 * and returns the hydrated object value; to be implemented
+	 * in each specific collection
+	 */
+	abstract protected function hydrateElement(string $key): object;
+
+	/**
+	 * Tries to find the key for the given element
+	 *
+	 * @param TValue $needle the element to search for
+	 * @return int|string|false the name of the key or false
+	 */
+	public function keyOf(mixed $needle): int|string|false
+	{
+		// quick lookup without having to hydrate the collection
+		// (keys in CMS collections are the object IDs)
+		if (
+			is_object($needle) === true &&
+			method_exists($needle, 'id') === true
+		) {
+			return $needle->id();
+		}
+
+		$this->hydrateAll();
+		return parent::keyOf($needle);
+	}
+
+	/**
+	 * Returns the last element
+	 *
+	 * @return TValue
+	 */
+	public function last()
+	{
+		$last = parent::last();
+
+		// `$last === null` could mean "empty collection"
+		// or "element found but not hydrated"
+		if ($last === null && $key = array_key_last($this->data)) {
+			return $this->hydrateElement($key);
+		}
+
+		return $last;
+	}
+
+	/**
+	 * Map a function to each element
+	 *
+	 * @return $this
+	 */
+	public function map(callable $callback): static
+	{
+		// to map a function, we need all values present
+		$this->hydrateAll();
+
+		return parent::map($callback);
+	}
+
+	/**
+	 * Moves the cursor to the next element
+	 * and returns it
+	 * @deprecated
+	 * @todo Remove in v6
+	 *
+	 * @return TValue
+	 */
+	public function next(): mixed
+	{
+		$next = parent::next();
+
+		// `$next === null` could mean "empty collection"
+		// or "element found but not hydrated"
+		if ($next === null && $key = $this->key()) {
+			return $this->hydrateElement($key);
+		}
+
+		return $next;
+	}
+
+	/**
+	 * Returns the nth element from the collection
+	 *
+	 * @return TValue|null
+	 */
+	public function nth(int $n)
+	{
+		$nth = parent::nth($n);
+
+		// `$nth === null` could mean "empty collection"
+		// or "element found but not hydrated"
+		if ($nth === null) {
+			$key = array_keys($this->data)[$n] ?? null;
+
+			if (is_string($key) === true) {
+				return $this->hydrateElement($key);
+			}
+		}
+
+		return $nth;
+	}
+
+	/**
+	 * Moves the cursor to the previous element
+	 * and returns it
+	 * @deprecated
+	 * @todo Remove in v6
+	 *
+	 * @return TValue
+	 */
+	public function prev(): mixed
+	{
+		$prev = parent::prev();
+
+		// `$prev === null` could mean "empty collection"
+		// or "element found but not hydrated"
+		if ($prev === null && $key = $this->key()) {
+			return $this->hydrateElement($key);
+		}
+
+		return $prev;
+	}
+
+	/**
+	 * Sorts the elements by any number of fields
+	 *
+	 * ```php
+	 * $collection->sort('fieldName');
+	 * $collection->sort('fieldName', 'desc');
+	 * $collection->sort('fieldName', 'asc', SORT_REGULAR);
+	 * $collection->sort(fn ($a) => ...);
+	 * ```
+	 *
+	 * @param string|callable $field Field name or value callback to sort by
+	 * @param string|null $direction asc or desc
+	 * @param int|null $method The sort flag, SORT_REGULAR, SORT_NUMERIC etc.
+	 * @return $this|static
+	 */
+	public function sort(...$args): static
+	{
+		// to sort through values, we need all values present
+		$this->hydrateAll();
+
+		return parent::sort(...$args);
+	}
+
+	/**
+	 * Converts all objects in the collection
+	 * to an array. This can also take a callback
+	 * function to further modify the array result.
+	 */
+	public function toArray(Closure|null $map = null): array
+	{
+		// to export an array, we need all values present
+		$this->hydrateAll();
+
+		return parent::toArray($map);
+	}
+
+	/**
+	 * Returns a non-associative array
+	 * with all values. If a mapping Closure is passed,
+	 * all values are processed by the Closure.
+	 */
+	public function values(Closure|null $map = null): array
+	{
+		// to export an array, we need all values present
+		$this->hydrateAll();
+
+		return parent::values($map);
+	}
+}

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -391,7 +391,7 @@ class Collection extends Iterator implements Stringable
 	 */
 	public function findBy(string $attribute, $value)
 	{
-		foreach ($this->data as $item) {
+		foreach ($this as $item) {
 			if ($this->getAttribute($item, $attribute) == $value) {
 				return $item;
 			}
@@ -516,7 +516,7 @@ class Collection extends Iterator implements Stringable
 		if (is_callable($field) === true) {
 			$groups = [];
 
-			foreach ($this->data as $key => $item) {
+			foreach ($this as $key => $item) {
 				// get the value to group by
 				$value = $field($item);
 
@@ -742,7 +742,7 @@ class Collection extends Iterator implements Stringable
 	): array {
 		$result = [];
 
-		foreach ($this->data as $item) {
+		foreach ($this as $item) {
 			$row = $this->getAttribute($item, $field);
 
 			if ($split !== null) {

--- a/tests/Cms/Collections/LazyCollectionTest.php
+++ b/tests/Cms/Collections/LazyCollectionTest.php
@@ -1,0 +1,343 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Iterator;
+use Kirby\Toolkit\Obj;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+class MockLazyCollection extends LazyCollection
+{
+	public bool $hydrated = false;
+	public bool $iterated = false;
+	public array $hydratedElements = [];
+
+	public function getIterator(): Iterator
+	{
+		$this->iterated = true;
+		return parent::getIterator();
+	}
+
+	protected function hydrateElement(string $key): object
+	{
+		// log for test assertions
+		$this->hydratedElements[] = $key;
+
+		return $this->data[$key] = new Obj(['id' => $key, 'type' => 'hydrated']);
+	}
+}
+
+#[CoversClass(LazyCollection::class)]
+class LazyCollectionTest extends TestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Cms.LazyCollection';
+
+	public function testHydrateAll(): void
+	{
+		$collection = new MockLazyCollection();
+		$collection->data = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$collection->hydrateAll();
+
+		$this->assertSame([
+			'a' => ['id' => 'a', 'type' => 'static'],
+			'b' => ['id' => 'b', 'type' => 'hydrated'],
+			'c' => ['id' => 'c', 'type' => 'hydrated']
+		], array_map(fn ($element) => $element->toArray(), $collection->data));
+		$this->assertSame(['b', 'c'], $collection->hydratedElements);
+		$this->assertTrue($collection->hydrated);
+
+		// another invocation should not hydrate again
+		$collection->iterated = false;
+		$collection->hydrateAll();
+		$this->assertFalse($collection->iterated);
+	}
+
+	public function testGet(): void
+	{
+		$collection = new MockLazyCollection();
+		$collection->data = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$this->assertSame('a', $collection->get('a')->id);
+		$this->assertSame('static', $collection->get('a')->type);
+		$this->assertSame('b', $collection->get('b')->id);
+		$this->assertSame('hydrated', $collection->get('b')->type);
+		$this->assertNull($collection->get('d'));
+
+		$this->assertSame(['b'], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+	}
+
+	public function testIterate(): void
+	{
+		$collection = new MockLazyCollection();
+		$collection->data = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$i = 0;
+		foreach ($collection as $key => $value) {
+			$this->assertSame($key, $value->id);
+			$this->assertSame($key === 'a' ? 'static' : 'hydrated', $value->type);
+
+			$i++;
+		}
+
+		$this->assertSame(3, $i);
+		$this->assertSame(['b', 'c'], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+	}
+
+	public function testFilter(): void
+	{
+		$collection = new MockLazyCollection();
+		$collection->data = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$result1 = $collection->filter('type', 'static');
+		$this->assertSame(['a'], $result1->pluck('id'));
+
+		$this->assertSame(['b', 'c'], $collection->hydratedElements);
+		$this->assertTrue($collection->hydrated);
+
+		// another operation should still work but no longer needs to hydrate
+		$result2 = $collection->filter('type', 'hydrated');
+		$this->assertSame(['b', 'c'], $result2->pluck('id'));
+	}
+
+	public function testFirst(): void
+	{
+		$collection = new MockLazyCollection();
+
+		$this->assertNull($collection->first());
+
+		$collection->data = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$this->assertSame('a', $collection->first()->id);
+		$this->assertSame('static', $collection->first()->type);
+
+		$this->assertSame([], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+
+		$collection->data = [
+			'a' => null,
+			'b' => null,
+			'c' => new Obj(['id' => 'c', 'type' => 'static'])
+		];
+
+		$this->assertSame('a', $collection->first()->id);
+		$this->assertSame('hydrated', $collection->first()->type);
+
+		$this->assertSame(['a'], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+	}
+
+	public function testKeyOf(): void
+	{
+		$objClass = new class () {
+			public string $id;
+
+			public function id(): string
+			{
+				return $this->id;
+			}
+
+			public function setId(string $id): static
+			{
+				$this->id = $id;
+				return $this;
+			}
+		};
+		$a = (clone $objClass)->setId('a');
+		$b = (clone $objClass)->setId('b');
+
+		$collection = new MockLazyCollection();
+		$collection->data = [
+			'a' => $a,
+			'b' => null,
+			'c' => null
+		];
+
+		$this->assertSame('a', $collection->keyOf($a));
+		$this->assertSame('b', $collection->keyOf($b));
+
+		// objects with ID can be looked up directly
+		$this->assertSame([], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+
+		$collection->data = [
+			$obj = new Obj(['type' => 'no-id'])
+		];
+
+		$this->assertSame(0, $collection->keyOf($obj));
+
+		$this->assertSame([], $collection->hydratedElements);
+		$this->assertTrue($collection->hydrated);
+	}
+
+	public function testLast(): void
+	{
+		$collection = new MockLazyCollection();
+
+		$this->assertNull($collection->last());
+
+		$collection->data = [
+			'a' => null,
+			'b' => null,
+			'c' => new Obj(['id' => 'c', 'type' => 'static'])
+		];
+
+		$this->assertSame('c', $collection->last()->id);
+		$this->assertSame('static', $collection->last()->type);
+
+		$this->assertSame([], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+
+		$collection->data = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$this->assertSame('c', $collection->last()->id);
+		$this->assertSame('hydrated', $collection->last()->type);
+
+		$this->assertSame(['c'], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+	}
+
+	public function testMap(): void
+	{
+		$collection = new MockLazyCollection();
+		$collection->data = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$result1 = $collection->map(function ($obj) {
+			$obj->mapped = $obj->id . ' mapped';
+			return $obj;
+		});
+		$this->assertSame(['a mapped', 'b mapped', 'c mapped'], $result1->pluck('mapped'));
+
+		$this->assertSame(['b', 'c'], $collection->hydratedElements);
+		$this->assertTrue($collection->hydrated);
+
+		// another operation should still work but no longer needs to hydrate
+		$result2 = $collection->map(function ($obj) {
+			$obj->mapped = $obj->id . ' mapped again';
+			return $obj;
+		});
+		$this->assertSame(['a mapped again', 'b mapped again', 'c mapped again'], $result2->pluck('mapped'));
+	}
+
+	public function testNth(): void
+	{
+		$collection = new MockLazyCollection();
+		$collection->data = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$this->assertSame('a', $collection->nth(0)->id);
+		$this->assertSame('static', $collection->nth(0)->type);
+		$this->assertSame('b', $collection->nth(1)->id);
+		$this->assertSame('hydrated', $collection->nth(1)->type);
+		$this->assertNull($collection->nth(3));
+
+		$this->assertSame(['b'], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+	}
+
+	public function testSort(): void
+	{
+		$collection = new MockLazyCollection();
+		$collection->data = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'c' => null,
+			'b' => null
+		];
+
+		$result1 = $collection->sort('id');
+		$this->assertSame(['a', 'b', 'c'], $result1->pluck('id'));
+
+		$this->assertSame(['c', 'b'], $collection->hydratedElements);
+		$this->assertTrue($collection->hydrated);
+
+		// another operation should still work but no longer needs to hydrate
+		$result2 = $collection->sort('id', 'desc');
+		$this->assertSame(['c', 'b', 'a'], $result2->pluck('id'));
+	}
+
+	public function testToArray(): void
+	{
+		$collection = new MockLazyCollection();
+		$collection->data = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$result = $collection->toArray();
+		$this->assertSame([
+			'a' => ['id' => 'a', 'type' => 'static'],
+			'b' => ['id' => 'b', 'type' => 'hydrated'],
+			'c' => ['id' => 'c', 'type' => 'hydrated'],
+		], $result);
+
+		$this->assertSame(['b', 'c'], $collection->hydratedElements);
+		$this->assertTrue($collection->hydrated);
+
+		// another operation should still work but no longer needs to hydrate
+		$result = $collection->toArray(fn ($obj) => $obj->type);
+		$this->assertSame([
+			'a' => 'static',
+			'b' => 'hydrated',
+			'c' => 'hydrated',
+		], $result);
+	}
+
+	public function testValues(): void
+	{
+		$collection = new MockLazyCollection();
+		$collection->data = [
+			'a' => $a = new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$result = $collection->values();
+		$this->assertSame(3, count($result));
+		$this->assertSame($a, $result[0]);
+
+		$this->assertSame(['b', 'c'], $collection->hydratedElements);
+		$this->assertTrue($collection->hydrated);
+
+		// another operation should still work but no longer needs to hydrate
+		$result = $collection->values(fn ($obj) => $obj->type);
+		$this->assertSame([
+			'static',
+			'hydrated',
+			'hydrated',
+		], $result);
+	}
+}


### PR DESCRIPTION
## Merge first

- [x] #7837 
- [x] #7838 

## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

The `LazyCollection` works by introducing a `null` value for collection elements. If a data key is set to `null`, this means "element exists but was not loaded yet". The loading then happens dynamically via a hydration method. This `hydrateElement` method is defined in the child collection and handles the actual loading and instance creation for the element object. This is the reason why `LazyCollection` is an `abstract` class.

What's important is that all collection methods need to hook into this dynamic behavior. I have overridden all core collection methods from parent classes that perform low-level actions directly on the data array. Then there are some methods that use `foreach`. For these, it's enough to replace `foreach ($this->data)` with `foreach ($this)` (making the loops use the custom iterator and therefore dynamically hydrate just as many elements as are needed until the loop is complete). Custom collection methods are currently made backwards-compatible by hydrating everything first. In v6, collection methods should call the hydration method themselves if they need to perform low-level actions.

Inherited `Iterator` methods (see PR 2) are implemented for now for backwards-compatibility but already marked as `@deprecated`. This allows us to clean them up in v6 as well.

This PR is the first step that only lazily hydrates the objects. Meaning that in this step, the collection needs to be initialized with all possible collection elements (each with a `null` value). This already brings performance improvements (see following PR 4). PR 5 will then also make the initialization lazy, which is useful if one only wants to retrieve a few specific collection elements by their ID.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features
<!-- 
e.g. New feature X which helps users to …
-->

- New `LazyCollection` class that initializes and loads its data and elements only when they are first needed

### ☠️ Deprecated

- Starting in Kirby 6, collection methods can no longer rely on the low-level `$collection->data` property to be populated. Collection methods should use `foreach ($collection)` instead of `foreach ($collection->data)`. If direct access to the data array is required, call `$collection->initialize()` (to initialize all keys) or `$collection->hydrate()` (to initialize all keys and values). During Kirby 5, collection methods still receive a fully hydrated collection for backwards-compatibility.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion