### PR TITLE
[Auth 5] refact: `Kirby\Auth\Method\BasicAuthMethod`

### DIFF
--- a/src/Auth/Method/BasicAuthMethod.php
+++ b/src/Auth/Method/BasicAuthMethod.php
@@ -128,14 +128,22 @@ class BasicAuthMethod extends Method
 	public function user(
 		BasicAuth|null $auth = null
 	): User|null {
-		/**
-		 * @var \Kirby\Http\Request\Auth\BasicAuth $auth
-		 */
-		$auth ??= $this->auth->kirby()->request()->auth();
+		$config = ['auth' => $auth];
 
-		return $this->authenticate(
-			$auth->username(),
-			$auth->password(),
-		);
+		// ensure basic auth method is actually available
+		// with the provided config
+		if (static::isAvailable($this->auth, $config, true) === true) {
+			/**
+			 * @var \Kirby\Http\Request\Auth\BasicAuth $auth
+			 */
+			$auth ??= $this->auth->kirby()->request()->auth();
+
+			return $this->authenticate(
+				$auth->username(),
+				$auth->password(),
+			);
+		}
+
+		return null;
 	}
 }

--- a/src/Auth/Method/BasicAuthMethod.php
+++ b/src/Auth/Method/BasicAuthMethod.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Kirby\Auth\Method;
+
+use Kirby\Auth\Method;
+use Kirby\Cms\Auth;
+use Kirby\Cms\User;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\PermissionException;
+use Kirby\Http\Request\Auth\BasicAuth;
+use SensitiveParameter;
+
+/**
+ * HTTP basic authentication
+ *
+ * @package   Kirby Auth
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class BasicAuthMethod extends Method
+{
+	/**
+	 * Basic auth authenticates on every request,
+	 * so `$long` isn't relevant here
+	 *
+	 * @throws \Kirby\Exception\InvalidArgumentException If the password is missing
+	 */
+	public function authenticate(
+		string $email,
+		#[SensitiveParameter]
+		string|null $password = null,
+		bool $long = false
+	): User {
+		if ($password === null) {
+			throw new InvalidArgumentException(
+				message: 'Missing password'
+			);
+		}
+
+		return $this->auth->validatePassword($email, $password);
+	}
+
+	/**
+	 * Checks whether the current request attempts
+	 * to use HTTP basic authentication
+	 *
+	 * @throws \Kirby\Exception\InvalidArgumentException if the authorization header is invalid
+	 * @throws \Kirby\Exception\PermissionException if basic authentication is not allowed
+	 */
+	public static function isAvailable(
+		Auth $auth,
+		array $options = [],
+		bool $fail = false
+	): bool {
+		$kirby   = $auth->kirby();
+		$request = $kirby->request();
+
+		if ($kirby->option('api.basicAuth', false) !== true) {
+			if ($fail === true) {
+				throw new PermissionException(
+					message: 'Basic authentication is not activated'
+				);
+			}
+
+			return false;
+		}
+
+		$requestAuth = $options['auth'] ?? $request->auth();
+
+		if ($requestAuth instanceof BasicAuth === false) {
+			if ($fail === true) {
+				throw new InvalidArgumentException(
+					message: 'Invalid authorization header'
+				);
+			}
+
+			return false;
+		}
+
+		// if logging in with password is disabled,
+		// basic auth cannot be possible either
+		if ($auth->methods()->has('password') !== true) {
+			if ($fail === true) {
+				throw new PermissionException(
+					message: 'Login with password is not enabled'
+				);
+			}
+
+			return false;
+		}
+
+		// if any login method requires 2FA,
+		// basic auth without 2FA would be a weakness
+		if ($auth->methods()->hasAnyWith2FA() === true) {
+			if ($fail === true) {
+				throw new PermissionException(
+					message: 'Basic authentication cannot be used with 2FA'
+				);
+			}
+
+			return false;
+		}
+
+		// only allow basic auth when https is enabled or
+		// insecure requests permitted
+		if (
+			$request->ssl() === false &&
+			$kirby->option('api.allowInsecure', false) !== true
+		) {
+			if ($fail === true) {
+				throw new PermissionException(
+					message: 'Basic authentication is only allowed over HTTPS'
+				);
+			}
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the user resolved from the basic auth header
+	 */
+	public function user(
+		BasicAuth|null $auth = null
+	): User|null {
+		/**
+		 * @var \Kirby\Http\Request\Auth\BasicAuth $auth
+		 */
+		$auth ??= $this->auth->kirby()->request()->auth();
+
+		return $this->authenticate(
+			$auth->username(),
+			$auth->password(),
+		);
+	}
+}

--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -236,7 +236,6 @@ class Auth
 		 * @var \Kirby\Auth\Method\BasicAuthMethod
 		 */
 		$basic = $this->methods()->get('basic-auth');
-		$basic::isAvailable($this, ['auth' => $auth], fail: true);
 		return $basic->user($auth);
 	}
 
