### PR TITLE
fix: Avoid history entries for redirect-only modals

### DIFF
--- a/panel/src/panel/dialog.js
+++ b/panel/src/panel/dialog.js
@@ -104,7 +104,9 @@ export default (panel) => {
 			const state = await parent.open.call(this, dialog, options);
 
 			// add it to the history
-			this.history.add(state, dialog.replace);
+			if (state?.id) {
+				this.history.add(state, dialog.replace);
+			}
 
 			return state;
 		},

--- a/panel/src/panel/drawer.js
+++ b/panel/src/panel/drawer.js
@@ -98,7 +98,9 @@ export default (panel) => {
 			// get the current state and add it to the history
 			// (we need to fetch the state freshly as it is altered by `this.tab()`)
 			const state = this.state();
-			this.history.add(state, drawer.replace);
+			if (state?.id) {
+				this.history.add(state, drawer.replace);
+			}
 
 			this.focus();
 


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

- The page create dialog auto-submits when no editable fields are visible (e.g. title/slug are auto-generated). When this is the case, the backend throws `Panel::go()`, which returns a dialog state/payload that only includes `redirect` and has no `id`.
- The frontend has tried in `dialog.open()` to always push new states into history, but `history.add()` requires a `state.id`.  Redirect states/payload therefore ran into the “The state needs an ID” error.
- The PR adds a guard to only add a state to history when an ID is set, so redirect-only modal responses skip history.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Fixed console error for skipped page create dialogs
 #7877


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion