### PR TITLE
fix: Do not regenerate existing thumb job files

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -80,12 +80,14 @@ return [
 		$template  = $mediaRoot . '/{{ name }}{{ attributes }}.{{ extension }}';
 		$thumbRoot = (new Filename($file->root(), $template, $options))->toString();
 		$thumbName = basename($thumbRoot);
+		$job       = $mediaRoot . '/.jobs/' . $thumbName . '.json';
 
-		// check if the thumb already exists
-		if (file_exists($thumbRoot) === false) {
+		// check if the thumb or job file already exists
+		if (
+			file_exists($thumbRoot) === false &&
+			file_exists($job) === false
+		) {
 			// if not, create job file
-			$job = $mediaRoot . '/.jobs/' . $thumbName . '.json';
-
 			try {
 				Data::write(
 					$job,

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -252,6 +252,36 @@ class MediaTest extends TestCase
 		$this->assertFalse($thumb);
 	}
 
+	public function testThumbWithExistingJobFile(): void
+	{
+		Dir::make(static::TMP . '/content');
+
+		// copy test image to content
+		F::copy(
+			static::FIXTURES . '/files/test.jpg',
+			static::TMP . '/content/test.jpg'
+		);
+
+		// get file object
+		$file = $this->app->file('test.jpg');
+		$this->assertIsFile($file);
+
+		// create job file with specific marker before calling thumb()
+		$dir = $file->mediaDir() . '/.jobs';
+		$job = $dir . '/test-64x64-crop.jpg.json';
+		$payload = '{"width":64,"height":64,"crop":"center","filename":"test.jpg","custom":"marker"}';
+
+		Dir::make($dir);
+		F::write($job, $payload);
+
+		// call thumb() which triggers file::version component
+		$file->thumb(['width' => 64, 'height' => 64, 'crop' => 'center']);
+
+		// job file should not have been overwritten
+		$this->assertFileExists($job);
+		$this->assertSame($payload, F::read($job));
+	}
+
 	public function testThumbWhenGenerationFails(): void
 	{
 		Dir::make(static::TMP . '/content');


### PR DESCRIPTION

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Thumb jobs files do not get regenerate if they already exist
#7861


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion