### PR TITLE
[User performance 4] perf: Implement `LazyCollection` for `Users`

### DIFF
--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -31,7 +31,7 @@ class Users extends LazyCollection
 	/**
 	 * Creates a new Collection with the given objects
 	 *
-	 * @param iterable<TValue> $objects
+	 * @param iterable<TUser> $objects
 	 * @param string|null $root Directory to dynamically load user
 	 *                          objects from during hydration
 	 * @param array $inject Props to inject into hydrated user objects

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\LogicException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\Str;
@@ -21,11 +22,28 @@ use Kirby\Uuid\HasUuids;
  * @license   https://getkirby.com/license
  *
  * @template TUser of \Kirby\Cms\User
- * @extends \Kirby\Cms\Collection<TUser>
+ * @extends \Kirby\Cms\LazyCollection<TUser>
  */
-class Users extends Collection
+class Users extends LazyCollection
 {
 	use HasUuids;
+
+	/**
+	 * Creates a new Collection with the given objects
+	 *
+	 * @param iterable<TValue> $objects
+	 * @param string|null $root Directory to dynamically load user
+	 *                          objects from during hydration
+	 * @param array $inject Props to inject into hydrated user objects
+	 */
+	public function __construct(
+		iterable $objects = [],
+		protected object|null $parent = null,
+		protected string|null $root = null,
+		protected array $inject = []
+	) {
+		parent::__construct($objects, $parent);
+	}
 
 	/**
 	 * All registered users methods
@@ -98,7 +116,7 @@ class Users extends Collection
 	{
 		$files = new Files([], $this->parent);
 
-		foreach ($this->data as $user) {
+		foreach ($this as $user) {
 			foreach ($user->files() as $fileKey => $file) {
 				$files->data[$fileKey] = $file;
 			}
@@ -126,31 +144,44 @@ class Users extends Collection
 	}
 
 	/**
+	 * Loads a user object, sets it in `$this->data[$key]`
+	 * and returns the hydrated user object
+	 */
+	protected function hydrateElement(string $key): User
+	{
+		if ($this->root === null) {
+			throw new LogicException('Cannot hydrate user "' . $key . '" with missing root'); // @codeCoverageIgnore
+		}
+
+		// get role information
+		$path = $this->root . '/' . $key . '/index.php';
+		if (is_file($path) === true) {
+			$credentials = F::load($path, allowOutput: false);
+		}
+
+		// create user model based on role
+		$user = User::factory([
+			'id'          => $key,
+			'model'       => $credentials['role'] ?? null,
+			'credentials' => is_array($credentials ?? null) ? $credentials : null
+		] + $this->inject);
+
+		return $this->data[$key] = $user;
+	}
+
+	/**
 	 * Loads a user from disk by passing the absolute path (root)
 	 */
 	public static function load(string $root, array $inject = []): static
 	{
-		$users = new static();
+		$users = new static(root: $root, inject: $inject);
 
 		foreach (Dir::read($root) as $userDirectory) {
 			if (is_dir($root . '/' . $userDirectory) === false) {
 				continue;
 			}
 
-			// get role information
-			$path = $root . '/' . $userDirectory . '/index.php';
-			if (is_file($path) === true) {
-				$credentials = F::load($path, allowOutput: false);
-			}
-
-			// create user model based on role
-			$user = User::factory([
-				'id'          => $userDirectory,
-				'model'       => $credentials['role'] ?? null,
-				'credentials' => is_array($credentials ?? null) ? $credentials : null
-			] + $inject);
-
-			$users->set($user->id(), $user);
+			$users->set($userDirectory, null);
 		}
 
 		return $users;


### PR DESCRIPTION
## Merge first

- [x] #7837 
- [x] #7838 
- [x] #7839 

## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

I've decided to start with `Users` because all accounts are stored in a single level and use a single collection, so there is no way to build "model trees" like we have always recommended for pages.

I suggest we ship this in 5.3 and then wait if there are any unforeseen issues or regressions. If everything works out, we can then implement the `LazyCollection` for our other core collections.

`LazyCollection` is of course most effective when just a few of the models are needed. If all collection elements are needed anyway during the request, `LazyCollection` cannot speed anything up. But I'm glad that the performance numbers show that there is no massive performance hit for those cases either. In the most relevant cases of "just a few collection elements/accounts" and "massive number of elements, but only a few are needed", no negative impact could be measured.

It's interesting that some views seem to load more accounts than one would expect. E.g. the site view but even more so the account view. For the account view I've traced it down to the "last admin" check mostly (therefore separate performance stats for admin and non-admin). There is also an interesting case in the users view, which needs to load all 20000 users to sort them by name field. Removing the sorting in the controller allows it to lazily load just the 20 paginated users, which makes the view load super quickly. So there is certainly expensive logic in the Panel that so far didn't make a difference and that we could now optimize in separate steps over time, allowing us to improve performance further.

## Performance

> All tested on my Mac mini M2 with PHP 8.4
> Timing values are TTFB measured using `h2load`:
> 296.49ms / 3.42s means "296 ms mean TTFB for 10 sequential requests, 3.42 s mean TTFB under load with 20 requests in parallel, 100 requests total" (numbers under load are better to compare because they fluctuate less during test executions)

### Frontend render using `$kirby->user()`

```
Baseline with 1 user:
23 ms

With 20000 users:
296.49ms / 3.42s @ Kirby 5.2.1
293.58ms / 3.10s @ PR 1 (Only load user credentials once)
127.20ms / 1.38s @ PR 4 (Lazy hydration)
```

### Starterkit site view

```
Baseline with 1 user:
75 ms

With 20000 users:
255.04ms / 2.79s @ Kirby 5.2.1
237.86ms / 2.73s @ PR 1 (Only load user credentials once)
114.46ms / 1.36s @ PR 4 (Lazy hydration)
```

### Users view

```
Baseline with 1 user:
65 ms

With 20000 users:
435.88ms / 4.88s @ Kirby 5.2.1
312.80ms / 3.30s @ PR 1 (Only load user credentials once)
308.57ms / 3.60s @ PR 4 (Lazy hydration)
```

### Account view (admin)

```
Baseline with 1 user:
70 ms

With 20000 users:
459.64ms / 5.38s @ Kirby 5.2.1
363.35ms / 4.34s @ PR 1 (Only load user credentials once)
371.18ms / 4.28s @ PR 4 (Lazy hydration)
```

### Account view (non-admin)

```
Baseline with 2 users:
75 ms

With 20000 users:
392.59ms / 4.79s @ Kirby 5.2.1
324.36ms / 3.67s @ PR 1 (Only load user credentials once)
327.61ms / 3.53s @ PR 4 (Lazy hydration)
```

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ⚡Performance

- Significantly improved performance when large numbers of user accounts are set up

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion