### PR TITLE
fix: Generate correct srcset for smaller images

### DIFF
--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -263,16 +263,19 @@ class ModelTest extends TestCase
 		$this->assertStringContainsString('test-38x.jpg 38w', $image['srcset']);
 		$this->assertStringContainsString('test-76x.jpg 76w', $image['srcset']);
 
-		// cards
+		// cards - test image is 128x128, so all requested sizes (352, 864, 1408)
+		// are larger than original, resulting in 128w (deduplicated to one entry)
 		$image = $panel->image('site.image', 'cards');
-		$this->assertStringContainsString('test-352x.jpg 352w', $image['srcset']);
-		$this->assertStringContainsString('test-864x.jpg 864w', $image['srcset']);
-		$this->assertStringContainsString('test-1408x.jpg 1408w', $image['srcset']);
+		$this->assertStringContainsString(' 128w', $image['srcset']);
+		// should only have one entry since all sizes result in 128w
+		$this->assertSame(1, substr_count($image['srcset'], 'w'));
 
-		// cardlets
+		// cardlets - test image is 128x128, so 96 stays 96, but 192 becomes 128
 		$image = $panel->image('site.image', 'cardlets');
 		$this->assertStringContainsString('test-96x.jpg 96w', $image['srcset']);
-		$this->assertStringContainsString('test-192x.jpg 192w', $image['srcset']);
+		$this->assertStringContainsString(' 128w', $image['srcset']);
+		// should have two entries (96w and 128w)
+		$this->assertSame(2, substr_count($image['srcset'], 'w'));
 
 		// table
 		$image = $panel->image('site.image', 'table');


### PR DESCRIPTION
## TODO 

This approach is valid when we find a way to cache the dimensions. Otherwise, this has a big performance impact. 

## Description

The `srcset()` method was generating incorrect width descriptors when requested image sizes were larger than the original image. For example, requesting a `760px` thumbnail from a 360px image would output `srcset="... 760w"` even though the actual thumbnail was only `360px` wide.                                        
                                     
The `srcset()` method now:                                                                                       
                                                                                                                
1. Instead of using the requested width directly for the width descriptor, it   
now calls `$thumb->width()` to get the actual width of the generated thumbnail.                                  
2. When multiple requested sizes result in the same actual width (e.g.,        
requesting 200, 300, and 400px from a 128px image all result in 128px), the srcset now only includes one entry 
instead of three identical ones.
3. Width descriptors (ending in w) are corrected, but pixel density descriptors (like 1x, 2x) are preserved as-is since they don't represent actual dimensions.

## Changelog 

### 🐛 Bug fixes

- Fixed srcset for images that are smaller than the requested size https://github.com/getkirby/kirby/issues/2071

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion