### PR TITLE
fix: Allow setting a first password for your own account

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -788,6 +788,7 @@
 	"user.create": "Add a new user",
 	"user.delete": "Delete this user",
 	"user.delete.confirm": "Do you really want to delete <br><strong>{email}</strong>?",
+	"user.setPassword": "Set password",
 
 	"users": "Users",
 

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -241,6 +241,15 @@ class User extends ModelWithContent
 	}
 
 	/**
+	 * Checks if the user has a stored password
+	 */
+	public function hasPassword(): bool
+	{
+		$password = $this->password();
+		return $password === '' || $password === null || $password === false ? false : true;
+	}
+
+	/**
 	 * Returns the user id
 	 */
 	public function id(): string
@@ -703,7 +712,7 @@ class User extends ModelWithContent
 		#[SensitiveParameter]
 		string|null $password = null
 	): bool {
-		if (empty($this->password()) === true) {
+		if ($this->hasPassword() === false) {
 			throw new NotFoundException(
 				key: 'user.password.undefined'
 			);

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -233,7 +233,7 @@ class User extends ModelWithContent
 		#[SensitiveParameter]
 		string|null $password = null
 	): string|null {
-		if ($password !== null) {
+		if ($password !== null && $password !== '' && $password !== false) {
 			$password = password_hash($password, PASSWORD_DEFAULT);
 		}
 

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -100,7 +100,7 @@ class User extends Model
 		$result[] = [
 			'dialog'   => $url . '/changePassword',
 			'icon'     => 'key',
-			'text'     => I18n::translate('user.changePassword'),
+			'text'     => I18n::translate('user.' . ($this->model->hasPassword() === true ? 'changePassword' : 'setPassword')),
 			'disabled' => $this->isDisabledDropdownOption('changePassword', $options, $permissions)
 		];
 

--- a/tests/Cms/User/UserPasswordAndSecretTest.php
+++ b/tests/Cms/User/UserPasswordAndSecretTest.php
@@ -13,6 +13,22 @@ class UserPasswordAndSecretTest extends ModelTestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Cms.UserPasswordAndSecret';
 
+	public function testHasPassword(): void
+	{
+		$user = new User([
+			'email' => 'test@getkirby.com'
+		]);
+
+		$this->assertFalse($user->hasPassword());
+
+		$user = new User([
+			'email'    => 'test@getkirby.com',
+			'password' => User::hashPassword('correct-horse-battery-staple')
+		]);
+
+		$this->assertTrue($user->hasPassword());
+	}
+
 	public function testPasswordTimestamp(): void
 	{
 		// create a user file

--- a/tests/Panel/Areas/UserDropdownsTest.php
+++ b/tests/Panel/Areas/UserDropdownsTest.php
@@ -43,7 +43,7 @@ class UserDropdownsTest extends AreaTestCase
 		$password = $options[6];
 
 		$this->assertSame('/users/editor/changePassword', $password['dialog']);
-		$this->assertSame('Change password', $password['text']);
+		$this->assertSame('Set password', $password['text']);
 
 		$this->assertSame('-', $options[7]);
 
@@ -51,6 +51,14 @@ class UserDropdownsTest extends AreaTestCase
 
 		$this->assertSame('/users/editor/delete', $delete['dialog']);
 		$this->assertSame('Delete this user', $delete['text']);
+	}
+
+	public function testUserDropdownWithPassword(): void
+	{
+		$options  = $this->dropdown('users/test')['options'];
+		$password = $options[6];
+
+		$this->assertSame('Change password', $password['text']);
 	}
 
 	public function testUserLanguageDropdown(): void

--- a/tests/Panel/Areas/UsersDialogsTest.php
+++ b/tests/Panel/Areas/UsersDialogsTest.php
@@ -166,6 +166,37 @@ class UsersDialogsTest extends AreaTestCase
 		$this->assertSame('Change', $props['submitButton']);
 	}
 
+	public function testChangePasswordWithoutPasswordForTheCurrentUser(): void
+	{
+		$this->installEditor();
+		$this->login('editor');
+
+		$dialog = $this->dialog('users/editor/changePassword');
+		$props  = $dialog['props'];
+
+		$this->assertFormDialog($dialog);
+
+		// a user without password can change their own password without providing the current (non-existing) password.
+		$this->assertArrayNotHasKey('currentPassword', $props['fields']);
+		$this->assertArrayNotHasKey('line', $props['fields']);
+	}
+
+	public function testChangePasswordWithoutPasswordForAnotherUser(): void
+	{
+		$this->installEditor();
+		$this->login();
+
+		$dialog = $this->dialog('users/editor/changePassword');
+		$props  = $dialog['props'];
+
+		$this->assertFormDialog($dialog);
+
+		// when a user tries to change the password of another user, they always need to provide the
+		// current password even if they have no password so far.
+		$this->assertArrayHasKey('currentPassword', $props['fields']);
+		$this->assertArrayHasKey('line', $props['fields']);
+	}
+
 	public function testChangePasswordOnSubmit(): void
 	{
 		$this->submit([


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements

- New `User::hasPassword()` method to provide a solid check for an existing password
- The user dropdown now uses "Set password" instead of "Change password" for users that don't have a password so far. 
<img width="280" height="294" alt="Screenshot 2026-01-12 at 15 28 51" src="https://github.com/user-attachments/assets/08a6bd34-2197-4589-ac21-27be324dbe7b" />

### 🐛 Bug fixes

- Users can now set their first password (if they had none so far) without providing their current one. This only works for their own account. A user without password cannot change the password of any other user. 
- Empty passwords are no longer incorrectly hashed

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion