### PR TITLE
fix: Handle offline issues in fetch requests

### DIFF
--- a/panel/src/api/request.js
+++ b/panel/src/api/request.js
@@ -1,4 +1,4 @@
-import { responder } from "@/panel/request.js";
+import { responder, safeFetch } from "@/panel/request.js";
 import { toLowerKeys } from "@/helpers/object.js";
 import { ltrim, rtrim } from "@/helpers/string";
 
@@ -46,7 +46,7 @@ export default (api) => {
 		const request = new Request(options.url, options);
 
 		// fetch the resquest's response
-		const { response } = await responder(request, await fetch(request));
+		const { response } = await responder(request, await safeFetch(request));
 
 		let data = response.json;
 

--- a/panel/src/errors/OfflineError.js
+++ b/panel/src/errors/OfflineError.js
@@ -1,0 +1,11 @@
+/**
+ * Signals a network failure while the Panel is offline
+ * @since 5.0.3
+ */
+export default class OfflineError extends Error {
+	constructor(message, { request, cause } = {}) {
+		super(message, { cause });
+
+		this.request = request;
+	}
+}

--- a/panel/src/panel/panel.js
+++ b/panel/src/panel/panel.js
@@ -22,6 +22,7 @@ import User from "./user.js";
 import View from "./view.js";
 import { isObject } from "@/helpers/object.js";
 import { isEmpty } from "@/helpers/string.js";
+import OfflineError from "@/errors/OfflineError.js";
 
 /**
  * Globals are just reactive objects
@@ -172,6 +173,11 @@ export default {
 	 */
 	error(error, openNotification = true) {
 		if (error.name === "AbortError") {
+			return;
+		}
+
+		if (error instanceof OfflineError) {
+			this.isOffline = true;
 			return;
 		}
 

--- a/panel/src/panel/request.js
+++ b/panel/src/panel/request.js
@@ -2,6 +2,7 @@ import { buildUrl, isSameOrigin, makeAbsolute } from "@/helpers/url.js";
 import { toLowerKeys } from "../helpers/object.js";
 import AuthError from "@/errors/AuthError.js";
 import JsonRequestError from "@/errors/JsonRequestError.js";
+import OfflineError from "@/errors/OfflineError.js";
 import RequestError from "@/errors/RequestError.js";
 
 /**
@@ -114,7 +115,7 @@ export const request = async (url, options = {}) => {
 	}
 
 	// parse the JSON response and react on errors
-	return await responder(request, await fetch(request));
+	return await responder(request, await safeFetch(request));
 };
 
 /**
@@ -165,6 +166,32 @@ export const responder = async (request, response) => {
 		request,
 		response
 	};
+};
+
+/**
+ * Fetches a request and converts network errors
+ * into a Panel offline state
+ *
+ * @param {Request} request
+ * @returns {Response}
+ */
+export const safeFetch = async (request) => {
+	try {
+		return await fetch(request);
+	} catch (error) {
+		if (error?.name === "AbortError") {
+			throw error;
+		}
+
+		if (typeof window !== "undefined" && window.panel?.events) {
+			window.panel.events.emit("offline", error);
+		}
+
+		throw new OfflineError("Panel is offline", {
+			cause: error,
+			request
+		});
+	}
 };
 
 export default request;

--- a/panel/src/panel/request.js
+++ b/panel/src/panel/request.js
@@ -183,9 +183,7 @@ export const safeFetch = async (request) => {
 			throw error;
 		}
 
-		if (typeof window !== "undefined" && window.panel?.events) {
-			window.panel.events.emit("offline", error);
-		}
+		window?.panel?.events?.emit("offline", error);
 
 		throw new OfflineError("Panel is offline", {
 			cause: error,


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->

- New `OfflineError` error type in `kirby/panel/src/errors/OfflineError.js`.
- `kirby/panel/src/panel/request.js` now uses `safeFetch()` and emits offline on network failures.
- `kirby/panel/src/api/request.js` uses `safeFetch()` instead of raw `fetch()`.
- `kirby/panel/src/panel/panel.js` catches `OfflineError` and sets `isOffline`.

### 🐛 Bug fixes

- https://github.com/getkirby/kirby/issues/6077

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion