### PR TITLE
[Auth 8] refact: `Kirby\Auth\Status` + `Kirby\Auth\State`

### DIFF
--- a/src/Auth/Method.php
+++ b/src/Auth/Method.php
@@ -3,7 +3,6 @@
 namespace Kirby\Auth;
 
 use Kirby\Cms\Auth;
-use Kirby\Cms\Auth\Status;
 use Kirby\Cms\User;
 use Kirby\Toolkit\Str;
 use SensitiveParameter;

--- a/src/Auth/Method/CodeMethod.php
+++ b/src/Auth/Method/CodeMethod.php
@@ -3,8 +3,8 @@
 namespace Kirby\Auth\Method;
 
 use Kirby\Auth\Method;
+use Kirby\Auth\Status;
 use Kirby\Cms\Auth;
-use Kirby\Cms\Auth\Status;
 use Kirby\Exception\InvalidArgumentException;
 
 /**

--- a/src/Auth/Method/PasswordMethod.php
+++ b/src/Auth/Method/PasswordMethod.php
@@ -4,8 +4,8 @@ namespace Kirby\Auth\Method;
 
 use InvalidArgumentException;
 use Kirby\Auth\Method;
+use Kirby\Auth\Status;
 use Kirby\Cms\Auth;
-use Kirby\Cms\Auth\Status;
 use Kirby\Cms\User;
 use SensitiveParameter;
 

--- a/src/Auth/Method/PasswordResetMethod.php
+++ b/src/Auth/Method/PasswordResetMethod.php
@@ -2,8 +2,8 @@
 
 namespace Kirby\Auth\Method;
 
+use Kirby\Auth\Status;
 use Kirby\Cms\Auth;
-use Kirby\Cms\Auth\Status;
 
 /**
  * Password-reset flow that triggers a challenge

--- a/src/Auth/Methods.php
+++ b/src/Auth/Methods.php
@@ -5,7 +5,6 @@ namespace Kirby\Auth;
 use Kirby\Api\Api;
 use Kirby\Cms\App;
 use Kirby\Cms\Auth;
-use Kirby\Cms\Auth\Status;
 use Kirby\Cms\User;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;

--- a/src/Auth/State.php
+++ b/src/Auth/State.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Kirby\Auth;
+
+/**
+ * Authentication states
+ *
+ * @package   Kirby Auth
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+enum State: string
+{
+	case Active       = 'active';
+	case Impersonated = 'impersonated';
+	case Pending      = 'pending';
+	case Inactive     = 'inactive';
+}

--- a/src/Auth/Status.php
+++ b/src/Auth/Status.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Kirby\Auth;
+
+use Kirby\Cms\App;
+use Kirby\Cms\User;
+use Kirby\Session\Session;
+
+/**
+ * Immutable authentication status value object
+ *
+ * Designed to avoid ad-hoc arrays and keep the
+ * status surface consistent across auth flows.
+ *
+ * @package   Kirby Auth
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class Status
+{
+	protected function __construct(
+		protected App $kirby,
+		protected State $state,
+		protected string|null $email = null,
+		protected string|null $mode = null,
+		protected string|null $challenge = null,
+		protected Pending|null $data = null,
+		protected string|null $fallback = null
+	) {
+	}
+
+	/**
+	 * Status when a user is logged in
+	 */
+	public static function active(App $kirby, User $user): static
+	{
+		return new static(
+			kirby: $kirby,
+			state: State::Active,
+			email: $user->email()
+		);
+	}
+
+	/**
+	 * Returns the active challenge type or the fallback if enabled
+	 */
+	public function challenge(bool $fallback = true): string|null
+	{
+		if ($this->state !== State::Pending) {
+			return null;
+		}
+
+		if ($fallback === false) {
+			return $this->challenge;
+		}
+
+		return $this->challenge ?? $this->fallback;
+	}
+
+	public function data(): Pending|null
+	{
+		return $this->data;
+	}
+
+	public function email(): string|null
+	{
+		return $this->email;
+	}
+
+	/**
+	 * Build a status object from the current auth context
+	 */
+	public static function for(
+		App $kirby,
+		User|null $user,
+		bool $impersonated,
+		Session $session,
+		array $challenges
+	): static {
+		if ($user !== null) {
+			return $impersonated === true ?
+				static::impersonated($kirby, $user) :
+				static::active($kirby, $user);
+		}
+
+		$email = $session->get('kirby.challenge.email');
+
+		if ($email !== null) {
+			$data     = $session->get('kirby.challenge.data');
+			$fallback = match ($challenges) {
+				[]      => null,
+				default => $challenges[array_key_last($challenges)]
+			};
+
+			return static::pending(
+				kirby:     $kirby,
+				email:     $email,
+				mode:      $session->get('kirby.challenge.mode'),
+				challenge: $session->get('kirby.challenge.type'),
+				data:      Pending::from($data ?? []),
+				fallback:  $fallback
+			);
+		}
+
+		return static::inactive($kirby);
+	}
+
+	/**
+	 * Status when a user is impersonated
+	 */
+	public static function impersonated(App $kirby, User $user): static
+	{
+		return new static(
+			kirby: $kirby,
+			state: State::Impersonated,
+			email: $user->email()
+		);
+	}
+
+	/**
+	 * Status when no auth is active
+	 */
+	public static function inactive(App $kirby): static
+	{
+		return new static(
+			kirby: $kirby,
+			state: State::Inactive
+		);
+	}
+
+	public function is(State $state): bool
+	{
+		return $this->state === $state;
+	}
+
+	public function mode(): string|null
+	{
+		return $this->mode;
+	}
+
+	/**
+	 * Status when a challenge is pending
+	 */
+	public static function pending(
+		App $kirby,
+		string|null $email = null,
+		string|null $mode = null,
+		string|null $challenge = null,
+		Pending|null $data = null,
+		string|null $fallback = null
+	): static {
+		return new static(
+			kirby:     $kirby,
+			state:     State::Pending,
+			email:     $email,
+			mode:      $mode,
+			challenge: $challenge,
+			data:      $data,
+			fallback:  $fallback
+		);
+	}
+
+	public function state(): State
+	{
+		return $this->state;
+	}
+
+	public function toArray(): array
+	{
+		return [
+			'challenge' => $this->challenge(),
+			'data'      => $this->data()?->public(),
+			'email'     => $this->email(),
+			'mode'      => $this->mode(),
+			'status'    => $this->state()->value
+		];
+	}
+
+	/**
+	 * Returns the user only when authenticated
+	 */
+	public function user(): User|null
+	{
+		if (
+			$this->email === null ||
+			(
+				$this->is(State::Active) === false &&
+				$this->is(State::Impersonated) === false
+			)
+		) {
+			return null;
+		}
+
+		return $this->kirby->user($this->email);
+	}
+}

--- a/src/Cms/Auth/Status.php
+++ b/src/Cms/Auth/Status.php
@@ -10,13 +10,14 @@ use Stringable;
 /**
  * Information container for the
  * authentication status
- * @since 3.5.1
  *
  * @package   Kirby Cms
  * @author    Lukas Bestle <lukas@getkirby.com>
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ * @since     3.5.1
+ * @deprecated 6.0.0 Use `Kirby\Auth\Status` instead
  */
 class Status implements Stringable
 {

--- a/src/Panel/Controller/View/LoginViewController.php
+++ b/src/Panel/Controller/View/LoginViewController.php
@@ -40,12 +40,7 @@ class LoginViewController extends ViewController
 
 	public function pending(): array
 	{
-		$status = $this->kirby->auth()->status();
-
-		return [
-			'email'     => $status->email(),
-			'challenge' => $status->challenge()
-		];
+		return $this->kirby->auth()->status()->toArray();
 	}
 
 	public function value(): array

--- a/tests/Auth/Method/CodeMethodTest.php
+++ b/tests/Auth/Method/CodeMethodTest.php
@@ -4,8 +4,8 @@ namespace Kirby\Auth\Method;
 
 use Kirby\Auth\Method;
 use Kirby\Auth\Methods;
+use Kirby\Auth\Status;
 use Kirby\Cms\Auth;
-use Kirby\Cms\Auth\Status;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Auth/Method/PasswordMethodTest.php
+++ b/tests/Auth/Method/PasswordMethodTest.php
@@ -4,8 +4,8 @@ namespace Kirby\Auth\Method;
 
 use InvalidArgumentException;
 use Kirby\Auth\Method;
+use Kirby\Auth\Status;
 use Kirby\Cms\Auth;
-use Kirby\Cms\Auth\Status;
 use Kirby\Cms\User;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Auth/Method/PasswordResetMethodTest.php
+++ b/tests/Auth/Method/PasswordResetMethodTest.php
@@ -4,8 +4,8 @@ namespace Kirby\Auth\Method;
 
 use Kirby\Auth\Method;
 use Kirby\Auth\Methods;
+use Kirby\Auth\Status;
 use Kirby\Cms\Auth;
-use Kirby\Cms\Auth\Status;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Auth/MethodsTest.php
+++ b/tests/Auth/MethodsTest.php
@@ -5,7 +5,6 @@ namespace Kirby\Auth;
 use Kirby\Api\Api;
 use Kirby\Auth\Method\CodeMethod;
 use Kirby\Auth\Method\PasswordMethod;
-use Kirby\Cms\Auth\Status;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;

--- a/tests/Auth/StatusTest.php
+++ b/tests/Auth/StatusTest.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace Kirby\Auth;
+
+use Kirby\Cms\App;
+use Kirby\Cms\User;
+use Kirby\Filesystem\Dir;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Status::class)]
+class StatusTest extends TestCase
+{
+	public const string TMP = KIRBY_TMP_DIR . '/Auth.Status';
+
+	protected App $app;
+
+	public function setUp(): void
+	{
+		$this->app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'users' => [
+				[
+					'email' => 'homer@simpsons.com',
+					'name'  => 'Homer Simpson'
+				]
+			]
+		]);
+	}
+
+	public function tearDown(): void
+	{
+		$this->app->session()->destroy();
+		Dir::remove(static::TMP);
+		App::destroy();
+	}
+
+	public function testActive(): void
+	{
+		$user   = $this->app->user('homer@simpsons.com');
+		$active = Status::active($this->app, $user);
+		$this->assertTrue($active->is(State::Active));
+	}
+
+	public function testChallenge(): void
+	{
+		// no challenge when not pending
+		$user   = $this->app->user('homer@simpsons.com');
+		$status = Status::active($this->app, $user);
+		$this->assertNull($status->challenge());
+
+		// with pending challenge
+		$status = Status::pending(
+			kirby: $this->app,
+			email: 'homer@simpsons.com',
+			mode: 'login',
+			challenge: 'totp',
+			fallback: 'email'
+		);
+		$this->assertSame('totp', $status->challenge());
+
+		// with faked challenge uses fallback
+		$status = Status::pending(
+			kirby: $this->app,
+			email: 'homer@simpsons.com',
+			mode: 'login',
+			fallback: 'email'
+		);
+		$this->assertSame('email', $status->challenge());
+		$this->assertNull($status->challenge(false));
+	}
+
+	public function testEmail(): void
+	{
+		$status = Status::inactive($this->app);
+		$this->assertNull($status->email());
+	}
+
+	public function testFor(): void
+	{
+		$session = $this->app->session();
+		$user    = $this->app->user('homer@simpsons.com');
+		$status  = Status::for(
+			kirby: $this->app,
+			user: $user,
+			impersonated: false,
+			session: $session,
+			challenges: ['totp']
+		);
+		$this->assertTrue($status->is(State::Active));
+
+		// pending status from session with fallback challenge
+		$session->set('kirby.challenge.email', 'homer@simpsons.com');
+		$session->set('kirby.challenge.mode', 'login');
+		$session->set('kirby.challenge.type', null);
+		$session->set('kirby.challenge.data', ['public' => 'bar']);
+
+		$status = Status::for(
+			kirby: $this->app,
+			user: null,
+			impersonated: false,
+			session: $session,
+			challenges: ['totp', 'email']
+		);
+
+		$this->assertTrue($status->is(State::Pending));
+		$this->assertSame('email', $status->challenge());
+		$this->assertSame('login', $status->mode());
+		$this->assertSame('bar', $status->data()?->public());
+
+		// inactive if no user and no challenge in session
+		$session->clear();
+		$status = Status::for(
+			kirby: $this->app,
+			user: null,
+			impersonated: false,
+			session: $session,
+			challenges: []
+		);
+		$this->assertTrue($status->is(State::Inactive));
+	}
+
+	public function testImpersonated(): void
+	{
+		$user         = $this->app->user('homer@simpsons.com');
+		$impersonated = Status::impersonated($this->app, $user);
+		$this->assertTrue($impersonated->is(State::Impersonated));
+	}
+
+	public function testInactive(): void
+	{
+		$inactive = Status::inactive($this->app);
+		$this->assertTrue($inactive->is(State::Inactive));
+	}
+
+	public function testMode(): void
+	{
+		$status = Status::inactive($this->app);
+		$this->assertNull($status->mode());
+
+		$status = Status::pending(
+			kirby: $this->app,
+			email: 'homer@simpsons.com',
+			mode: 'password-reset'
+		);
+		$this->assertSame('password-reset', $status->mode());
+	}
+
+	public function testPending(): void
+	{
+		$pending = Status::pending($this->app, 'homer@simpsons.com');
+		$this->assertTrue($pending->is(State::Pending));
+	}
+
+	public function testState(): void
+	{
+		$user         = $this->app->user('homer@simpsons.com');
+		$active       = Status::active($this->app, $user);
+		$impersonated = Status::impersonated($this->app, $user);
+		$pending      = Status::pending($this->app, 'homer@simpsons.com');
+		$inactive     = Status::inactive($this->app);
+
+		$this->assertTrue($active->is(State::Active));
+		$this->assertTrue($impersonated->is(State::Impersonated));
+		$this->assertTrue($pending->is(State::Pending));
+		$this->assertTrue($inactive->is(State::Inactive));
+
+		$this->assertFalse($active->is(State::Impersonated));
+		$this->assertFalse($impersonated->is(State::Active));
+		$this->assertFalse($pending->is(State::Active));
+		$this->assertFalse($inactive->is(State::Pending));
+	}
+
+	public function testToArray(): void
+	{
+		$status = Status::pending(
+			kirby:     $this->app,
+			email:     'homer@simpsons.com',
+			mode:      'password-reset',
+			challenge: 'totp',
+			data:       new Pending(public: ['foo' => 'bar'])
+		);
+
+		$this->assertSame([
+			'challenge' => 'totp',
+			'data'      => ['foo' => 'bar'],
+			'email'     => 'homer@simpsons.com',
+			'mode'      => 'password-reset',
+			'status'    => 'pending'
+		], $status->toArray());
+	}
+
+	public function testUser(): void
+	{
+		// only active/impersonated states return a user
+		$pending = Status::pending($this->app, 'homer@simpsons.com');
+		$this->assertNull($pending->user());
+
+		$inactive = Status::inactive($this->app);
+		$this->assertNull($inactive->user());
+
+		$user   = $this->app->user('homer@simpsons.com');
+		$active = Status::active($this->app, $user);
+		$name   = $active->user()?->name()->value();
+		$this->assertSame('Homer Simpson', $name);
+
+		$impersonated = Status::impersonated($this->app, $user);
+		$name         = $impersonated->user()?->name()->value();
+		$this->assertSame('Homer Simpson', $name);
+
+		// if the stored email no longer exists, return null
+		$app   = $this->app->clone(['users' => []]);
+		$user  = new User(['email' => 'invalid@simpsons.com']);
+		$stale = Status::active($app, $user);
+		$this->assertNull($stale->user());
+	}
+}

