### PR TITLE
[User performance 5] perf: Lazy initialization

### DIFF
--- a/src/Cms/LazyCollection.php
+++ b/src/Cms/LazyCollection.php
@@ -261,7 +261,7 @@ abstract class LazyCollection extends Collection
 			return;
 		}
 
-		throw new LogicException('Lazy initialization is not implemented for ' . static::class); // @codeCoverageIgnore
+		throw new LogicException(static::class . ' class does not implement `initialize()` method that is required for lazy initialization'); // @codeCoverageIgnore
 	}
 
 	/**

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -205,9 +205,7 @@ class Users extends LazyCollection
 			$this->data[$userDirectory] = null;
 		}
 
-		foreach ($existing as $id => $user) {
-			$this->data[$id] = $user;
-		}
+		$this->data = [...$this->data, ...$existing];
 
 		$this->initialized = true;
 	}

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -211,7 +211,7 @@ class Users extends LazyCollection
 	}
 
 	/**
-	 * Loads a user from disk by passing the absolute path (root)
+	 * Loads users from disk by passing the absolute directory path (root)
 	 */
 	public static function load(string $root, array $inject = []): static
 	{

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -147,14 +147,22 @@ class Users extends LazyCollection
 	 * Loads a user object, sets it in `$this->data[$key]`
 	 * and returns the hydrated user object
 	 */
-	protected function hydrateElement(string $key): User
+	protected function hydrateElement(string $key): User|null
 	{
 		if ($this->root === null) {
 			throw new LogicException('Cannot hydrate user "' . $key . '" with missing root'); // @codeCoverageIgnore
 		}
 
+		// check if the user directory exists if not all keys have been
+		// populated in the collection, otherwise we can assume that
+		// this method will only be called on "unhydrated" user IDs
+		$root = $this->root . '/' . $key;
+		if ($this->initialized === false && is_dir($root) === false) {
+			return null;
+		}
+
 		// get role information
-		$path = $this->root . '/' . $key . '/index.php';
+		$path = $root . '/index.php';
 		if (is_file($path) === true) {
 			$credentials = F::load($path, allowOutput: false);
 		}
@@ -170,19 +178,47 @@ class Users extends LazyCollection
 	}
 
 	/**
+	 * Ensures that the IDs for all valid users are loaded in the
+	 * `$data` array and sets `$initialized` to `true` afterwards
+	 */
+	public function initializeAll(): void
+	{
+		// skip another initialization if no longer needed
+		if ($this->initialized === true) {
+			return;
+		}
+
+		if ($this->root === null) {
+			throw new LogicException('Cannot initialize users with missing root'); // @codeCoverageIgnore
+		}
+
+		// ensure the order matches the filesystem, even if
+		// individual users have been hydrated/added before
+		$existing   = $this->data;
+		$this->data = [];
+
+		foreach (Dir::read($this->root) as $userDirectory) {
+			if (is_dir($this->root . '/' . $userDirectory) === false) {
+				continue;
+			}
+
+			$this->data[$userDirectory] = null;
+		}
+
+		foreach ($existing as $id => $user) {
+			$this->data[$id] = $user;
+		}
+
+		$this->initialized = true;
+	}
+
+	/**
 	 * Loads a user from disk by passing the absolute path (root)
 	 */
 	public static function load(string $root, array $inject = []): static
 	{
 		$users = new static(root: $root, inject: $inject);
-
-		foreach (Dir::read($root) as $userDirectory) {
-			if (is_dir($root . '/' . $userDirectory) === false) {
-				continue;
-			}
-
-			$users->set($userDirectory, null);
-		}
+		$users->initialized = false;
 
 		return $users;
 	}

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -183,7 +183,7 @@ class Users extends LazyCollection
 	 */
 	public function initializeAll(): void
 	{
-		// skip another initialization if no longer needed
+		// skip another initialization if it already has been initialized
 		if ($this->initialized === true) {
 			return;
 		}

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -689,7 +689,7 @@ class Collection extends Iterator implements Stringable
 		$collection = clone $this;
 
 		foreach ($keys as $key) {
-			unset($collection->data[$key]);
+			unset($collection->{$key});
 		}
 
 		return $collection;

--- a/tests/Cms/Collections/LazyCollectionTest.php
+++ b/tests/Cms/Collections/LazyCollectionTest.php
@@ -18,12 +18,51 @@ class MockLazyCollection extends LazyCollection
 		return parent::getIterator();
 	}
 
-	protected function hydrateElement(string $key): object
+	protected function hydrateElement(string $key): object|null
 	{
 		// log for test assertions
 		$this->hydratedElements[] = $key;
 
 		return $this->data[$key] = new Obj(['id' => $key, 'type' => 'hydrated']);
+	}
+}
+
+class MockLazyCollectionWithInitialization extends MockLazyCollection
+{
+	public bool $initialized = false;
+	public array|null $targetData = null;
+
+	protected function hydrateElement(string $key): object|null
+	{
+		if (
+			is_array($this->targetData) &&
+			array_key_exists($key, $this->targetData) === false
+		) {
+			// log for test assertions
+			$this->hydratedElements[] = $key;
+
+			return null;
+		}
+
+		return parent::hydrateElement($key);
+	}
+
+	public function initializeAll(): void
+	{
+		if ($this->initialized === true) {
+			return;
+		}
+
+		if (is_array($this->targetData)) {
+			$existing = $this->data;
+			$this->data = $this->targetData;
+
+			foreach ($existing as $id => $user) {
+				$this->data[$id] = $user;
+			}
+		}
+
+		$this->initialized = true;
 	}
 }
 
@@ -57,6 +96,38 @@ class LazyCollectionTest extends TestCase
 		$this->assertFalse($collection->iterated);
 	}
 
+	public function testInitializeAll(): void
+	{
+		$collection1 = new MockLazyCollection();
+		$collection1->data = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		// should not throw an exception because there is no need to initialize
+		$collection1->initializeAll();
+
+		$collection2 = new MockLazyCollectionWithInitialization();
+		$collection2->targetData = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$collection2->initializeAll();
+
+		$this->assertSame($collection2->targetData, $collection2->data);
+		$this->assertSame([], $collection2->hydratedElements);
+		$this->assertFalse($collection2->hydrated);
+		$this->assertTrue($collection2->initialized);
+
+		// another invocation should not initialize again
+		$collection2->iterated = false;
+		$collection2->initializeAll();
+		$this->assertFalse($collection2->iterated);
+	}
+
 	public function testGet(): void
 	{
 		$collection = new MockLazyCollection();
@@ -73,6 +144,27 @@ class LazyCollectionTest extends TestCase
 		$this->assertNull($collection->get('d'));
 
 		$this->assertSame(['b'], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+	}
+
+	public function testGetUnitialized(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->targetData = [
+			'a' => new Obj(['id' => 'a', 'type' => 'initialized']),
+			'b' => null,
+			'c' => null
+		];
+
+		// getting a single element shouldn't have to initialize the
+		// entire structure, but just hydrate the single requested value
+		$this->assertSame('a', $collection->get('a')->id);
+		$this->assertSame('hydrated', $collection->get('a')->type);
+
+		$this->assertNull($collection->get('d'));
+
+		$this->assertFalse($collection->initialized);
+		$this->assertSame(['a', 'd'], $collection->hydratedElements);
 		$this->assertFalse($collection->hydrated);
 	}
 
@@ -96,6 +188,123 @@ class LazyCollectionTest extends TestCase
 		$this->assertSame(3, $i);
 		$this->assertSame(['b', 'c'], $collection->hydratedElements);
 		$this->assertFalse($collection->hydrated);
+	}
+
+	public function testIterateUnitialized(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->targetData = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$i = 0;
+		foreach ($collection as $key => $value) {
+			$this->assertSame($key, $value->id);
+			$this->assertSame($key === 'a' ? 'static' : 'hydrated', $value->type);
+
+			$i++;
+		}
+
+		$this->assertSame(3, $i);
+		$this->assertSame(['b', 'c'], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+		$this->assertTrue($collection->initialized);
+	}
+
+	public function testUnset(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->data = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		unset($collection->a, $collection->b);
+
+		$this->assertSame([], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+
+		$this->assertSame([
+			'c' => ['id' => 'c', 'type' => 'hydrated']
+		], $collection->toArray());
+	}
+
+	public function testUnsetUnitialized(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->targetData = [
+			'a' => new Obj(['id' => 'a', 'type' => 'initialized']),
+			'b' => null,
+			'c' => null
+		];
+
+		unset($collection->a, $collection->b);
+
+		$this->assertSame([], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+		$this->assertTrue($collection->initialized);
+
+		$this->assertSame([
+			'c' => ['id' => 'c', 'type' => 'hydrated']
+		], $collection->toArray());
+	}
+
+	public function testChunk(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->targetData = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$result = $collection->chunk(2);
+
+		$this->assertSame([], $result->hydratedElements);
+		$this->assertFalse($result->hydrated);
+		$this->assertTrue($result->initialized);
+
+		$this->assertSame(2, $result->count());
+		$this->assertSame(['a', 'b'], $result->first()->pluck('id'));
+		$this->assertSame(['c'], $result->last()->pluck('id'));
+	}
+
+	public function testCount(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->targetData = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$this->assertSame(3, $collection->count());
+
+		$this->assertSame([], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+		$this->assertTrue($collection->initialized);
+	}
+
+	public function testFlip(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->targetData = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$result = $collection->flip();
+
+		$this->assertSame([], $result->hydratedElements);
+		$this->assertFalse($result->hydrated);
+		$this->assertTrue($result->initialized);
+
+		$this->assertSame(3, $result->count());
+		$this->assertSame(['c', 'b', 'a'], $result->pluck('id'));
 	}
 
 	public function testFilter(): void
@@ -147,6 +356,62 @@ class LazyCollectionTest extends TestCase
 
 		$this->assertSame(['a'], $collection->hydratedElements);
 		$this->assertFalse($collection->hydrated);
+	}
+
+	public function testFirstUnitialized(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+
+		$this->assertNull($collection->first());
+		$this->assertTrue($collection->initialized);
+
+		$collection->initialized = false;
+		$collection->targetData = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$this->assertSame('a', $collection->first()->id);
+		$this->assertSame('static', $collection->first()->type);
+
+		$this->assertSame([], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+		$this->assertTrue($collection->initialized);
+	}
+
+	public function testHas(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->targetData = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$this->assertTrue($collection->has('a'));
+		$this->assertTrue($collection->has('b'));
+		$this->assertFalse($collection->has('d'));
+
+		$this->assertSame([], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+		$this->assertTrue($collection->initialized);
+	}
+
+	public function testKeys(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->targetData = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$this->assertSame(['a', 'b', 'c'], $collection->keys());
+
+		$this->assertSame([], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+		$this->assertTrue($collection->initialized);
 	}
 
 	public function testKeyOf(): void
@@ -223,6 +488,28 @@ class LazyCollectionTest extends TestCase
 		$this->assertFalse($collection->hydrated);
 	}
 
+	public function testLastUnitialized(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+
+		$this->assertNull($collection->last());
+		$this->assertTrue($collection->initialized);
+
+		$collection->initialized = false;
+		$collection->targetData = [
+			'a' => null,
+			'b' => null,
+			'c' => new Obj(['id' => 'c', 'type' => 'static'])
+		];
+
+		$this->assertSame('c', $collection->last()->id);
+		$this->assertSame('static', $collection->last()->type);
+
+		$this->assertSame([], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+		$this->assertTrue($collection->initialized);
+	}
+
 	public function testMap(): void
 	{
 		$collection = new MockLazyCollection();
@@ -266,6 +553,99 @@ class LazyCollectionTest extends TestCase
 
 		$this->assertSame(['b'], $collection->hydratedElements);
 		$this->assertFalse($collection->hydrated);
+	}
+
+	public function testNthUnitialized(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+
+		$this->assertNull($collection->nth(3));
+		$this->assertTrue($collection->initialized);
+
+		$collection->initialized = false;
+		$collection->targetData = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$this->assertSame('a', $collection->nth(0)->id);
+		$this->assertSame('static', $collection->nth(0)->type);
+		$this->assertSame('b', $collection->nth(1)->id);
+		$this->assertSame('hydrated', $collection->nth(1)->type);
+		$this->assertNull($collection->nth(3));
+
+		$this->assertSame(['b'], $collection->hydratedElements);
+		$this->assertFalse($collection->hydrated);
+		$this->assertTrue($collection->initialized);
+	}
+
+	public function testRandom(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->targetData = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$result = $collection->random(2);
+
+		$this->assertSame([], $result->hydratedElements);
+		$this->assertFalse($result->hydrated);
+		$this->assertTrue($result->initialized);
+
+		$this->assertSame(2, $result->count());
+		$this->assertInstanceOf(Obj::class, $result->first());
+		$this->assertInstanceOf(Obj::class, $result->last());
+	}
+
+	public function testShuffle(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->targetData = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$result = $collection->shuffle();
+
+		$this->assertSame([], $result->hydratedElements);
+		$this->assertFalse($result->hydrated);
+		$this->assertTrue($result->initialized);
+
+		$this->assertSame(3, $result->count());
+		$this->assertInstanceOf(Obj::class, $result->first());
+		$this->assertInstanceOf(Obj::class, $result->last());
+	}
+
+	public function testSlice(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->targetData = [
+			'a' => $a = new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$result1 = $collection->slice(1, 1);
+
+		$this->assertSame([], $result1->hydratedElements);
+		$this->assertFalse($result1->hydrated);
+		$this->assertTrue($result1->initialized);
+
+		$this->assertSame(1, $result1->count());
+		$this->assertSame(['b' => null], $result1->data);
+
+		$result2 = $collection->slice(0, 2);
+
+		$this->assertSame([], $result2->hydratedElements);
+		$this->assertFalse($result2->hydrated);
+		$this->assertTrue($result2->initialized);
+
+		$this->assertSame(2, $result2->count());
+		$this->assertSame(['a' => $a, 'b' => null], $result2->data);
 	}
 
 	public function testSort(): void


### PR DESCRIPTION
## Merge first

- [x] #7837 
- [x] #7838 
- [x] #7839 
- [x] #7841

## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

This PR extends the `LazyCollection` concept by integrating an optional lazy initialization mode. Lazy initialization means that the keys of the collection elements also only need to be loaded when they are needed. A `Dir::read()` is already pretty expensive when there are thousands of children in a directory. If only specific children are needed (e.g. just the currently logged in user), this operation can be skipped. This is the reason why this PR mainly improves performance for the frontend render case (and that one dramatically).

Child collections can decide if they just want to hydrate lazily or also want to initialize lazily. Default is just the lazy hydration mode.

Similar to PR 3, there are collection methods that perform low-level operations on the data array and that depend on all keys being there. These methods then dynamically trigger the initialization.

## Performance

> All tested on my Mac mini M2 with PHP 8.4
> Timing values are TTFB measured using `h2load`:
> 296.49ms / 3.42s means "296 ms mean TTFB for 10 sequential requests, 3.42 s mean TTFB under load with 20 requests in parallel, 100 requests total" (numbers under load are better to compare because they fluctuate less during test executions)

### Frontend render using `$kirby->user()`

```
Baseline with 1 user:
23 ms

With 20000 users:
296.49ms / 3.42s @ Kirby 5.2.1
293.58ms / 3.10s @ PR 1 (Only load user credentials once)
127.20ms / 1.38s @ PR 4 (Lazy hydration)
 20.02ms / 0.24s @ PR 5 (Lazy initialization)
```

### Starterkit site view

```
Baseline with 1 user:
75 ms

With 20000 users:
255.04ms / 2.79s @ Kirby 5.2.1
237.86ms / 2.73s @ PR 1 (Only load user credentials once)
114.46ms / 1.36s @ PR 4 (Lazy hydration)
112.67ms / 1.16s @ PR 5 (Lazy initialization)
```

### Users view

```
Baseline with 1 user:
65 ms

With 20000 users:
435.88ms / 4.88s @ Kirby 5.2.1
312.80ms / 3.30s @ PR 1 (Only load user credentials once)
308.57ms / 3.60s @ PR 4 (Lazy hydration)
305.56ms / 3.54s @ PR 5 (Lazy initialization)
```

### Account view (admin)

```
Baseline with 1 user:
70 ms

With 20000 users:
459.64ms / 5.38s @ Kirby 5.2.1
363.35ms / 4.34s @ PR 1 (Only load user credentials once)
371.18ms / 4.28s @ PR 4 (Lazy hydration)
368.34ms / 3.80s @ PR 5 (Lazy initialization)
```

### Account view (non-admin)

```
Baseline with 2 users:
75 ms

With 20000 users:
392.59ms / 4.79s @ Kirby 5.2.1
324.36ms / 3.67s @ PR 1 (Only load user credentials once)
327.61ms / 3.53s @ PR 4 (Lazy hydration)
290.66ms / 3.47s @ PR 5 (Lazy initialization)
```

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

*No additional release notes (covered by PRs 3 and 4)*