### PR TITLE
feat: Support file HTTP range requests

### DIFF
--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -54,7 +54,7 @@ class Media
 			}
 
 			// send the file to the browser
-			return Response::file($file->publish()->mediaRoot());
+			return Response::file($file->publish()->root());
 		}
 
 		// try to generate a thumb for the file

--- a/src/Cms/Media.php
+++ b/src/Cms/Media.php
@@ -7,6 +7,7 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
+use Kirby\Http\Response;
 use Kirby\Toolkit\Str;
 use Throwable;
 

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -626,7 +626,7 @@ class F
 				$handle = fopen($file, 'rb');
 
 				if ($handle === false) {
-					return false;
+					return false; // @codeCoverageIgnore
 				}
 
 				if ($offset > 0) {

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -600,6 +600,52 @@ class F
 	}
 
 	/**
+	 * Reads a specific byte range from a file
+	 * @since 6.0.0
+	 *
+	 * @param string $file The path to the file
+	 * @param int $offset The byte offset to start reading from
+	 * @param int|null $length The number of bytes to read (null = read to end)
+	 */
+	public static function range(
+		string $file,
+		int $offset = 0,
+		int|null $length = null
+	): string|false {
+		if (str_contains($file, '://') === true) {
+			return false;
+		}
+
+		// exit early on empty paths that would trigger a PHP `ValueError`
+		if ($file === '') {
+			return false;
+		}
+
+		return Helpers::handleErrors(
+			function () use ($file, $offset, $length): string|false {
+				$handle = fopen($file, 'rb');
+
+				if ($handle === false) {
+					return false;
+				}
+
+				if ($offset > 0) {
+					fseek($handle, $offset);
+				}
+
+				$content = $length !== null
+					? fread($handle, $length)
+					: fread($handle, filesize($file) - $offset);
+
+				fclose($handle);
+				return $content;
+			},
+			fn (int $errno, string $errstr): bool => str_contains($errstr, 'No such file'),
+			false
+		);
+	}
+
+	/**
 	 * Reads the content of a file or requests the
 	 * contents of a remote HTTP or HTTPS URL
 	 *
@@ -616,9 +662,9 @@ class F
 			return false;
 		}
 
-		// to increase performance, directly try to load the file without checking
-		// if it exists; fall back to a `false` return value if it doesn't exist
-		// while letting other warnings through
+		// to increase performance, directly try to load the file
+		// without checking if it exists; fall back to return `false`
+		// if it doesn't exist while letting other warnings through
 		return Helpers::handleErrors(
 			fn (): string|false => file_get_contents($file),
 			fn (int $errno, string $errstr): bool => str_contains($errstr, 'No such file'),

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -601,7 +601,7 @@ class F
 
 	/**
 	 * Reads a specific byte range from a file
-	 * @since 6.0.0
+	 * @since 5.3.0
 	 *
 	 * @param string $file The path to the file
 	 * @param int $offset The byte offset to start reading from

--- a/src/Http/Range.php
+++ b/src/Http/Range.php
@@ -42,7 +42,7 @@ class Range
 		$range = substr($range, 6);
 
 		// support only single ranges (not multiple ranges like "0-100,200-300")
-		if (str_contains($range, ',')) {
+		if (str_contains($range, ',') === true) {
 			return false;
 		}
 
@@ -63,17 +63,17 @@ class Range
 				return false;
 			}
 
-			$suffixLength = (int)$endStr;
+			$suffix = (int)$endStr;
 
-			if ($suffixLength <= 0) {
+			if ($suffix <= 0) {
 				return false;
 			}
 
-			if ($suffixLength > $size) {
-				$suffixLength = $size;
+			if ($suffix > $size) {
+				$suffix = $size;
 			}
 
-			$start = $size - $suffixLength;
+			$start = $size - $suffix;
 			$end   = $size - 1;
 
 			return [$start, $end];

--- a/src/Http/Range.php
+++ b/src/Http/Range.php
@@ -14,7 +14,7 @@ use Kirby\Filesystem\F;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
- * @since     6.0.0
+ * @since     5.3.0
  */
 class Range
 {

--- a/src/Http/Range.php
+++ b/src/Http/Range.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Kirby\Http;
+
+use Kirby\Filesystem\F;
+
+/**
+ * Handles HTTP Range requests (RFC 7233)
+ * for partial content delivery, primarily
+ * used for video streaming in browsers
+ *
+ * @package   Kirby Http
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ * @since     6.0.0
+ */
+class Range
+{
+	/**
+	 * Parses the Range header and returns start and end byte positions
+	 *
+	 * @return array{int, int}|false Array of [start, end] or false if invalid
+	 */
+	public static function parse(
+		string $range,
+		int $size
+	): array|false {
+		if ($size <= 0) {
+			return false;
+		}
+
+		$range = trim($range);
+
+		// only support byte ranges (not other units)
+		if (strncasecmp($range, 'bytes=', 6) !== 0) {
+			return false;
+		}
+
+		// extract the range part after "bytes="
+		$range = substr($range, 6);
+
+		// support only single ranges (not multiple ranges like "0-100,200-300")
+		if (str_contains($range, ',')) {
+			return false;
+		}
+
+		// split start and end
+		$parts = explode('-', $range, 2);
+
+		if (count($parts) !== 2) {
+			return false;
+		}
+
+		[$startStr, $endStr] = $parts;
+		$startStr = trim($startStr);
+		$endStr   = trim($endStr);
+
+		// handle "bytes=-500" (last 500 bytes)
+		if ($startStr === '') {
+			if (is_numeric($endStr) === false) {
+				return false;
+			}
+
+			$suffixLength = (int)$endStr;
+
+			if ($suffixLength <= 0) {
+				return false;
+			}
+
+			if ($suffixLength > $size) {
+				$suffixLength = $size;
+			}
+
+			$start = $size - $suffixLength;
+			$end   = $size - 1;
+
+			return [$start, $end];
+		}
+
+		// validate that start is numeric
+		if (is_numeric($startStr) === false) {
+			return false;
+		}
+
+		$start = (int)$startStr;
+
+		// handle "bytes=1024-" (from byte 1024 to end)
+		if ($endStr === '') {
+			$end = $size - 1;
+		} elseif (is_numeric($endStr) === false) {
+			return false;
+		} else {
+			$end = (int)$endStr;
+
+			// clamp end to file size if a client overshoots
+			if ($end >= $size) {
+				$end = $size - 1;
+			}
+		}
+
+		// validate the range
+		if (
+			$start < 0 ||
+			$start >= $size ||
+			$end < $start
+		) {
+			return false;
+		}
+
+		return [$start, $end];
+	}
+
+	/**
+	 * Creates a response for a partial file request (byte-range)
+	 */
+	public static function response(
+		string $file,
+		string $range,
+		array $props = []
+	): Response {
+		// parse the Range header (e.g., "bytes=0-1" or "bytes=1024-")
+		$size   = filesize($file);
+		$parsed = static::parse($range, $size);
+
+		// if the range is invalid, return 416 Range Not Satisfiable
+		if ($parsed === false) {
+			return new Response(
+				code: 416,
+				body: 'Requested Range Not Satisfiable',
+				headers: [
+					'Content-Range' => 'bytes */' . $size
+				]
+			);
+		}
+
+		[$start, $end] = $parsed;
+		$length        = $end - $start + 1;
+
+		// read only the requested byte range from the file
+		$body = F::range($file, offset: $start, length: $length);
+
+		$props = Response::ensureSafeMimeType([
+			'body' => $body,
+			'code' => 206, // Partial Content
+			'type' => F::extensionToMime(F::extension($file)),
+			'headers' => [
+				'Accept-Ranges'  => 'bytes',
+				'Content-Range'  => 'bytes ' . $start . '-' . $end . '/' . $size,
+				'Content-Length' => $length,
+				...$props['headers'] ?? []
+			],
+			...$props
+		]);
+
+		return new Response($props);
+	}
+}

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -165,7 +165,7 @@ class Response implements Stringable
 	 * Ensures safe MIME type handling by forcing plain text
 	 * for files without recognizable MIME types to harden
 	 * against attacks from malicious file uploads
-	 * @since 6.0.0
+	 * @since 5.3.0
 	 * @internal
 	 */
 	public static function ensureSafeMimeType(array $props): array

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -4,6 +4,7 @@ namespace Kirby\Http;
 
 use Closure;
 use Exception;
+use Kirby\Cms\App;
 use Kirby\Exception\LogicException;
 use Kirby\Filesystem\F;
 use Stringable;
@@ -161,6 +162,23 @@ class Response implements Stringable
 	}
 
 	/**
+	 * Ensures safe MIME type handling by forcing plain text
+	 * for files without recognizable MIME types to harden
+	 * against attacks from malicious file uploads
+	 * @since 6.0.0
+	 * @internal
+	 */
+	public static function ensureSafeMimeType(array $props): array
+	{
+		if ($props['type'] === null) {
+			$props['type'] = 'text/plain';
+			$props['headers']['X-Content-Type-Options'] = 'nosniff';
+		}
+
+		return $props;
+	}
+
+	/**
 	 * Creates a response for a file and
 	 * sends the file content to the browser
 	 *
@@ -168,23 +186,24 @@ class Response implements Stringable
 	 */
 	public static function file(string $file, array $props = []): static
 	{
-		$props = [
+		$request = App::instance(lazy: true)?->request();
+
+		// handle byte-range requests (e.g., for video streaming in Safari)
+		if ($range = $request?->header('Range')) {
+			return Range::response($file, $range, $props);
+		}
+
+		// always indicate that byte-range requests are supported
+		$props['headers'] = [
+			'Accept-Ranges' => 'bytes',
+			...$props['headers'] ?? []
+		];
+
+		$props = static::ensureSafeMimeType([
 			'body' => F::read($file),
 			'type' => F::extensionToMime(F::extension($file)),
 			...$props
-		];
-
-		// if we couldn't serve a correct MIME type, force
-		// the browser to display the file as plain text to
-		// harden against attacks from malicious file uploads
-		if ($props['type'] === null) {
-			if (isset($props['headers']) !== true) {
-				$props['headers'] = [];
-			}
-
-			$props['type'] = 'text/plain';
-			$props['headers']['X-Content-Type-Options'] = 'nosniff';
-		}
+		]);
 
 		return new static($props);
 	}

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -7,6 +7,7 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
+use Kirby\Http\Response;
 
 class MediaTest extends TestCase
 {

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -513,6 +513,33 @@ class FTest extends TestCase
 		I18n::$locale = $locale;
 	}
 
+
+	public function testRange(): void
+	{
+		file_put_contents($this->test, 'my content is awesome');
+
+		// read from offset 3 to end
+		$this->assertSame('content is awesome', F::range($this->test, offset: 3));
+
+		// read from offset 11
+		$this->assertSame('is awesome', F::range($this->test, offset: 11));
+
+		// read first 10 bytes
+		$this->assertSame('my content', F::range($this->test, length: 10));
+
+		// read first 2 bytes
+		$this->assertSame('my', F::range($this->test, length: 2));
+
+		// read 7 bytes starting from offset 3
+		$this->assertSame('content', F::range($this->test, offset: 3, length: 7));
+
+		// read 2 bytes starting from offset 11
+		$this->assertSame('is', F::range($this->test, offset: 11, length: 2));
+
+		// read 6 bytes starting from offset 14 (edge case - reads to end)
+		$this->assertSame('awesome', F::range($this->test, offset: 14, length: 7));
+	}
+
 	public function testRead(): void
 	{
 		file_put_contents($this->test, $content = 'my content is awesome');

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -538,6 +538,12 @@ class FTest extends TestCase
 
 		// read 6 bytes starting from offset 14 (edge case - reads to end)
 		$this->assertSame('awesome', F::range($this->test, offset: 14, length: 7));
+
+		// remote path
+		$this->assertFalse(F::range('https://example.com/file.txt'));
+
+		// empty path
+		$this->assertFalse(F::range(''));
 	}
 
 	public function testRead(): void

--- a/tests/Http/RangeTest.php
+++ b/tests/Http/RangeTest.php
@@ -12,6 +12,10 @@ class RangeTest extends TestCase
 
 	public function testParse(): void
 	{
+		// invalid size
+		$result = Range::parse('bytes=0-1', 0);
+		$this->assertFalse($result);
+
 		// standard range
 		$result = Range::parse('bytes=0-100', 1000);
 		$this->assertSame([0, 100], $result);
@@ -52,6 +56,14 @@ class RangeTest extends TestCase
 		$result = Range::parse('bytes=-500', 1000);
 		$this->assertSame([500, 999], $result);
 
+		// suffix byte range with invalid length
+		$result = Range::parse('bytes=-0', 1000);
+		$this->assertFalse($result);
+
+		// suffix byte range exceeding size (clamped)
+		$result = Range::parse('bytes=-1500', 1000);
+		$this->assertSame([0, 999], $result);
+
 		// start beyond file size
 		$result = Range::parse('bytes=2000-3000', 1000);
 		$this->assertFalse($result);
@@ -78,6 +90,10 @@ class RangeTest extends TestCase
 
 		// malformed range
 		$result = Range::parse('bytes=abc-def', 1000);
+		$this->assertFalse($result);
+
+		// non-numeric end
+		$result = Range::parse('bytes=0-abc', 1000);
 		$this->assertFalse($result);
 
 		// missing equals

--- a/tests/Http/RangeTest.php
+++ b/tests/Http/RangeTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Kirby\Http;
+
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Range::class)]
+class RangeTest extends TestCase
+{
+	public const string FIXTURES = __DIR__ . '/fixtures';
+
+	public function testParse(): void
+	{
+		// standard range
+		$result = Range::parse('bytes=0-100', 1000);
+		$this->assertSame([0, 100], $result);
+
+		// open-ended range (to end of file)
+		$result = Range::parse('bytes=500-', 1000);
+		$this->assertSame([500, 999], $result);
+
+		// open-ended range with whitespace
+		$result = Range::parse('bytes=0- ', 1000);
+		$this->assertSame([0, 999], $result);
+
+		// Safari probe
+		$result = Range::parse('bytes=0-1', 1000);
+		$this->assertSame([0, 1], $result);
+
+		// case-insensitive unit
+		$result = Range::parse('Bytes=0-1', 1000);
+		$this->assertSame([0, 1], $result);
+
+		// single byte
+		$result = Range::parse('bytes=0-0', 1000);
+		$this->assertSame([0, 0], $result);
+
+		// last byte
+		$result = Range::parse('bytes=999-999', 1000);
+		$this->assertSame([999, 999], $result);
+
+		// not bytes unit
+		$result = Range::parse('items=0-100', 1000);
+		$this->assertFalse($result);
+
+		// multiple ranges
+		$result = Range::parse('bytes=0-100,200-300', 1000);
+		$this->assertFalse($result);
+
+		// suffix byte range (last N bytes)
+		$result = Range::parse('bytes=-500', 1000);
+		$this->assertSame([500, 999], $result);
+
+		// start beyond file size
+		$result = Range::parse('bytes=2000-3000', 1000);
+		$this->assertFalse($result);
+
+		// end before start
+		$result = Range::parse('bytes=100-50', 1000);
+		$this->assertFalse($result);
+
+		// start equals file size
+		$result = Range::parse('bytes=1000-1000', 1000);
+		$this->assertFalse($result);
+
+		// end beyond file size (clamped)
+		$result = Range::parse('bytes=0-1000', 1000);
+		$this->assertSame([0, 999], $result);
+
+		// negative start
+		$result = Range::parse('bytes=-5-10', 1000);
+		$this->assertFalse($result);
+
+		// empty range
+		$result = Range::parse('bytes=', 1000);
+		$this->assertFalse($result);
+
+		// malformed range
+		$result = Range::parse('bytes=abc-def', 1000);
+		$this->assertFalse($result);
+
+		// missing equals
+		$result = Range::parse('bytes 0-100', 1000);
+		$this->assertFalse($result);
+
+		// malformed with text
+		$result = Range::parse('bytes=start-end', 1000);
+		$this->assertFalse($result);
+	}
+
+	public function testResponseWithValidRange(): void
+	{
+		$file = static::FIXTURES . '/download.json';
+		$size = filesize($file);
+
+		$response = Range::response($file, 'bytes=0-5');
+
+		$this->assertSame(206, $response->code());
+		$this->assertSame('bytes', $response->header('Accept-Ranges'));
+		$this->assertSame('bytes 0-5/' . $size, $response->header('Content-Range'));
+		$this->assertSame(6, (int)$response->header('Content-Length'));
+		$this->assertSame('{"foo"', $response->body());
+	}
+
+	public function testResponseWithOpenEndedRange(): void
+	{
+		$file = static::FIXTURES . '/download.json';
+		$size = filesize($file);
+
+		$response = Range::response($file, 'bytes=8-');
+
+		$this->assertSame(206, $response->code());
+		$this->assertSame('bytes 8-' . ($size - 1) . '/' . $size, $response->header('Content-Range'));
+		$this->assertSame('"bar"}', $response->body());
+	}
+
+	public function testResponseWithSafariProbe(): void
+	{
+		$file = static::FIXTURES . '/download.json';
+		$size = filesize($file);
+
+		// Safari sends bytes=0-1 as an initial probe
+		$response = Range::response($file, 'bytes=0-1');
+
+		$this->assertSame(206, $response->code());
+		$this->assertSame('bytes 0-1/' . $size, $response->header('Content-Range'));
+		$this->assertSame(2, (int)$response->header('Content-Length'));
+		$this->assertSame('{"', $response->body());
+	}
+
+	public function testResponseWithInvalidRange(): void
+	{
+		$file = static::FIXTURES . '/download.json';
+		$size = filesize($file);
+
+		// beyond file size
+		$response = Range::response($file, 'bytes=1000-2000');
+
+		$this->assertSame(416, $response->code());
+		$this->assertSame('bytes */' . $size, $response->header('Content-Range'));
+		$this->assertSame('Requested Range Not Satisfiable', $response->body());
+	}
+
+	public function testResponseWithInvalidMimeType(): void
+	{
+		$file     = static::FIXTURES . '/download.xyz';
+		$response = Range::response($file, 'bytes=0-3');
+
+		$this->assertSame(206, $response->code());
+		$this->assertSame('text/plain', $response->type());
+		$this->assertSame('nosniff', $response->header('X-Content-Type-Options'));
+		$this->assertSame('test', $response->body());
+	}
+}

--- a/tests/Http/RangeTest.php
+++ b/tests/Http/RangeTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(Range::class)]
 class RangeTest extends TestCase
 {
-	public const string FIXTURES = __DIR__ . '/fixtures';
+	public const FIXTURES = __DIR__ . '/fixtures';
 
 	public function testParse(): void
 	{

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -17,6 +17,7 @@ class ResponseTest extends TestCase
 
 	public function tearDown(): void
 	{
+		App::destroy();
 		HeadersSent::$value = false;
 	}
 

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Http;
 
 use Exception;
+use Kirby\Cms\App;
 use Kirby\Exception\LogicException;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -32,6 +33,36 @@ class ResponseTest extends TestCase
 		]);
 
 		$this->assertSame('test', $response->body());
+	}
+
+	public function testCharset(): void
+	{
+		$response = new Response();
+		$this->assertSame('UTF-8', $response->charset());
+
+		$response = new Response('', 'text/html', 200, [], 'test');
+		$this->assertSame('test', $response->charset());
+
+		$response = new Response([
+			'charset' => 'test'
+		]);
+
+		$this->assertSame('test', $response->charset());
+	}
+
+	public function testCode(): void
+	{
+		$response = new Response();
+		$this->assertSame(200, $response->code());
+
+		$response = new Response('', 'text/html', 404);
+		$this->assertSame(404, $response->code());
+
+		$response = new Response([
+			'code' => 404
+		]);
+
+		$this->assertSame(404, $response->code());
 	}
 
 	public function testDownload(): void
@@ -204,8 +235,35 @@ class ResponseTest extends TestCase
 		$this->assertSame(201, $response->code());
 		$this->assertSame('{"foo": "bar"}', $response->body());
 		$this->assertSame([
+			'Accept-Ranges' => 'bytes',
 			'Pragma' => 'no-cache'
 		], $response->headers());
+	}
+
+	public function testFileWithAcceptRangesHeader(): void
+	{
+		$file = static::FIXTURES . '/download.json';
+		$response = Response::file($file);
+
+		$this->assertSame('bytes', $response->header('Accept-Ranges'));
+	}
+
+	public function testFileWithRangeRequestHeader(): void
+	{
+		$file = static::FIXTURES . '/download.json';
+		$size = filesize($file);
+
+		new App([
+			'server' => [
+				'HTTP_RANGE' => 'bytes=0-'
+			]
+		]);
+
+		$response = Response::file($file);
+
+		$this->assertSame(206, $response->code());
+		$this->assertSame('bytes 0-' . ($size - 1) . '/' . $size, $response->header('Content-Range'));
+		$this->assertSame(file_get_contents($file), $response->body());
 	}
 
 	public function testFileInvalid(): void
@@ -218,6 +276,7 @@ class ResponseTest extends TestCase
 		$this->assertSame(200, $response->code());
 		$this->assertSame('test', $response->body());
 		$this->assertSame([
+			'Accept-Ranges' => 'bytes',
 			'X-Content-Type-Options' => 'nosniff',
 		], $response->headers());
 
@@ -232,54 +291,10 @@ class ResponseTest extends TestCase
 		$this->assertSame(201, $response->code());
 		$this->assertSame('test', $response->body());
 		$this->assertSame([
+			'Accept-Ranges' => 'bytes',
 			'Pragma' => 'no-cache',
 			'X-Content-Type-Options' => 'nosniff',
 		], $response->headers());
-	}
-
-	public function testType(): void
-	{
-		$response = new Response();
-		$this->assertSame('text/html', $response->type());
-
-		$response = new Response('', 'image/jpeg');
-		$this->assertSame('image/jpeg', $response->type());
-
-		$response = new Response([
-			'type' => 'image/jpeg'
-		]);
-
-		$this->assertSame('image/jpeg', $response->type());
-	}
-
-	public function testCharset(): void
-	{
-		$response = new Response();
-		$this->assertSame('UTF-8', $response->charset());
-
-		$response = new Response('', 'text/html', 200, [], 'test');
-		$this->assertSame('test', $response->charset());
-
-		$response = new Response([
-			'charset' => 'test'
-		]);
-
-		$this->assertSame('test', $response->charset());
-	}
-
-	public function testCode(): void
-	{
-		$response = new Response();
-		$this->assertSame(200, $response->code());
-
-		$response = new Response('', 'text/html', 404);
-		$this->assertSame(404, $response->code());
-
-		$response = new Response([
-			'code' => 404
-		]);
-
-		$this->assertSame(404, $response->code());
 	}
 
 	public function testRedirect(): void
@@ -371,6 +386,21 @@ class ResponseTest extends TestCase
 		$this->assertSame($code, 200);
 	}
 
+	public function testToArray(): void
+	{
+		// default setup
+		$response = new Response();
+		$expected = [
+			'type'    => 'text/html',
+			'charset' => 'UTF-8',
+			'code'    => 200,
+			'headers' => [],
+			'body'    => '',
+		];
+
+		$this->assertSame($expected, $response->toArray());
+	}
+
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState(false)]
 	public function testToString(): void
@@ -395,18 +425,18 @@ class ResponseTest extends TestCase
 		$this->assertSame($code, 200);
 	}
 
-	public function testToArray(): void
+	public function testType(): void
 	{
-		// default setup
 		$response = new Response();
-		$expected = [
-			'type'    => 'text/html',
-			'charset' => 'UTF-8',
-			'code'    => 200,
-			'headers' => [],
-			'body'    => '',
-		];
+		$this->assertSame('text/html', $response->type());
 
-		$this->assertSame($expected, $response->toArray());
+		$response = new Response('', 'image/jpeg');
+		$this->assertSame('image/jpeg', $response->type());
+
+		$response = new Response([
+			'type' => 'image/jpeg'
+		]);
+
+		$this->assertSame('image/jpeg', $response->type());
 	}
 }


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- Kirby now can handle HTTP range requests for partial content delivery
#1207 
- New `Filesystem\F::range($file, $offset, $length)` method to only read parts of a file
- New `Http\Range` class for handling HTTP range requests


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
  - [x] https://github.com/getkirby/sandbox/commit/c651623a77cfc74cc8ca951b59d56eb4e761d6fa
- [x] Add changes & docs to release notes draft in Notion