--- a/tests/Auth/StatusTest.php
+++ b/tests/Auth/StatusTest.php
@@ -2,10 +2,7 @@
 
 namespace Kirby\Auth;
 
-use Kirby\Cms\App;
 use Kirby\Cms\User;
-use Kirby\Filesystem\Dir;
-use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(Status::class)]
@@ -13,14 +10,11 @@ class StatusTest extends TestCase
 {
 	public const string TMP = KIRBY_TMP_DIR . '/Auth.Status';
 
-	protected App $app;
-
 	public function setUp(): void
 	{
-		$this->app = new App([
-			'roots' => [
-				'index' => static::TMP
-			],
+		parent::setUp();
+
+		$this->app = $this->app->clone([
 			'users' => [
 				[
 					'email' => 'homer@simpsons.com',
@@ -28,13 +22,6 @@ class StatusTest extends TestCase
 				]
 			]
 		]);
-	}
-
-	public function tearDown(): void
-	{
-		$this->app->session()->destroy();
-		Dir::remove(static::TMP);
-		App::destroy();
 	}
 
 	public function testActive(): void

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -4,9 +4,9 @@ namespace Kirby\Cms;
 
 use Kirby\Auth\Method;
 use Kirby\Auth\Methods;
+use Kirby\Auth\Status;
 use Kirby\Cache\FileCache;
 use Kirby\Cms\Auth\Challenge;
-use Kirby\Cms\Auth\Status;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Filesystem\Mime;
@@ -251,6 +251,7 @@ class AppPluginsTest extends TestCase
 		$status = $auth->createChallenge('homer@simpsons.com');
 		$this->assertSame([
 			'challenge' => 'dummy',
+			'data'      => null,
 			'email'     => 'homer@simpsons.com',
 			'mode'      => 'login',
 			'status'    => 'pending'

--- a/tests/Cms/Auth/AuthChallengeTest.php
+++ b/tests/Cms/Auth/AuthChallengeTest.php
@@ -97,6 +97,7 @@ class AuthChallengeTest extends TestCase
 		$status = $auth->createChallenge('marge@simpsons.com');
 		$this->assertSame([
 			'challenge' => 'email',
+			'data'      => null,
 			'email'     => 'marge@simpsons.com',
 			'mode'      => 'login',
 			'status'    => 'pending'
@@ -119,6 +120,7 @@ class AuthChallengeTest extends TestCase
 		$status = $auth->createChallenge('invalid@example.com');
 		$this->assertSame([
 			'challenge' => 'email',
+			'data'      => null,
 			'email'     => 'invalid@example.com',
 			'mode'      => 'login',
 			'status'    => 'pending'
@@ -134,6 +136,7 @@ class AuthChallengeTest extends TestCase
 		$status = $auth->createChallenge('error@getkirby.com');
 		$this->assertSame([
 			'challenge' => 'email',
+			'data'      => null,
 			'email'     => 'error@getkirby.com',
 			'mode'      => 'login',
 			'status'    => 'pending'
@@ -170,6 +173,7 @@ class AuthChallengeTest extends TestCase
 		$status = $auth->createChallenge('marge@simpsons.com');
 		$this->assertSame([
 			'challenge' => 'email',
+			'data'      => null,
 			'email'     => 'marge@simpsons.com',
 			'mode'      => 'login',
 			'status'    => 'pending'
@@ -229,6 +233,7 @@ class AuthChallengeTest extends TestCase
 		$status = $auth->createChallenge('marge@simpsons.com');
 		$this->assertSame([
 			'challenge' => 'email',
+			'data'      => null,
 			'email'     => 'marge@simpsons.com',
 			'mode'      => 'login',
 			'status'    => 'pending'
@@ -241,6 +246,7 @@ class AuthChallengeTest extends TestCase
 		$status = $auth->createChallenge('invalid@example.com');
 		$this->assertSame([
 			'challenge' => 'email',
+			'data'      => null,
 			'email'     => 'invalid@example.com',
 			'mode'      => 'login',
 			'status'    => 'pending'
@@ -256,6 +262,7 @@ class AuthChallengeTest extends TestCase
 		$status = $this->auth->createChallenge('marge@simpsons.com', true);
 		$this->assertSame([
 			'challenge' => 'email',
+			'data'      => null,
 			'email'     => 'marge@simpsons.com',
 			'mode'      => 'login',
 			'status'    => 'pending'
@@ -272,6 +279,7 @@ class AuthChallengeTest extends TestCase
 		$status = $this->auth->createChallenge('test@xn--exmple-cua.com');
 		$this->assertSame([
 			'challenge' => 'email',
+			'data'      => null,
 			'email'     => 'test@exämple.com',
 			'mode'      => 'login',
 			'status'    => 'pending'
@@ -320,6 +328,7 @@ class AuthChallengeTest extends TestCase
 		$status = $this->auth->login2fa('marge@simpsons.com', 'springfield123');
 		$this->assertSame([
 			'challenge' => 'email',
+			'data'      => null,
 			'email'     => 'marge@simpsons.com',
 			'mode'      => '2fa',
 			'status'    => 'pending'
@@ -345,6 +354,7 @@ class AuthChallengeTest extends TestCase
 		$status = $this->auth->login2fa('marge@simpsons.com', 'springfield123', true);
 		$this->assertSame([
 			'challenge' => 'email',
+			'data'      => null,
 			'email'     => 'marge@simpsons.com',
 			'mode'      => '2fa',
 			'status'    => 'pending'
@@ -430,6 +440,7 @@ class AuthChallengeTest extends TestCase
 			$this->assertSame(['challengeDestroyed' => true], $e->getDetails());
 			$this->assertSame([
 				'challenge' => null,
+				'data'      => null,
 				'email'     => null,
 				'mode'      => null,
 				'status'    => 'inactive'
@@ -450,6 +461,7 @@ class AuthChallengeTest extends TestCase
 			$this->assertSame(['challengeDestroyed' => false], $e->getDetails());
 			$this->assertSame([
 				'challenge' => 'email',
+				'data'      => null,
 				'email'     => 'marge@simpsons.com',
 				'mode'      => null,
 				'status'    => 'pending'
@@ -478,6 +490,7 @@ class AuthChallengeTest extends TestCase
 			$this->assertSame(['challengeDestroyed' => true], $e->getDetails());
 			$this->assertSame([
 				'challenge' => null,
+				'data'      => null,
 				'email'     => null,
 				'mode'      => null,
 				'status'    => 'inactive'
@@ -559,6 +572,7 @@ class AuthChallengeTest extends TestCase
 
 		$this->assertSame([
 			'challenge' => null,
+			'data'      => null,
 			'email'     => null,
 			'mode'      => null,
 			'status'    => 'inactive'

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -4,7 +4,7 @@ namespace Kirby\Cms;
 
 use Kirby\Auth\Limits;
 use Kirby\Auth\Methods;
-use Kirby\Cms\Auth\Status;
+use Kirby\Auth\Status;
 use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -201,6 +201,7 @@ class AuthTest extends TestCase
 
 		$this->assertSame([
 			'challenge' => null,
+			'data'      => null,
 			'email'     => null,
 			'mode'      => null,
 			'status'    => 'inactive'
@@ -223,6 +224,7 @@ class AuthTest extends TestCase
 
 		$this->assertSame([
 			'challenge' => null,
+			'data'      => null,
 			'email'     => null,
 			'mode'      => null,
 			'status'    => 'inactive'

--- a/tests/Cms/Auth/StatusTest.php
+++ b/tests/Cms/Auth/StatusTest.php
@@ -7,6 +7,9 @@ use Kirby\Cms\TestCase;
 use Kirby\Exception\InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 
+/**
+ * @deprecated 6.0.0
+ */
 #[CoversClass(Status::class)]
 class StatusTest extends TestCase
 {


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->


### Merge first

- [x] https://github.com/getkirby/kirby/pull/7835
- [x] https://github.com/getkirby/kirby/pull/7836
- [x] https://github.com/getkirby/kirby/pull/7844
- [x] https://github.com/getkirby/kirby/pull/7845
- [x] https://github.com/getkirby/kirby/pull/7847
- [x] https://github.com/getkirby/kirby/pull/7849

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- New`Kirby\Auth\Status` class and `Kirby\Auth\State` enum

### ☠️ Deprecated
<!-- 
e.g. Deprecate method X. Use method Y instead.
-->
- `Kirby\Cms\Auth\Status`: use `Kirby\Auth\Status` instead

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
Everywhere where `Kirby\Cms\Auth\Status` got returned or expected as parameter, `Kirby\Auth\Status` is now used.



## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to https://github.com/getkirby/kirby/pull/7848