### PR TITLE
feat: allow separator between view buttons

### DIFF
--- a/panel/src/components/View/Buttons/Buttons.vue
+++ b/panel/src/components/View/Buttons/Buttons.vue
@@ -1,13 +1,15 @@
 <template>
-	<k-button-group v-if="buttons.length" class="k-view-buttons">
-		<component
-			:is="component(button)"
-			v-for="button in buttons"
-			:key="button.key"
-			v-bind="button.props"
-			@action="$emit('action', $event)"
-		/>
-	</k-button-group>
+	<nav v-if="buttons.length" class="k-view-buttons">
+		<k-button-group v-for="(group, index) in groups" :key="index">
+			<component
+				:is="component(button)"
+				v-for="button in group"
+				:key="button.key"
+				v-bind="button.props"
+				@action="$emit('action', $event)"
+			/>
+		</k-button-group>
+	</nav>
 </template>
 
 <script>
@@ -27,6 +29,11 @@ export default {
 		}
 	},
 	emits: ["action"],
+	computed: {
+		groups() {
+			return this.$helper.array.split(this.buttons, "-");
+		}
+	},
 	methods: {
 		component(button) {
 			if (this.$helper.isComponent(button.component)) {
@@ -38,3 +45,10 @@ export default {
 	}
 };
 </script>
+
+<style>
+.k-view-buttons {
+	display: flex;
+	gap: var(--spacing-3);
+}
+</style>

--- a/panel/src/components/Views/Preview/PreviewView.vue
+++ b/panel/src/components/Views/Preview/PreviewView.vue
@@ -24,9 +24,7 @@
 				</k-dropdown-content>
 			</k-button-group>
 
-			<k-button-group>
-				<k-view-buttons :buttons="buttons" />
-			</k-button-group>
+			<k-view-buttons :buttons="buttons" />
 		</header>
 		<main class="k-preview-view-grid">
 			<template v-if="versionId === 'compare'">

--- a/src/Panel/Ui/Buttons/ViewButtons.php
+++ b/src/Panel/Ui/Buttons/ViewButtons.php
@@ -69,6 +69,12 @@ class ViewButtons
 		$buttons = [];
 
 		foreach ($this->buttons ?? [] as $name => $button) {
+			// separator, keep as is in array
+			if ($button === '-') {
+				$buttons[] = '-';
+				continue;
+			}
+
 			$buttons[] = ViewButton::factory(
 				button: $button,
 				name: $name,


### PR DESCRIPTION
## Description
I noticed with Kirby SEO and a bunch of other plugins that the view buttons can get crowded pretty quickly. So this PR adds an option to add a separator similar to the one that can be found on the side nav:

<img width="1188" height="342" src="https://github.com/user-attachments/assets/8f86f62f-966b-4b05-a555-55c7bde0f734" />

It can be added like so:
```yaml
buttons:
  - open
  - preview
  - utm-share
  - '-'
  - languages
  - content-translator
  - '-'
  - status
  - robots
  - settings
```

AI Disclosure: This PR was written with Claude Opus 4.5 & Claude Code

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features
- Added support for view button separators using `-` in blueprints

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion