### PR TITLE
fix: Prevent double escape in select field

### DIFF
--- a/src/Field/FieldOptions.php
+++ b/src/Field/FieldOptions.php
@@ -81,7 +81,7 @@ class FieldOptions
 
 	public function render(ModelWithContent $model): array
 	{
-		return $this->resolve($model)->render($model);
+		return $this->resolve($model)->render($model, $this->safeMode);
 	}
 
 	public function resolve(ModelWithContent $model): Options

--- a/src/Option/Option.php
+++ b/src/Option/Option.php
@@ -65,16 +65,19 @@ class Option
 	/**
 	 * Renders all data for the option
 	 */
-	public function render(ModelWithContent $model): array
-	{
+	public function render(
+		ModelWithContent $model,
+		bool $safeMode = true
+	): array {
 		$info = I18n::translate($this->info, $this->info);
 		$text = I18n::translate($this->text, $this->text);
+		$method = $safeMode === true ? 'toSafeString' : 'toString';
 
 		return [
 			'disabled' => $this->disabled,
 			'icon'     => $this->icon,
-			'info'     => $info ? $model->toSafeString($info) : $info,
-			'text'     => $text ? $model->toSafeString($text) : $text,
+			'info'     => $info ? $model->$method($info) : $info,
+			'text'     => $text ? $model->$method($text) : $text,
 			'value'    => $this->value
 		];
 	}

--- a/src/Option/Options.php
+++ b/src/Option/Options.php
@@ -63,12 +63,12 @@ class Options extends Collection
 		return $collection;
 	}
 
-	public function render(ModelWithContent $model): array
+	public function render(ModelWithContent $model, bool $safeMode = true): array
 	{
 		$options = [];
 
 		foreach ($this->data as $key => $option) {
-			$options[$key] = $option->render($model);
+			$options[$key] = $option->render($model, $safeMode);
 		}
 
 		return array_values($options);

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1342,8 +1342,8 @@ class Str
 		array $data = [],
 		array $options = []
 	): string {
-		$start    = $options['start'] ?? '{{1,2}';
-		$end      = $options['end'] ?? '}{1,2}';
+		$start    = $options['start'] ?? '(?:{{|{<|{)';
+		$end      = $options['end'] ?? '(?:}}|>}|})';
 		$fallback = $options['fallback'] ?? null;
 		$callback = $options['callback'] ?? null;
 

--- a/tests/Option/OptionTest.php
+++ b/tests/Option/OptionTest.php
@@ -87,4 +87,19 @@ class OptionTest extends TestCase
 		$model = new Page(['slug' => 'test']);
 		$this->assertSame($expected, $option->render($model));
 	}
+
+	public function testRenderWithoutSafeMode(): void
+	{
+		$option = Option::factory([
+			'value' => 'test',
+			'text'  => "{{ page.something.or('String with <> HTML chars') }}",
+			'info'  => "{< page.something.or('String with <> HTML chars') >}"
+		]);
+
+		$model  = new Page(['slug' => 'test']);
+		$result = $option->render($model, safeMode: false);
+
+		$this->assertSame('String with <> HTML chars', $result['text']);
+		$this->assertSame('String with <> HTML chars', $result['info']);
+	}
 }

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -1272,6 +1272,16 @@ class StrTest extends TestCase
 				'From a to b',
 			],
 			[
+				'From {< b >} to {< a >}',
+				['a' => 'b', 'b' => 'a'],
+				'From a to b',
+			],
+			[
+				'Mix {{ b }}, { a }, {< b >}',
+				['a' => 'A', 'b' => 'B'],
+				'Mix B, A, B',
+			],
+			[
 				'From dbf to daf',
 				['a' => 'b', 'b' => 'a'],
 				'From a to b',


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Select field: Fixed double escaping of option text
#5995

### Refactored
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- `Str::template()` by default also replaces placeholders wrapped in `{< >}`

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion