### PR TITLE
fix: Always preserve data attributes

### DIFF
--- a/panel/src/index.js
+++ b/panel/src/index.js
@@ -9,6 +9,7 @@ import Legacy from "./panel/legacy.js";
 import Libraries from "./libraries/index.js";
 import Panel from "./panel/panel.js";
 
+import preserveDataAttrs from "./mixins/preserveDataAttrs.js";
 import preserveListeners from "./mixins/preserveListeners.js";
 
 /**
@@ -34,6 +35,7 @@ app.use(Components);
 /**
  * Add global mixins
  */
+app.mixin(preserveDataAttrs);
 app.mixin(preserveListeners);
 
 /**

--- a/panel/src/mixins/preserveDataAttrs.js
+++ b/panel/src/mixins/preserveDataAttrs.js
@@ -1,0 +1,17 @@
+/**
+ * Ensures that even when a component prohibits to
+ * inherit non-prop attributes, all `data-` attributes
+ * are still applied
+ */
+export default {
+	mounted() {
+		// only if the component prohibits to inherit non-prop attributes
+		if (this.$options.inheritAttrs === false) {
+			for (const attr in this.$attrs) {
+				if (attr.startsWith("data-") === true) {
+					this.$el.setAttribute(attr, this.$attrs[attr]);
+				}
+			}
+		}
+	}
+};


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Adds a global mixin that ensures when `inheritAttrs: false` is set, all `data-` attributes are applied to the root element nevertheless