### PR TITLE
fix: Do not reload view on dialog/drawer submit

### DIFF
--- a/panel/src/panel/feature.js
+++ b/panel/src/panel/feature.js
@@ -214,6 +214,10 @@ export default (panel, key, defaults) => {
 		async refresh(options = {}) {
 			options.url ??= this.url();
 
+			if (!options.url) {
+				return;
+			}
+
 			const response = await this.get(options.url, options);
 			const state = response["$" + this.key()];
 

--- a/panel/src/panel/modal.js
+++ b/panel/src/panel/modal.js
@@ -295,8 +295,16 @@ export default (panel, key, defaults) => {
 				// handle any redirects
 				this.successRedirect(success);
 			} else {
-				// reload the parent view to show changes
-				panel.view.reload(success.reload);
+				if (panel.dialog.isOpen === true) {
+					panel.dialog.refresh();
+				}
+
+				if (panel.drawer.isOpen === true) {
+					panel.drawer.refresh();
+				}
+
+				// refresh the parent view to show changes
+				panel.view.refresh(success.reload);
 			}
 
 			return success;


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

So far when a PHP-backend nested drawer would be submitted, the whole view gets reloaded. And with that, we don't return to the parent drawer but all drawers are closed. I think we haven't run into that much because our nested drawers (blocks, structure) aren't PHP-backed so far and thus do not enter `modal.success()`.

Instead of reloading the view, we are now refreshing the view. And also refreshing any open (parent) dialog or drawer.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Fixed closing all drawers/dialogs when a nested drawer/dialog got submitted

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion