### PR TITLE
fix: Reactivity for active marks/nodes in writer

### DIFF
--- a/panel/src/components/Forms/Writer/Editor.js
+++ b/panel/src/components/Forms/Writer/Editor.js
@@ -4,7 +4,7 @@ import { Schema, DOMParser, DOMSerializer } from "prosemirror-model";
 import { keymap } from "prosemirror-keymap";
 import { baseKeymap } from "prosemirror-commands";
 import { inputRules, undoInputRule } from "prosemirror-inputrules";
-import { toRaw } from "vue";
+import { reactive, toRaw } from "vue";
 
 // Prosemirror utils
 import utils from "./Utils";
@@ -39,6 +39,22 @@ export default class Editor extends Emitter {
 		};
 
 		this.init(options);
+	}
+
+	get activeMarks() {
+		return this.active.marks;
+	}
+
+	get activeNodes() {
+		return this.active.nodes;
+	}
+
+	get activeMarkAttrs() {
+		return this.active.markAttrs;
+	}
+
+	get activeNodeAttrs() {
+		return this.active.nodeAttrs;
 	}
 
 	blur() {
@@ -375,6 +391,14 @@ export default class Editor extends Emitter {
 		this.focused = false;
 		// this.selection = { from: 0, to: 0 };
 
+		// Initialize reactive state for active marks and nodes
+		this.active = reactive({
+			marks: [],
+			nodes: [],
+			markAttrs: {},
+			nodeAttrs: {}
+		});
+
 		this.events = this.createEvents();
 		this.extensions = this.createExtensions();
 		this.nodes = this.createNodes();
@@ -419,8 +443,8 @@ export default class Editor extends Emitter {
 
 	get isActive() {
 		return Object.entries({
-			...this.activeMarks,
-			...this.activeNodes
+			...this.active.marks,
+			...this.active.nodes
 		}).reduce(
 			(types, [name, value]) => ({
 				...types,
@@ -485,11 +509,11 @@ export default class Editor extends Emitter {
 	}
 
 	setActiveNodesAndMarks() {
-		this.activeMarks = Object.values(this.schema.marks)
+		this.active.marks = Object.values(this.schema.marks)
 			.filter((mark) => utils.markIsActive(this.state, mark))
 			.map((mark) => mark.name);
 
-		this.activeMarkAttrs = Object.entries(this.schema.marks).reduce(
+		this.active.markAttrs = Object.entries(this.schema.marks).reduce(
 			(marks, [name, mark]) => ({
 				...marks,
 				[name]: utils.getMarkAttrs(this.state, mark)
@@ -497,11 +521,11 @@ export default class Editor extends Emitter {
 			{}
 		);
 
-		this.activeNodes = Object.values(this.schema.nodes)
+		this.active.nodes = Object.values(this.schema.nodes)
 			.filter((node) => utils.nodeIsActive(this.state, node))
 			.map((node) => node.name);
 
-		this.activeNodeAttrs = Object.entries(this.schema.nodes).reduce(
+		this.active.nodeAttrs = Object.entries(this.schema.nodes).reduce(
 			(nodes, [name, node]) => ({
 				...nodes,
 				[name]: utils.getNodeAttrs(this.state, node)

--- a/panel/src/components/Forms/Writer/Toolbar.vue
+++ b/panel/src/components/Forms/Writer/Toolbar.vue
@@ -308,8 +308,15 @@ export default {
 				return "|";
 			}
 
+			// Check if this is a node or a mark by looking at
+			// the button name property - if it's defined in the
+			// schema, we can determine its type
+			const isNode = this.editor.schema.nodes[entry.name ?? type];
+
 			return {
-				current: this.isMarkActive({ ...entry, name: type }),
+				current: isNode
+					? this.isNodeActive({ ...entry, name: type })
+					: this.isMarkActive({ ...entry, name: type }),
 				icon: entry.icon,
 				label: entry.label,
 				click: (e) => this.command(entry.command ?? type, e)


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Fixes #7875 by making the active states in `Editor.js` properly reactive. Added gets for the old names to avoid breaking changes (they still remain reactive then with this change).
