### PR TITLE
fix: PageCreateDialog do not validate when draft

### DIFF
--- a/panel/src/components/Dialogs/Dialog.vue
+++ b/panel/src/components/Dialogs/Dialog.vue
@@ -8,6 +8,7 @@
 				$attrs.class
 			]"
 			:data-size="size"
+			:novalidate="novalidate"
 			method="dialog"
 			@click.stop
 			@submit.prevent="$emit('submit')"

--- a/panel/src/components/Dialogs/PageCreateDialog.vue
+++ b/panel/src/components/Dialogs/PageCreateDialog.vue
@@ -4,7 +4,7 @@
 		v-bind="$props"
 		class="k-page-create-dialog"
 		@cancel="$emit('cancel')"
-		@submit="$emit('submit', value)"
+		@submit="submit"
 	>
 		<k-select-field
 			v-if="templates.length > 1"
@@ -17,10 +17,11 @@
 			@input="pick($event)"
 		/>
 		<k-dialog-fields
+			ref="fields"
 			:fields="fields"
 			:value="value"
 			@input="$emit('input', $event)"
-			@submit="$emit('submit', $event)"
+			@submit="submit"
 		/>
 	</k-form-dialog>
 </template>
@@ -66,6 +67,25 @@ export default {
 					title: this.value.title
 				}
 			});
+		},
+		submit() {
+			// when novalidate is set on the form (for drafts),
+			// manually validate title and slug
+			if (this.novalidate === true) {
+				const fields = this.$refs.fields.$el;
+				const title = fields.querySelector('input[name="title"]');
+				const slug = fields.querySelector('input[name="slug"]');
+
+				// check title & slug validity and show native validation message
+				if (title?.checkValidity() === false) {
+					return title.reportValidity();
+				}
+				if (slug?.checkValidity() === false) {
+					return slug.reportValidity();
+				}
+			}
+
+			this.$emit("submit", this.value);
 		}
 	}
 };

--- a/panel/src/components/Forms/Field.vue
+++ b/panel/src/components/Forms/Field.vue
@@ -20,6 +20,7 @@
 				<slot name="label">
 					<k-label
 						:input="input"
+						:novalidate="novalidate"
 						:required="required"
 						:title="label"
 						type="field"
@@ -60,6 +61,14 @@ export const props = {
 		input: {
 			type: [String, Number, Boolean],
 			default: null
+		},
+		/**
+		 * Disables the invalid indicator for this field's label
+		 * @since 5.3.0
+		 */
+		novalidate: {
+			default: false,
+			type: Boolean
 		},
 		translate: Boolean,
 		type: String

--- a/panel/src/components/Text/Label.vue
+++ b/panel/src/components/Text/Label.vue
@@ -12,14 +12,16 @@
 		<span v-else class="k-label-text">
 			<slot />
 		</span>
-		<abbr v-if="required" :title="$t(type + '.required')">✶</abbr>
-		<abbr
-			:title="$t(type + '.invalid')"
-			data-theme="negative"
-			class="k-label-invalid"
-		>
-			&times;
-		</abbr>
+		<template v-if="!novalidate">
+			<abbr v-if="required" :title="$t(type + '.required')"> ✶ </abbr>
+			<abbr
+				:title="$t(type + '.invalid')"
+				data-theme="negative"
+				class="k-label-invalid"
+			>
+				&times;
+			</abbr>
+		</template>
 	</component>
 </template>
 
@@ -46,6 +48,14 @@ export default {
 		 */
 		link: {
 			type: String
+		},
+		/**
+		 * Disables the invalid indicator for this label
+		 * @since 5.3.0
+		 */
+		novalidate: {
+			default: false,
+			type: Boolean
 		},
 		/**
 		 * Whether a value is required for the input

--- a/panel/src/mixins/dialog.js
+++ b/panel/src/mixins/dialog.js
@@ -11,6 +11,14 @@ export default {
 	mixins: [Buttons],
 	props: {
 		/**
+		 * Disables native browser form validation
+		 * @since 5.3.0
+		 */
+		novalidate: {
+			default: false,
+			type: Boolean
+		},
+		/**
 		 * Width of the dialog
 		 * @values "small", "default", "medium", "large", "huge"
 		 */


### PR DESCRIPTION

## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

@bastianallgeier I can add lab examples still, but would be great to get a first look at it, if you also think this is the right/a better approach as our previous attempts.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Page create dialog: When creating a draft, validations for custom  fields are correctly ignored now (will be enforced when draft gets published later)
#7079


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion