### PR TITLE
refact: Getting rid of the terrible Kirby\Panel\Field class (Big step 1)

### DIFF
--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -29,6 +29,7 @@ use Kirby\Form\Field\MultiselectField;
 use Kirby\Form\Field\NumberField;
 use Kirby\Form\Field\ObjectField;
 use Kirby\Form\Field\PagePickerField;
+use Kirby\Form\Field\PasswordField;
 use Kirby\Form\Field\RadioField;
 use Kirby\Form\Field\RangeField;
 use Kirby\Form\Field\SelectField;
@@ -268,6 +269,7 @@ class Core
 			'number'      => NumberField::class,
 			'object'      => ObjectField::class,
 			'pages'       => PagePickerField::class,
+			'password'    => PasswordField::class,
 			'radio'       => RadioField::class,
 			'range'       => RangeField::class,
 			'select'      => SelectField::class,

--- a/src/Form/Field/PasswordField.php
+++ b/src/Form/Field/PasswordField.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+/**
+ * Password field
+ *
+ * @package   Kirby Field
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class PasswordField extends TextField
+{
+	public function icon(): string
+	{
+		return $this->icon ?? 'key';
+	}
+}

--- a/src/Form/Field/SlugField.php
+++ b/src/Form/Field/SlugField.php
@@ -110,6 +110,15 @@ class SlugField extends TextField
 		return $this->icon ?? 'url';
 	}
 
+	public function label(): string
+	{
+		if ($this->label === null || $this->label === []) {
+			return $this->i18n('slug');
+		}
+
+		return parent::label();
+	}
+
 	public function path(): string|null
 	{
 		return $this->path;

--- a/src/Form/Mixin/Label.php
+++ b/src/Form/Mixin/Label.php
@@ -14,7 +14,7 @@ trait Label
 	public function label(): string|null
 	{
 		if ($this->label === null || $this->label === []) {
-			return Str::ucfirst($this->name());
+			return Str::label($this->name());
 		}
 
 		return $this->stringTemplateI18n($this->label);

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -8,6 +8,7 @@ use Kirby\Cms\Page;
 use Kirby\Cms\Roles;
 use Kirby\Form\Field\EmailField;
 use Kirby\Form\Field\HiddenField;
+use Kirby\Form\Field\PasswordField;
 use Kirby\Panel\Form\Field\RoleField;
 use Kirby\Panel\Form\Field\TitleField;
 use Kirby\Panel\Form\Field\TranslationField;
@@ -132,11 +133,7 @@ class Field
 	 */
 	public static function password(array $props = []): array
 	{
-		return [
-			'label' => I18n::translate('password'),
-			'type'  => 'password',
-			...$props
-		];
+		return PasswordField::factory($props)->toArray();
 	}
 
 	/**

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -7,6 +7,7 @@ use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Cms\Roles;
 use Kirby\Panel\Form\Field\TranslationField;
+use Kirby\Panel\Form\Field\UsernameField;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
 
@@ -228,11 +229,6 @@ class Field
 
 	public static function username(array $props = []): array
 	{
-		return [
-			'icon'  => 'user',
-			'label' => I18n::translate('name'),
-			'type'  => 'text',
-			...$props
-		];
+		return UsernameField::factory($props)->toArray();
 	}
 }

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -9,12 +9,12 @@ use Kirby\Cms\Roles;
 use Kirby\Form\Field\EmailField;
 use Kirby\Form\Field\HiddenField;
 use Kirby\Form\Field\PasswordField;
+use Kirby\Form\Field\SlugField;
 use Kirby\Panel\Form\Field\RoleField;
 use Kirby\Panel\Form\Field\TitleField;
 use Kirby\Panel\Form\Field\TranslationField;
 use Kirby\Panel\Form\Field\UsernameField;
 use Kirby\Toolkit\I18n;
-use Kirby\Toolkit\Str;
 
 /**
  * Provides common field prop definitions
@@ -173,12 +173,7 @@ class Field
 
 	public static function slug(array $props = []): array
 	{
-		return [
-			'label' => I18n::translate('slug'),
-			'type'  => 'slug',
-			'allow' => Str::$defaults['slug']['allowed'],
-			...$props
-		];
+		return SlugField::factory($props)->toArray();
 	}
 
 	public static function template(

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -6,6 +6,7 @@ use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Cms\Roles;
+use Kirby\Form\Field\HiddenField;
 use Kirby\Panel\Form\Field\TitleField;
 use Kirby\Panel\Form\Field\TranslationField;
 use Kirby\Panel\Form\Field\UsernameField;
@@ -80,7 +81,7 @@ class Field
 
 	public static function hidden(): array
 	{
-		return ['hidden' => true];
+		return HiddenField::factory([])->toArray();
 	}
 
 	/**

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -6,6 +6,7 @@ use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Cms\Roles;
+use Kirby\Form\Field\EmailField;
 use Kirby\Form\Field\HiddenField;
 use Kirby\Panel\Form\Field\TitleField;
 use Kirby\Panel\Form\Field\TranslationField;
@@ -31,12 +32,7 @@ class Field
 	 */
 	public static function email(array $props = []): array
 	{
-		return [
-			'label'   => I18n::translate('email'),
-			'type'    => 'email',
-			'counter' => false,
-			...$props
-		];
+		return EmailField::factory($props)->toArray();
 	}
 
 	/**

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -6,6 +6,7 @@ use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Cms\Roles;
+use Kirby\Panel\Form\Field\TitleField;
 use Kirby\Panel\Form\Field\TranslationField;
 use Kirby\Panel\Form\Field\UsernameField;
 use Kirby\Toolkit\I18n;
@@ -211,12 +212,7 @@ class Field
 
 	public static function title(array $props = []): array
 	{
-		return [
-			'label' => I18n::translate('title'),
-			'type'  => 'text',
-			'icon'  => 'title',
-			...$props
-		];
+		return TitleField::factory($props)->toArray();
 	}
 
 	/**

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -8,6 +8,7 @@ use Kirby\Cms\Page;
 use Kirby\Cms\Roles;
 use Kirby\Form\Field\EmailField;
 use Kirby\Form\Field\HiddenField;
+use Kirby\Panel\Form\Field\RoleField;
 use Kirby\Panel\Form\Field\TitleField;
 use Kirby\Panel\Form\Field\TranslationField;
 use Kirby\Panel\Form\Field\UsernameField;
@@ -75,9 +76,9 @@ class Field
 	}
 
 
-	public static function hidden(): array
+	public static function hidden(array $props = []): array
 	{
-		return HiddenField::factory([])->toArray();
+		return HiddenField::factory($props)->toArray();
 	}
 
 	/**
@@ -158,19 +159,19 @@ class Field
 				$kirby->user()?->isAdmin() === true
 		);
 
-		// turn roles into radio field options
-		$roles = $roles->values(fn ($role) => [
-			'text'  => $role->title(),
-			'info'  => $role->description() ?? I18n::translate('role.description.placeholder'),
-			'value' => $role->name()
+		$field = new RoleField(...[
+			'roles' => $roles,
+			...$props
 		]);
 
-		return [
-			'label'   => I18n::translate('role'),
-			'type'    => count($roles) < 1 ? 'hidden' : 'radio',
-			'options' => $roles,
-			...$props
-		];
+		if (count($field->options()) <= 1) {
+			return static::hidden([
+				'name' => 'role',
+				...$props
+			]);
+		}
+
+		return $field->toArray();
 	}
 
 	public static function slug(array $props = []): array

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -6,6 +6,7 @@ use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Cms\Roles;
+use Kirby\Panel\Form\Field\TranslationField;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
 
@@ -222,22 +223,7 @@ class Field
 	 */
 	public static function translation(array $props = []): array
 	{
-		$translations = [];
-		foreach (App::instance()->translations() as $translation) {
-			$translations[] = [
-				'text'  => $translation->name(),
-				'value' => $translation->code()
-			];
-		}
-
-		return [
-			'label'   => I18n::translate('language'),
-			'type'    => 'select',
-			'icon'    => 'translate',
-			'options' => $translations,
-			'empty'   => false,
-			...$props
-		];
+		return TranslationField::factory($props)->toArray();
 	}
 
 	public static function username(array $props = []): array

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -10,13 +10,13 @@ use Kirby\Form\Field\EmailField;
 use Kirby\Form\Field\HiddenField;
 use Kirby\Form\Field\PasswordField;
 use Kirby\Form\Field\SlugField;
+use Kirby\Panel\Form\Field\FilePositionField;
 use Kirby\Panel\Form\Field\PagePositionField;
 use Kirby\Panel\Form\Field\RoleField;
 use Kirby\Panel\Form\Field\TemplateField;
 use Kirby\Panel\Form\Field\TitleField;
 use Kirby\Panel\Form\Field\TranslationField;
 use Kirby\Panel\Form\Field\UsernameField;
-use Kirby\Toolkit\I18n;
 
 /**
  * Provides common field prop definitions
@@ -44,40 +44,14 @@ class Field
 	 */
 	public static function filePosition(File $file, array $props = []): array
 	{
-		$index   = 0;
-		$options = [];
-
-		foreach ($file->siblings(false)->sorted() as $sibling) {
-			$index++;
-
-			$options[] = [
-				'value' => $index,
-				'text'  => $index
-			];
-
-			$options[] = [
-				'value'    => $sibling->id(),
-				'text'     => $sibling->filename(),
-				'disabled' => true
-			];
-		}
-
-		$index++;
-
-		$options[] = [
-			'value' => $index,
-			'text'  => $index
-		];
-
-		return [
-			'label'   => I18n::translate('file.sort'),
-			'type'    => 'select',
-			'empty'   => false,
-			'options' => $options,
+		$field = new FilePositionField(...[
+			'file'     => $file,
+			'required' => true,
 			...$props
-		];
-	}
+		]);
 
+		return $field->toArray();
+	}
 
 	public static function hidden(array $props = []): array
 	{

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -11,6 +11,7 @@ use Kirby\Form\Field\HiddenField;
 use Kirby\Form\Field\PasswordField;
 use Kirby\Form\Field\SlugField;
 use Kirby\Panel\Form\Field\RoleField;
+use Kirby\Panel\Form\Field\TemplateField;
 use Kirby\Panel\Form\Field\TitleField;
 use Kirby\Panel\Form\Field\TranslationField;
 use Kirby\Panel\Form\Field\UsernameField;
@@ -180,24 +181,10 @@ class Field
 		array|null $blueprints = [],
 		array|null $props = []
 	): array {
-		$options = [];
-
-		foreach ($blueprints as $blueprint) {
-			$options[] = [
-				'text'  => $blueprint['title'] ?? $blueprint['text']  ?? null,
-				'value' => $blueprint['name']  ?? $blueprint['value'] ?? null,
-			];
-		}
-
-		return [
-			'label'    => I18n::translate('template'),
-			'type'     => 'select',
-			'empty'    => false,
-			'options'  => $options,
-			'icon'     => 'template',
-			'disabled' => count($options) <= 1,
-			...$props
-		];
+		return (new TemplateField(...[
+			'blueprints' => $blueprints,
+			...$props,
+		]))->toArray();
 	}
 
 	public static function title(array $props = []): array

--- a/src/Panel/Field.php
+++ b/src/Panel/Field.php
@@ -10,6 +10,7 @@ use Kirby\Form\Field\EmailField;
 use Kirby\Form\Field\HiddenField;
 use Kirby\Form\Field\PasswordField;
 use Kirby\Form\Field\SlugField;
+use Kirby\Panel\Form\Field\PagePositionField;
 use Kirby\Panel\Form\Field\RoleField;
 use Kirby\Panel\Form\Field\TemplateField;
 use Kirby\Panel\Form\Field\TitleField;
@@ -88,45 +89,18 @@ class Field
 	 */
 	public static function pagePosition(Page $page, array $props = []): array
 	{
-		$index    = 0;
-		$options  = [];
-		$siblings = $page->parentModel()->children()->listed()->not($page);
-
-		foreach ($siblings as $sibling) {
-			$index++;
-
-			$options[] = [
-				'value' => $index,
-				'text'  => $index
-			];
-
-			$options[] = [
-				'value'    => $sibling->id(),
-				'text'     => $sibling->title()->value(),
-				'disabled' => true
-			];
-		}
-
-		$index++;
-
-		$options[] = [
-			'value' => $index,
-			'text'  => $index
-		];
-
-		// if only one available option,
-		// hide field when not in debug mode
-		if (count($options) < 2) {
-			return static::hidden();
-		}
-
-		return [
-			'label'    => I18n::translate('page.changeStatus.position'),
-			'type'     => 'select',
+		$field = new PagePositionField(...[
+			'page'     => $page,
 			'required' => true,
-			'options'  => $options,
 			...$props
-		];
+		]);
+
+		// hide filed when there is only one available option
+		if (count($field->options()) < 2) {
+			return static::hidden($props);
+		}
+
+		return $field->toArray();
 	}
 
 	/**

--- a/src/Panel/Form/Field/FilePositionField.php
+++ b/src/Panel/Form/Field/FilePositionField.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Kirby\Panel\Form\Field;
+
+use Kirby\Cms\File;
+use Kirby\Form\Field\SelectField;
+
+class FilePositionField extends SelectField
+{
+	public function __construct(
+		protected File $file,
+		...$props
+	) {
+		parent::__construct(...$props);
+	}
+
+	public function label(): string
+	{
+		if ($this->label === null || $this->label === []) {
+			return $this->i18n('file.sort');
+		}
+
+		return parent::label();
+	}
+
+	public function name(): string
+	{
+		return $this->name ?? 'position';
+	}
+
+	public function options(): array
+	{
+		$index   = 0;
+		$options = [];
+
+		foreach ($this->file->siblings(false)->sorted() as $sibling) {
+			$index++;
+
+			$options[] = [
+				'value' => $index,
+				'text'  => $index
+			];
+
+			$options[] = [
+				'value'    => $sibling->id(),
+				'text'     => $sibling->filename(),
+				'disabled' => true
+			];
+		}
+
+		$index++;
+
+		$options[] = [
+			'value' => $index,
+			'text'  => $index
+		];
+
+		return $options;
+	}
+
+	public function type(): string
+	{
+		return 'select';
+	}
+}

--- a/src/Panel/Form/Field/PagePositionField.php
+++ b/src/Panel/Form/Field/PagePositionField.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Kirby\Panel\Form\Field;
+
+use Kirby\Cms\Page;
+use Kirby\Form\Field\SelectField;
+
+class PagePositionField extends SelectField
+{
+	public function __construct(
+		protected Page $page,
+		...$props
+	) {
+		parent::__construct(...$props);
+	}
+
+	public function label(): string
+	{
+		if ($this->label === null || $this->label === []) {
+			return $this->i18n('page.changeStatus.position');
+		}
+
+		return parent::label();
+	}
+
+	public function name(): string
+	{
+		return $this->name ?? 'position';
+	}
+
+	public function options(): array
+	{
+		$index    = 0;
+		$options  = [];
+		$siblings = $this->page->parentModel()->children()->listed()->not($this->page);
+
+		foreach ($siblings as $sibling) {
+			$index++;
+
+			$options[] = [
+				'value' => $index,
+				'text'  => $index
+			];
+
+			$options[] = [
+				'value'    => $sibling->id(),
+				'text'     => $sibling->title()->value(),
+				'disabled' => true
+			];
+		}
+
+		$index++;
+
+		$options[] = [
+			'value' => $index,
+			'text'  => $index
+		];
+
+		return $options;
+	}
+
+	public function type(): string
+	{
+		return 'select';
+	}
+}

--- a/src/Panel/Form/Field/RoleField.php
+++ b/src/Panel/Form/Field/RoleField.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Kirby\Panel\Form\Field;
+
+use Kirby\Cms\App;
+use Kirby\Cms\Roles;
+use Kirby\Form\Field\RadioField;
+
+class RoleField extends RadioField
+{
+	public function __construct(
+		protected Roles|null $roles = null,
+		...$props
+	) {
+		parent::__construct(...$props);
+	}
+
+	public function label(): string
+	{
+		if ($this->label === null || $this->label === []) {
+			return $this->i18n('role');
+		}
+
+		return parent::label();
+	}
+
+	public function name(): string
+	{
+		return $this->name ?? 'role';
+	}
+
+	public function options(): array
+	{
+		// turn roles into radio field options
+		return $this->roles()->values(fn ($role) => [
+			'text'  => $role->title(),
+			'info'  => $role->description() ?? $this->i18n('role.description.placeholder'),
+			'value' => $role->name()
+		]);
+	}
+
+	public function roles(): Roles
+	{
+		return $this->roles ?? App::instance()->roles();
+	}
+
+	public function type(): string
+	{
+		return 'radio';
+	}
+}

--- a/src/Panel/Form/Field/TemplateField.php
+++ b/src/Panel/Form/Field/TemplateField.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Kirby\Panel\Form\Field;
+
+use Kirby\Form\Field\SelectField;
+
+class TemplateField extends SelectField
+{
+	public function __construct(
+		protected array $blueprints = [],
+		...$props
+	) {
+		parent::__construct(...$props);
+	}
+
+	public function isDisabled(): bool
+	{
+		return $this->disabled() === true || count($this->blueprints) <= 1;
+	}
+
+	public function icon(): string
+	{
+		return $this->icon ?? 'template';
+	}
+
+	public function label(): string
+	{
+		if ($this->label === null || $this->label === []) {
+			return $this->i18n('template');
+		}
+
+		return parent::label();
+	}
+
+	public function name(): string
+	{
+		return $this->name ?? 'template';
+	}
+
+	public function options(): array
+	{
+		$options = [];
+
+		foreach ($this->blueprints as $blueprint) {
+			$options[] = [
+				'text'  => $blueprint['title'] ?? $blueprint['text']  ?? null,
+				'value' => $blueprint['name']  ?? $blueprint['value'] ?? null,
+			];
+		}
+
+		return $options;
+	}
+
+	public function type(): string
+	{
+		return 'select';
+	}
+}

--- a/src/Panel/Form/Field/TitleField.php
+++ b/src/Panel/Form/Field/TitleField.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kirby\Panel\Form\Field;
+
+use Kirby\Form\Field\TextField;
+
+class TitleField extends TextField
+{
+	public function icon(): string
+	{
+		return $this->icon ?? 'title';
+	}
+
+	public function label(): string
+	{
+		if ($this->label === null || $this->label === []) {
+			return $this->i18n('title');
+		}
+
+		return parent::label();
+	}
+
+	public function name(): string
+	{
+		return $this->name ?? 'title';
+	}
+
+	public function type(): string
+	{
+		return 'text';
+	}
+}

--- a/src/Panel/Form/Field/TranslationField.php
+++ b/src/Panel/Form/Field/TranslationField.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Kirby\Panel\Form\Field;
+
+use Kirby\Cms\App;
+use Kirby\Form\Field\SelectField;
+
+class TranslationField extends SelectField
+{
+	public function icon(): string
+	{
+		return $this->icon ?? 'translate';
+	}
+
+	public function label(): string
+	{
+		if ($this->label === null || $this->label === []) {
+			return $this->i18n('language');
+		}
+
+		return parent::label();
+	}
+
+	public function name(): string
+	{
+		return $this->name ?? 'translation';
+	}
+
+	public function options(): array
+	{
+		$translations = [];
+
+		foreach (App::instance()->translations() as $translation) {
+			$translations[] = [
+				'text'  => $translation->name(),
+				'value' => $translation->code()
+			];
+		}
+
+		return $translations;
+	}
+
+	public function type(): string
+	{
+		return 'select';
+	}
+}

--- a/src/Panel/Form/Field/UsernameField.php
+++ b/src/Panel/Form/Field/UsernameField.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Kirby\Panel\Form\Field;
+
+use Kirby\Form\Field\TextField;
+
+class UsernameField extends TextField
+{
+	public function icon(): string
+	{
+		return $this->icon ?? 'user';
+	}
+
+	public function label(): string
+	{
+		if ($this->label === null || $this->label === []) {
+			return $this->i18n('name');
+		}
+
+		return parent::label();
+	}
+
+	public function name(): string
+	{
+		return $this->name ?? 'username';
+	}
+
+	public function type(): string
+	{
+		return 'text';
+	}
+}

--- a/tests/Form/Field/PasswordFieldTest.php
+++ b/tests/Form/Field/PasswordFieldTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(PasswordField::class)]
+class PasswordFieldTest extends TestCase
+{
+	public function testProps(): void
+	{
+		$field = $this->field('password');
+		$props = $field->props();
+
+		ksort($props);
+
+		$expected = [
+			'after'        => null,
+			'autocomplete' => null,
+			'autofocus'    => false,
+			'before'       => null,
+			'converter'    => null,
+			'counter'      => true,
+			'disabled'     => false,
+			'font'         => 'sans-serif',
+			'help'         => null,
+			'hidden'       => false,
+			'icon'         => 'key',
+			'label'        => 'Password',
+			'maxlength'    => null,
+			'minlength'    => null,
+			'name'         => 'password',
+			'pattern'      => null,
+			'placeholder'  => null,
+			'required'     => false,
+			'saveable'     => true,
+			'spellcheck'   => null,
+			'translate'    => true,
+			'type'         => 'password',
+			'when'         => null,
+			'width'        => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
+	}
+}

--- a/tests/Form/Field/SlugFieldTest.php
+++ b/tests/Form/Field/SlugFieldTest.php
@@ -27,7 +27,7 @@ class SlugFieldTest extends TestCase
 			'help'         => null,
 			'hidden'       => false,
 			'icon'         => 'url',
-			'label'        => 'Slug',
+			'label'        => 'URL appendix',
 			'maxlength'    => null,
 			'minlength'    => null,
 			'name'         => 'slug',
@@ -47,4 +47,14 @@ class SlugFieldTest extends TestCase
 
 		$this->assertSame($expected, $props);
 	}
+
+	public function testLabel(): void
+	{
+		$field = $this->field('slug', [
+			'label' => 'Test'
+		]);
+
+		$this->assertSame('Test', $field->label());
+	}
+
 }

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -286,7 +286,11 @@ class FieldTest extends TestCase
 			'disabled' => true
 		];
 
-		$this->assertSame($expected, $field);
+		$this->assertSame('Template', $field['label']);
+		$this->assertSame('select', $field['type']);
+		$this->assertSame([], $field['options']);
+		$this->assertSame('template', $field['icon']);
+		$this->assertSame(true, $field['disabled']);
 
 		// select option format
 		$options = [

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -362,7 +362,6 @@ class FieldTest extends TestCase
 		$this->assertSame('Language', $field['label']);
 		$this->assertSame('select', $field['type']);
 		$this->assertSame('translate', $field['icon']);
-		$this->assertFalse($field['empty']);
 		$this->assertCount($this->app->translations()->count(), $field['options']);
 
 		// with custom props

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -171,13 +171,9 @@ class FieldTest extends TestCase
 	public function testRole(): void
 	{
 		$field = Field::role();
-		$expected = [
-			'label'   => 'Role',
-			'type'    => 'hidden',
-			'options' => []
-		];
 
-		$this->assertSame($expected, $field);
+		$this->assertSame('role', $field['name']);
+		$this->assertSame('hidden', $field['type']);
 
 		// without authenticated user
 		$this->app = $this->app->clone([
@@ -200,52 +196,50 @@ class FieldTest extends TestCase
 		]);
 
 		$field = Field::role();
-		$expected = [
-			'label'   => 'Role',
-			'type'    => 'radio',
-			'options' => [
-				[
-					'text' => 'Client',
-					'info' => 'No description',
-					'value' => 'client'
-				],
-				[
-					'text' => 'Editor',
-					'info' => 'Editor description',
-					'value' => 'editor'
-				],
-			]
+
+		$options = [
+			[
+				'text' => 'Client',
+				'info' => 'No description',
+				'value' => 'client'
+			],
+			[
+				'text' => 'Editor',
+				'info' => 'Editor description',
+				'value' => 'editor'
+			],
 		];
 
-		$this->assertSame($expected, $field);
+		$this->assertSame('Role', $field['label']);
+		$this->assertSame('radio', $field['type']);
+		$this->assertSame($options, $field['options']);
 
 		// with authenticated admin
 		$this->app->impersonate('kirby');
 
 		$field = Field::role();
-		$expected = [
-			'label'   => 'Role',
-			'type'    => 'radio',
-			'options' => [
-				[
-					'text' => 'Admin',
-					'info' => 'Admin description',
-					'value' => 'admin'
-				],
-				[
-					'text' => 'Client',
-					'info' => 'No description',
-					'value' => 'client'
-				],
-				[
-					'text' => 'Editor',
-					'info' => 'Editor description',
-					'value' => 'editor'
-				],
-			]
+
+		$options = [
+			[
+				'text' => 'Admin',
+				'info' => 'Admin description',
+				'value' => 'admin'
+			],
+			[
+				'text' => 'Client',
+				'info' => 'No description',
+				'value' => 'client'
+			],
+			[
+				'text' => 'Editor',
+				'info' => 'Editor description',
+				'value' => 'editor'
+			],
 		];
 
-		$this->assertSame($expected, $field);
+		$this->assertSame('Role', $field['label']);
+		$this->assertSame('radio', $field['type']);
+		$this->assertSame($options, $field['options']);
 	}
 
 	public function testSlug(): void

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -46,7 +46,6 @@ class FieldTest extends TestCase
 
 		$this->assertSame('Change position', $field['label']);
 		$this->assertSame('select', $field['type']);
-		$this->assertFalse($field['empty']);
 
 		// check options
 		$this->assertCount(5, $field['options']);

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -275,13 +275,10 @@ class FieldTest extends TestCase
 	{
 		// default
 		$field = Field::title();
-		$expected = [
-			'label' => 'Title',
-			'type'  => 'text',
-			'icon'  => 'title'
-		];
 
-		$this->assertSame($expected, $field);
+		$this->assertSame('Title', $field['label']);
+		$this->assertSame('text', $field['type']);
+		$this->assertSame('title', $field['icon']);
 
 		// with custom props
 		$field = Field::title([

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -82,7 +82,7 @@ class FieldTest extends TestCase
 	public function testHidden(): void
 	{
 		$field = Field::hidden();
-		$this->assertSame(['hidden' => true], $field);
+		$this->assertSame(true, $field['hidden']);
 	}
 
 	public function testPagePosition(): void

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -244,13 +244,9 @@ class FieldTest extends TestCase
 	{
 		// default
 		$field = Field::slug();
-		$expected = [
-			'label' => 'URL appendix',
-			'type'  => 'slug',
-			'allow' => 'a-z0-9'
-		];
 
-		$this->assertSame($expected, $field);
+		$this->assertSame('URL appendix', $field['label']);
+		$this->assertSame('slug', $field['type']);
 
 		// with custom props
 		$field = Field::slug([

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -13,13 +13,10 @@ class FieldTest extends TestCase
 	{
 		// default
 		$field = Field::email();
-		$expected = [
-			'label'   => 'Email',
-			'type'    => 'email',
-			'counter' => false
-		];
 
-		$this->assertSame($expected, $field);
+		$this->assertSame('Email', $field['label']);
+		$this->assertSame('email', $field['type']);
+		$this->assertSame(false, $field['counter']);
 
 		// with custom props
 		$field = Field::email([

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -153,12 +153,10 @@ class FieldTest extends TestCase
 	{
 		// default
 		$field = Field::password();
-		$expected = [
-			'label'   => 'Password',
-			'type'    => 'password',
-		];
 
-		$this->assertSame($expected, $field);
+		$this->assertSame('Password', $field['label']);
+		$this->assertSame('key', $field['icon']);
+		$this->assertSame('password', $field['type']);
 
 		// with custom props
 		$field = Field::password([

--- a/tests/Panel/FieldTest.php
+++ b/tests/Panel/FieldTest.php
@@ -376,13 +376,10 @@ class FieldTest extends TestCase
 	{
 		// default
 		$field = Field::username();
-		$expected = [
-			'icon'  => 'user',
-			'label' => 'Name',
-			'type'  => 'text',
-		];
 
-		$this->assertSame($expected, $field);
+		$this->assertSame('user', $field['icon']);
+		$this->assertSame('Name', $field['label']);
+		$this->assertSame('text', $field['type']);
 
 		// with custom props
 		$field = Field::username([

--- a/tests/Panel/Form/Field/FilePositionFieldTest.php
+++ b/tests/Panel/Form/Field/FilePositionFieldTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Kirby\Panel\Form\Field;
+
+use Kirby\Form\Field\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(FilePositionField::class)]
+class FilePositionFieldTest extends TestCase
+{
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->app = $this->app->clone([
+			'site' => [
+				'files' => [
+					['filename' => 'a.jpg'],
+					['filename' => 'b.jpg'],
+					['filename' => 'c.jpg']
+				]
+			]
+		]);
+	}
+
+	public function testProps(): void
+	{
+		$file = $this->app->site()->file('b.jpg');
+
+		$field = new FilePositionField(
+			file: $file
+		);
+
+		$props = $field->props();
+
+		ksort($props);
+
+		$expected = [
+			'autofocus'   => false,
+			'disabled'    => false,
+			'help'        => null,
+			'hidden'      => false,
+			'icon'        => null,
+			'label'       => 'Change position',
+			'name'        => 'position',
+			'options'     => [
+				[
+					'value' => 1,
+					'text'  => 1
+				],
+				[
+					'value'    => 'a.jpg',
+					'text'     => 'a.jpg',
+					'disabled' => true
+				],
+				[
+					'value' => 2,
+					'text'  => 2
+				],
+				[
+					'value'    => 'c.jpg',
+					'text'     => 'c.jpg',
+					'disabled' => true
+				],
+				[
+					'value' => 3,
+					'text'  => 3
+				],
+			],
+			'placeholder' => '—',
+			'required'    => false,
+			'saveable'    => true,
+			'translate'   => true,
+			'type'        => 'select',
+			'when'        => null,
+			'width'       => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
+	}
+
+	public function testLabel(): void
+	{
+		$field = new FilePositionField(
+			file: $this->app->file('b.jpg'),
+			label: 'Test'
+		);
+
+		$this->assertSame('Test', $field->label());
+	}
+}

--- a/tests/Panel/Form/Field/PagePositionFieldTest.php
+++ b/tests/Panel/Form/Field/PagePositionFieldTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Kirby\Panel\Form\Field;
+
+use Kirby\Form\Field\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(PagePositionField::class)]
+class PagePositionFieldTest extends TestCase
+{
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->app = $this->app->clone([
+			'site' => [
+				'children' => [
+					['slug' => 'a', 'num' => 1],
+					['slug' => 'b', 'num' => 2],
+					['slug' => 'c', 'num' => 3]
+				]
+			]
+		]);
+	}
+
+	public function testProps(): void
+	{
+		$field = new PagePositionField(
+			page: $this->app->page('b')
+		);
+
+		$props = $field->props();
+
+		ksort($props);
+
+		$expected = [
+			'autofocus'   => false,
+			'disabled'    => false,
+			'help'        => null,
+			'hidden'      => false,
+			'icon'        => null,
+			'label'       => 'Please select a position',
+			'name'        => 'position',
+			'options'     => [
+				[
+					'value' => 1,
+					'text'  => 1
+				],
+				[
+					'value'    => 'a',
+					'text'     => 'a',
+					'disabled' => true
+				],
+				[
+					'value' => 2,
+					'text'  => 2
+				],
+				[
+					'value'    => 'c',
+					'text'     => 'c',
+					'disabled' => true
+				],
+				[
+					'value' => 3,
+					'text'  => 3
+				],
+			],
+			'placeholder' => '—',
+			'required'    => false,
+			'saveable'    => true,
+			'translate'   => true,
+			'type'        => 'select',
+			'when'        => null,
+			'width'       => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
+	}
+
+	public function testLabel(): void
+	{
+		$field = new PagePositionField(
+			page: $this->app->page('b'),
+			label: 'Test'
+		);
+
+		$this->assertSame('Test', $field->label());
+	}
+}

--- a/tests/Panel/Form/Field/RoleFieldTest.php
+++ b/tests/Panel/Form/Field/RoleFieldTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Kirby\Panel\Form\Field;
+
+use Kirby\Cms\Roles;
+use Kirby\Form\Field\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(RoleField::class)]
+class RoleFieldTest extends TestCase
+{
+	public function testProps(): void
+	{
+		$field = new RoleField();
+		$props = $field->props();
+
+		ksort($props);
+
+		// test options separately
+		unset($props['options']);
+
+		$expected = [
+			'autofocus'   => false,
+			'columns'     => 1,
+			'disabled'    => false,
+			'help'        => null,
+			'hidden'      => false,
+			'label'       => 'Role',
+			'name'        => 'role',
+			'required'    => false,
+			'saveable'    => true,
+			'translate'   => true,
+			'type'        => 'radio',
+			'when'        => null,
+			'width'       => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
+		$this->assertCount($this->app->roles()->count(), $field->options());
+	}
+
+	public function testOptions(): void
+	{
+		$roles = Roles::factory([
+			[
+				'name'        => 'admin',
+				'title'       => 'Admin',
+				'description' => 'Admin description'
+			],
+			[
+				'name'        => 'editor',
+				'title'       => 'Editor',
+				'description' => 'Editor description'
+			],
+			[
+				'name'  => 'client',
+				'title' => 'Client'
+			]
+		]);
+
+		$field = new RoleField(roles: $roles);
+
+		$expected = [
+			[
+				'text'  => 'Admin',
+				'info'  => 'Admin description',
+				'value' => 'admin'
+			],
+			[
+				'text'  => 'Client',
+				'info'  => 'No description',
+				'value' => 'client'
+			],
+			[
+				'text'  => 'Editor',
+				'info'  => 'Editor description',
+				'value' => 'editor'
+			]
+		];
+
+		$this->assertSame($expected, $field->options());
+	}
+
+	public function testLabel(): void
+	{
+		$field = new RoleField(
+			label: 'Test'
+		);
+
+		$this->assertSame('Test', $field->label());
+	}
+}

--- a/tests/Panel/Form/Field/TemplateFieldTest.php
+++ b/tests/Panel/Form/Field/TemplateFieldTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Kirby\Panel\Form\Field;
+
+use Kirby\Form\Field\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(TemplateField::class)]
+class TemplateFieldTest extends TestCase
+{
+	public function testProps(): void
+	{
+		$field = new TemplateField();
+		$props = $field->props();
+
+		ksort($props);
+
+		$expected = [
+			'autofocus'   => false,
+			'disabled'    => true,
+			'help'        => null,
+			'hidden'      => false,
+			'icon'        => 'template',
+			'label'       => 'Template',
+			'name'        => 'template',
+			'options'     => [],
+			'placeholder' => '—',
+			'required'    => false,
+			'saveable'    => true,
+			'translate'   => true,
+			'type'        => 'select',
+			'when'        => null,
+			'width'       => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
+	}
+
+	public function testLabel(): void
+	{
+		$field = new TemplateField(
+			label: 'Test'
+		);
+
+		$this->assertSame('Test', $field->label());
+	}
+
+	public function testOptions(): void
+	{
+		$field = new TemplateField(blueprints: [
+			[
+				'title' => 'A',
+				'name'  => 'a'
+			],
+			[
+				'title' => 'B',
+				'name'  => 'b'
+			]
+		]);
+
+		$expected = [
+			[
+				'text'  => 'A',
+				'value' => 'a'
+			],
+			[
+				'text'  => 'B',
+				'value' => 'b'
+			]
+		];
+
+		$this->assertFalse($field->isDisabled());
+		$this->assertSame($expected, $field->options());
+	}
+}

--- a/tests/Panel/Form/Field/TitleFieldTest.php
+++ b/tests/Panel/Form/Field/TitleFieldTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Kirby\Panel\Form\Field;
+
+use Kirby\Form\Field\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(TitleField::class)]
+class TitleFieldTest extends TestCase
+{
+	public function testProps(): void
+	{
+		$field = new TitleField();
+		$props = $field->props();
+
+		ksort($props);
+
+		$expected = [
+			'after'        => null,
+			'autocomplete' => null,
+			'autofocus'    => false,
+			'before'       => null,
+			'converter'    => null,
+			'counter'      => true,
+			'disabled'     => false,
+			'font'         => 'sans-serif',
+			'help'         => null,
+			'hidden'       => false,
+			'icon'         => 'title',
+			'label'        => 'Title',
+			'maxlength'    => null,
+			'minlength'    => null,
+			'name'         => 'title',
+			'pattern'      => null,
+			'placeholder'  => null,
+			'required'     => false,
+			'saveable'     => true,
+			'spellcheck'   => null,
+			'translate'    => true,
+			'type'         => 'text',
+			'when'         => null,
+			'width'        => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
+	}
+
+	public function testLabel(): void
+	{
+		$field = new TitleField(
+			label: 'Test'
+		);
+
+		$this->assertSame('Test', $field->label());
+	}
+}

--- a/tests/Panel/Form/Field/TranslationFieldTest.php
+++ b/tests/Panel/Form/Field/TranslationFieldTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Kirby\Panel\Form\Field;
+
+use Kirby\Form\Field\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(TranslationField::class)]
+class TranslationFieldTest extends TestCase
+{
+	public function testProps(): void
+	{
+		$field = new TranslationField();
+		$props = $field->props();
+
+		ksort($props);
+
+		// test options separately
+		unset($props['options']);
+
+		$expected = [
+			'autofocus'   => false,
+			'disabled'    => false,
+			'help'        => null,
+			'hidden'      => false,
+			'icon'        => 'translate',
+			'label'       => 'Language',
+			'name'        => 'translation',
+			'placeholder' => '—',
+			'required'    => false,
+			'saveable'    => true,
+			'translate'   => true,
+			'type'        => 'select',
+			'when'        => null,
+			'width'       => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
+		$this->assertCount($this->app->translations()->count(), $field->options());
+	}
+
+	public function testLabel(): void
+	{
+		$field = new TranslationField(
+			label: 'Test'
+		);
+
+		$this->assertSame('Test', $field->label());
+	}
+}

--- a/tests/Panel/Form/Field/UsernameFieldTest.php
+++ b/tests/Panel/Form/Field/UsernameFieldTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Kirby\Panel\Form\Field;
+
+use Kirby\Form\Field\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(UsernameField::class)]
+class UsernameFieldTest extends TestCase
+{
+	public function testProps(): void
+	{
+		$field = new UsernameField();
+		$props = $field->props();
+
+		ksort($props);
+
+		$expected = [
+			'after'        => null,
+			'autocomplete' => null,
+			'autofocus'    => false,
+			'before'       => null,
+			'converter'    => null,
+			'counter'      => true,
+			'disabled'     => false,
+			'font'         => 'sans-serif',
+			'help'         => null,
+			'hidden'       => false,
+			'icon'         => 'user',
+			'label'        => 'Name',
+			'maxlength'    => null,
+			'minlength'    => null,
+			'name'         => 'username',
+			'pattern'      => null,
+			'placeholder'  => null,
+			'required'     => false,
+			'saveable'     => true,
+			'spellcheck'   => null,
+			'translate'    => true,
+			'type'         => 'text',
+			'when'         => null,
+			'width'        => '1/1',
+		];
+
+		$this->assertSame($expected, $props);
+	}
+
+	public function testLabel(): void
+	{
+		$field = new UsernameField(
+			label: 'Test'
+		);
+
+		$this->assertSame('Test', $field->label());
+	}
+}

--- a/tests/Reflection/ConstructorTest.php
+++ b/tests/Reflection/ConstructorTest.php
@@ -14,12 +14,22 @@ class ReflectableTestClass
 	}
 }
 
+class ReflectableTestChildClass extends ReflectableTestClass
+{
+	public function __construct(
+		protected $c,
+		...$props
+	) {
+		parent::__construct(...$props);
+	}
+}
+
 #[CoversClass(Constructor::class)]
 class ConstructorTest extends TestCase
 {
-	public function reflection(): Constructor
+	public function reflection(string $class = ReflectableTestClass::class): Constructor
 	{
-		return new Constructor(ReflectableTestClass::class);
+		return new Constructor($class);
 	}
 
 	public function testClassifyArguments(): void
@@ -40,6 +50,22 @@ class ConstructorTest extends TestCase
 
 		$this->assertSame($accepted, $result['accepted']);
 		$this->assertSame($ignored, $result['ignored']);
+	}
+
+	public function testClassifyArgumentsWithNestedParameters(): void
+	{
+		$accepted = [
+			'a' => 'Test A',
+			'b' => 'Test B',
+			'c' => 'Test C'
+		];
+
+		$result = $this->reflection(ReflectableTestChildClass::class)->classifyArguments([
+			...$accepted,
+		]);
+
+		$this->assertSame($accepted, $result['accepted']);
+		$this->assertSame([], $result['ignored']);
 	}
 
 	public function testGetAcceptedArguments(): void
@@ -73,6 +99,30 @@ class ConstructorTest extends TestCase
 		$this->assertSame([], $result);
 	}
 
+	public function testGetAcceptedArgumentsWithNestedParameters(): void
+	{
+		$accepted = [
+			'a' => 'Test A',
+			'b' => 'Test B',
+			'c' => 'Test C'
+		];
+
+		$result = $this->reflection(ReflectableTestChildClass::class)->getAcceptedArguments($accepted);
+
+		$this->assertSame($accepted, $result);
+	}
+
+	public function testGetAllParameters(): void
+	{
+		$parameters = $this->reflection()->getAllParameters();
+
+		$this->assertCount(2, $parameters);
+
+		$parameters = $this->reflection(ReflectableTestChildClass::class)->getAllParameters();
+
+		$this->assertCount(3, $parameters);
+	}
+
 	public function testGetIgnoredArguments(): void
 	{
 		$accepted = [
@@ -104,10 +154,45 @@ class ConstructorTest extends TestCase
 		$this->assertSame([], $result);
 	}
 
-	public function testParamsNames(): void
+	public function testGetIgnoredArgumentsWithNestedParameters(): void
+	{
+		$accepted = [
+			'a' => 'Test A',
+			'b' => 'Test B',
+			'c' => 'Test C'
+		];
+
+		$ignored = [
+			'd' => 'Test D'
+		];
+
+		$result = $this->reflection(ReflectableTestChildClass::class)->getIgnoredArguments($ignored);
+
+		$this->assertSame($ignored, $result);
+	}
+
+	public function testGetParameterNames(): void
 	{
 		$result = $this->reflection()->getParameterNames();
 
 		$this->assertSame(['a', 'b'], $result);
+	}
+
+	public function testGetParameterNamesWithNestedParameters(): void
+	{
+		$result = $this->reflection(ReflectableTestChildClass::class)->getParameterNames();
+
+		$this->assertSame(['c', 'a', 'b'], $result);
+	}
+
+	public function testGetParentParameters(): void
+	{
+		$parameters = $this->reflection()->getParentParameters();
+
+		$this->assertSame([], $parameters);
+
+		$parameters = $this->reflection(ReflectableTestChildClass::class)->getParentParameters();
+
+		$this->assertCount(2, $parameters);
 	}
 }


### PR DESCRIPTION
## Changelog

### Enhancements

#### Variadic parameter reflection

The `Kirby\Reflection\Constructor` class can now resolve variadic parameters in the constructor and reflect all parameters from parent classes recursively. 

Example: 

```php
class A 
{
  public function __construct()
  {
    public string $a,
    public string $b
  }
}

class B extends A
{
  public function __construct()
  {
    public string $c,
    ...
  }
}

$reflection = new Kirby\Reflection\Constructor(B::class);

// The following methods will now consider all parameters `c`, `a` and `b` (in this order)
$reflection->classifyArguments();
$reflection->getAcceptedArguments();
$reflection->getAllParameters();
$reflection->getIgnoredArguments();
$reflection->getParameterNames();
```

In order to achieve this, there are two new methods: 
  - `::getAllParameters()`
  - `::getParentParameters()`

#### New fields

- new `Kirby\Form\Field\PasswordField`
- new `Kirby\Panel\Form\Field\FilePositionField`
- new `Kirby\Panel\Form\Field\PagePositionField`
- new `Kirby\Panel\Form\Field\RoleField`
- new `Kirby\Panel\Form\Field\TemplateField`
- new `Kirby\Panel\Form\Field\TitleField`
- new `Kirby\Panel\Form\Field\TranslationField`

#### Field improvements

- The `Label` mixin does now define a protected `::labelFallback()` method, which can be used by consuming classes to create a useful auto-generated label. By default, the field type is used, but we also have a couple useful translations for field labels, which make more sense. 
- The `Kirby\Form\Field\SlugField` does now get the 'slug' translation string as default label 
- The Label mixin now uses the Str::label method for label fallbacks. 

### Refactoring

- The `Kirby\Panel\Field` class uses the new classes and improvements above to replace its logic. In a next step, we can remove it more easily in all places where it is being used.