@@ -654,7 +653,7 @@ class Auth
 
 		try {
 			return $this->user = match ($this->type()) {
-				'basic' => $this->methods()->get('basic-auth')->user(),
+				'basic' => $this->currentUserFromBasicAuth(),
 				default => $this->currentUserFromSession($session)
 			};
 

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Auth\Method\BasicAuthMethod;
 use Kirby\Auth\Method\CodeMethod;
 use Kirby\Auth\Method\PasswordMethod;
 use Kirby\Auth\Method\PasswordResetMethod;
@@ -136,6 +137,7 @@ class Core
 	public function authMethods(): array
 	{
 		return [
+			'basic-auth'     => BasicAuthMethod::class,
 			'code'           => CodeMethod::class,
 			'password'       => PasswordMethod::class,
 			'password-reset' => PasswordResetMethod::class

--- a/tests/Auth/Method/BasicAuthMethodTest.php
+++ b/tests/Auth/Method/BasicAuthMethodTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Kirby\Auth\Method;
+
+use Kirby\Auth\Method;
+use Kirby\Auth\Methods;
+use Kirby\Cms\App;
+use Kirby\Cms\Auth;
+use Kirby\Cms\User;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\PermissionException;
+use Kirby\Http\Request;
+use Kirby\Http\Request\Auth\BasicAuth;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\Stub;
+
+#[CoversClass(Method::class)]
+#[CoversClass(BasicAuthMethod::class)]
+class BasicAuthMethodTest extends TestCase
+{
+	protected function request(bool $isSsl, object|null $header): Request
+	{
+		return new class ($isSsl, $header) extends Request {
+			public function __construct(
+				protected bool $ssl,
+				protected object|null $header
+			) {
+				parent::__construct(options: [
+					'url' => [
+						'scheme' => $ssl ? 'https' : 'http',
+						'host'   => 'example.com'
+					]
+				]);
+			}
+
+			public function ssl(): bool
+			{
+				return $this->ssl;
+			}
+
+			public function auth(): \Kirby\Http\Request\Auth|false|null
+			{
+				return $this->header;
+			}
+		};
+	}
+
+	protected function auth(
+		bool $auth = true,
+		bool $isSsl = true,
+		bool $allowInsecure = false,
+		bool $hasPassword = true,
+		bool $hasAnyWith2FA = false,
+		object|null $header = null
+	): Auth&Stub {
+		$kirby   = $this->createStub(App::class);
+		$request = $this->request($isSsl, $header);
+		$kirby->method('request')->willReturn($request);
+		$kirby->method('option')->willReturnCallback(
+			function (string $key) use ($auth, $allowInsecure) {
+				return match ($key) {
+					'api.basicAuth'     => $auth,
+					'api.allowInsecure' => $allowInsecure,
+					default              => null
+				};
+			}
+		);
+
+		$methods = $this->createStub(Methods::class);
+		$methods->method('has')->willReturn($hasPassword);
+		$methods->method('hasAnyWith2FA')->willReturn($hasAnyWith2FA);
+
+		$auth = $this->createStub(Auth::class);
+		$auth->method('kirby')->willReturn($kirby);
+		$auth->method('methods')->willReturn($methods);
+
+		return $auth;
+	}
+
+	protected function header(
+		string $user = 'kirby',
+		string $password = 'secret'
+	): BasicAuth {
+		$header = $this->createStub(BasicAuth::class);
+		$header->method('username')->willReturn($user);
+		$header->method('password')->willReturn($password);
+
+		return $header;
+	}
+
+	public function testAuthenticate(): void
+	{
+		$user = $this->createStub(User::class);
+		$auth = $this->auth(header: $this->header());
+		$auth->method('validatePassword')
+			->willReturnCallback(function (...$args) use ($user) {
+				$this->assertSame(['kirby@getkirby.com', 'topsecret'], $args);
+				return $user;
+			});
+
+		$method = new BasicAuthMethod(auth: $auth);
+		$result = $method->authenticate('kirby@getkirby.com', 'topsecret');
+		$this->assertSame($user, $result);
+	}
+
+	public function testAuthenticateWithoutPassword(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Missing password');
+
+		$auth   = $this->auth();
+		$method = new BasicAuthMethod(auth: $auth);
+		$method->authenticate('kirby@getkirby.com');
+	}
+
+	public function testIsAvailable(): void
+	{
+		$header = $this->header();
+		$auth   = $this->auth(header: $header);
+		$this->assertTrue(BasicAuthMethod::isAvailable($auth));
+	}
+
+	public function testIsAvailableDisabled(): void
+	{
+		$auth = $this->auth(auth: false, header: $this->header());
+		$this->assertFalse(BasicAuthMethod::isAvailable($auth));
+
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('Basic authentication is not activated');
+		BasicAuthMethod::isAvailable($auth, fail: true);
+	}
+
+	public function testIsAvailableInvalidHeader(): void
+	{
+		$auth = $this->auth(header: null);
+		$this->assertFalse(BasicAuthMethod::isAvailable($auth));
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid authorization header');
+		BasicAuthMethod::isAvailable($auth, fail: true);
+	}
+
+	public function testIsAvailableWithoutPasswordLogin(): void
+	{
+		$auth = $this->auth(hasPassword: false, header: $this->header());
+		$this->assertFalse(BasicAuthMethod::isAvailable($auth));
+
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('Login with password is not enabled');
+		BasicAuthMethod::isAvailable($auth, fail: true);
+	}
+
+	public function testIsAvailableWith2FA(): void
+	{
+		$auth = $this->auth(hasAnyWith2FA: true, header: $this->header());
+		$this->assertFalse(BasicAuthMethod::isAvailable($auth));
+
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('Basic authentication cannot be used with 2FA');
+		BasicAuthMethod::isAvailable($auth, fail: true);
+	}
+
+	public function testIsAvailableInsecure(): void
+	{
+		$auth = $this->auth(isSsl: false, allowInsecure: false, header: $this->header());
+		$this->assertFalse(BasicAuthMethod::isAvailable($auth));
+
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('Basic authentication is only allowed over HTTPS');
+		BasicAuthMethod::isAvailable($auth, fail: true);
+	}
+
+	public function testIsAvailableInsecureAllowed(): void
+	{
+		$auth = $this->auth(isSsl: false, allowInsecure: true, header: $this->header());
+		$this->assertTrue(BasicAuthMethod::isAvailable($auth));
+	}
+
+	public function testUser(): void
+	{
+		$user   = $this->createStub(User::class);
+		$header = $this->header('homer', 'donut');
+		$auth   = $this->auth(header: $header);
+		$auth->method('validatePassword')
+			->willReturnCallback(function (...$args) use ($user) {
+				$this->assertSame(['homer', 'donut'], $args);
+				return $user;
+			});
+
+		$method = new BasicAuthMethod(auth: $auth);
+		$this->assertSame($user, $method->user($header));
+	}
+}

--- a/tests/Cms/CoreTest.php
+++ b/tests/Cms/CoreTest.php
@@ -44,6 +44,7 @@ class CoreTest extends TestCase
 	{
 		$authMethods = $this->core->authMethods();
 		$this->assertArrayHasKey('code', $authMethods);
+		$this->assertArrayHasKey('basic-auth', $authMethods);
 		$this->assertArrayHasKey('password', $authMethods);
 		$this->assertArrayHasKey('password-reset', $authMethods);
 	}


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

This PR moves most of the basic auth logic out of the `Auth` class and instead creates a new Auth method class for Basic Auth. This way Basic Auth authentication is much closer to other methods like password, code etc.

`BasicAuthMethod::isAvailable()` takes care of the various checks made to ensure basic auth can be actually used in the request. 

### Merge first

- [x] https://github.com/getkirby/kirby/pull/7835
- [x] https://github.com/getkirby/kirby/pull/7836
- [x] https://github.com/getkirby/kirby/pull/7844

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- New `Kirby\Auth\Method\BasicAuthMethod` class


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to https://github.com/getkirby/kirby/pull/7848