### PR TITLE
fix: Add `hasCustomDomain` method to language model

### DIFF
--- a/panel/src/components/Dialogs/LinkDialog.vue
+++ b/panel/src/components/Dialogs/LinkDialog.vue
@@ -63,7 +63,7 @@ export default {
 				this.values.href.startsWith("page://") &&
 				window.panel.language.code &&
 				window.panel.language.default === false &&
-				window.panel.language.hasAbsoluteUrl === false
+				window.panel.language.hasCustomDomain === false
 			) {
 				permalink = "/" + window.panel.language.code + permalink;
 			}

--- a/panel/src/components/Dialogs/LinkDialog.vue
+++ b/panel/src/components/Dialogs/LinkDialog.vue
@@ -62,7 +62,8 @@ export default {
 			if (
 				this.values.href.startsWith("page://") &&
 				window.panel.language.code &&
-				window.panel.language.default === false
+				window.panel.language.default === false &&
+				window.panel.language.hasAbsoluteUrl === false
 			) {
 				permalink = "/" + window.panel.language.code + permalink;
 			}

--- a/panel/src/panel/language.js
+++ b/panel/src/panel/language.js
@@ -6,7 +6,7 @@ export const defaults = () => {
 		code: null,
 		default: false,
 		direction: "ltr",
-		hasAbsoluteUrl: false,
+		hasCustomDomain: false,
 		name: null,
 		rules: null
 	};

--- a/panel/src/panel/language.js
+++ b/panel/src/panel/language.js
@@ -6,6 +6,7 @@ export const defaults = () => {
 		code: null,
 		default: false,
 		direction: "ltr",
+		hasAbsoluteUrl: false,
 		name: null,
 		rules: null
 	};

--- a/panel/src/panel/language.test.js
+++ b/panel/src/panel/language.test.js
@@ -13,7 +13,7 @@ describe.concurrent("panel.language", () => {
 			code: null,
 			default: false,
 			direction: "ltr",
-			hasAbsoluteUrl: false,
+			hasCustomDomain: false,
 			name: null,
 			rules: null
 		};
@@ -34,22 +34,22 @@ describe.concurrent("panel.language", () => {
 		expect(language.isDefault).toStrictEqual(true);
 	});
 
-	it("should have hasAbsoluteUrl property", async () => {
+	it("should have hasCustomDomain property", async () => {
 		const language = Language();
 
 		// default state
-		expect(language.hasAbsoluteUrl).toStrictEqual(false);
+		expect(language.hasCustomDomain).toStrictEqual(false);
 
 		// set to true
 		language.set({
-			hasAbsoluteUrl: true
+			hasCustomDomain: true
 		});
-		expect(language.hasAbsoluteUrl).toStrictEqual(true);
+		expect(language.hasCustomDomain).toStrictEqual(true);
 
 		// set to false
 		language.set({
-			hasAbsoluteUrl: false
+			hasCustomDomain: false
 		});
-		expect(language.hasAbsoluteUrl).toStrictEqual(false);
+		expect(language.hasCustomDomain).toStrictEqual(false);
 	});
 });

--- a/panel/src/panel/language.test.js
+++ b/panel/src/panel/language.test.js
@@ -13,6 +13,7 @@ describe.concurrent("panel.language", () => {
 			code: null,
 			default: false,
 			direction: "ltr",
+			hasAbsoluteUrl: false,
 			name: null,
 			rules: null
 		};
@@ -31,5 +32,24 @@ describe.concurrent("panel.language", () => {
 		});
 
 		expect(language.isDefault).toStrictEqual(true);
+	});
+
+	it("should have hasAbsoluteUrl property", async () => {
+		const language = Language();
+
+		// default state
+		expect(language.hasAbsoluteUrl).toStrictEqual(false);
+
+		// set to true
+		language.set({
+			hasAbsoluteUrl: true
+		});
+		expect(language.hasAbsoluteUrl).toStrictEqual(true);
+
+		// set to false
+		language.set({
+			hasAbsoluteUrl: false
+		});
+		expect(language.hasAbsoluteUrl).toStrictEqual(false);
 	});
 });

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -547,13 +547,14 @@ class Language implements Stringable
 	public function toArray(): array
 	{
 		return [
-			'code'      => $this->code(),
-			'default'   => $this->isDefault(),
-			'direction' => $this->direction(),
-			'locale'    => $this->locale(),
-			'name'      => $this->name(),
-			'rules'     => $this->rules(),
-			'url'       => $this->url()
+			'code'           => $this->code(),
+			'default'        => $this->isDefault(),
+			'direction'      => $this->direction(),
+			'hasAbsoluteUrl' => Url::isAbsolute($this->url),
+			'locale'         => $this->locale(),
+			'name'           => $this->name(),
+			'rules'          => $this->rules(),
+			'url'            => $this->url(),
 		];
 	}
 

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -302,9 +302,9 @@ class Language implements Stringable
 	}
 
 	/**
-	 * Check if the language url is absolute
+	 * Check if the language url is custom domain
 	 */
-	public function hasAbsoluteUrl(): bool
+	public function hasCustomDomain(): bool
 	{
 		return Url::isAbsolute($this->url);
 	}
@@ -555,14 +555,14 @@ class Language implements Stringable
 	public function toArray(): array
 	{
 		return [
-			'code'           => $this->code(),
-			'default'        => $this->isDefault(),
-			'direction'      => $this->direction(),
-			'hasAbsoluteUrl' => $this->hasAbsoluteUrl(),
-			'locale'         => $this->locale(),
-			'name'           => $this->name(),
-			'rules'          => $this->rules(),
-			'url'            => $this->url(),
+			'code'            => $this->code(),
+			'default'         => $this->isDefault(),
+			'direction'       => $this->direction(),
+			'hasCustomDomain' => $this->hasCustomDomain(),
+			'locale'          => $this->locale(),
+			'name'            => $this->name(),
+			'rules'           => $this->rules(),
+			'url'             => $this->url(),
 		];
 	}
 

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -302,6 +302,14 @@ class Language implements Stringable
 	}
 
 	/**
+	 * Check if the language url is absolute
+	 */
+	public function hasAbsoluteUrl(): bool
+	{
+		return Url::isAbsolute($this->url);
+	}
+
+	/**
 	 * Checks if the language is the same
 	 * as the given language or language code
 	 * @since 5.0.0
@@ -550,7 +558,7 @@ class Language implements Stringable
 			'code'           => $this->code(),
 			'default'        => $this->isDefault(),
 			'direction'      => $this->direction(),
-			'hasAbsoluteUrl' => Url::isAbsolute($this->url),
+			'hasAbsoluteUrl' => $this->hasAbsoluteUrl(),
 			'locale'         => $this->locale(),
 			'name'           => $this->name(),
 			'rules'          => $this->rules(),

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -697,13 +697,14 @@ class LanguageTest extends TestCase
 		]);
 
 		$expected = [
-			'code'      => 'de',
-			'default'   => false,
-			'direction' => 'ltr',
-			'locale'    => [LC_ALL => 'de_DE'],
-			'name'      => 'Deutsch',
-			'rules'     => $language->rules(),
-			'url'       => '/de'
+			'code'           => 'de',
+			'default'        => false,
+			'direction'      => 'ltr',
+			'hasAbsoluteUrl' => false,
+			'locale'         => [LC_ALL => 'de_DE'],
+			'name'           => 'Deutsch',
+			'rules'          => $language->rules(),
+			'url'            => '/de'
 		];
 
 		$this->assertSame($expected, $language->toArray());
@@ -747,6 +748,50 @@ class LanguageTest extends TestCase
 		]);
 
 		$this->assertSame('/en', $language->url());
+	}
+
+	public function testHasAbsoluteUrl(): void
+	{
+		// default
+		$language = new Language([
+			'code' => 'en',
+			'url'  => null
+		]);
+		$this->assertFalse($language->hasAbsoluteUrl());
+
+		// relative url - false
+		$language = new Language([
+			'code' => 'en',
+			'url'  => '/en'
+		]);
+		$this->assertFalse($language->hasAbsoluteUrl());
+
+		// root url - false
+		$language = new Language([
+			'code' => 'en',
+			'url'  => '/'
+		]);
+		$this->assertFalse($language->hasAbsoluteUrl());
+
+		// absolute http url - true
+		$language = new Language([
+			'code' => 'en',
+			'url'  => 'http://example.com'
+		]);
+		$this->assertTrue($language->hasAbsoluteUrl());
+
+		// absolute https url - true
+		$language = new Language([
+			'code' => 'en',
+			'url'  => 'https://example.com/en'
+		]);
+		$this->assertTrue($language->hasAbsoluteUrl());
+
+		// no url - false
+		$language = new Language([
+			'code' => 'en'
+		]);
+		$this->assertFalse($language->hasAbsoluteUrl());
 	}
 
 	public function testUpdate(): void

--- a/tests/Cms/Languages/LanguageTest.php
+++ b/tests/Cms/Languages/LanguageTest.php
@@ -697,14 +697,14 @@ class LanguageTest extends TestCase
 		]);
 
 		$expected = [
-			'code'           => 'de',
-			'default'        => false,
-			'direction'      => 'ltr',
-			'hasAbsoluteUrl' => false,
-			'locale'         => [LC_ALL => 'de_DE'],
-			'name'           => 'Deutsch',
-			'rules'          => $language->rules(),
-			'url'            => '/de'
+			'code'            => 'de',
+			'default'         => false,
+			'direction'       => 'ltr',
+			'hasCustomDomain' => false,
+			'locale'          => [LC_ALL => 'de_DE'],
+			'name'            => 'Deutsch',
+			'rules'           => $language->rules(),
+			'url'             => '/de'
 		];
 
 		$this->assertSame($expected, $language->toArray());
@@ -750,48 +750,48 @@ class LanguageTest extends TestCase
 		$this->assertSame('/en', $language->url());
 	}
 
-	public function testHasAbsoluteUrl(): void
+	public function testHasCustomDomain(): void
 	{
 		// default
 		$language = new Language([
 			'code' => 'en',
 			'url'  => null
 		]);
-		$this->assertFalse($language->hasAbsoluteUrl());
+		$this->assertFalse($language->hasCustomDomain());
 
 		// relative url - false
 		$language = new Language([
 			'code' => 'en',
 			'url'  => '/en'
 		]);
-		$this->assertFalse($language->hasAbsoluteUrl());
+		$this->assertFalse($language->hasCustomDomain());
 
 		// root url - false
 		$language = new Language([
 			'code' => 'en',
 			'url'  => '/'
 		]);
-		$this->assertFalse($language->hasAbsoluteUrl());
+		$this->assertFalse($language->hasCustomDomain());
 
 		// absolute http url - true
 		$language = new Language([
 			'code' => 'en',
 			'url'  => 'http://example.com'
 		]);
-		$this->assertTrue($language->hasAbsoluteUrl());
+		$this->assertTrue($language->hasCustomDomain());
 
 		// absolute https url - true
 		$language = new Language([
 			'code' => 'en',
 			'url'  => 'https://example.com/en'
 		]);
-		$this->assertTrue($language->hasAbsoluteUrl());
+		$this->assertTrue($language->hasCustomDomain());
 
 		// no url - false
 		$language = new Language([
 			'code' => 'en'
 		]);
-		$this->assertFalse($language->hasAbsoluteUrl());
+		$this->assertFalse($language->hasCustomDomain());
 	}
 
 	public function testUpdate(): void

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -303,22 +303,24 @@ class ViewTest extends TestCase
 
 		$expected = [
 			[
-				'code'      => 'en',
-				'default'   => true,
-				'direction' => 'ltr',
-				'locale'    => [LC_ALL => 'en'],
-				'name'      => 'English',
-				'rules'     => Language::loadRules('en'),
-				'url'       => '/en'
+				'code'           => 'en',
+				'default'        => true,
+				'direction'      => 'ltr',
+				'hasAbsoluteUrl' => false,
+				'locale'         => [LC_ALL => 'en'],
+				'name'           => 'English',
+				'rules'          => Language::loadRules('en'),
+				'url'            => '/en'
 			],
 			[
-				'code'      => 'de',
-				'default'   => false,
-				'direction' => 'ltr',
-				'locale'    => [LC_ALL => 'de'],
-				'name'      => 'Deutsch',
-				'rules'     => Language::loadRules('de'),
-				'url'       => '/de'
+				'code'           => 'de',
+				'default'        => false,
+				'direction'      => 'ltr',
+				'hasAbsoluteUrl' => false,
+				'locale'         => [LC_ALL => 'de'],
+				'name'           => 'Deutsch',
+				'rules'          => Language::loadRules('de'),
+				'url'            => '/de'
 			]
 		];
 

--- a/tests/Panel/ViewTest.php
+++ b/tests/Panel/ViewTest.php
@@ -303,24 +303,24 @@ class ViewTest extends TestCase
 
 		$expected = [
 			[
-				'code'           => 'en',
-				'default'        => true,
-				'direction'      => 'ltr',
-				'hasAbsoluteUrl' => false,
-				'locale'         => [LC_ALL => 'en'],
-				'name'           => 'English',
-				'rules'          => Language::loadRules('en'),
-				'url'            => '/en'
+				'code'            => 'en',
+				'default'         => true,
+				'direction'       => 'ltr',
+				'hasCustomDomain' => false,
+				'locale'          => [LC_ALL => 'en'],
+				'name'            => 'English',
+				'rules'           => Language::loadRules('en'),
+				'url'             => '/en'
 			],
 			[
-				'code'           => 'de',
-				'default'        => false,
-				'direction'      => 'ltr',
-				'hasAbsoluteUrl' => false,
-				'locale'         => [LC_ALL => 'de'],
-				'name'           => 'Deutsch',
-				'rules'          => Language::loadRules('de'),
-				'url'            => '/de'
+				'code'            => 'de',
+				'default'         => false,
+				'direction'       => 'ltr',
+				'hasCustomDomain' => false,
+				'locale'          => [LC_ALL => 'de'],
+				'name'            => 'Deutsch',
+				'rules'           => Language::loadRules('de'),
+				'url'             => '/de'
 			]
 		];
 


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Expose language absolute URL check from PHP to panel state to properly handle multi-domain language configurations in writer field links.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Writer Text field cannot handle multi-domain multi-language page links #7786

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion