### PR TITLE
fix: Emit single choice input click

### DIFF
--- a/panel/src/components/Forms/Input/ChoiceInput.vue
+++ b/panel/src/components/Forms/Input/ChoiceInput.vue
@@ -17,6 +17,7 @@
 			}"
 			:class="[variant === 'invisible' ? 'sr-only' : null, $attrs.class]"
 			:data-variant="variant"
+			@click="$emit('click', $event)"
 			@input="$emit('input', $event.target.checked)"
 		/>
 		<span v-if="label || info" class="k-choice-input-label">
@@ -61,7 +62,8 @@ export const props = {
  * @example <k-choice-input :value="value" @input="value = $event" />
  */
 export default {
-	mixins: [Input, props]
+	mixins: [Input, props],
+	emits: ["click", "input"]
 };
 </script>
 

--- a/panel/src/components/Forms/Input/RadioInput.vue
+++ b/panel/src/components/Forms/Input/RadioInput.vue
@@ -15,7 +15,7 @@
 				<li v-for="(choice, index) in choices" :key="index">
 					<k-choice-input
 						v-bind="choice"
-						@click.native.stop="toggle(choice.value)"
+						@click="toggle(choice.value)"
 						@input="$emit('input', choice.value)"
 					/>
 				</li>


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Added an explicit click emit from the `<input>` in `k-choice-input` as listening for a click event on the whole  `k-choice-input` would be triggered twice when clicking the input label (first the actual click, then the browser hopping from the Abel onto the input tag, which also triggers another click event). This way when clicking the radio input label resetting the input works now again (if enabled) - before it was reset and set immediately again due to the two click events.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Radio input: Fixed resetting via clicking the input label
#5845


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion