### PR TITLE
feat: `<k-collapsible>`

### DIFF
--- a/panel/lab/components/breadcrumbs/index.vue
+++ b/panel/lab/components/breadcrumbs/index.vue
@@ -3,6 +3,9 @@
 		<k-lab-example label="Default">
 			<k-breadcrumb :crumbs="crumbs" />
 		</k-lab-example>
+		<k-lab-example label="Too many">
+			<k-breadcrumb :crumbs="tooMany" />
+		</k-lab-example>
 		<k-lab-example label="Too long">
 			<k-breadcrumb :crumbs="tooLong" />
 		</k-lab-example>
@@ -42,6 +45,38 @@ export default {
 				{
 					label: "some-super-long-filename-that-might-cause-problems.jpg",
 					link: "/blog/exploring-the-universe/some-super-long-filename-that-might-cause-problems.jpg"
+				}
+			];
+		},
+		tooMany() {
+			return [
+				{
+					label: "Home",
+					link: "/"
+				},
+				{
+					label: "Category",
+					link: "/category"
+				},
+				{
+					label: "Subcategory",
+					link: "/category/subcategory"
+				},
+				{
+					label: "Article",
+					link: "/category/subcategory/article"
+				},
+				{
+					label: "Details",
+					link: "/category/subcategory/article/details"
+				},
+				{
+					label: "Subdetails",
+					link: "/category/subcategory/article/details/foo"
+				},
+				{
+					label: "Final",
+					link: "/category/subcategory/article/details/foo/final"
 				}
 			];
 		}

--- a/panel/lab/components/collapsible/index.php
+++ b/panel/lab/components/collapsible/index.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'docs' => 'k-collapsible',
+];

--- a/panel/lab/components/collapsible/index.vue
+++ b/panel/lab/components/collapsible/index.vue
@@ -1,0 +1,111 @@
+<template>
+	<k-lab-examples>
+		<k-lab-example label="Default" :code="false">
+			<k-grid data-variant="fields" style="--columns: 2">
+				<k-number-field
+					label="Number of buttons"
+					:min="1"
+					:max="10"
+					:step="1"
+					:value="buttons"
+					@input="buttons = $event"
+				/>
+				<k-toggles-field
+					label="Direction"
+					:options="[
+						{ value: 'start', icon: 'angle-left' },
+						{ value: 'end', icon: 'angle-right' }
+					]"
+					:labels="false"
+					:grow="true"
+					:value="direction"
+					@input="direction = $event"
+				/>
+				<k-range-field
+					label="Slide to resize"
+					:min="0"
+					:max="95"
+					:step="0.1"
+					:value="width"
+					style="--span: 2"
+					@input="width = $event"
+				/>
+
+				<div
+					class="k-lab-if-space-frame"
+					:style="{ width: width + '%', '--span': 2 }"
+				>
+					<k-collapsible :direction="direction" class="k-lab-collapsible">
+						<template #default="{ offset }">
+							<k-button
+								v-for="n in visibleButtons(offset)"
+								:key="n"
+								:text="'Button ' + n"
+								variant="filled"
+							/>
+						</template>
+
+						<template #fallback="{ offset, total }">
+							<k-button :text="total - offset" icon="dots" variant="filled" />
+						</template>
+					</k-collapsible>
+				</div>
+			</k-grid>
+		</k-lab-example>
+
+		<k-lab-example label="No fallback" :code="false">
+			<div class="k-lab-if-space-frame" :style="{ width: width + '%' }">
+				<k-collapsible :direction="direction" class="k-lab-collapsible">
+					<template #default="{ offset }">
+						<k-button
+							v-for="n in visibleButtons(offset)"
+							:key="n"
+							:text="'Button ' + n"
+							variant="filled"
+						/>
+					</template>
+				</k-collapsible>
+			</div>
+		</k-lab-example>
+	</k-lab-examples>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			buttons: 6,
+			direction: "end",
+			width: 70
+		};
+	},
+	methods: {
+		visibleButtons(offset) {
+			const count = Math.min(offset, this.buttons);
+
+			if (this.direction === "start") {
+				// show last `count` buttons
+				return Array.from(
+					{ length: count },
+					(_, i) => this.buttons - count + 1 + i
+				);
+			}
+
+			// show first `count` buttons
+			return Array.from({ length: count }, (_, i) => i + 1);
+		}
+	}
+};
+</script>
+
+<style>
+.k-lab-if-space-frame {
+	background-color: var(--color-green-200);
+	border: 1px dashed var(--color-gray-500);
+	border-radius: var(--rounded);
+}
+.k-lab-collapsible {
+	display: flex;
+	gap: var(--spacing-1);
+}
+</style>

--- a/panel/lab/components/tabs/index.vue
+++ b/panel/lab/components/tabs/index.vue
@@ -4,7 +4,7 @@
 			<k-tabs :tabs="tabs.slice(0, 2)" />
 		</k-lab-example>
 		<k-lab-example label="too many tabs">
-			<k-tabs :tabs="tabs" />
+			<k-tabs :tabs="tabs" tab="f" />
 		</k-lab-example>
 		<k-lab-example label="theme: notice">
 			<k-tabs :tabs="tabs" theme="notice" />

--- a/panel/lab/internals/panel/observers/index.php
+++ b/panel/lab/internals/panel/observers/index.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'source' => 'panel/src/panel/observers.js'
+];

--- a/panel/lab/internals/panel/observers/index.vue
+++ b/panel/lab/internals/panel/observers/index.vue
@@ -1,0 +1,51 @@
+<template>
+	<k-lab-examples>
+		<k-lab-example label="resize" :code="false">
+			<k-text>
+				<p>
+					<code>window.panel.observers.resize</code> is a resize observer meant
+					to subscribe to element widths/heights.
+				</p>
+			</k-text>
+
+			<div ref="frame" class="frame">
+				{{ frame.width }}&times;{{ frame.height }}
+			</div>
+		</k-lab-example>
+	</k-lab-examples>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			frame: {}
+		};
+	},
+	mounted() {
+		const frame = this.$refs.frame;
+		this.$panel.observers.resize.observe(frame);
+
+		frame.addEventListener("resize", ({ detail }) => {
+			this.frame = {
+				width: Math.round(detail.width),
+				height: Math.round(detail.height)
+			};
+		});
+	},
+	beforeUnmount() {
+		this.$panel.observers.resize.unobserve(this.$refs.frame);
+	}
+};
+</script>
+
+<style>
+.k-lab-example .frame {
+	width: 30vw;
+	height: 15vh;
+	background: var(--color-yellow-300);
+	margin-top: var(--spacing-6);
+	display: grid;
+	place-items: center;
+}
+</style>

--- a/panel/src/components/Drawers/Elements/Header.vue
+++ b/panel/src/components/Drawers/Elements/Header.vue
@@ -1,20 +1,13 @@
 <template>
 	<header class="k-drawer-header">
-		<nav class="k-breadcrumb k-drawer-breadcrumb">
-			<ol>
-				<li v-for="(crumb, index) in breadcrumb" :key="crumb.id">
-					<k-button
-						:icon="crumb.props.icon"
-						:text="crumb.props.title"
-						:current="index === breadcrumb.length - 1"
-						variant="dimmed"
-						class="k-breadcrumb-link"
-						@click="$emit('crumb', crumb.id)"
-					/>
-				</li>
-			</ol>
-		</nav>
+		<k-breadcrumb
+			:crumbs="crumbs"
+			class="k-drawer-breadcrumb"
+			@crumb="$emit('crumb', $event)"
+		/>
+
 		<k-drawer-tabs :tab="tab" :tabs="tabs" @open="$emit('tab', $event)" />
+
 		<nav class="k-drawer-options">
 			<slot />
 			<k-button class="k-drawer-option" icon="check" type="submit" />
@@ -45,6 +38,17 @@ export const props = {
 			default: () => ({}),
 			type: Object
 		}
+	},
+	computed: {
+		crumbs() {
+			return this.breadcrumb.map((crumb, index) => ({
+				click: () => this.$emit("crumb", crumb.id),
+				current: index === this.breadcrumb.length - 1,
+				icon: crumb.props.icon,
+				text: crumb.props.title,
+				variant: "dimmed"
+			}));
+		}
 	}
 };
 
@@ -73,7 +77,8 @@ export default {
 }
 
 .k-drawer-breadcrumb {
-	flex-grow: 1;
+	flex: 1 1 auto;
+	min-width: 0;
 }
 
 .k-drawer-options {

--- a/panel/src/components/Drawers/Elements/Header.vue
+++ b/panel/src/components/Drawers/Elements/Header.vue
@@ -2,6 +2,7 @@
 	<header class="k-drawer-header">
 		<k-breadcrumb
 			:crumbs="crumbs"
+			icon="bars"
 			class="k-drawer-breadcrumb"
 			@crumb="$emit('crumb', $event)"
 		/>

--- a/panel/src/components/Misc/Collapsible.vue
+++ b/panel/src/components/Misc/Collapsible.vue
@@ -81,9 +81,8 @@ export default {
 				this.total = expanded.total;
 			}
 
-			this.$nextTick(() => {
-				this.isUpdating = false;
-			});
+			await this.$nextTick();
+			this.isUpdating = false;
 		},
 		async fitItemsInSpace(available) {
 			// Show all items so we can measure them

--- a/panel/src/components/Misc/Collapsible.vue
+++ b/panel/src/components/Misc/Collapsible.vue
@@ -1,0 +1,254 @@
+<script>
+import { cloneVNode, h } from "vue";
+
+/**
+ * Measures available horizontal space and determines
+ * how many children from the default slot can fit.
+ *
+ * Exposes `offset` (visible count) and `total` to slots.
+ * When items overflow and a fallback slot exists,
+ * the fallback is rendered and items are hidden.
+ * @since 6.0.0
+ */
+export default {
+	inheritAttrs: false,
+	props: {
+		/**
+		 * Direction to collapse items and
+		 * which side to place the fallback
+		 * @values "start", "end"
+		 */
+		direction: {
+			type: String,
+			default: "end"
+		},
+		element: {
+			type: String,
+			default: "div"
+		}
+	},
+	data() {
+		return {
+			isCollapsed: false,
+			isUpdating: false,
+			offset: Infinity,
+			total: 0
+		};
+	},
+	computed: {
+		hasFallback() {
+			return Boolean(this.$slots.fallback);
+		}
+	},
+	mounted() {
+		this.observe();
+	},
+	unmounted() {
+		this.unobserve();
+	},
+	updated() {
+		if (this.isUpdating === false) {
+			this.calculate();
+		}
+	},
+	methods: {
+		async calculate() {
+			if (
+				this.isUpdating ||
+				!(this.$el instanceof Element) ||
+				!this.$slots.default
+			) {
+				return;
+			}
+
+			this.isUpdating = true;
+
+			const available = this.$el.getBoundingClientRect().width;
+
+			// First: try fitting all items without fallback
+			this.isCollapsed = false;
+			const expanded = await this.fitItemsInSpace(available);
+
+			// Second: if overflowing and fallback exists,
+			// show fallback and shrink items to fit
+			if (expanded.overflown && this.hasFallback) {
+				this.isCollapsed = true;
+				const collapsed = await this.fitItemsInSpace(available);
+				this.offset = collapsed.offset;
+				this.total = collapsed.total;
+			} else {
+				this.offset = expanded.offset;
+				this.total = expanded.total;
+			}
+
+			this.$nextTick(() => {
+				this.isUpdating = false;
+			});
+		},
+		async fitItemsInSpace(available) {
+			// Show all items so we can measure them
+			this.offset = Infinity;
+			await this.$nextTick();
+
+			// Separate fallback elements from items using data attribute
+			const children = [...this.$el.children];
+			const items = children.filter(
+				(el) => !el.hasAttribute("data-collapsible-fallback")
+			);
+			const fallbacks = children.filter((el) =>
+				el.hasAttribute("data-collapsible-fallback")
+			);
+
+			const total = items.length;
+			const style = getComputedStyle(this.$el);
+			const gap = parseFloat(style.columnGap ?? style.gap) ?? 0;
+
+			// Handle edge cases
+			if (available === 0) {
+				return { offset: 0, total, overflown: total > 0 };
+			}
+
+			if (total === 0) {
+				return { offset: 0, total, overflown: false };
+			}
+
+			// Measure each item's width
+			const widths = items.map((el) => this.measure(el));
+
+			// Use appropriate fitting strategy
+			if (this.isCollapsed) {
+				return this.shrinkUntilFallbackFits({
+					available,
+					fallbacks,
+					gap,
+					total,
+					widths
+				});
+			}
+
+			return this.growUntilFull({ available, gap, total, widths });
+		},
+		growUntilFull({ available, gap, total, widths }) {
+			let count = 0;
+
+			while (count < total && this.width(widths, count + 1, gap) <= available) {
+				count++;
+			}
+
+			return { offset: count, total, overflown: count < total };
+		},
+		measure(element) {
+			const rect = element.getBoundingClientRect();
+			const style = getComputedStyle(element);
+			const left = parseFloat(style.marginLeft) ?? 0;
+			const right = parseFloat(style.marginRight) ?? 0;
+			// Use scrollWidth to get natural width without flex shrinking
+			const width = Math.max(rect.width, element.scrollWidth);
+			return width + left + right;
+		},
+		measureFallback(elements, gap) {
+			if (elements.length === 0) {
+				return 0;
+			}
+
+			const widths = elements.map((el) => this.measure(el));
+			return (
+				widths.reduce((sum, w) => sum + w, 0) + (elements.length - 1) * gap
+			);
+		},
+		observe() {
+			if (this.$el instanceof Element) {
+				this.$panel.observers.resize.observe(this.$el);
+				this.$el.addEventListener("resize", this.onResize);
+				this.calculate();
+			}
+		},
+		onResize() {
+			if (this.isUpdating === false) {
+				this.calculate();
+			}
+		},
+		async shrinkUntilFallbackFits({
+			available,
+			fallbacks,
+			gap,
+			total,
+			widths
+		}) {
+			let count = total;
+
+			while (count >= 0) {
+				this.offset = count;
+				await this.$nextTick();
+
+				const fallback = this.measureFallback(fallbacks, gap);
+				const items = this.width(widths, count, gap);
+				gap = count > 0 && fallback > 0 ? gap : 0;
+				const needed = items + gap + fallback;
+
+				if (needed <= available) {
+					break;
+				}
+
+				count--;
+			}
+
+			return { offset: Math.max(0, count), total, overflown: true };
+		},
+		/**
+		 * Calculates total width of `count` items including gaps.
+		 * direction=end: uses first N items
+		 * direction=start: uses last N items
+		 *
+		 * @param {number[]} widths
+		 * @param {number} count
+		 * @param {number} gap
+		 * @returns {number}
+		 */
+		width(widths, count, gap) {
+			if (count <= 0) {
+				return 0;
+			}
+
+			const slice =
+				this.direction === "start"
+					? widths.slice(-count)
+					: widths.slice(0, count);
+
+			return slice.reduce((sum, w) => sum + w, 0) + (count - 1) * gap;
+		},
+		unobserve() {
+			if (this.$el instanceof Element) {
+				this.$panel.observers.resize.unobserve(this.$el);
+				this.$el.removeEventListener("resize", this.onResize);
+			}
+		}
+	},
+
+	render() {
+		const props = { offset: this.offset, total: this.total };
+		const slot = this.$slots.default?.(props) ?? [];
+
+		// Get all fallback vnodes and mark them with a data attribute
+		let fallbacks = [];
+
+		if (this.isCollapsed) {
+			const fallback = this.$slots.fallback?.(props) ?? [];
+			fallbacks = fallback.map((vnode) =>
+				cloneVNode(vnode, { "data-collapsible-fallback": "" })
+			);
+		}
+
+		// Position fallback based on direction
+		if (fallbacks.length === 0) {
+			return h(this.element, this.$attrs, slot);
+		}
+
+		if (this.direction === "start") {
+			return h(this.element, this.$attrs, [...fallbacks, ...slot]);
+		}
+
+		return h(this.element, this.$attrs, [...slot, ...fallbacks]);
+	}
+};
+</script>

--- a/panel/src/components/Misc/index.js
+++ b/panel/src/components/Misc/index.js
@@ -1,6 +1,7 @@
 import Draggable from "./Draggable.vue";
 import ErrorBoundary from "./ErrorBoundary.vue";
 import Fatal from "./Fatal.vue";
+import Collapsible from "./Collapsible.vue";
 import Icon from "./Icon.vue";
 import Icons from "./Icons.vue";
 import Notification from "./Notification.vue";
@@ -13,6 +14,7 @@ export default {
 		app.component("k-draggable", Draggable);
 		app.component("k-error-boundary", ErrorBoundary);
 		app.component("k-fatal", Fatal);
+		app.component("k-collapsible", Collapsible);
 		app.component("k-icon", Icon);
 		app.component("k-icons", Icons);
 		app.component("k-notification", Notification);

--- a/panel/src/components/Navigation/Breadcrumb.vue
+++ b/panel/src/components/Navigation/Breadcrumb.vue
@@ -1,25 +1,28 @@
 <template>
 	<nav :aria-label="label" class="k-breadcrumb">
-		<div v-if="crumbs.length > 1" class="k-breadcrumb-dropdown">
-			<k-button icon="home" @click="$refs.dropdown.toggle()" />
-			<k-dropdown ref="dropdown" :options="dropdown" />
-		</div>
+		<k-collapsible direction="start" element="ol">
+			<!-- Responsive fallback -->
+			<template #fallback="{ offset, total }">
+				<li v-if="offset !== 0">
+					<k-button v-bind="button(first)" />
+				</li>
+				<li>
+					<k-button
+						:icon="offset === 0 ? (first.icon ?? 'home') : 'dots'"
+						size="sm"
+						@click="$refs.dropdown.toggle()"
+					/>
+					<k-dropdown ref="dropdown" :options="dropdown(offset, total)" />
+				</li>
+			</template>
 
-		<ol>
-			<li v-for="(crumb, index) in crumbs" :key="index">
-				<k-button
-					:icon="crumb.loading ? 'loader' : crumb.icon"
-					:link="crumb.link"
-					:disabled="!crumb.link"
-					:text="crumb.text ?? crumb.label"
-					:title="crumb.text ?? crumb.label"
-					:current="index === crumbs.length - 1 ? 'page' : false"
-					variant="dimmed"
-					size="sm"
-					class="k-breadcrumb-link"
-				/>
-			</li>
-		</ol>
+			<!-- Crumbs list -->
+			<template #default="{ offset }">
+				<li v-for="(crumb, index) in visible(offset)" :key="crumb.link">
+					<k-button v-bind="button(crumb, index === offset - 1)" />
+				</li>
+			</template>
+		</k-collapsible>
 	</nav>
 </template>
 
@@ -47,12 +50,42 @@ export default {
 		}
 	},
 	computed: {
-		dropdown() {
-			return this.crumbs.map((link) => ({
-				...link,
-				text: link.label,
+		first() {
+			return this.crumbs[0];
+		}
+	},
+	methods: {
+		button(crumb, isCurrent = false) {
+			const label = crumb.text ?? crumb.label;
+
+			return {
+				current: isCurrent ? "page" : false,
+				disabled: !crumb.link,
+				icon: crumb.loading ? "loader" : crumb.icon,
+				link: crumb.link,
+				size: "sm",
+				text: label,
+				title: label,
+				variant: "dimmed"
+			};
+		},
+		dropdown(offset, total) {
+			const start = offset > 0 ? 1 : 0;
+
+			// Skip first crumb (except when all crumbs are hidden)
+			// and get remaining hidden crumbs to show in the dropdown
+			return this.crumbs.slice(start, total - offset).map((crumb) => ({
+				...crumb,
+				text: crumb.label,
 				icon: "angle-right"
 			}));
+		},
+		visible(offset) {
+			if (offset > 0) {
+				return this.crumbs.slice(-offset);
+			}
+
+			return [];
 		}
 	}
 };
@@ -61,59 +94,29 @@ export default {
 <style>
 .k-breadcrumb {
 	--breadcrumb-divider: "/";
-	overflow-x: clip;
 	padding: 2px;
 }
 
 .k-breadcrumb ol {
-	display: none;
+	display: flex;
 	gap: 0.125rem;
 	align-items: center;
 }
 .k-breadcrumb ol li {
+	flex-shrink: 0;
 	display: flex;
 	align-items: center;
-	min-width: 0;
-	transition: flex-shrink 0.1s;
-}
-.k-breadcrumb ol li:has(.k-icon) {
-	/*
-	 * without a useful min-width, the item will vanish completely on hover of a very long other item.
-	 * 2.25rem helps to keep at least the icon visible for items with icons.
-	 */
-	min-width: 2.25rem;
 }
 .k-breadcrumb ol li:not(:last-child)::after {
 	content: var(--breadcrumb-divider);
 	opacity: 0.175;
-	flex-shrink: 0;
 }
 
 .k-breadcrumb .k-icon[data-type="loader"] {
 	opacity: 0.5;
 }
-.k-breadcrumb ol li:is(:hover, :focus-within) {
-	flex-shrink: 0;
-}
-.k-button.k-breadcrumb-link {
-	flex-shrink: 1;
-	min-width: 0;
-	justify-content: flex-start;
-}
 
-.k-breadcrumb-dropdown {
-	display: grid;
-}
-.k-breadcrumb-dropdown .k-dropdown {
-	width: 15rem;
-}
-
-@container (min-width: 40em) {
-	.k-breadcrumb ol {
-		display: flex;
-	}
-	.k-breadcrumb-dropdown {
-		display: none;
-	}
+.k-breadcrumb .k-dropdown {
+	max-width: 15rem;
 }
 </style>

--- a/panel/src/components/Navigation/Breadcrumb.vue
+++ b/panel/src/components/Navigation/Breadcrumb.vue
@@ -10,6 +10,7 @@
 					<k-button
 						:icon="offset === 0 ? (first.icon ?? 'home') : 'dots'"
 						size="sm"
+						variant="dimmed"
 						@click="$refs.dropdown.toggle()"
 					/>
 					<k-dropdown ref="dropdown" :options="dropdown(offset, total)" />
@@ -59,10 +60,10 @@ export default {
 			const label = crumb.text ?? crumb.label;
 
 			return {
+				...crumb,
 				current: isCurrent ? "page" : false,
-				disabled: !crumb.link,
+				disabled: !crumb.link && !crumb.click && !crumb.dialog && !crumb.drawer,
 				icon: crumb.loading ? "loader" : crumb.icon,
-				link: crumb.link,
 				size: "sm",
 				text: label,
 				title: label,
@@ -76,8 +77,9 @@ export default {
 			// and get remaining hidden crumbs to show in the dropdown
 			return this.crumbs.slice(start, total - offset).map((crumb) => ({
 				...crumb,
-				text: crumb.label,
-				icon: "angle-right"
+				text: crumb.text ?? crumb.label,
+				icon: "angle-right",
+				variant: null // remove dimmed variant in dropdown
 			}));
 		},
 		visible(offset) {

--- a/panel/src/components/Navigation/Breadcrumb.vue
+++ b/panel/src/components/Navigation/Breadcrumb.vue
@@ -8,7 +8,7 @@
 				</li>
 				<li>
 					<k-button
-						:icon="offset === 0 ? (first.icon ?? 'home') : 'dots'"
+						:icon="offset === 0 ? (first.icon ?? icon) : 'dots'"
 						size="sm"
 						variant="dimmed"
 						@click="$refs.dropdown.toggle()"
@@ -44,6 +44,14 @@ export default {
 		crumbs: {
 			type: Array,
 			default: () => []
+		},
+		/**
+		 * Fallback dropdown button icon
+		 * @since 6.0.0
+		 */
+		icon: {
+			type: String,
+			default: "home"
 		},
 		label: {
 			type: String,

--- a/panel/src/components/View/Topbar.vue
+++ b/panel/src/components/View/Topbar.vue
@@ -1,14 +1,13 @@
 <template>
 	<div class="k-topbar">
-		<!-- mobile menu opener -->
 		<k-button
 			icon="bars"
 			class="k-panel-menu-proxy"
 			@click="$panel.menu.toggle()"
 		/>
-		<!-- breadcrumb -->
+
 		<k-breadcrumb :crumbs="crumbs" class="k-topbar-breadcrumb" />
-		<div class="k-topbar-spacer" />
+
 		<div class="k-topbar-signals">
 			<slot />
 		</div>
@@ -49,17 +48,10 @@ export default {
 	align-items: center;
 	gap: var(--spacing-1);
 }
-
 .k-topbar-breadcrumb {
 	margin-inline-start: -2px;
-	flex-shrink: 1;
-	min-width: 0;
+	flex: 1;
 }
-
-.k-topbar-spacer {
-	flex-grow: 1;
-}
-
 .k-topbar-signals {
 	display: flex;
 	align-items: center;

--- a/panel/src/panel/observers.js
+++ b/panel/src/panel/observers.js
@@ -1,0 +1,22 @@
+import { reactive } from "vue";
+
+/**
+ * @since 6.0.0
+ */
+export default () => {
+	return reactive({
+		resize: new ResizeObserver((entries) => {
+			for (const index in entries) {
+				const item = entries[index];
+				item.target.dispatchEvent(
+					new CustomEvent("resize", {
+						detail: {
+							width: item.contentRect.width,
+							height: item.contentRect.height
+						}
+					})
+				);
+			}
+		})
+	});
+};

--- a/panel/src/panel/panel.js
+++ b/panel/src/panel/panel.js
@@ -8,6 +8,7 @@ import Dropdown from "./dropdown.js";
 import Events from "./events.js";
 import Notification from "./notification.js";
 import Language from "./language.js";
+import Observers from "./observers.js";
 import Plugins from "./plugins.js";
 import Menu from "./menu.js";
 import Search from "./search.js";
@@ -79,6 +80,7 @@ export default {
 		this.activation = Activation(this);
 		this.drag = Drag(this);
 		this.events = Events(this);
+		this.observers = Observers(this);
 		this.searcher = Search(this);
 		this.theme = Theme(this);
 		this.upload = Upload(this);

--- a/panel/vitest.setup.js
+++ b/panel/vitest.setup.js
@@ -1,3 +1,10 @@
 import { createApp } from "vue";
 
 globalThis.app ??= createApp();
+
+// mock for ResizeObserver
+globalThis.ResizeObserver = class ResizeObserver {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+};


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- New `<k-collapsible>` component that can wrap a list of elements with a default and fallback slot and provide the necessary data how many elements fit in the current container width to render the element as a responsive list of visible and hidden elements (the latter represented by the fallback slot content).
- New `$panel.observers` JS module

### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- `<k-breadcrumb>` has a new responsive behavior (backend by `<k-collapsible>`)


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion