### PR TITLE
feat: Template stacks

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -569,11 +569,11 @@ if (Helpers::hasOverride('stack') === false) { // @codeCoverageIgnore
 	 */
 	function stack(
 		string $name,
-		string $glue = '',
+		string $glue = PHP_EOL,
 		bool $return = false,
 		bool $clear = true
 	): string|null {
-		$content = match (Stack::isOpen()) {
+		$content = match (Stack::isRendering()) {
 			true  => Stack::placeholder($name, $glue, $clear),
 			false => Stack::render($name, $glue, $clear)
 		};

--- a/config/helpers.php
+++ b/config/helpers.php
@@ -18,6 +18,7 @@ use Kirby\Plugin\Assets as PluginAssets;
 use Kirby\Plugin\Plugin;
 use Kirby\Template\Slot;
 use Kirby\Template\Snippet;
+use Kirby\Template\Stack;
 use Kirby\Toolkit\Date;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
@@ -132,6 +133,16 @@ if (Helpers::hasOverride('e') === false) { // @codeCoverageIgnore
 	function e(mixed $condition, mixed $value, mixed $alternative = null): void
 	{
 		echo $condition ? $value : $alternative;
+	}
+}
+
+if (Helpers::hasOverride('endpush') === false) { // @codeCoverageIgnore
+	/**
+	 * Ends the last started stack push
+	 */
+	function endpush(): void
+	{
+		Stack::end();
 	}
 }
 
@@ -436,6 +447,24 @@ if (Helpers::hasOverride('params') === false) { // @codeCoverageIgnore
 	}
 }
 
+if (Helpers::hasOverride('push') === false) { // @codeCoverageIgnore
+	/**
+	 * Pushes content to a stack or starts capturing output
+	 */
+	function push(
+		string $name,
+		string|Stringable|null $content = null,
+		bool $unique = false
+	): void {
+		if ($content === null) {
+			Stack::begin($name, $unique);
+			return;
+		}
+
+		Stack::push($name, $content, $unique);
+	}
+}
+
 if (Helpers::hasOverride('qr') === false) { // @codeCoverageIgnore
 	/**
 	 * Creates a QR code object
@@ -531,6 +560,30 @@ if (Helpers::hasOverride('snippet') === false) { // @codeCoverageIgnore
 		bool $slots = false
 	): Snippet|string|null {
 		return App::instance()->snippet($name, $data, $return, $slots);
+	}
+}
+
+if (Helpers::hasOverride('stack') === false) { // @codeCoverageIgnore
+	/**
+	 * Renders a stack and optionally clears it
+	 */
+	function stack(
+		string $name,
+		string $glue = '',
+		bool $return = false,
+		bool $clear = true
+	): string|null {
+		$content = match (Stack::isOpen()) {
+			true  => Stack::placeholder($name, $glue, $clear),
+			false => Stack::render($name, $glue, $clear)
+		};
+
+		if ($return === true) {
+			return $content;
+		}
+
+		echo $content;
+		return null;
 	}
 }
 

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -29,6 +29,7 @@ use Kirby\Query\Query;
 use Kirby\Session\AutoSession;
 use Kirby\Session\Session;
 use Kirby\Template\Snippet;
+use Kirby\Template\Stack;
 use Kirby\Template\Template;
 use Kirby\Text\KirbyTag;
 use Kirby\Text\KirbyTags;
@@ -109,6 +110,7 @@ class App
 
 		// start with a fresh snippet and version cache
 		Snippet::$cache = [];
+		Stack::reset();
 		VersionCache::reset();
 
 		// start with a fresh Query runner option

--- a/src/Template/Stack.php
+++ b/src/Template/Stack.php
@@ -79,7 +79,7 @@ class Stack
 	/**
 	 * Returns whether stacks are currently rendered
 	 */
-	public static function isOpen(): bool
+	public static function isRendering(): bool
 	{
 		return static::$depths > 0;
 	}
@@ -97,7 +97,7 @@ class Stack
 	 */
 	public static function placeholder(
 		string $name,
-		string $glue = '',
+		string $glue = PHP_EOL,
 		bool $clear = true
 	): string {
 		$token = '<!--kirby-stack:' . Str::uuid() . '-->';
@@ -137,7 +137,7 @@ class Stack
 	 */
 	public static function render(
 		string $name,
-		string $glue = '',
+		string $glue = PHP_EOL,
 		bool $clear = true
 	): string {
 		$content = implode($glue, static::$stacks[$name] ?? []);

--- a/src/Template/Stack.php
+++ b/src/Template/Stack.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Kirby\Template;
+
+use Kirby\Toolkit\Str;
+use Stringable;
+
+/**
+ * Simple stack storage for template output
+ *
+ * @package   Kirby Template
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class Stack
+{
+	/**
+	 * Render depth counter
+	 */
+	protected static int $depths = 0;
+
+	/**
+	 * Names of stacks currently capturing output
+	 */
+	protected static array $active = [];
+
+	/**
+	 * Deferred stack placeholders
+	 */
+	protected static array $placeholders = [];
+
+	/**
+	 * Stored stack contents
+	 */
+	protected static array $stacks = [];
+
+	/**
+	 * Starts capturing output for a stack
+	 */
+	public static function begin(string $name, bool $unique = false): void
+	{
+		static::$active[] = [
+			'name'   => $name,
+			'unique' => $unique
+		];
+		ob_start();
+	}
+
+	/**
+	 * Marks the end of a render cycle
+	 */
+	public static function close(): void
+	{
+		if (static::$depths > 0) {
+			static::$depths--;
+		}
+	}
+
+	/**
+	 * Ends the last started stack capture
+	 */
+	public static function end(): void
+	{
+		$active = array_pop(static::$active);
+
+		if ($active === null) {
+			return;
+		}
+
+		static::push(
+			$active['name'],
+			ob_get_clean(),
+			$active['unique']
+		);
+	}
+
+	/**
+	 * Returns whether stacks are currently rendered
+	 */
+	public static function isOpen(): bool
+	{
+		return static::$depths > 0;
+	}
+
+	/**
+	 * Marks the beginning of a render cycle
+	 */
+	public static function open(): void
+	{
+		static::$depths++;
+	}
+
+	/**
+	 * Creates a placeholder for deferred rendering
+	 */
+	public static function placeholder(
+		string $name,
+		string $glue = '',
+		bool $clear = true
+	): string {
+		$token = '<!--kirby-stack:' . Str::uuid() . '-->';
+
+		static::$placeholders[$token] = [
+			'name'  => $name,
+			'glue'  => $glue,
+			'clear' => $clear
+		];
+
+		return $token;
+	}
+
+	/**
+	 * Pushes content to a stack
+	 */
+	public static function push(
+		string $name,
+		string|Stringable $content,
+		bool $unique = false
+	): void {
+		$content = (string)$content;
+
+		if ($unique === true) {
+			$existing = static::$stacks[$name] ?? [];
+
+			if (in_array($content, $existing, true) === true) {
+				return;
+			}
+		}
+
+		static::$stacks[$name][] = $content;
+	}
+
+	/**
+	 * Renders a stack and optionally clears it
+	 */
+	public static function render(
+		string $name,
+		string $glue = '',
+		bool $clear = true
+	): string {
+		$content = implode($glue, static::$stacks[$name] ?? []);
+
+		if ($clear === true) {
+			unset(static::$stacks[$name]);
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Replaces placeholders with rendered stack contents
+	 */
+	public static function replace(string $content): string
+	{
+		if (static::$placeholders === []) {
+			return $content;
+		}
+
+		foreach (static::$placeholders as $token => $config) {
+			$content = str_replace(
+				$token,
+				static::render(...$config),
+				$content
+			);
+		}
+
+		static::$placeholders = [];
+
+		return $content;
+	}
+
+	/**
+	 * Resets all stacks
+	 */
+	public static function reset(): void
+	{
+		static::$active = [];
+		static::$stacks = [];
+		static::$placeholders = [];
+		static::$depths = 0;
+	}
+}

--- a/src/Toolkit/Tpl.php
+++ b/src/Toolkit/Tpl.php
@@ -3,6 +3,7 @@
 namespace Kirby\Toolkit;
 
 use Kirby\Filesystem\F;
+use Kirby\Template\Stack;
 use Throwable;
 
 /**
@@ -29,6 +30,7 @@ class Tpl
 			return '';
 		}
 
+		Stack::open();
 		ob_start();
 
 		try {
@@ -39,6 +41,11 @@ class Tpl
 
 		$content = ob_get_contents();
 		ob_end_clean();
+		Stack::close();
+
+		if (Stack::isOpen() === false) {
+			$content = Stack::replace($content);
+		}
 
 		if (isset($exception) === true) {
 			throw $exception;

--- a/src/Toolkit/Tpl.php
+++ b/src/Toolkit/Tpl.php
@@ -3,7 +3,6 @@
 namespace Kirby\Toolkit;
 
 use Kirby\Filesystem\F;
-use Kirby\Template\Stack;
 use Throwable;
 
 /**
@@ -30,7 +29,6 @@ class Tpl
 			return '';
 		}
 
-		Stack::open();
 		ob_start();
 
 		try {
@@ -41,12 +39,6 @@ class Tpl
 
 		$content = ob_get_contents();
 		ob_end_clean();
-		Stack::close();
-
-		if (Stack::isOpen() === false) {
-			$content = Stack::replace($content);
-		}
-
 		if (isset($exception) === true) {
 			throw $exception;
 		}

--- a/tests/Template/StackTest.php
+++ b/tests/Template/StackTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Kirby\Template;
+
+use Kirby\Toolkit\Tpl;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Stack::class)]
+class StackTest extends TestCase
+{
+	public const string FIXTURES = __DIR__ . '/fixtures';
+
+	protected function setUp(): void
+	{
+		Stack::reset();
+	}
+
+	public function testCapture(): void
+	{
+		Stack::begin('footer');
+		echo 'Hello';
+		Stack::end();
+
+		Stack::begin('footer');
+		echo 'Hello';
+		Stack::end();
+
+		$output = Stack::render('footer');
+		$this->assertSame('HelloHello', $output);
+	}
+
+	public function testCaptureUnique(): void
+	{
+		Stack::begin('footer');
+		echo 'Hello';
+		Stack::end();
+
+		Stack::begin('footer', unique: true);
+		echo 'Hello';
+		Stack::end();
+
+		$output = Stack::render('footer');
+		$this->assertSame('Hello', $output);
+	}
+
+	public function testDeferredRendering(): void
+	{
+		$output = Tpl::load(static::FIXTURES . '/stack-order.php');
+		$this->assertSame('Hello', trim($output));
+	}
+
+	public function testEndWithoutBegin(): void
+	{
+		Stack::end();
+		$this->assertSame('', Stack::render('missing'));
+	}
+
+	public function testOpenClose(): void
+	{
+		$this->assertFalse(Stack::isOpen());
+
+		Stack::open();
+		$this->assertTrue(Stack::isOpen());
+
+		Stack::open();
+		$this->assertTrue(Stack::isOpen());
+
+		Stack::close();
+		$this->assertTrue(Stack::isOpen());
+
+		Stack::close();
+		$this->assertFalse(Stack::isOpen());
+	}
+
+	public function testHelpers(): void
+	{
+		push('head');
+		echo 'Meta';
+		endpush();
+
+		$output = stack('head', return: true);
+		$this->assertSame('Meta', $output);
+	}
+
+	public function testHelpersEcho(): void
+	{
+		push('body', 'Content');
+
+		ob_start();
+		stack('body');
+		$this->assertSame('Content', ob_get_clean());
+	}
+
+	public function testPushAndRenderClears(): void
+	{
+		Stack::push('scripts', 'a');
+		Stack::push('scripts', 'b');
+
+		$this->assertSame('ab', Stack::render('scripts'));
+		$this->assertSame('', Stack::render('scripts'));
+	}
+
+	public function testPushUnique(): void
+	{
+		Stack::push('styles', 'a', unique: true);
+		Stack::push('styles', 'a', unique: true);
+		Stack::push('styles', 'b', unique: true);
+
+		$this->assertSame('ab', Stack::render('styles'));
+	}
+
+	public function testRenderWithoutClear(): void
+	{
+		Stack::push('styles', 'a');
+
+		$this->assertSame('a', Stack::render('styles', clear: false));
+		$this->assertSame('a', Stack::render('styles', clear: false));
+	}
+
+}

--- a/tests/Template/StackTest.php
+++ b/tests/Template/StackTest.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Template;
 
-use Kirby\Toolkit\Tpl;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(Stack::class)]
@@ -26,7 +25,7 @@ class StackTest extends TestCase
 		Stack::end();
 
 		$output = Stack::render('footer');
-		$this->assertSame('HelloHello', $output);
+		$this->assertSame('Hello' . PHP_EOL . 'Hello', $output);
 	}
 
 	public function testCaptureUnique(): void
@@ -45,7 +44,7 @@ class StackTest extends TestCase
 
 	public function testDeferredRendering(): void
 	{
-		$output = Tpl::load(static::FIXTURES . '/stack-order.php');
+		$output = Snippet::load(static::FIXTURES . '/stack-order.php');
 		$this->assertSame('Hello', trim($output));
 	}
 
@@ -55,21 +54,21 @@ class StackTest extends TestCase
 		$this->assertSame('', Stack::render('missing'));
 	}
 
-	public function testOpenClose(): void
+	public function testIsRendering(): void
 	{
-		$this->assertFalse(Stack::isOpen());
+		$this->assertFalse(Stack::isRendering());
 
 		Stack::open();
-		$this->assertTrue(Stack::isOpen());
+		$this->assertTrue(Stack::isRendering());
 
 		Stack::open();
-		$this->assertTrue(Stack::isOpen());
+		$this->assertTrue(Stack::isRendering());
 
 		Stack::close();
-		$this->assertTrue(Stack::isOpen());
+		$this->assertTrue(Stack::isRendering());
 
 		Stack::close();
-		$this->assertFalse(Stack::isOpen());
+		$this->assertFalse(Stack::isRendering());
 	}
 
 	public function testHelpers(): void
@@ -96,7 +95,7 @@ class StackTest extends TestCase
 		Stack::push('scripts', 'a');
 		Stack::push('scripts', 'b');
 
-		$this->assertSame('ab', Stack::render('scripts'));
+		$this->assertSame('a' . PHP_EOL . 'b', Stack::render('scripts'));
 		$this->assertSame('', Stack::render('scripts'));
 	}
 
@@ -106,7 +105,7 @@ class StackTest extends TestCase
 		Stack::push('styles', 'a', unique: true);
 		Stack::push('styles', 'b', unique: true);
 
-		$this->assertSame('ab', Stack::render('styles'));
+		$this->assertSame('a' . PHP_EOL . 'b', Stack::render('styles'));
 	}
 
 	public function testRenderWithoutClear(): void

--- a/tests/Template/fixtures/stack-order.php
+++ b/tests/Template/fixtures/stack-order.php
@@ -1,0 +1,2 @@
+<?php stack('foo') ?>
+<?php push('foo') ?>Hello<?php endpush() ?>


### PR DESCRIPTION
## Description

Could be a solution for https://feedback.getkirby.com/535

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features
<!-- 
e.g. New feature X which helps users to …
-->
- Template stacks let snippets and templates push output onto a stack and render this stack anywhere else in your template (e.g. pushing a CSS `<link>` tag on a stack from inside your blocks snippets and render this stack inside `<head>`). This can be done independent of rendering the stack and pushing to the stack. 

```php
// in template (e.g. header.php)
<?php stack('head') ?>

// in any snippet or template (order doesn’t matter)
<?php push('head') ?>
<link rel="stylesheet" href="/assets/css/foo.css">
<?php endpush() ?>
```

Direct push (no buffering)
```php
<?php push('head', '<link rel="stylesheet" href="/assets/css/foo.css">') ?>
```

Unique pushes (dedupe identical content)

```php
<?php push('head', '<link rel="stylesheet" href="/assets/css/foo.css">', unique: true) ?>
```

Returning instead of echoing

```php
<?php $styles = stack('head', return: true); ?>
```

Custom glue

```php
<?php stack('head', glue: '') ?> // join with newlines
```

### Breaking changes
- New global helper functions: `push()`, `endpush()` and `stack()`

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
  - [x] https://github.com/getkirby/sandbox/pull/23
- [x] Add changes & docs to release notes draft in Notion