### PR TITLE
[Auth] refact: `$user->changeSecret()`

### DIFF
--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -131,7 +131,7 @@ trait UserActions
 	public function changeSecret(string $secret, mixed $content): static
 	{
 		return $this->commit(
-			'changeSecrets',
+			'changeSecret',
 			[
 				'user'        => $this,
 				'secret'      => $secret,

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -114,23 +114,41 @@ trait UserActions
 	/**
 	 * Changes the user's TOTP secret
 	 * @since 4.0.0
+	 * @deprecated 6.0.0 Use `self::changeSecret('totp')` instead
 	 */
 	public function changeTotp(
 		#[SensitiveParameter]
 		string|null $secret
 	): static {
-		return $this->commit('changeTotp', ['user' => $this, 'secret' => $secret], function ($user, $secret) {
-			$this->writeSecret('totp', $secret);
+		UserRules::changeTotp($this, $secret);
+		return $this->changeSecret('totp', $secret);
+	}
 
-			// keep the user logged in to the current browser
-			// if they changed their own TOTP secret
-			// (regenerate the session token, update the login timestamp)
-			if ($user->isLoggedIn() === true) {
-				$user->loginPasswordless();
+	/**
+	 * Stores secrets for the user
+	 * @since 6.0.0
+	 */
+	public function changeSecret(string $secret, mixed $content): static
+	{
+		return $this->commit(
+			'changeSecrets',
+			[
+				'user'        => $this,
+				'secret'      => $secret,
+				'credentials' => $content
+			],
+			function ($user, $secret, $credentials) {
+				$this->writeSecret($secret, $credentials);
+
+				// keep the user logged in to the current browser
+				// (regenerate the session token, update the login timestamp)
+				if ($user->isLoggedIn() === true) {
+					$user->loginPasswordless();
+				}
+
+				return $user;
 			}
-
-			return $user;
-		});
+		);
 	}
 
 	/**

--- a/src/Cms/UserRules.php
+++ b/src/Cms/UserRules.php
@@ -134,8 +134,33 @@ class UserRules
 	}
 
 	/**
+	 * Validates if the user secret can be changed
+	 * @since 6.0.0
+	 *
+	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the secret
+	 */
+	public static function changeSecret(
+		User $user,
+		string $secret,
+		#[SensitiveParameter]
+		mixed $content
+	): void {
+		$currentUser = $user->kirby()->user();
+
+		if (
+			$currentUser->is($user) === false &&
+			$currentUser->isAdmin() === false
+		) {
+			throw new PermissionException(
+				message: 'You cannot change user secrets for ' . $user->email()
+			);
+		}
+	}
+
+	/**
 	 * Validates if the TOTP can be changed
 	 * @since 4.0.0
+	 * @deprecated 6.0.0
 	 *
 	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the password
 	 */

--- a/src/Panel/Controller/Dialog/UserTotpDisableDialogController.php
+++ b/src/Panel/Controller/Dialog/UserTotpDisableDialogController.php
@@ -85,7 +85,7 @@ class UserTotpDisableDialogController extends UserDialogController
 			}
 
 			// Remove the TOTP secret from the account
-			$this->user->changeTotp(null);
+			$this->user->changeSecret('totp', null);
 
 			return [
 				'message' => $this->i18n('login.totp.disable.success')

--- a/src/Panel/Controller/Dialog/UserTotpEnableDialogController.php
+++ b/src/Panel/Controller/Dialog/UserTotpEnableDialogController.php
@@ -75,7 +75,7 @@ class UserTotpEnableDialogController extends DialogController
 			);
 		}
 
-		$this->user->changeTotp($secret);
+		$this->user->changeSecret('totp', $secret);
 
 		return [
 			'message' => $this->i18n('login.totp.enable.success')

--- a/tests/Cms/User/UserChangeSecretTest.php
+++ b/tests/Cms/User/UserChangeSecretTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\Filesystem\F;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(User::class)]
+class UserChangeSecretTest extends ModelTestCase
+{
+	public const string TMP = KIRBY_TMP_DIR . '/Cms.UserChangeSecret';
+
+	protected User $admin;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->admin = new User([
+			'id'    => 'admin',
+			'email' => 'admin@domain.com',
+			'role'  => 'admin'
+		]);
+
+		$this->app->users()->add($this->admin);
+	}
+
+	public function tearDown(): void
+	{
+		parent::tearDown();
+		$this->app->session()->destroy();
+		MockTime::reset();
+	}
+
+	public function testChangeSecret(): void
+	{
+		$file = static::TMP . '/site/accounts/admin/.htpasswd';
+		F::write($file, 'a very secure hash');
+
+		$user = $this->admin;
+		$this->assertNull($user->secret('custom'));
+
+		$user->changeSecret('custom', 'abc123');
+		$this->assertSame(
+			"a very secure hash\n" . '{"custom":"abc123"}',
+			F::read($file)
+		);
+		$this->assertSame('abc123', $user->secret('custom'));
+
+		$user->changeSecret('custom', null);
+		$this->assertSame('a very secure hash', F::read($file));
+		$this->assertNull($user->secret('custom'));
+	}
+
+	public function testChangeSecretKeepsUserLoggedIn(): void
+	{
+		$file = static::TMP . '/site/accounts/admin/.htpasswd';
+		F::write($file, 'a very secure hash');
+
+		$user = $this->admin;
+		$user->loginPasswordless();
+
+		$session   = $this->app->session();
+		$token     = $session->token();
+		$timestamp = $session->data()->get('kirby.loginTimestamp');
+		$this->assertSame(MockTime::$time, $timestamp);
+
+		MockTime::$time += 60;
+
+		$user->changeSecret('custom', 'abc123');
+
+		$session = $this->app->session();
+		$this->assertSame($user, $this->app->user());
+		$this->assertNotSame($token, $session->token());
+		$this->assertSame(MockTime::$time, $session->get('kirby.loginTimestamp'));
+	}
+}

--- a/tests/Cms/User/UserChangeTotpTest.php
+++ b/tests/Cms/User/UserChangeTotpTest.php
@@ -5,6 +5,9 @@ namespace Kirby\Cms;
 use Kirby\Filesystem\F;
 use PHPUnit\Framework\Attributes\CoversClass;
 
+/**
+ * @deprecated 6.0.0
+ */
 #[CoversClass(User::class)]
 class UserChangeTotpTest extends ModelTestCase
 {

--- a/tests/Cms/User/UserRulesTest.php
+++ b/tests/Cms/User/UserRulesTest.php
@@ -217,6 +217,35 @@ class UserRulesTest extends ModelTestCase
 		UserRules::changeRole($user, 'editor');
 	}
 
+	public function testChangeSecret(): void
+	{
+		$this->expectNotToPerformAssertions();
+
+		// as user for themselves
+		$this->app->impersonate('user@domain.com');
+		$user = $this->app->user('user@domain.com');
+		UserRules::changeSecret($user, 'my-secret', 'abcdef');
+		UserRules::changeSecret($user, 'my-secret', null);
+
+		// as admin for other users
+		$this->app->impersonate('admin@domain.com');
+		$user = $this->app->user('user@domain.com');
+		UserRules::changeSecret($user, 'my-secret', 'abcdef');
+		UserRules::changeSecret($user, 'my-secret', null);
+	}
+
+	public function testChangeSecretAsAnotherUser(): void
+	{
+		$this->expectException(PermissionException::class);
+
+		$this->app->impersonate('user@domain.com');
+		$user = $this->app->user('another-user@domain.com');
+		UserRules::changeSecret($user, 'my-secret', 'abcdef');
+	}
+
+	/**
+	 * @deprecate 6.0.0
+	 */
 	public function testChangeTotp(): void
 	{
 		$this->expectNotToPerformAssertions();
@@ -234,6 +263,9 @@ class UserRulesTest extends ModelTestCase
 		UserRules::changeTotp($user, null);
 	}
 
+	/**
+	 * @deprecate 6.0.0
+	 */
 	public function testChangeTotpAsAnotherUser(): void
 	{
 		$this->expectException(PermissionException::class);
@@ -243,6 +275,9 @@ class UserRulesTest extends ModelTestCase
 		UserRules::changeTotp($user, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567');
 	}
 
+	/**
+	 * @deprecate 6.0.0
+	 */
 	public function testChangeTotpInvalidSecret(): void
 	{
 		$this->expectException(InvalidArgumentException::class);

--- a/tests/Panel/Controller/Dialog/UserTotpDisableDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/UserTotpDisableDialogControllerTest.php
@@ -71,7 +71,7 @@ class UserTotpDisableDialogControllerTest extends TestCase
 		$totp     = new Totp();
 		$secret   = $totp->secret();
 		$password = 'foobar123';
-		$user->changeTotp($secret);
+		$user->changeSecret('totp', $secret);
 		$user->changePassword($password);
 
 		$_GET['password'] = $password;

--- a/tests/Panel/Controller/Dropdown/UserSettingsDropdownControllerTest.php
+++ b/tests/Panel/Controller/Dropdown/UserSettingsDropdownControllerTest.php
@@ -90,7 +90,7 @@ class UserSettingsDropdownControllerTest extends TestCase
 
 		$this->app->impersonate('test@getkirby.com');
 
-		$user = $this->app->user('test')->changeTotp('ABCDEFGHIJKLMNOPQRSTUVWXYZ234567');
+		$user = $this->app->user('test')->changeSecret('totp', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567');
 		$controller = new UserSettingsDropdownController($user);
 		$options    = $controller->load();
 		$this->assertCount(10, $options);
@@ -123,7 +123,7 @@ class UserSettingsDropdownControllerTest extends TestCase
 		$controller = new UserSettingsDropdownController($user);
 		$this->assertSame('enable', $controller->totpMode());
 
-		$user = $user->changeTotp('ABCDEFGHIJKLMNOPQRSTUVWXYZ234567');
+		$user = $user->changeSecret('totp', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567');
 		$controller = new UserSettingsDropdownController($user);
 		$this->assertSame('disable', $controller->totpMode());
 
@@ -131,7 +131,7 @@ class UserSettingsDropdownControllerTest extends TestCase
 		$controller = new UserSettingsDropdownController($user);
 		$this->assertSame('disable', $controller->totpMode());
 
-		$user = $user->changeTotp(null);
+		$user = $user->changeSecret('totp', null);
 		$controller = new UserSettingsDropdownController($user);
 		$this->assertNull($controller->totpMode());
 	}


### PR DESCRIPTION
## Description

With more things on the horizon that need to be kept as user secret, I think it's not a good way forward to create specific methods for each of them. THat's why I refactored the existing `$user->changeTotp()` as more generic ``$user->changeSecret()`.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- New `$user->changeSecret($type, $secret)` method

### ☠️ Deprecated
<!-- 
e.g. Deprecate method X. Use method Y instead.
-->
- `$user->changeTotp()` as been deprecated, use `$user->changeSecret($'totp', $secret)` instead


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to https://github.com/getkirby/kirby/pull/7848