### PR TITLE
fix: Inject title and slug values to temporary page model

### DIFF
--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -273,18 +273,17 @@ class PageCreateDialog
 		}
 
 		$props = [
-			'slug'     => '__new__',
+			'slug'     => $this->slug ?? '__new__',
 			'template' => $this->template,
 			'model'    => $this->template,
-			'parent'   => $this->parent instanceof Page ? $this->parent : null
+			'parent'   => $this->parent instanceof Page ? $this->parent : null,
+			'content'  => ['title' => $this->title],
 		];
 
 		// make sure that a UUID gets generated
 		// and added to content right away
 		if (Uuids::enabled() === true) {
-			$props['content'] = [
-				'uuid' => $this->uuid = Uuid::generate()
-			];
+			$props['content']['uuid'] = $this->uuid = Uuid::generate();
 		}
 
 		$this->model = Page::factory($props);

--- a/tests/Panel/PageCreateDialogTest.php
+++ b/tests/Panel/PageCreateDialogTest.php
@@ -405,4 +405,42 @@ class PageCreateDialogTest extends AreaTestCase
 		$this->assertInstanceOf(MemoryStorage::class, $model->storage());
 		$this->assertNull($model->uuid());
 	}
+
+	public function testResolveTitleSlugFields(): void
+	{
+		$app = $this->app([
+			'blueprints' => [
+				'pages/test' => [
+					'fields' => [
+						'foo' => [
+							'type'    => 'text',
+							'default' => '{{ page.title }}'
+						],
+						'bar' => [
+							'type'    => 'text',
+							'default' => '{{ page.slug }}'
+						]
+					]
+				]
+			]
+		]);
+		$app->impersonate('kirby');
+
+		$dialog = new PageCreateDialog(
+			null,
+			null,
+			'test',
+			null,
+			'bar-slug',
+			'Foo title'
+		);
+
+		$dialog->submit([]);
+		$page = $app->page('bar-slug');
+
+		$this->assertSame('Foo title', $page->title()->value());
+		$this->assertSame('Foo title', $page->foo()->value());
+		$this->assertSame('bar-slug', $page->slug());
+		$this->assertSame('bar-slug', $page->bar()->value());
+	}
 }


### PR DESCRIPTION

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Using page title in blueprint field #7834


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion