### PR TITLE
feat: Icon support for tags

### DIFF
--- a/panel/lab/components/inputs/checkboxes/index.vue
+++ b/panel/lab/components/inputs/checkboxes/index.vue
@@ -36,6 +36,14 @@
 				/>
 			</k-lab-example>
 
+			<k-lab-example label="Options with info & icon">
+				<k-checkboxes-input
+					:options="optionsWithInfoAndIcon"
+					:value="value"
+					@input="value = $event"
+				/>
+			</k-lab-example>
+
 			<k-lab-example label="Focus" class="k-lab-input-examples-focus">
 				<k-checkboxes-input
 					ref="input"
@@ -96,6 +104,27 @@ export default {
 				{ text: "Option A", value: "a", info: "This is some info text" },
 				{ text: "Option B", value: "b", info: "This is some info text" },
 				{ text: "Option C", value: "c", info: "This is some info text" }
+			];
+		},
+		optionsWithInfoAndIcon() {
+			return [
+				{
+					text: "Option A",
+					value: "a",
+					info: "This is some info text",
+					icon: "heart"
+				},
+				{
+					text: "Option B",
+					value: "b",
+					info: "This is some info text"
+				},
+				{
+					text: "Option C",
+					value: "c",
+					info: "This is some info text",
+					icon: "star"
+				}
 			];
 		}
 	}

--- a/panel/lab/components/inputs/choice/index.vue
+++ b/panel/lab/components/inputs/choice/index.vue
@@ -49,6 +49,15 @@
 					@input="value = $event"
 				/>
 			</k-lab-example>
+			<k-lab-example label="Label & Info & Icon">
+				<k-choice-input
+					:checked="value"
+					info="This is some info text"
+					icon="heart"
+					label="Option"
+					@input="value = $event"
+				/>
+			</k-lab-example>
 			<k-lab-example label="Type: radio">
 				<k-choice-input
 					:checked="value"

--- a/panel/lab/components/inputs/multiselect/index.vue
+++ b/panel/lab/components/inputs/multiselect/index.vue
@@ -36,6 +36,14 @@
 				/>
 			</k-lab-example>
 
+			<k-lab-example label="Options with info & icon">
+				<k-multiselect-input
+					:options="optionsWithInfoAndIcon"
+					:value="value"
+					@input="value = $event"
+				/>
+			</k-lab-example>
+
 			<k-lab-example label="Focus" class="k-lab-input-examples-focus">
 				<k-multiselect-input
 					ref="input"
@@ -96,6 +104,27 @@ export default {
 				{ text: "Option A", value: "a", info: "This is some info text" },
 				{ text: "Option B", value: "b", info: "This is some info text" },
 				{ text: "Option C", value: "c", info: "This is some info text" }
+			];
+		},
+		optionsWithInfoAndIcon() {
+			return [
+				{
+					text: "Option A",
+					value: "a",
+					info: "This is some info text",
+					icon: "heart"
+				},
+				{
+					text: "Option B",
+					value: "b",
+					info: "This is some info text"
+				},
+				{
+					text: "Option C",
+					value: "c",
+					info: "This is some info text",
+					icon: "star"
+				}
 			];
 		}
 	}

--- a/panel/lab/components/inputs/radio/index.vue
+++ b/panel/lab/components/inputs/radio/index.vue
@@ -36,6 +36,14 @@
 				/>
 			</k-lab-example>
 
+			<k-lab-example label="Options with info & icon">
+				<k-radio-input
+					:options="optionsWithInfoAndIcon"
+					:value="value"
+					@input="value = $event"
+				/>
+			</k-lab-example>
+
 			<k-lab-example label="Focus" class="k-lab-input-examples-focus">
 				<k-radio-input
 					ref="input"
@@ -78,6 +86,27 @@ export default {
 				{ text: "Option A", value: "a", info: "This is some info text" },
 				{ text: "Option B", value: "b", info: "This is some info text" },
 				{ text: "Option C", value: "c", info: "This is some info text" }
+			];
+		},
+		optionsWithInfoAndIcon() {
+			return [
+				{
+					text: "Option A",
+					value: "a",
+					info: "This is some info text",
+					icon: "heart"
+				},
+				{
+					text: "Option B",
+					value: "b",
+					info: "This is some info text"
+				},
+				{
+					text: "Option C",
+					value: "c",
+					info: "This is some info text",
+					icon: "star"
+				}
 			];
 		}
 	}

--- a/panel/lab/components/inputs/tags/index.vue
+++ b/panel/lab/components/inputs/tags/index.vue
@@ -64,6 +64,14 @@
 					@input="value = $event"
 				/>
 			</k-lab-example>
+
+			<k-lab-example label="With icon & info">
+				<k-tags-input
+					:options="optionsWithInfoAndIcon"
+					:value="value"
+					@input="value = $event"
+				/>
+			</k-lab-example>
 		</k-lab-examples>
 	</k-lab-form>
 </template>
@@ -81,6 +89,27 @@ export default {
 				{ text: "Option A", value: "a" },
 				{ text: "Option B", value: "b" },
 				{ text: "Option C", value: "c" }
+			];
+		},
+		optionsWithInfoAndIcon() {
+			return [
+				{
+					text: "Option A",
+					value: "a",
+					info: "This is some info text",
+					icon: "heart"
+				},
+				{
+					text: "Option B",
+					value: "b",
+					info: "This is some info text"
+				},
+				{
+					text: "Option C",
+					value: "c",
+					info: "This is some info text",
+					icon: "star"
+				}
 			];
 		}
 	}

--- a/panel/src/components/Dropdowns/PicklistDropdown.vue
+++ b/panel/src/components/Dropdowns/PicklistDropdown.vue
@@ -109,6 +109,9 @@ export default {
 	border-radius: var(--picklist-rounded);
 	padding-block: 0.375rem;
 }
+.k-picklist-dropdown .k-picklist-input-options .k-choice-input-label {
+	flex-grow: 1;
+}
 .k-picklist-dropdown .k-picklist-input-options li + li {
 	margin-top: 0;
 }

--- a/panel/src/components/Dropdowns/PicklistDropdown.vue
+++ b/panel/src/components/Dropdowns/PicklistDropdown.vue
@@ -128,6 +128,8 @@ export default {
 	.k-picklist-input-options
 	.k-choice-input:not([aria-disabled="true"]):hover {
 	background-color: var(--dropdown-color-hr);
+
+	--choice-color-border: var(--dropdown-color-bg);
 }
 .k-picklist-dropdown
 	.k-picklist-input-options

--- a/panel/src/components/Forms/Input/CheckboxesInput.vue
+++ b/panel/src/components/Forms/Input/CheckboxesInput.vue
@@ -59,6 +59,8 @@ export default {
 	},
 	computed: {
 		choices() {
+			const hasIcons = this.options.some((option) => option.icon);
+
 			return this.options.map((option, index) => {
 				const checked = this.selected.includes(option.value);
 
@@ -68,6 +70,7 @@ export default {
 					disabled:
 						this.disabled || option.disabled || (!checked && this.isFull),
 					id: `${this.id}-${index}`,
+					icon: option.icon ?? (hasIcons ? "blank" : null),
 					info: option.info,
 					label: option.text,
 					name: this.name ?? this.id,

--- a/panel/src/components/Forms/Input/ChoiceInput.vue
+++ b/panel/src/components/Forms/Input/ChoiceInput.vue
@@ -2,6 +2,7 @@
 	<label
 		:aria-disabled="disabled"
 		:class="['k-choice-input', $attrs.class]"
+		:data-has-icon="Boolean(icon)"
 		:style="$attrs.style"
 	>
 		<input
@@ -20,6 +21,9 @@
 			@click="$emit('click', $event)"
 			@input="$emit('input', $event.target.checked)"
 		/>
+
+		<k-icon v-if="icon" :type="icon" class="k-choice-input-icon" />
+
 		<span v-if="label || info" class="k-choice-input-label">
 			<!-- eslint-disable-next-line vue/no-v-html -->
 			<span class="k-choice-input-label-text" v-html="label" />
@@ -39,6 +43,9 @@ export const props = {
 			type: Boolean
 		},
 		info: {
+			type: String
+		},
+		icon: {
 			type: String
 		},
 		label: {
@@ -73,14 +80,19 @@ export default {
 	gap: var(--spacing-3);
 	min-width: 0;
 }
+.k-choice-input-icon {
+	--icon-size: var(--text-md);
+	position: relative;
+}
+.k-choice-input-icon,
 .k-choice-input input {
 	top: 2px;
 }
 .k-choice-input-label {
 	display: flex;
-	line-height: 1.25rem;
 	flex-direction: column;
 	min-width: 0;
+	line-height: 1.25rem;
 	color: var(--choice-color-text);
 }
 .k-choice-input-label > * {
@@ -88,7 +100,12 @@ export default {
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
+.k-choice-input-label-icon {
+	grid-area: icon;
+	--icon-size: var(--text-md);
+}
 .k-choice-input-label-info {
+	grid-area: info;
 	color: var(--choice-color-info);
 }
 .k-choice-input[aria-disabled="true"] {

--- a/panel/src/components/Forms/Input/RadioInput.vue
+++ b/panel/src/components/Forms/Input/RadioInput.vue
@@ -48,12 +48,15 @@ export default {
 	mixins: [Input, props],
 	computed: {
 		choices() {
+			const hasIcons = this.options.some((option) => option.icon);
+
 			return this.options.map((option, index) => {
 				return {
 					autofocus: this.autofocus && index === 0,
 					checked: this.value === option.value,
 					disabled: this.disabled || option.disabled,
 					id: `${this.id}-${index}`,
+					icon: option.icon ?? (hasIcons ? "blank" : null),
 					info: option.info,
 					label: option.text,
 					name: this.name ?? this.id,

--- a/panel/src/components/Navigation/Tag.vue
+++ b/panel/src/components/Navigation/Tag.vue
@@ -172,7 +172,7 @@ button.k-tag:not([aria-disabled="true"]) {
 	background-clip: padding-box;
 }
 .k-tag-icon {
-	padding-inline-start: var(--spacing-2);
+	padding-inline: var(--spacing-2);
 }
 .k-tag-text {
 	padding-inline: var(--spacing-2);
@@ -180,6 +180,9 @@ button.k-tag:not([aria-disabled="true"]) {
 	overflow: hidden;
 	white-space: nowrap;
 	text-overflow: ellipsis;
+}
+.k-tag:has(.k-tag-icon) .k-tag-text {
+	padding-inline-start: 0;
 }
 .k-tag:has(.k-tag-toggle) .k-tag-text {
 	padding-inline-end: 0;

--- a/panel/src/components/Navigation/Tag.vue
+++ b/panel/src/components/Navigation/Tag.vue
@@ -11,7 +11,11 @@
 		<!-- @slot Replaces the image/icon frame created via the `image` prop -->
 		<slot name="image">
 			<k-image-frame v-if="image?.src" v-bind="image" class="k-tag-image" />
-			<k-icon-frame v-else-if="image" v-bind="image" class="k-tag-image" />
+			<k-icon-frame
+				v-else-if="image || icon"
+				v-bind="image ?? { icon }"
+				class="k-tag-icon"
+			/>
 		</slot>
 
 		<template v-if="text">
@@ -76,6 +80,10 @@ export default {
 		 * HTML element to use
 		 */
 		element: String,
+		/**
+		 * Shortcut for tags with icons (alternative to `image`)
+		 */
+		icon: String,
 		/**
 		 * See `k-image-frame` or `k-icon-frame` for available options
 		 */
@@ -162,6 +170,9 @@ button.k-tag:not([aria-disabled="true"]) {
 	border-start-start-radius: var(--tag-rounded);
 	border-end-start-radius: var(--tag-rounded);
 	background-clip: padding-box;
+}
+.k-tag-icon {
+	padding-inline-start: var(--spacing-2);
 }
 .k-tag-text {
 	padding-inline: var(--spacing-2);

--- a/panel/src/components/Navigation/Tags.vue
+++ b/panel/src/components/Navigation/Tags.vue
@@ -19,6 +19,7 @@
 				:disabled="disabled"
 				:element="element"
 				:html="html"
+				:icon="item.icon"
 				:image="item.image"
 				:link="item.link"
 				:removable="removable && !disabled"


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features
<!-- 
e.g. New feature X which helps users to …
-->
- Support for option icons in checkboxes, multiselect, radio and tags field
#7673
<img width="311" height="317" alt="Screenshot 2026-01-24 at 12 50 28" src="https://github.com/user-attachments/assets/fb868141-5770-4d24-bf36-c90d35f8d775" />
<img width="266" height="234" alt="Screenshot 2026-01-24 at 12 47 19" src="https://github.com/user-attachments/assets/cc618087-4ede-4b2b-ab97-9e692a96328d" />
<img width="267" height="231" alt="Screenshot 2026-01-24 at 12 47 09" src="https://github.com/user-attachments/assets/53ecd5a2-6e0e-4699-8fd0-39d7e2d94be7" />


### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- `<k-tag>`: support for `icon`
- `<k-checkboxes-input>`, `<k-radio-input>`, `<k-toggle-input>`: support for additional `icon` alongside text and info for the label

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
  - [x] Lab inputs examples
  - [x] https://github.com/getkirby/sandbox/pull/24
- [x] Add changes & docs to release notes draft in Notion