### PR TITLE
fix: Allow selecting any file blueprint if none is specified

### DIFF
--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -124,11 +124,12 @@ class Blueprint
 				continue;
 			}
 
+			$template  = $section->template();
 			$templates = match ($section->type()) {
 				'files'  => [
 					...$templates,
-					...($section->template()
-						? [$section->template()]
+					...($template
+						? [$template]
 						: App::instance()->blueprints('files'))
 				],
 				'fields' => [

--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -125,7 +125,12 @@ class Blueprint
 			}
 
 			$templates = match ($section->type()) {
-				'files'  => [...$templates, $section->template() ?? 'default'],
+				'files'  => [
+					...$templates,
+					...($section->template()
+						? [$section->template()]
+						: App::instance()->blueprints('files'))
+				],
 				'fields' => [
 					...$templates,
 					...$this->acceptedFileTemplatesFromFields($section->fields())

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -192,7 +192,7 @@ class File extends ModelWithContent
 			if ($template === 'default') {
 				$blueprints[$template] = [
 					'name'  => 'default',
-					'title' => 'Default – (default)',
+					'title' => '– (default)',
 				];
 				continue;
 			}

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -192,7 +192,7 @@ class File extends ModelWithContent
 			if ($template === 'default') {
 				$blueprints[$template] = [
 					'name'  => 'default',
-					'title' => '– (default)',
+					'title' => 'Default – (default)',
 				];
 				continue;
 			}

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -317,6 +317,44 @@ class BlueprintTest extends TestCase
 		$this->assertSame(['a', 'b'], $blueprint->acceptedFileTemplates());
 	}
 
+	public function testAcceptedFileTemplatesFromAllAvailable(): void
+	{
+		$this->app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'blueprints' => [
+				'files/image' => [
+					'name' => 'image',
+				],
+				'files/document' => [
+					'name' => 'document',
+				],
+				'files/video' => [
+					'name' => 'video',
+				],
+			]
+		]);
+
+		// Files section without template should include all available templates
+		$blueprint = new Blueprint([
+			'model' => $this->model,
+			'name'  => 'default',
+			'sections' => [
+				'files' => [
+					'type' => 'files',
+					// No template specified - should get all available
+				],
+			]
+		]);
+
+		$expected = ['default', 'image', 'document', 'video'];
+		$result = $blueprint->acceptedFileTemplates();
+		sort($expected);
+		sort($result);
+		$this->assertSame($expected, $result);
+	}
+
 	public function testButtons(): void
 	{
 		$blueprint = new Blueprint([

--- a/tests/Cms/File/FilePermissionsTest.php
+++ b/tests/Cms/File/FilePermissionsTest.php
@@ -143,4 +143,37 @@ class FilePermissionsTest extends ModelTestCase
 
 		$this->assertTrue($file->permissions()->can('changeTemplate'));
 	}
+
+	public function testCanChangeTemplateWithAllAvailable(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/test' => [
+					'sections' => [
+						'files' => [
+							'type' => 'files',
+							// No template specified - should get all available
+						]
+					]
+				],
+				'files/image' => [
+					'title' => 'Image'
+				],
+				'files/document' => [
+					'title' => 'Document'
+				],
+				'files/video' => [
+					'title' => 'Video'
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		$page = new Page(['slug' => 'test', 'template' => 'test']);
+		$file = new File(['filename' => 'test.jpg', 'parent' => $page]);
+
+		// Should be able to change template because multiple templates are available
+		$this->assertTrue($file->permissions()->can('changeTemplate'));
+	}
 }

--- a/tests/Cms/FilesSectionTemplateChangeTest.php
+++ b/tests/Cms/FilesSectionTemplateChangeTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Kirby\Cms;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Blueprint::class)]
+#[CoversClass(FilePermissions::class)]
+class FilesSectionTemplateChangeTest extends TestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Cms.FilesSectionTemplateChange';
+
+	public function setUp(): void
+	{
+		$this->app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'blueprints' => [
+				// User's files blueprints from the forum post
+				'files/images' => [
+					'title' => 'Images',
+					'options' => [
+						'changeName' => true,
+						'changeTemplate' => true,
+						'delete' => true,
+						'read' => true,
+						'replace' => true,
+						'update' => true,
+					],
+					'accept' => [
+						'extension' => 'jpg,jpeg,png'
+					]
+				],
+				'files/documents' => [
+					'title' => 'Documents',
+					'options' => [
+						'changeName' => true,
+						'changeTemplate' => true,
+						'delete' => true,
+						'read' => true,
+						'replace' => true,
+						'update' => true,
+					],
+					'accept' => [
+						'extension' => 'pdf,doc,docx'
+					]
+				],
+				'files/videos' => [
+					'title' => 'Videos',
+					'options' => [
+						'changeName' => true,
+						'changeTemplate' => true,
+						'delete' => true,
+						'read' => true,
+						'replace' => true,
+						'update' => true,
+					],
+					'accept' => [
+						'extension' => 'mp4,avi,mov'
+					]
+				],
+				// User's page blueprint from the forum post
+				'pages/default' => [
+					'title' => 'Default',
+					'sections' => [
+						'sitemedia' => [
+							'type' => 'files',
+							'layout' => 'cards',
+							'size' => 'medium',
+							'info' => 'Template: {{ file.template }} <br /> {{ file.dimensions.width }} x {{ file.dimensions.height }} px <br /> {{ file.niceSize }}',
+							'search' => true,
+							'limit' => 60,
+							'sortable' => true,
+							// No template specified - this was the bug!
+						]
+					]
+				],
+			],
+			'users' => [
+				['id' => 'admin', 'role' => 'admin']
+			]
+		]);
+
+	}
+
+	public function tearDown(): void
+	{
+		if (is_dir(static::TMP)) {
+			rmdir(static::TMP);
+		}
+	}
+
+	public function testFilesSectionWithoutTemplateShowsAllAvailableTemplates(): void
+	{
+		$this->app->impersonate('admin');
+
+		$model = new Page(['slug' => 'test']);
+
+		$blueprint = new Blueprint([
+			'model' => $model,
+			'name'  => 'default',
+			'sections' => [
+				'sitemedia' => [
+					'type' => 'files',
+					'layout' => 'cards',
+					'size' => 'medium',
+					'info' => 'Template: {{ file.template }} <br /> {{ file.dimensions.width }} x {{ file.dimensions.height }} px <br /> {{ file.niceSize }}',
+					'search' => true,
+					'limit' => 60,
+					'sortable' => true,
+					// No template specified - this should now show all available templates
+				]
+			]
+		]);
+
+		$templates = $blueprint->acceptedFileTemplates();
+
+		// Should include all available file templates + default
+		$expected = ['default', 'images', 'documents', 'videos'];
+		sort($expected);
+		sort($templates);
+
+		$this->assertSame($expected, $templates);
+	}
+
+	public function testFileCanChangeTemplateWithMultipleBlueprintsAvailable(): void
+	{
+		$this->app->impersonate('admin');
+
+		$page = new Page(['slug' => 'test', 'template' => 'default']);
+		$file = new File(['filename' => 'test.jpg', 'parent' => $page]);
+
+		// Before the fix: this would return false because only 'default' template was available
+		// After the fix: this should return true because multiple templates are available
+		$this->assertTrue($file->permissions()->can('changeTemplate'));
+
+		// Verify we get templates that can actually handle jpg files
+		$availableTemplates = $file->blueprints();
+		$templateNames = array_map(fn ($bp) => $bp['name'], $availableTemplates);
+
+		// Should include default and images (which accepts jpg), but not documents/videos
+		$expectedNames = ['default', 'images'];
+		sort($expectedNames);
+		sort($templateNames);
+
+		$this->assertSame($expectedNames, $templateNames);
+	}
+}

--- a/tests/Cms/FilesSectionTemplateChangeTest.php
+++ b/tests/Cms/FilesSectionTemplateChangeTest.php
@@ -131,8 +131,7 @@ class FilesSectionTemplateChangeTest extends TestCase
 		$page = new Page(['slug' => 'test', 'template' => 'default']);
 		$file = new File(['filename' => 'test.jpg', 'parent' => $page]);
 
-		// Before the fix: this would return false because only 'default' template was available
-		// After the fix: this should return true because multiple templates are available
+		// This should return true because multiple templates are available
 		$this->assertTrue($file->permissions()->can('changeTemplate'));
 
 		// Verify we get templates that can actually handle jpg files


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

🐛 Bug fixes

- Fixed "Change Template" options for files: All available file templates are shown when sections don't define available templates #6761.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion