### PR TITLE
[Auth 4] refact: `Kirby\Auth\Methods`

### DIFF
--- a/config/api/routes/auth.php
+++ b/config/api/routes/auth.php
@@ -62,11 +62,11 @@ return [
 			$long     = $this->requestBody('long');
 			$password = $this->requestBody('password');
 
-			$methods = $auth->methods()->enabled();
+			$methods = $auth->methods();
 			$method  = match (true) {
-				$password !== ''                  => 'password',
-				isset($methods['code'])           => 'code',
-				isset($methods['password-reset']) => 'password-reset',
+				$password !== ''                         => 'password',
+				$methods->hasAvailable('code')           => 'code',
+				$methods->hasAvailable('password-reset') => 'password-reset',
 				default => throw new InvalidArgumentException(
 					message: 'Login without password is not enabled'
 				)

--- a/config/api/routes/auth.php
+++ b/config/api/routes/auth.php
@@ -49,6 +49,7 @@ return [
 		'method'  => 'POST',
 		'auth'    => false,
 		'action'  => function () {
+			// @codeCoverageIgnoreStart
 			$auth = $this->kirby()->auth();
 
 			// csrf token check
@@ -58,26 +59,7 @@ return [
 				);
 			}
 
-			$email    = $this->requestBody('email');
-			$long     = $this->requestBody('long');
-			$password = $this->requestBody('password');
-
-			$methods = $auth->methods();
-			$method  = match (true) {
-				$password !== ''                         => 'password',
-				$methods->hasAvailable('code')           => 'code',
-				$methods->hasAvailable('password-reset') => 'password-reset',
-				default => throw new InvalidArgumentException(
-					message: 'Login without password is not enabled'
-				)
-			};
-
-			$result = $auth->authenticate(
-				method:   $method,
-				email:    $email,
-				password: $password,
-				long:     $long
-			);
+			$result = $auth->methods()->authenticateApiRequest($this);
 
 			if ($result instanceof User) {
 				return [
@@ -92,6 +74,7 @@ return [
 				'status'    => 'ok',
 				'challenge' => $result->challenge()
 			];
+			// @codeCoverageIgnoreEnd
 		}
 	],
 	[

--- a/src/Auth/Exception/LoginNotPermittedException.php
+++ b/src/Auth/Exception/LoginNotPermittedException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Kirby\Auth\Exception;
+
+use Kirby\Exception\PermissionException;
+
+/**
+ * Thrown for any invalid login
+ */
+class LoginNotPermittedException extends PermissionException
+{
+	protected static string $defaultKey = 'access.login';
+}

--- a/src/Auth/Method.php
+++ b/src/Auth/Method.php
@@ -43,6 +43,22 @@ abstract class Method
 	): User|Status;
 
 	/**
+	 * Checks if this method can be used in the current context
+	 */
+	public static function isAvailable(Auth $auth, array $options = []): bool
+	{
+		return true;
+	}
+
+	/**
+	 * Returns the config options for this method
+	 */
+	public function options(): array
+	{
+		return $this->options;
+	}
+
+	/**
 	 * Returns the identifier of the method (e.g. 'password')
 	 */
 	public static function type(): string

--- a/src/Auth/Method.php
+++ b/src/Auth/Method.php
@@ -45,9 +45,21 @@ abstract class Method
 	/**
 	 * Checks if this method can be used in the current context
 	 */
-	public static function isAvailable(Auth $auth, array $options = []): bool
-	{
+	public static function isAvailable(
+		Auth $auth,
+		array $options = []
+	): bool {
 		return true;
+	}
+
+	/**
+	 * Checks if this method uses challenges
+	 */
+	public static function isUsingChallenges(
+		Auth $auth,
+		array $options = []
+	): bool {
+		return false;
 	}
 
 	/**

--- a/src/Auth/Method.php
+++ b/src/Auth/Method.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Kirby\Auth;
+
+use Kirby\Cms\Auth;
+use Kirby\Cms\Auth\Status;
+use Kirby\Cms\User;
+use Kirby\Toolkit\Str;
+use SensitiveParameter;
+
+/**
+ * Base class for authentication methods
+ *
+ * Each method either logs the user in or returns a
+ * pending status that expects a follow-up challenge
+ *
+ * @package   Kirby Auth
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+abstract class Method
+{
+	public function __construct(
+		protected Auth $auth,
+		protected array $options = []
+	) {
+	}
+
+	/**
+	 * Attempts to authenticate the given user credentials
+	 *
+	 * Implementations should either return a logged-in user,
+	 * a pending status if a challenge is required.
+	 */
+	abstract public function authenticate(
+		string $email,
+		#[SensitiveParameter]
+		string|null $password = null,
+		bool $long = false
+	): User|Status;
+
+	/**
+	 * Returns the identifier of the method (e.g. 'password')
+	 */
+	public static function type(): string
+	{
+		return Str::camelToKebab(lcfirst(basename(str_replace(['\\', 'Method'], ['/', ''], static::class))));
+	}
+}

--- a/src/Auth/Method/CodeMethod.php
+++ b/src/Auth/Method/CodeMethod.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Kirby\Auth\Method;
+
+use Kirby\Auth\Method;
+use Kirby\Cms\Auth\Status;
+
+/**
+ * Passwordless login via one-time code
+ * or any other available challenge
+ *
+ * @package   Kirby Auth
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class CodeMethod extends Method
+{
+	public function authenticate(
+		string $email,
+		string|null $password = null,
+		bool $long = false
+	): Status {
+		// no password required; directly create challenge
+		return $this->auth->createChallenge(
+			mode: 'login',
+			email: $email,
+			long:  $long,
+		);
+	}
+}

--- a/src/Auth/Method/CodeMethod.php
+++ b/src/Auth/Method/CodeMethod.php
@@ -36,14 +36,10 @@ class CodeMethod extends Method
 	public static function isAvailable(Auth $auth, array $options = []): bool
 	{
 		// don't allow to circumvent 2FA by 1FA code method
-		if (static::isWithoutAny2FA($auth) === false) {
-			return false;
-		}
+		static::isWithoutAny2FA($auth);
 
 		// only one code-based mode can be active at once
-		if (static::isWithoutPasswordReset($auth) === false) {
-			return false;
-		}
+		static::isWithoutPasswordReset($auth);
 
 		return true;
 	}
@@ -62,13 +58,9 @@ class CodeMethod extends Method
 	{
 		// don't allow to circumvent 2FA by 1FA code method
 		if ($auth->methods()->hasAnyWith2FA() === true) {
-			if ($auth->kirby()->option('debug') === true) {
-				throw new InvalidArgumentException(
-					message: 'The "' . static::type() . '" login method cannot be enabled when 2FA is required'
-				);
-			}
-
-			return false;
+			throw new InvalidArgumentException(
+				message: 'The "' . static::type() . '" login method cannot be enabled when 2FA is required'
+			);
 		}
 
 		return true;
@@ -80,13 +72,9 @@ class CodeMethod extends Method
 	protected static function isWithoutPasswordReset(Auth $auth): bool
 	{
 		if ($auth->methods()->has('password-reset') === true) {
-			if ($auth->kirby()->option('debug') === true) {
-				throw new InvalidArgumentException(
-					message: 'The "code" and "password-reset" login methods cannot be enabled together'
-				);
-			}
-
-			return false;
+			throw new InvalidArgumentException(
+				message: 'The "code" and "password-reset" login methods cannot be enabled together'
+			);
 		}
 
 		return true;

--- a/src/Auth/Method/CodeMethod.php
+++ b/src/Auth/Method/CodeMethod.php
@@ -48,6 +48,13 @@ class CodeMethod extends Method
 		return true;
 	}
 
+	public static function isUsingChallenges(
+		Auth $auth,
+		array $options = []
+	): bool {
+		return true;
+	}
+
 	/**
 	 * Don't allow to circumvent 2FA by 1FA code method
 	 */

--- a/src/Auth/Method/CodeMethod.php
+++ b/src/Auth/Method/CodeMethod.php
@@ -3,7 +3,9 @@
 namespace Kirby\Auth\Method;
 
 use Kirby\Auth\Method;
+use Kirby\Cms\Auth;
 use Kirby\Cms\Auth\Status;
+use Kirby\Exception\InvalidArgumentException;
 
 /**
  * Passwordless login via one-time code
@@ -30,4 +32,57 @@ class CodeMethod extends Method
 			long:  $long,
 		);
 	}
+
+	public static function isAvailable(Auth $auth, array $options = []): bool
+	{
+		// don't allow to circumvent 2FA by 1FA code method
+		if (static::isWithoutAny2FA($auth) === false) {
+			return false;
+		}
+
+		// only one code-based mode can be active at once
+		if (static::isWithoutPasswordReset($auth) === false) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Don't allow to circumvent 2FA by 1FA code method
+	 */
+	protected static function isWithoutAny2FA(Auth $auth): bool
+	{
+		// don't allow to circumvent 2FA by 1FA code method
+		if ($auth->methods()->hasAnyWith2FA() === true) {
+			if ($auth->kirby()->option('debug') === true) {
+				throw new InvalidArgumentException(
+					message: 'The "' . static::type() . '" login method cannot be enabled when 2FA is required'
+				);
+			}
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Only one code-based mode can be active at once
+	 */
+	protected static function isWithoutPasswordReset(Auth $auth): bool
+	{
+		if ($auth->methods()->has('password-reset') === true) {
+			if ($auth->kirby()->option('debug') === true) {
+				throw new InvalidArgumentException(
+					message: 'The "code" and "password-reset" login methods cannot be enabled together'
+				);
+			}
+
+			return false;
+		}
+
+		return true;
+	}
+
 }

--- a/src/Auth/Method/PasswordMethod.php
+++ b/src/Auth/Method/PasswordMethod.php
@@ -4,6 +4,7 @@ namespace Kirby\Auth\Method;
 
 use InvalidArgumentException;
 use Kirby\Auth\Method;
+use Kirby\Cms\Auth;
 use Kirby\Cms\Auth\Status;
 use Kirby\Cms\User;
 use SensitiveParameter;
@@ -61,7 +62,17 @@ class PasswordMethod extends Method
 	 */
 	protected function has2FA(User $user): bool
 	{
-		$option = $this->options['2fa'] ?? null;
+		return static::isUsingChallenges(
+			$this->auth,
+			$this->options
+		);
+	}
+
+	public static function isUsingChallenges(
+		Auth $auth,
+		array $options = []
+	): bool {
+		$option = $options['2fa'] ?? null;
 
 		if ($option === true) {
 			return true;

--- a/src/Auth/Method/PasswordMethod.php
+++ b/src/Auth/Method/PasswordMethod.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Kirby\Auth\Method;
+
+use InvalidArgumentException;
+use Kirby\Auth\Method;
+use Kirby\Cms\Auth\Status;
+use Kirby\Cms\User;
+use SensitiveParameter;
+
+/**
+ * Authenticates a user with email + password
+ * and optionally triggers a 2FA challenge
+ *
+ * @package   Kirby Auth
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class PasswordMethod extends Method
+{
+	/**
+	 * @throws \Kirby\Exception\InvalidArgumentException If the password is missing
+	 */
+	public function authenticate(
+		string $email,
+		#[SensitiveParameter]
+		string|null $password = null,
+		bool $long = false
+	): User|Status {
+		if ($password === null) {
+			throw new InvalidArgumentException(
+				message: 'Missing password'
+			);
+		}
+
+		$user = $this->auth->validatePassword($email, $password);
+
+		// two-factor flow: create a challenge after password validation
+		if ($this->has2FA($user) === true) {
+			return $this->auth->createChallenge(
+				mode:  '2fa',
+				email: $email,
+				long:  $long,
+			);
+		}
+
+		// log the user in with a cookie-based session
+		$user->loginPasswordless([
+			'createMode' => 'cookie',
+			'long'       => $long === true
+		]);
+
+		return $user;
+	}
+
+	/**
+	 * Checks whether a second-factor is required
+	 */
+	protected function has2FA(User $user): bool
+	{
+		$option = $this->options['2fa'] ?? null;
+
+		if ($option === true) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/src/Auth/Method/PasswordResetMethod.php
+++ b/src/Auth/Method/PasswordResetMethod.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Auth\Method;
 
+use Kirby\Cms\Auth;
 use Kirby\Cms\Auth\Status;
 
 /**
@@ -26,5 +27,15 @@ class PasswordResetMethod extends CodeMethod
 			email: $email,
 			long:  false,
 		);
+	}
+
+	public static function isAvailable(Auth $auth, array $options = []): bool
+	{
+		// don't allow to circumvent 2FA by 1FA code method
+		if (static::isWithoutAny2FA($auth) === false) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/src/Auth/Method/PasswordResetMethod.php
+++ b/src/Auth/Method/PasswordResetMethod.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kirby\Auth\Method;
+
+use Kirby\Cms\Auth\Status;
+
+/**
+ * Password-reset flow that triggers a challenge
+ *
+ * @package   Kirby Auth
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class PasswordResetMethod extends CodeMethod
+{
+	public function authenticate(
+		string $email,
+		string|null $password = null,
+		bool $long = false
+	): Status {
+		return $this->auth->createChallenge(
+			mode: 'password-reset',
+			email: $email,
+			long:  false,
+		);
+	}
+}

--- a/src/Auth/Method/PasswordResetMethod.php
+++ b/src/Auth/Method/PasswordResetMethod.php
@@ -32,9 +32,7 @@ class PasswordResetMethod extends CodeMethod
 	public static function isAvailable(Auth $auth, array $options = []): bool
 	{
 		// don't allow to circumvent 2FA by 1FA code method
-		if (static::isWithoutAny2FA($auth) === false) {
-			return false;
-		}
+		static::isWithoutAny2FA($auth);
 
 		return true;
 	}

--- a/src/Auth/Methods.php
+++ b/src/Auth/Methods.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Kirby\Auth;
+
+use Kirby\Cms\App;
+use Kirby\Cms\Auth;
+use Kirby\Cms\Auth\Status;
+use Kirby\Cms\User;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\NotFoundException;
+use Kirby\Toolkit\A;
+
+/**
+ * Handler for all auth methods
+ *
+ * @package   Kirby Auth
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class Methods
+{
+	/**
+	 * Available auth method classes
+	 * from the core and plugins
+	 */
+	public static array $methods = [];
+
+	protected $enabled;
+
+	public function __construct(
+		protected Auth $auth,
+		protected App $kirby
+	) {
+	}
+
+	/**
+	 * Authenticates via the specific auth method
+	 *
+	 * @throws \Kirby\Exception\InvalidArgumentException If auth method type does not exists
+	 */
+	public function authenticate(
+		string $type,
+		string $email,
+		string|null $password = null,
+		bool $long = false
+	): User|Status {
+		$method = $this->get($type);
+		return $method->authenticate($email, $password, $long);
+	}
+
+	/**
+	 * Returns the auth method class for the provided type
+	 */
+	public function class(string $type): string
+	{
+		if (
+			($class = static::$methods[$type] ?? null) &&
+			is_subclass_of($class, Method::class) === true
+		) {
+			return $class;
+		}
+
+		throw new NotFoundException(
+			message: 'Unsupported auth method: ' . $type
+		);
+	}
+
+	/**
+	 * Returns normalized array of enabled methods
+	 * by the `auth.methods` config option
+	 *
+	 * @throws \Kirby\Exception\InvalidArgumentException If config is invalid (only in debug mode)
+	 */
+	public function enabled(): array
+	{
+		if (isset($this->enabled) === true) {
+			return $this->enabled; // @codeCoverageIgnore
+		}
+
+		$default = ['password' => []];
+		$methods = A::wrap($this->kirby->option('auth.methods', $default));
+
+		// normalize the syntax variants
+		$normalized = [];
+		$uses2fa    = false;
+
+		foreach ($methods as $key => $value) {
+			if (is_int($key) === true) {
+				// ['password']
+				$normalized[$value] = [];
+			} elseif ($value === true) {
+				// ['password' => true]
+				$normalized[$key] = [];
+			} else {
+				// ['password' => [...]]
+				$normalized[$key] = $value;
+
+				if (isset($value['2fa']) === true && $value['2fa'] === true) {
+					$uses2fa = true;
+				}
+			}
+		}
+
+		// 2FA must not be circumvented by code-based modes
+		foreach (['code', 'password-reset'] as $method) {
+			if ($uses2fa === true && isset($normalized[$method]) === true) {
+				unset($normalized[$method]);
+
+				if ($this->kirby->option('debug') === true) {
+					throw new InvalidArgumentException(
+						message: 'The "' . $method . '" login method cannot be enabled when 2FA is required'
+					);
+				}
+			}
+		}
+
+		// only one code-based mode can be active at once
+		if (
+			isset($normalized['code']) === true &&
+			isset($normalized['password-reset']) === true
+		) {
+			unset($normalized['code']);
+
+			if ($this->kirby->option('debug') === true) {
+				throw new InvalidArgumentException(
+					message: 'The "code" and "password-reset" login methods cannot be enabled together'
+				);
+			}
+		}
+
+		return $this->enabled = $normalized;
+	}
+
+	/**
+	 * Returns an instance of the requested auth method
+	 */
+	public function get(string $type): Method
+	{
+		$method = $this->class($type);
+		return new $method(
+			auth:    $this->auth,
+			options: $this->enabled()[$type] ?? []
+		);
+	}
+}

--- a/src/Auth/Methods.php
+++ b/src/Auth/Methods.php
@@ -28,12 +28,14 @@ class Methods
 	 */
 	public static array $methods = [];
 
+	protected $available;
 	protected $enabled;
 
 	public function __construct(
 		protected Auth $auth,
 		protected App $kirby
-	) {}
+	) {
+	}
 
 	/**
 	 * Authenticates via the specific auth method
@@ -63,6 +65,10 @@ class Methods
 	 */
 	public function available(): array
 	{
+		if (isset($this->available) === true) {
+			return $this->available; // @codeCoverageIgnore
+		}
+
 		$available = [];
 
 		foreach ($this->enabled() as $type => $options) {
@@ -73,7 +79,7 @@ class Methods
 			}
 		}
 
-		return $available;
+		return $this->available = $available;
 	}
 
 	/**
@@ -161,6 +167,22 @@ class Methods
 	public function has(string $type): bool
 	{
 		return in_array($type, array_keys($this->enabled()), true);
+	}
+
+	/**
+	 * Checks if any available method is using challenges
+	 */
+	public function hasAnyAvailableUsingChallenges(): bool
+	{
+		foreach ($this->available() as $method => $options) {
+			$class = $this->class($method);
+
+			if ($class::isUsingChallenges($this->auth, $options) === true) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Auth/Methods.php
+++ b/src/Auth/Methods.php
@@ -49,11 +49,15 @@ class Methods
 		string|null $password = null,
 		bool $long = false
 	): User|Status {
+		if ($this->has($type) === false) {
+			throw new InvalidArgumentException(
+				message: 'Auth method "' . $type . '" is not enabled'
+			);
+		}
+
 		$method = $this->get($type);
 
-		if (
-			$method === null ||
-			$method::isAvailable($this->auth, $method->options()) === false) {
+		if ($method::isAvailable($this->auth, $method->options()) === false) {
 			throw new InvalidArgumentException(
 				message: 'Auth method "' . $type . '" is not available'
 			);
@@ -177,12 +181,8 @@ class Methods
 	 * (This is based on the config. You might need to check
 	 * yourself if the method should be available in your context)
 	 */
-	public function get(string $type): Method|null
+	public function get(string $type): Method
 	{
-		if ($this->has($type) === false) {
-			return null;
-		}
-
 		$method = $this->class($type);
 
 		return new $method(

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Closure;
+use Kirby\Auth\Methods;
 use Kirby\Blueprint\PageBlueprint;
 use Kirby\Blueprint\Section;
 use Kirby\Content\Field;
@@ -48,6 +49,7 @@ trait AppPlugins
 		'areas' => [],
 		'assetMethods' => [],
 		'authChallenges' => [],
+		'authMethods' => [],
 		'blockMethods' => [],
 		'blockModels' => [],
 		'blocksMethods' => [],
@@ -166,6 +168,18 @@ trait AppPlugins
 		return $this->extensions['authChallenges'] = Auth::$challenges = [
 			...Auth::$challenges,
 			...$challenges
+		];
+	}
+
+	/**
+	 * Registers additional authentication methods
+	 * @since 6.0.0
+	 */
+	protected function extendAuthMethods(array $methods): array
+	{
+		return $this->extensions['authMethods'] = Methods::$methods = [
+			...Methods::$methods,
+			...$methods
 		];
 	}
 
@@ -816,6 +830,7 @@ trait AppPlugins
 		PageBlueprint::$presets = $this->core->blueprintPresets();
 
 		$this->extendAuthChallenges($this->core->authChallenges());
+		$this->extendAuthMethods($this->core->authMethods());
 		$this->extendCacheTypes($this->core->cacheTypes());
 		$this->extendComponents($this->core->components());
 		$this->extendBlueprints($this->core->blueprints());

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -434,6 +434,14 @@ class Auth
 	}
 
 	/**
+	 * @since 6.0.0
+	 */
+	public function kirby(): App
+	{
+		return $this->kirby;
+	}
+
+	/**
 	 * Returns the auth rate limits object
 	 * @since 6.0.0
 	 */

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -769,7 +769,7 @@ class Auth
 
 			// keep throwing the original error in debug mode,
 			// otherwise hide it to avoid leaking security-relevant information
-			$this->fail($e, new PermissionException(key: 'access.login'));
+			$this->fail($e, new LoginNotPermittedException());
 		}
 	}
 

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -3,8 +3,10 @@
 namespace Kirby\Cms;
 
 use Kirby\Auth\Csrf;
+use Kirby\Auth\Exception\LoginNotPermittedException;
 use Kirby\Auth\Exception\RateLimitException;
 use Kirby\Auth\Limits;
+use Kirby\Auth\Methods;
 use Kirby\Cms\Auth\Challenge;
 use Kirby\Cms\Auth\Status;
 use Kirby\Exception\Exception;
@@ -44,6 +46,7 @@ class Auth
 	protected User|null $impersonate = null;
 
 	protected Limits $limits;
+	protected Methods $methods;
 
 	/**
 	 * Cache of the auth status object
@@ -68,8 +71,38 @@ class Auth
 	public function __construct(
 		protected App $kirby
 	) {
-		$this->csrf   = new Csrf($kirby);
-		$this->limits = new Limits($kirby);
+		$this->csrf    = new Csrf($kirby);
+		$this->limits  = new Limits($kirby);
+		$this->methods = new Methods($this, $kirby);
+	}
+
+	/**
+	 * Login a user with email and (maybe optional) password
+	 * as well as an auth challenge, if required by the auth method
+	 *
+	 * @throws \Kirby\Exception\PermissionException If the rate limit was exceeded if any other error occurred with debug mode off
+	 * @throws \Kirby\Exception\NotFoundException If the email was invalid
+	 * @throws \Kirby\Exception\InvalidArgumentException If the password is not valid (via `$user->login()`)
+	 */
+	public function authenticate(
+		string $method,
+		string $email,
+		#[SensitiveParameter]
+		string|null $password = null,
+		bool $long = false
+	): User|Status {
+		$result = $this->methods()->authenticate(
+			type:      $method,
+			email:     $email,
+			password:  $password,
+			long:      $long
+		);
+
+		if ($result instanceof User === true) {
+			$this->setUser($result);
+		}
+
+		return $result;
 	}
 
 	/**
@@ -440,18 +473,14 @@ class Auth
 		string $password,
 		bool $long = false
 	): User {
-		// session options
-		$options = [
-			'createMode' => 'cookie',
-			'long'       => $long === true
-		];
+		$user = $this->authenticate('password', $email, $password, $long);
 
-		// validate the user and log in to the session
-		$user = $this->validatePassword($email, $password);
-		$user->loginPasswordless($options);
-
-		// clear the status cache
-		$this->status = null;
+		if ($user instanceof User === false) {
+			// if a method returned a pending status here,
+			// it's a misconfiguration (e.g. password + 2FA active);
+			// keep the existing login signature strict
+			throw new LoginNotPermittedException(); // @codeCoverageIgnore
+		}
 
 		return $user;
 	}
@@ -463,6 +492,8 @@ class Auth
 	 * @throws \Kirby\Exception\PermissionException If the rate limit was exceeded or if any other error occurred with debug mode off
 	 * @throws \Kirby\Exception\NotFoundException If the email was invalid
 	 * @throws \Kirby\Exception\InvalidArgumentException If the password is not valid (via `$user->login()`)
+	 *
+	 * @deprecated 6.0.0 Use `self::authenticate()` instead
 	 */
 	public function login2fa(
 		string $email,
@@ -496,6 +527,15 @@ class Auth
 
 		// clear the status cache
 		$this->status = null;
+	}
+
+	/**
+	 * Returns the auth methods handler
+	 * @since 6.0.0
+	 */
+	public function methods(): Methods
+	{
+		return $this->methods;
 	}
 
 	/**

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -2,6 +2,9 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Auth\Method\CodeMethod;
+use Kirby\Auth\Method\PasswordMethod;
+use Kirby\Auth\Method\PasswordResetMethod;
 use Kirby\Cache\ApcuCache;
 use Kirby\Cache\FileCache;
 use Kirby\Cache\MemCached;
@@ -123,6 +126,19 @@ class Core
 		return [
 			'email' => EmailChallenge::class,
 			'totp'  => TotpChallenge::class,
+		];
+	}
+
+	/**
+	 * Returns a list of all default auth method classes
+	 * @since 6.0.0
+	 */
+	public function authMethods(): array
+	{
+		return [
+			'code'           => CodeMethod::class,
+			'password'       => PasswordMethod::class,
+			'password-reset' => PasswordResetMethod::class
 		];
 	}
 

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -3,7 +3,6 @@
 namespace Kirby\Cms;
 
 use Kirby\Cms\System\UpdateStatus;
-use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Toolkit\A;
@@ -303,58 +302,12 @@ class System
 	 *
 	 * @throws \Kirby\Exception\InvalidArgumentException If the configuration is invalid
 	 *                                                   (only in debug mode)
+	 *
+	 * @deprecated 6.0.0 Use `$kirby->auth()->methods()->enabled()` instead
 	 */
 	public function loginMethods(): array
 	{
-		$default = ['password' => []];
-		$methods = A::wrap($this->app->option('auth.methods', $default));
-
-		// normalize the syntax variants
-		$normalized = [];
-		$uses2fa = false;
-		foreach ($methods as $key => $value) {
-			if (is_int($key) === true) {
-				// ['password']
-				$normalized[$value] = [];
-			} elseif ($value === true) {
-				// ['password' => true]
-				$normalized[$key] = [];
-			} else {
-				// ['password' => [...]]
-				$normalized[$key] = $value;
-
-				if (isset($value['2fa']) === true && $value['2fa'] === true) {
-					$uses2fa = true;
-				}
-			}
-		}
-
-		// 2FA must not be circumvented by code-based modes
-		foreach (['code', 'password-reset'] as $method) {
-			if ($uses2fa === true && isset($normalized[$method]) === true) {
-				unset($normalized[$method]);
-
-				if ($this->app->option('debug') === true) {
-					$message = 'The "' . $method . '" login method cannot be enabled when 2FA is required';
-					throw new InvalidArgumentException($message);
-				}
-			}
-		}
-
-		// only one code-based mode can be active at once
-		if (
-			isset($normalized['code']) === true &&
-			isset($normalized['password-reset']) === true
-		) {
-			unset($normalized['code']);
-
-			if ($this->app->option('debug') === true) {
-				$message = 'The "code" and "password-reset" login methods cannot be enabled together';
-				throw new InvalidArgumentException($message);
-			}
-		}
-
-		return $normalized;
+		return $this->app->auth()->methods()->enabled();
 	}
 
 	/**

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -307,7 +307,7 @@ class System
 	 */
 	public function loginMethods(): array
 	{
-		return $this->app->auth()->methods()->enabled();
+		return $this->app->auth()->methods()->available();
 	}
 
 	/**

--- a/tests/Auth/CsrfTest.php
+++ b/tests/Auth/CsrfTest.php
@@ -2,9 +2,6 @@
 
 namespace Kirby\Auth;
 
-use Kirby\Cms\App;
-use Kirby\Filesystem\Dir;
-use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(Csrf::class)]
@@ -16,20 +13,8 @@ class CsrfTest extends TestCase
 
 	public function setUp(): void
 	{
-		$this->app = new App([
-			'roots' => [
-				'index' => static::TMP
-			],
-		]);
-
+		parent::setUp();
 		$this->csrf = new Csrf($this->app);
-	}
-
-	public function tearDown(): void
-	{
-		$this->app->session()->destroy();
-		Dir::remove(static::TMP);
-		$_GET = [];
 	}
 
 	public function testFromSession1(): void

--- a/tests/Auth/Exception/LoginNotPermittedExceptionTest.php
+++ b/tests/Auth/Exception/LoginNotPermittedExceptionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kirby\Auth\Exception;
+
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(LoginNotPermittedException::class)]
+class LoginNotPermittedExceptionTest extends TestCase
+{
+	public function testDefaults(): void
+	{
+		$exception = new LoginNotPermittedException();
+		$this->assertSame('error.access.login', $exception->getKey());
+		$this->assertSame('Invalid login', $exception->getMessage());
+		$this->assertSame(403, $exception->getHttpCode());
+	}
+}

--- a/tests/Auth/Exception/LoginNotPermittedExceptionTest.php
+++ b/tests/Auth/Exception/LoginNotPermittedExceptionTest.php
@@ -2,8 +2,8 @@
 
 namespace Kirby\Auth\Exception;
 
-use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
 
 #[CoversClass(LoginNotPermittedException::class)]
 class LoginNotPermittedExceptionTest extends TestCase

--- a/tests/Auth/Exception/RateLimitExceptionTest.php
+++ b/tests/Auth/Exception/RateLimitExceptionTest.php
@@ -2,8 +2,8 @@
 
 namespace Kirby\Auth\Exception;
 
-use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
 
 #[CoversClass(RateLimitException::class)]
 class RateLimitExceptionTest extends TestCase

--- a/tests/Auth/LimitsTest.php
+++ b/tests/Auth/LimitsTest.php
@@ -3,9 +3,7 @@
 namespace Kirby\Auth;
 
 use Kirby\Auth\Exception\RateLimitException;
-use Kirby\Cms\App;
 use Kirby\Filesystem\Dir;
-use Kirby\TestCase;
 
 class LimitsTest extends TestCase
 {
@@ -17,8 +15,9 @@ class LimitsTest extends TestCase
 
 	public function setUp(): void
 	{
+		parent::setUp();
 		$self      = $this;
-		$this->app = new App([
+		$this->app = $this->app->clone([
 			'roots' => [
 				'index' => static::TMP
 			],
@@ -36,11 +35,6 @@ class LimitsTest extends TestCase
 
 		Dir::make(static::TMP . '/site/accounts');
 		$this->limits = new Limits($this->app);
-	}
-
-	public function tearDown(): void
-	{
-		Dir::remove(static::TMP);
 	}
 
 	public function testEnsure(): void

--- a/tests/Auth/Method/CodeMethodTest.php
+++ b/tests/Auth/Method/CodeMethodTest.php
@@ -99,6 +99,12 @@ class CodeMethodTest extends TestCase
 		CodeMethod::isAvailable($auth);
 	}
 
+	public function testIsUsingChallenges(): void
+	{
+		$auth = $this->auth();
+		$this->assertTrue(CodeMethod::isUsingChallenges($auth));
+	}
+
 	public function testType(): void
 	{
 		$this->assertSame('code', CodeMethod::type());

--- a/tests/Auth/Method/CodeMethodTest.php
+++ b/tests/Auth/Method/CodeMethodTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Kirby\Auth\Method;
+
+use Kirby\Auth\Method;
+use Kirby\Cms\Auth;
+use Kirby\Cms\Auth\Status;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Method::class)]
+#[CoversClass(CodeMethod::class)]
+class CodeMethodTest extends TestCase
+{
+	public function testAuthenticate(): void
+	{
+		$args   = null;
+		$status = $this->createStub(Status::class);
+		$auth   = $this->createStub(Auth::class);
+		$auth->method('createChallenge')
+			->willReturnCallback(function (...$x) use (&$args, $status) {
+				$args = $x;
+				return $status;
+			});
+
+		$method = new CodeMethod(auth: $auth);
+
+		$result = $method->authenticate('marge@simpsons.com', long: true);
+		$this->assertInstanceOf(Status::class, $result);
+		$this->assertSame($status, $result);
+		$this->assertSame(['marge@simpsons.com', true, 'login'], $args);
+
+		$result = $method->authenticate('lisa@simpsons.com', long: false);
+		$this->assertSame($status, $result);
+		$this->assertSame(['lisa@simpsons.com', false, 'login'], $args);
+	}
+
+	public function testType(): void
+	{
+		$this->assertSame('code', CodeMethod::type());
+	}
+}

--- a/tests/Auth/Method/CodeMethodTest.php
+++ b/tests/Auth/Method/CodeMethodTest.php
@@ -3,8 +3,11 @@
 namespace Kirby\Auth\Method;
 
 use Kirby\Auth\Method;
+use Kirby\Auth\Methods;
+use Kirby\Cms\App;
 use Kirby\Cms\Auth;
 use Kirby\Cms\Auth\Status;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -12,6 +15,29 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(CodeMethod::class)]
 class CodeMethodTest extends TestCase
 {
+	protected function auth(
+		bool $has2fa = false,
+		bool $hasPasswordReset = false,
+		bool $debug = false
+	): Auth {
+		$methods = $this->createStub(Methods::class);
+		$methods->method('hasAnyWith2FA')->willReturn($has2fa);
+		$methods->method('has')->willReturnCallback(
+			fn (string $type) => $type === 'password-reset' ? $hasPasswordReset : false
+		);
+
+		$kirby = $this->createStub(App::class);
+		$kirby->method('option')->willReturnCallback(
+			fn (string $key) => $key === 'debug' ? $debug : null
+		);
+
+		$auth = $this->createStub(Auth::class);
+		$auth->method('methods')->willReturn($methods);
+		$auth->method('kirby')->willReturn($kirby);
+
+		return $auth;
+	}
+
 	public function testAuthenticate(): void
 	{
 		$args   = null;
@@ -33,6 +59,44 @@ class CodeMethodTest extends TestCase
 		$result = $method->authenticate('lisa@simpsons.com', long: false);
 		$this->assertSame($status, $result);
 		$this->assertSame(['lisa@simpsons.com', false, 'login'], $args);
+	}
+
+	public function testIsAvailable(): void
+	{
+		$auth = $this->auth();
+		$this->assertTrue(CodeMethod::isAvailable($auth));
+	}
+
+	public function testIsAvailableWith2FA(): void
+	{
+		$auth = $this->auth(has2fa: true);
+		$this->assertFalse(CodeMethod::isAvailable($auth));
+	}
+
+	public function testIsAvailableWith2FADebug(): void
+	{
+		$auth = $this->auth(has2fa: true, debug: true);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('The "code" login method cannot be enabled when 2FA is required');
+
+		CodeMethod::isAvailable($auth);
+	}
+
+	public function testIsAvailableWithPasswordReset(): void
+	{
+		$auth = $this->auth(hasPasswordReset: true);
+		$this->assertFalse(CodeMethod::isAvailable($auth));
+	}
+
+	public function testIsAvailableWithPasswordResetDebug(): void
+	{
+		$auth = $this->auth(hasPasswordReset: true, debug: true);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('The "code" and "password-reset" login methods cannot be enabled together');
+
+		CodeMethod::isAvailable($auth);
 	}
 
 	public function testType(): void

--- a/tests/Auth/Method/CodeMethodTest.php
+++ b/tests/Auth/Method/CodeMethodTest.php
@@ -4,7 +4,6 @@ namespace Kirby\Auth\Method;
 
 use Kirby\Auth\Method;
 use Kirby\Auth\Methods;
-use Kirby\Cms\App;
 use Kirby\Cms\Auth;
 use Kirby\Cms\Auth\Status;
 use Kirby\Exception\InvalidArgumentException;
@@ -17,8 +16,7 @@ class CodeMethodTest extends TestCase
 {
 	protected function auth(
 		bool $has2fa = false,
-		bool $hasPasswordReset = false,
-		bool $debug = false
+		bool $hasPasswordReset = false
 	): Auth {
 		$methods = $this->createStub(Methods::class);
 		$methods->method('hasAnyWith2FA')->willReturn($has2fa);
@@ -26,14 +24,8 @@ class CodeMethodTest extends TestCase
 			fn (string $type) => $type === 'password-reset' ? $hasPasswordReset : false
 		);
 
-		$kirby = $this->createStub(App::class);
-		$kirby->method('option')->willReturnCallback(
-			fn (string $key) => $key === 'debug' ? $debug : null
-		);
-
 		$auth = $this->createStub(Auth::class);
 		$auth->method('methods')->willReturn($methods);
-		$auth->method('kirby')->willReturn($kirby);
 
 		return $auth;
 	}
@@ -67,15 +59,9 @@ class CodeMethodTest extends TestCase
 		$this->assertTrue(CodeMethod::isAvailable($auth));
 	}
 
-	public function testIsAvailableWith2FA(): void
+	public function testIsAvailableWith2F(): void
 	{
 		$auth = $this->auth(has2fa: true);
-		$this->assertFalse(CodeMethod::isAvailable($auth));
-	}
-
-	public function testIsAvailableWith2FADebug(): void
-	{
-		$auth = $this->auth(has2fa: true, debug: true);
 
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The "code" login method cannot be enabled when 2FA is required');
@@ -86,12 +72,6 @@ class CodeMethodTest extends TestCase
 	public function testIsAvailableWithPasswordReset(): void
 	{
 		$auth = $this->auth(hasPasswordReset: true);
-		$this->assertFalse(CodeMethod::isAvailable($auth));
-	}
-
-	public function testIsAvailableWithPasswordResetDebug(): void
-	{
-		$auth = $this->auth(hasPasswordReset: true, debug: true);
 
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The "code" and "password-reset" login methods cannot be enabled together');

--- a/tests/Auth/Method/MethodTest.php
+++ b/tests/Auth/Method/MethodTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Kirby\Auth\Method;
+
+use Kirby\Auth\Method;
+use Kirby\Cms\Auth;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Method::class)]
+class MethodTest extends TestCase
+{
+	public function testisAvailable(): void
+	{
+		$auth = $this->createStub(Auth::class);
+		$this->assertTrue(Method::isAvailable($auth));
+	}
+
+	public function testIsUsingChallenges(): void
+	{
+		$auth = $this->createStub(Auth::class);
+		$this->assertFalse(Method::isUsingChallenges($auth));
+	}
+}

--- a/tests/Auth/Method/PasswordMethodTest.php
+++ b/tests/Auth/Method/PasswordMethodTest.php
@@ -90,6 +90,14 @@ class PasswordMethodTest extends TestCase
 		$this->assertTrue(PasswordMethod::isAvailable($auth));
 	}
 
+	public function testIsUsingChallenges(): void
+	{
+		$auth = $this->createStub(Auth::class);
+
+		$this->assertFalse(PasswordMethod::isUsingChallenges($auth));
+		$this->assertTrue(PasswordMethod::isUsingChallenges($auth, ['2fa' => true]));
+	}
+
 	public function testOptions(): void
 	{
 		$auth   = $this->createStub(Auth::class);

--- a/tests/Auth/Method/PasswordMethodTest.php
+++ b/tests/Auth/Method/PasswordMethodTest.php
@@ -84,6 +84,20 @@ class PasswordMethodTest extends TestCase
 		$method->authenticate('marge@simpsons.com');
 	}
 
+	public function testIsAvailable(): void
+	{
+		$auth = $this->createStub(Auth::class);
+		$this->assertTrue(PasswordMethod::isAvailable($auth));
+	}
+
+	public function testOptions(): void
+	{
+		$auth   = $this->createStub(Auth::class);
+		$method = new PasswordMethod(auth: $auth, options: ['2fa' => true]);
+
+		$this->assertSame(['2fa' => true], $method->options());
+	}
+
 	public function testType(): void
 	{
 		$this->assertSame('password', PasswordMethod::type());

--- a/tests/Auth/Method/PasswordMethodTest.php
+++ b/tests/Auth/Method/PasswordMethodTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Kirby\Auth\Method;
+
+use InvalidArgumentException;
+use Kirby\Auth\Method;
+use Kirby\Cms\Auth;
+use Kirby\Cms\Auth\Status;
+use Kirby\Cms\User;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use RuntimeException;
+
+#[CoversClass(Method::class)]
+#[CoversClass(PasswordMethod::class)]
+class PasswordMethodTest extends TestCase
+{
+	public function testAuthenticate(): void
+	{
+		$login = [];
+		$user  = $this->createStub(User::class);
+		$user->method('loginPasswordless')
+			->willReturnCallback(function ($options) use (&$login) {
+				$login[] = $options;
+			});
+
+		$validate = null;
+		$auth     = $this->createStub(Auth::class);
+		$auth->method('validatePassword')
+			->willReturnCallback(function (...$args) use (&$validate, $user) {
+				$validate = $args;
+				return $user;
+			});
+		$auth->method('createChallenge')
+			->willReturnCallback(function () {
+				throw new RuntimeException('createChallenge should not be called');
+			});
+
+		$method = new PasswordMethod(auth: $auth);
+		$result = $method->authenticate('marge@simpsons.com', 'springfield123', true);
+
+		$this->assertInstanceOf(User::class, $result);
+		$this->assertSame($user, $result);
+		$this->assertSame(['marge@simpsons.com', 'springfield123'], $validate);
+		$this->assertSame([[
+			'createMode' => 'cookie',
+			'long'       => true
+		]], $login);
+	}
+
+	public function testAuthenticateWith2FA(): void
+	{
+		$status       = $this->createStub(Status::class);
+		$user         = $this->createStub(User::class);
+		$validate     = null;
+		$challenge    = null;
+		$auth         = $this->createStub(Auth::class);
+		$auth->method('validatePassword')
+			->willReturnCallback(function (...$args) use (&$validate, $user) {
+				$validate = $args;
+				return $user;
+			});
+		$auth->method('createChallenge')
+			->willReturnCallback(function (...$args) use (&$challenge, $status) {
+				$challenge = $args;
+				return $status;
+			});
+
+		$method = new PasswordMethod(auth: $auth, options: ['2fa' => true]);
+		$result = $method->authenticate('marge@simpsons.com', 'springfield123');
+
+		$this->assertSame($status, $result);
+		$this->assertSame(['marge@simpsons.com', 'springfield123'], $validate);
+		$this->assertSame(['marge@simpsons.com', false, '2fa'], $challenge);
+	}
+
+	public function testAuthenticateWithoutPassword(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Missing password');
+
+		$auth   = $this->createStub(Auth::class);
+		$method = new PasswordMethod(auth: $auth);
+		$method->authenticate('marge@simpsons.com');
+	}
+
+	public function testType(): void
+	{
+		$this->assertSame('password', PasswordMethod::type());
+	}
+}

--- a/tests/Auth/Method/PasswordResetMethodTest.php
+++ b/tests/Auth/Method/PasswordResetMethodTest.php
@@ -4,7 +4,6 @@ namespace Kirby\Auth\Method;
 
 use Kirby\Auth\Method;
 use Kirby\Auth\Methods;
-use Kirby\Cms\App;
 use Kirby\Cms\Auth;
 use Kirby\Cms\Auth\Status;
 use Kirby\Exception\InvalidArgumentException;
@@ -15,19 +14,13 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(PasswordResetMethod::class)]
 class PasswordResetMethodTest extends TestCase
 {
-	protected function auth(bool $has2fa = false, bool $debug = false): Auth
+	protected function auth(bool $has2fa = false): Auth
 	{
 		$methods = $this->createStub(Methods::class);
 		$methods->method('hasAnyWith2FA')->willReturn($has2fa);
 
-		$kirby = $this->createStub(App::class);
-		$kirby->method('option')->willReturnCallback(
-			fn (string $key) => $key === 'debug' ? $debug : null
-		);
-
 		$auth = $this->createStub(Auth::class);
 		$auth->method('methods')->willReturn($methods);
-		$auth->method('kirby')->willReturn($kirby);
 
 		return $auth;
 	}
@@ -64,12 +57,6 @@ class PasswordResetMethodTest extends TestCase
 	public function testIsAvailableWith2FA(): void
 	{
 		$auth = $this->auth(has2fa: true);
-		$this->assertFalse(PasswordResetMethod::isAvailable($auth));
-	}
-
-	public function testIsAvailableWith2FADebug(): void
-	{
-		$auth = $this->auth(has2fa: true, debug: true);
 
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The "password-reset" login method cannot be enabled when 2FA is required');

--- a/tests/Auth/Method/PasswordResetMethodTest.php
+++ b/tests/Auth/Method/PasswordResetMethodTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Kirby\Auth\Method;
+
+use Kirby\Auth\Method;
+use Kirby\Cms\Auth;
+use Kirby\Cms\Auth\Status;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Method::class)]
+#[CoversClass(PasswordResetMethod::class)]
+class PasswordResetMethodTest extends TestCase
+{
+	public function testAuthenticate(): void
+	{
+		$args   = null;
+		$status = $this->createStub(Status::class);
+		$auth   = $this->createStub(Auth::class);
+		$auth->method('createChallenge')
+			->willReturnCallback(function (...$x) use (&$args, $status) {
+				$args = $x;
+				return $status;
+			});
+
+		$method = new PasswordResetMethod(auth: $auth);
+
+		$result = $method->authenticate('marge@simpsons.com');
+		$this->assertInstanceOf(Status::class, $result);
+		$this->assertSame($status, $result);
+		$this->assertSame(['marge@simpsons.com', false, 'password-reset'], $args);
+
+		// Password reset should ignore `long: true`
+		$result = $method->authenticate('lisa@simpsons.com', long: true);
+		$this->assertSame(['lisa@simpsons.com', false, 'password-reset'], $args);
+	}
+
+	public function testType(): void
+	{
+		$this->assertSame('password-reset', PasswordResetMethod::type());
+	}
+}

--- a/tests/Auth/Method/PasswordResetMethodTest.php
+++ b/tests/Auth/Method/PasswordResetMethodTest.php
@@ -57,7 +57,7 @@ class PasswordResetMethodTest extends TestCase
 
 	public function testIsAvailable(): void
 	{
-		$auth = $this->auth(has2fa: false);
+		$auth = $this->auth();
 		$this->assertTrue(PasswordResetMethod::isAvailable($auth));
 	}
 
@@ -75,6 +75,12 @@ class PasswordResetMethodTest extends TestCase
 		$this->expectExceptionMessage('The "password-reset" login method cannot be enabled when 2FA is required');
 
 		PasswordResetMethod::isAvailable($auth);
+	}
+
+	public function testIsUsingChallenges(): void
+	{
+		$auth = $this->auth();
+		$this->assertTrue(PasswordResetMethod::isUsingChallenges($auth));
 	}
 
 	public function testType(): void

--- a/tests/Auth/MethodsTest.php
+++ b/tests/Auth/MethodsTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Kirby\Auth;
+
+use Kirby\Auth\Method\PasswordMethod;
+use Kirby\Cms\App;
+use Kirby\Cms\Auth;
+use Kirby\Cms\Auth\Status;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\NotFoundException;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+class DummyStatus extends Status
+{
+	public function __construct()
+	{
+	}
+}
+
+class DummyMethod extends Method
+{
+	public static array $calls = [];
+	protected Status $status;
+
+	public function __construct(Auth $auth, array $options = [])
+	{
+		parent::__construct($auth, $options);
+		$this->status = $options['status'] ?? new DummyStatus();
+	}
+
+	public function authenticate(string $email, string|null $password = null, bool $long = false): Status
+	{
+		self::$calls[] = func_get_args();
+		return $this->status;
+	}
+}
+
+#[CoversClass(Methods::class)]
+class MethodsTest extends TestCase
+{
+	public const string TMP = KIRBY_TMP_DIR . '/Auth.Methods';
+
+	protected function app(array $options = []): App
+	{
+		return new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'options' => $options
+		]);
+	}
+
+	protected function methods(): Methods
+	{
+		$app = $this->app();
+		return new Methods($app->auth(), $app);
+	}
+
+	public function testAuthenticate(): void
+	{
+		$status = new DummyStatus();
+
+		DummyMethod::$calls = [];
+		Methods::$methods   = ['dummy' => DummyMethod::class];
+
+		$app = $this->app([
+			'auth' => [
+				'methods' => [
+					'dummy' => ['status' => $status]
+				]
+			]
+		]);
+		$methods = new Methods($app->auth(), $app);
+		$result  = $methods->authenticate('dummy', 'mail@getkirby.com', 'secret', true);
+
+		$this->assertSame($status, $result);
+		$this->assertSame([['mail@getkirby.com', 'secret', true]], DummyMethod::$calls);
+	}
+
+	public function testClass(): void
+	{
+		$methods = $this->methods();
+		$this->assertSame(PasswordMethod::class, $methods->class('password'));
+	}
+
+	public function testClassInvalid(): void
+	{
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('Unsupported auth method: unknown');
+
+		$methods = $this->methods();
+		$methods->class('unknown');
+	}
+
+	public function testEnabledDefaults(): void
+	{
+		$app     = $this->app();
+		$methods = new Methods($app->auth(), $app);
+		$this->assertSame(['password' => []], $methods->enabled());
+	}
+
+	public function testEnabledWith2FA(): void
+	{
+		$app = $this->app([
+			'auth' => [
+				'methods' => [
+					'password'       => ['2fa' => true],
+					'code'           => true,
+					'password-reset' => []
+				]
+			]
+		]);
+
+		$methods = new Methods($app->auth(), $app);
+
+		$this->assertSame([
+			'password' => ['2fa' => true]
+		], $methods->enabled());
+	}
+
+	public function testEnabledWith2FADebug(): void
+	{
+		$app = $this->app([
+			'debug' => true,
+			'auth'  => [
+				'methods' => [
+					'password' => ['2fa' => true],
+					'code'     => []
+				]
+			]
+		]);
+		$methods = new Methods($app->auth(), $app);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('The "code" login method cannot be enabled when 2FA is required');
+
+		$methods->enabled();
+	}
+
+	public function testEnabledCodePasswordResetConflict(): void
+	{
+		$app = $this->app([
+			'auth' => [
+				'methods' => ['password', 'code', 'password-reset']
+			]
+		]);
+		$methods = new Methods($app->auth(), $app);
+
+		$this->assertSame([
+			'password'       => [],
+			'password-reset' => []
+		], $methods->enabled());
+	}
+
+	public function testEnabledCodePasswordResetConflictDebug(): void
+	{
+		$app = $this->app([
+			'debug' => true,
+			'auth' => [
+				'methods' => ['password', 'code', 'password-reset']
+			]
+		]);
+		$methods = new Methods($app->auth(), $app);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('The "code" and "password-reset" login methods cannot be enabled together');
+
+		$methods->enabled();
+	}
+}

--- a/tests/Auth/MethodsTest.php
+++ b/tests/Auth/MethodsTest.php
@@ -101,6 +101,28 @@ class MethodsTest extends TestCase
 		], $methods);
 	}
 
+	public function testAvailableDebugRethrowsException(): void
+	{
+		$app = $this->app->clone([
+			'options' => [
+				'debug' => true,
+				'auth' => [
+					'methods' => [
+						'password' => ['2fa' => true],
+						'code'
+					]
+				]
+			]
+		]);
+
+		$methods = $app->auth()->methods();
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('The "code" login method cannot be enabled when 2FA is required');
+
+		$methods->available();
+	}
+
 	public function testAuthenticateApiRequest(): void
 	{
 		$api = $this->createStub(Api::class);

--- a/tests/Auth/MethodsTest.php
+++ b/tests/Auth/MethodsTest.php
@@ -144,6 +144,38 @@ class MethodsTest extends TestCase
 		$this->assertFalse($methods->has('password-reset'));
 	}
 
+	public function testHasAnyAvailableUsingChallenges(): void
+	{
+		$app = $this->app([
+			'auth' => [
+				'methods' => [
+					'password' => ['2fa' => true],
+				]
+			]
+		]);
+
+		$methods = new Methods($app->auth(), $app);
+		$this->assertTrue($methods->hasAnyAvailableUsingChallenges());
+
+		$app = $this->app([
+			'auth' => [
+				'methods' => ['password', 'code']
+			]
+		]);
+
+		$methods = new Methods($app->auth(), $app);
+		$this->assertTrue($methods->hasAnyAvailableUsingChallenges());
+
+		$app = $this->app([
+			'auth' => [
+				'methods' => ['password']
+			]
+		]);
+
+		$methods = new Methods($app->auth(), $app);
+		$this->assertFalse($methods->hasAnyAvailableUsingChallenges());
+	}
+
 	public function testHasAnyWith2FA(): void
 	{
 		$app = $this->app([

--- a/tests/Auth/MethodsTest.php
+++ b/tests/Auth/MethodsTest.php
@@ -45,7 +45,7 @@ class MethodsTest extends TestCase
 		$this->app = $this->app->clone([
 			'options' => [
 				'auth' => [
-					'methods' => ['code']
+					'methods' => ['password' => ['2fa' => true], 'code']
 				]
 			]
 		]);
@@ -53,8 +53,8 @@ class MethodsTest extends TestCase
 		$methods = $this->app->auth()->methods();
 
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Auth method "password" is not available');
-		$methods->authenticate('password', 'marge@simpsons.com', 'secret123');
+		$this->expectExceptionMessage('Auth method "code" is not available');
+		$methods->authenticate('code', 'marge@simpsons.com', 'secret123');
 	}
 
 	public function testAuthenticateInvalid(): void
@@ -62,7 +62,7 @@ class MethodsTest extends TestCase
 		$methods = $this->app->auth()->methods();
 
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Auth method "foo" is not available');
+		$this->expectExceptionMessage('Auth method "foo" is not enabled');
 		$methods->authenticate('foo', 'marge@simpsons.com', 'secret123');
 	}
 
@@ -255,7 +255,6 @@ class MethodsTest extends TestCase
 		$methods = $app->auth()->methods();
 		$this->assertInstanceOf(PasswordMethod::class, $methods->get('password'));
 		$this->assertInstanceOf(CodeMethod::class, $methods->get('code'));
-		$this->assertNull($methods->get('foo'));
 	}
 
 	public function testHas(): void

--- a/tests/Auth/TestCase.php
+++ b/tests/Auth/TestCase.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Kirby\Auth;
+
+use Kirby\Cms\App;
+use Kirby\Email\Email;
+use Kirby\Filesystem\Dir;
+use Kirby\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+	public function setUp(): void
+	{
+		Email::$debug = true;
+		Email::$emails = [];
+		$_SERVER['SERVER_NAME'] = 'kirby.test';
+
+		$this->app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'options' => [
+				'auth' => [
+					'debug' => true,
+				]
+			]
+		]);
+
+		Dir::make(static::TMP);
+	}
+
+	public function tearDown(): void
+	{
+		$this->app->session()->destroy();
+		Email::$debug = false;
+		Email::$emails = [];
+		unset($_SERVER['SERVER_NAME']);
+		$_GET = [];
+		Dir::remove(static::TMP);
+		App::destroy();
+	}
+}

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -208,6 +208,11 @@ class AuthTest extends TestCase
 		$this->auth->impersonate('lisa@simpsons.com');
 	}
 
+	public function testKirby(): void
+	{
+		$this->assertInstanceOf(App::class, $this->auth->kirby());
+	}
+
 	public function testLimits(): void
 	{
 		$this->assertInstanceOf(Limits::class, $this->auth->limits());

--- a/tests/Cms/CoreTest.php
+++ b/tests/Cms/CoreTest.php
@@ -37,6 +37,15 @@ class CoreTest extends TestCase
 	{
 		$authChallenges = $this->core->authChallenges();
 		$this->assertArrayHasKey('email', $authChallenges);
+		$this->assertArrayHasKey('totp', $authChallenges);
+	}
+
+	public function testAuthMethods(): void
+	{
+		$authMethods = $this->core->authMethods();
+		$this->assertArrayHasKey('code', $authMethods);
+		$this->assertArrayHasKey('password', $authMethods);
+		$this->assertArrayHasKey('password-reset', $authMethods);
 	}
 
 	public function testBlueprintPresets(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

This PR creates dedicated handler classes for the auth methods `password`, `code` and `password-reset`. This allows us to move logic out of the main `Auth` class but also achieve a more structured handling of the different method types. Method classes can themselves determine whether they are available to be used (moving that logic away from the oonfig normalization). The new `Kirby\Auth\Methods` class helps to orchestrate the individual method classes and features a bunch of methods to help us for future features/aspects (e.g. `::hasAny2FA()`, `hasAnyAvaibaleUsingChallgens()`).

I think it becomes most apparent in `routes/auth.php` how this can help us to clean up logic and put it where it belongs (the individual methods). Also the future PR for a basic auth method (https://github.com/getkirby/kirby/pull/7845) shows the potential.

Re: code coverage it fails because of `routes/auth.php` which is hard to test, I fear. I cannot get any test to not get stuck on PHPUnit - I think because of something with the CSRF check.

### Merge first

- [x] https://github.com/getkirby/kirby/pull/7835
- [x] https://github.com/getkirby/kirby/pull/7836


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- New `authMethods` plugin extension

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- New `Kirby\Auth\Methods` and individual `Kirby\Auth\Method` classes
- New `Kirby\Auth\Exception\LoginNotPermittedException`

### ☠️ Deprecated
<!-- 
e.g. Deprecate method X. Use method Y instead.
-->
- `Kirby\Cms\Auth::login2fa()`  → Use `Kirby\Cms\Auth::authenticate()` instead
- `Kirby\Cms\System::loginMethods()`  → Use `$kirby->auth()->methods()->enabled()` instead

## Documentation

```php
public class FooMethod extends \Kirby\Auth\Method
{
	public function authenticate(
		string $email,
		#[SensitiveParameter]
		string|null $password = null,
		bool $long = false
	): User|Status {
		// returns either the logged in user
		// or creates a challenge and returns the 
		// pending auth status
	}

	public static function isAvailable(
		Auth $auth,
		array $options = []
	): bool {
		// some condition if the auth method
		// should be available, by default true
	}

	public static function isUsingChallenges(
		Auth $auth,
		array $options = []
	): bool {
		// if a challenge is created by the method,
		// default false
	}
}

// register custom auth method
App::plugin(
	name: 'my/plugin',
	extensions: ['authMethods' => ['foo' => FooMethod::class]]
);
```

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to https://github.com/getkirby/kirby/pull/7848