### PR TITLE
fix: Block options positioning

### DIFF
--- a/panel/src/components/Forms/Blocks/BlockOptions.vue
+++ b/panel/src/components/Forms/Blocks/BlockOptions.vue
@@ -1,6 +1,7 @@
 <template>
 	<k-toolbar
 		:buttons="buttons"
+		data-inline="true"
 		class="k-block-options"
 		@mousedown.native.prevent
 	/>


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

After trying a bunch of CSS reverts etc., I realized I think all we need to do is treating the blocks options toolbar as inline - and then the existing CSS rules seem to work just fine for this use case as well.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Blocks: Fixed options toolbar position when open
#7637

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion