### PR TITLE
feat: Drawer sizes / fix: resize behavior

### DIFF
--- a/panel/lab/components/drawers/1_drawer/index.vue
+++ b/panel/lab/components/drawers/1_drawer/index.vue
@@ -33,6 +33,25 @@
 				Open
 			</k-button>
 		</k-lab-example>
+		<k-lab-example :flex="true" label="Sizes">
+			<k-button
+				v-for="size in ['tiny', 'small', 'default', 'large', 'huge']"
+				:key="size"
+				icon="open"
+				variant="filled"
+				@click="
+					$panel.drawer.open({
+						component: 'k-drawer',
+						props: {
+							size,
+							title: 'Drawer'
+						}
+					})
+				"
+			>
+				{{ size }}
+			</k-button>
+		</k-lab-example>
 		<k-lab-example :flex="true" label="Nested">
 			<k-button
 				icon="open"

--- a/panel/lab/internals/panel/observers/index.php
+++ b/panel/lab/internals/panel/observers/index.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'source' => 'panel/src/panel/observers.js'
+];

--- a/panel/lab/internals/panel/observers/index.vue
+++ b/panel/lab/internals/panel/observers/index.vue
@@ -1,0 +1,51 @@
+<template>
+	<k-lab-examples>
+		<k-lab-example label="frames" :code="false">
+			<k-text>
+				<p>
+					<code>window.panel.observers.resize</code> is a resize observer meant
+					to subscribe to element widths/heights.
+				</p>
+			</k-text>
+
+			<div ref="frame" class="frame">
+				{{ frame.width }}&times;{{ frame.height }}
+			</div>
+		</k-lab-example>
+	</k-lab-examples>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			frame: {}
+		};
+	},
+	mounted() {
+		const frame = this.$refs.frame;
+		this.$panel.observers.resize.observe(frame);
+
+		frame.addEventListener("resize", ({ detail }) => {
+			this.frame = {
+				width: Math.round(detail.width),
+				height: Math.round(detail.height)
+			};
+		});
+	},
+	beforeUnmount() {
+		this.$panel.observers.resize.unobserve(this.$refs.frame);
+	}
+};
+</script>
+
+<style>
+.k-lab-example .frame {
+	width: 40vw;
+	height: 30vh;
+	background: var(--color-yellow-300);
+	margin-top: var(--spacing-6);
+	display: grid;
+	place-items: center;
+}
+</style>

--- a/panel/src/components/Drawers/Drawer.vue
+++ b/panel/src/components/Drawers/Drawer.vue
@@ -66,7 +66,7 @@ export default {
 	--drawer-header-height: 2.5rem;
 	--drawer-header-padding: 1rem;
 	--drawer-shadow: var(--shadow-xl);
-	--drawer-width: 50rem;
+	--drawer-width: 48rem;
 }
 
 /**
@@ -97,15 +97,15 @@ export default {
 }
 
 .k-drawer[data-size="tiny"] {
-	--drawer-width: 26rem;
+	--drawer-width: 28rem;
 }
 .k-drawer[data-size="small"] {
-	--drawer-width: 34rem;
+	--drawer-width: 38rem;
 }
 .k-drawer[data-size="large"] {
-	--drawer-width: 64rem;
+	--drawer-width: 62rem;
 }
 .k-drawer[data-size="huge"] {
-	--drawer-width: 82rem;
+	--drawer-width: 74rem;
 }
 </style>

--- a/panel/src/components/Drawers/Drawer.vue
+++ b/panel/src/components/Drawers/Drawer.vue
@@ -3,6 +3,7 @@
 		<form
 			:class="$vnode.data.staticClass"
 			:aria-current="current"
+			:data-size="size"
 			class="k-drawer"
 			method="dialog"
 			@submit.prevent="$emit('submit')"
@@ -93,5 +94,18 @@ export default {
 .k-drawer:not([aria-current="true"]) {
 	display: none;
 	pointer-events: none;
+}
+
+.k-drawer[data-size="tiny"] {
+	--drawer-width: 26rem;
+}
+.k-drawer[data-size="small"] {
+	--drawer-width: 34rem;
+}
+.k-drawer[data-size="large"] {
+	--drawer-width: 64rem;
+}
+.k-drawer[data-size="huge"] {
+	--drawer-width: 82rem;
 }
 </style>

--- a/panel/src/components/Layout/Tabs.vue
+++ b/panel/src/components/Layout/Tabs.vue
@@ -64,7 +64,6 @@ export default {
 	},
 	data() {
 		return {
-			observer: null,
 			visible: this.tabs,
 			invisible: []
 		};
@@ -85,22 +84,23 @@ export default {
 	watch: {
 		tabs: {
 			async handler() {
-				// disconnect any previous observer
-				this.observer?.disconnect();
 				await this.$nextTick();
 
 				// only if $el exists (more than one tab),
 				// add new observer and measure tab sizes
 				if (this.$el instanceof Element) {
-					this.observer = new ResizeObserver(this.resize);
-					this.observer.observe(this.$el);
+					this.$panel.observers.resize.unobserve(this.$el);
+					this.$panel.observers.resize.observe(this.$el);
+					this.$el.addEventListener("resize", this.resize);
 				}
 			},
 			immediate: true
 		}
 	},
 	destroyed() {
-		this.observer?.disconnect();
+		if (this.$el instanceof Element) {
+			this.$panel.observers.resize.unobserve(this.$el);
+		}
 	},
 	methods: {
 		button(tab) {
@@ -122,9 +122,9 @@ export default {
 
 			return button;
 		},
-		async resize() {
+		async resize({ detail }) {
 			// container width
-			const width = this.$el.offsetWidth;
+			const width = detail.width;
 
 			// reset all tabs
 			this.visible = this.tabs;

--- a/panel/src/components/Navigation/Breadcrumb.vue
+++ b/panel/src/components/Navigation/Breadcrumb.vue
@@ -66,7 +66,7 @@ export default {
 }
 
 .k-breadcrumb ol {
-	display: none;
+	display: flex;
 	gap: 0.125rem;
 	align-items: center;
 }
@@ -102,18 +102,22 @@ export default {
 }
 
 .k-breadcrumb-dropdown {
-	display: grid;
+	display: none;
 }
 .k-breadcrumb-dropdown .k-dropdown-content {
 	width: 15rem;
 }
 
-@container (min-width: 40em) {
-	.k-breadcrumb ol {
-		display: flex;
-	}
-	.k-breadcrumb-dropdown {
+/**
+ * On small screens replace breadcrumb bar by dropdown,
+ * but only if there are two crumbs or more
+ */
+@container (max-width: 40em) {
+	.k-breadcrumb ol:has(> :nth-child(2)) {
 		display: none;
+	}
+	.k-breadcrumb:has(ol > :nth-child(2)) .k-breadcrumb-dropdown {
+		display: grid;
 	}
 }
 </style>

--- a/panel/src/mixins/drawer.js
+++ b/panel/src/mixins/drawer.js
@@ -32,6 +32,15 @@ export default {
 			type: Array
 		},
 		/**
+		 * Width of the drawer
+		 * @since 5.3.0
+		 * @values "tiny", "small", "default", "large"
+		 */
+		size: {
+			default: "default",
+			type: String
+		},
+		/**
 		 * The default title for the drawer header
 		 */
 		title: String,

--- a/panel/src/panel/observers.js
+++ b/panel/src/panel/observers.js
@@ -3,7 +3,7 @@ import { reactive } from "vue";
 /**
  * @since 5.3.0
  */
-export default (panel) => {
+export default () => {
 	return reactive({
 		resize: new ResizeObserver((entries) => {
 			for (const index in entries) {

--- a/panel/src/panel/observers.js
+++ b/panel/src/panel/observers.js
@@ -1,0 +1,22 @@
+import { reactive } from "vue";
+
+/**
+ * @since 5.3.0
+ */
+export default (panel) => {
+	return reactive({
+		resize: new ResizeObserver((entries) => {
+			for (const index in entries) {
+				const item = entries[index];
+				item.target.dispatchEvent(
+					new CustomEvent("resize", {
+						detail: {
+							width: item.contentRect.width,
+							height: item.contentRect.height
+						}
+					})
+				);
+			}
+		})
+	});
+};

--- a/panel/src/panel/panel.js
+++ b/panel/src/panel/panel.js
@@ -8,6 +8,7 @@ import Dropdown from "./dropdown.js";
 import Events from "./events.js";
 import Notification from "./notification.js";
 import Language from "./language.js";
+import Observers from "./observers.js";
 import Plugins from "./plugins.js";
 import Menu from "./menu.js";
 import Search from "./search.js";
@@ -75,6 +76,7 @@ export default {
 		this.activation = Activation(this);
 		this.drag = Drag(this);
 		this.events = Events(this);
+		this.observers = Observers(this);
 		this.searcher = Search(this);
 		this.theme = Theme(this);
 		this.upload = Upload(this);

--- a/panel/vitest.setup.js
+++ b/panel/vitest.setup.js
@@ -2,3 +2,10 @@ import Vue from "vue";
 
 Vue.config.productionTip = false;
 Vue.config.devtools = false;
+
+// mock for ResizeObserver
+globalThis.ResizeObserver = class ResizeObserver {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+};


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- Drawers have new `size` option (tiny, small, default, large huge)
- New central `$panel.observers.resize` Resize Observer 

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Breadcrumbs never collapse to dropdown if they have only one crumb

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- `k-tabs` uses `$panel.observers.resize`

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion