### PR TITLE
fix: OptionQuery stores array key for assoc arrays

### DIFF
--- a/src/Option/OptionsQuery.php
+++ b/src/Option/OptionsQuery.php
@@ -10,11 +10,12 @@ use Kirby\Cms\StructureObject;
 use Kirby\Cms\User;
 use Kirby\Content\Field;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Toolkit\A;
 use Kirby\Toolkit\Collection;
 use Kirby\Toolkit\Obj;
 
 /**
- * Options derrived from running a query against
+ * Options derived from running a query against
  * pages, files, users or structures to create
  * options out of them.
  *
@@ -38,11 +39,14 @@ class OptionsQuery extends OptionsProvider
 
 	protected function collection(array $array): Collection
 	{
+		$isAssociative = A::isAssociative($array);
+
 		foreach ($array as $key => $value) {
 			if (is_scalar($value) === true) {
 				$array[$key] = new Obj([
-					'key'   => new Field(null, 'key', $key),
-					'value' => new Field(null, 'value', $value),
+					'key'          => new Field(null, 'key', $key),
+					'value'        => new Field(null, 'value', $value),
+					'hasStringKey' => $isAssociative,
 				]);
 			}
 		}
@@ -72,6 +76,12 @@ class OptionsQuery extends OptionsProvider
 	protected function itemToDefaults(array|object $item): array
 	{
 		return match (true) {
+			$item instanceof Obj && $item->hasStringKey === true => [
+				'arrayItem',
+				'{{ item.value }}',
+				'{{ item.key }}'
+			],
+
 			is_array($item),
 			$item instanceof Obj => [
 				'arrayItem',

--- a/tests/Option/OptionsQueryTest.php
+++ b/tests/Option/OptionsQueryTest.php
@@ -21,6 +21,11 @@ class MyPage extends Page
 		return ['tag1', 'tag2', 'tag3'];
 	}
 
+	public function myAssocArray(): array
+	{
+		return ['myValue' => 'My text', 'otherValue' => 'Other text'];
+	}
+
 	public function myHtmlArray(): array
 	{
 		return [
@@ -118,6 +123,16 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('tag2', $options[1]['value']);
 		$this->assertSame('tag3', $options[2]['value']);
 		$this->assertSame('tag3', $options[2]['text']);
+
+		// associative array uses the array key as value by default
+		$options = (new OptionsQuery(
+			query: 'page.myAssocArray',
+		))->render($model);
+
+		$this->assertSame('myValue', $options[0]['value']);
+		$this->assertSame('My text', $options[0]['text']);
+		$this->assertSame('otherValue', $options[1]['value']);
+		$this->assertSame('Other text', $options[1]['text']);
 	}
 
 	public function testResolveForStructure(): void


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Options from query: if the query returns an associative array, Kirby now uses the array keys as values by default
#5807

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion