### PR TITLE
fix: `A::get()` prefer dotted prefix

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -289,6 +289,23 @@ class A
 			$keys     = explode('.', $key);
 			$firstKey = array_shift($keys);
 
+			// prefer a dotted prefix key if it exists
+			// (e.g. plugin namespaces).
+			for ($i = count($keys); $i > 0; $i--) {
+				$prefix = $firstKey . '.' . implode('.', array_slice($keys, 0, $i));
+
+				if (
+					isset($array[$prefix]) === true &&
+					is_array($array[$prefix]) === true
+				) {
+					return static::get(
+						$array[$prefix],
+						implode('.', array_slice($keys, $i)),
+						$default
+					);
+				}
+			}
+
 			// if the input array also uses dot notation,
 			// try to find a subset of the $keys
 			if (isset($array[$firstKey]) === false) {

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -269,6 +269,24 @@ class ATest extends TestCase
 		$this->assertSame('default', A::get($data, 'grand.ma.cousins.4.name', 'default'));
 	}
 
+	public function testGetWithDotNotationPrefersFullPrefix(): void
+	{
+		$data = [
+			'author' => [
+				'some_theme_setting' => true
+			],
+			'author.name' => [
+				'option' => [
+					'setting' => false
+				]
+			]
+		];
+
+		$this->assertFalse(
+			A::get($data, 'author.name.option.setting')
+		);
+	}
+
 	public function testGetWithNonexistingOptions(): void
 	{
 		$data = [


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

This changes `A::get()` to prefer full dotted-prefix keys (e.g. `vendorname.pluginname`) before recursing into top-level arrays. This fixes a collision where a top-level vendor config array (like `presprog`) prevented plugin options stored under `presprog.pluginname` from resolving. Added a unit test that reproduces the reported scenario and asserts the dotted-prefix value is returned.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- `A::get()`: Prefer dotted prefix keys to avoid option collisions of full dotted prefix vs. nested array, e.g. with plugin options
#6242



### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion