### PR TITLE
fix: Smartypants quoted entities replacement

### DIFF
--- a/src/Text/SmartyPants.php
+++ b/src/Text/SmartyPants.php
@@ -37,6 +37,7 @@ class SmartyPants
 	{
 		return [
 			'attr'                       => 1,
+			'convert.quot'               => true,
 			'doublequote.open'           => '&#8220;',
 			'doublequote.close'          => '&#8221;',
 			'doublequote.low'            => '&#8222;',
@@ -76,6 +77,7 @@ class SmartyPants
 		$this->parser  = new SmartyPantsTypographer($this->options['attr']);
 
 		// configuration
+		$this->parser->convert_quot               = $this->options['convert.quot'];
 		$this->parser->smart_doublequote_open     = $this->options['doublequote.open'];
 		$this->parser->smart_doublequote_close    = $this->options['doublequote.close'];
 		$this->parser->smart_singlequote_open     = $this->options['singlequote.open'];
@@ -111,7 +113,6 @@ class SmartyPants
 	{
 		// prepare the text
 		$text ??= '';
-		$text   = str_replace('&quot;', '"', $text);
 
 		// parse the text
 		return $this->parser->transform($text);

--- a/tests/Text/SmartyPantsTest.php
+++ b/tests/Text/SmartyPantsTest.php
@@ -25,10 +25,29 @@ class SmartyPantsTest extends TestCase
 		$this->assertSame('', $parser->parse(''));
 	}
 
+	public function testParseHtml(): void
+	{
+		$parser   = new SmartyPants();
+		$result   = $parser->parse('<img alt="Test with &quot;quotes&quot;" src="/test.jpg">');
+		$expected = '<img alt="Test with &quot;quotes&quot;" src="/test.jpg">';
+
+		$this->assertSame($expected, $result);
+	}
+
+	public function testParseQuotedEntities(): void
+	{
+		$parser   = new SmartyPants();
+		$result   = $parser->parse('This is &quot;quoted&quot;');
+		$expected = 'This is &#8220;quoted&#8221;';
+
+		$this->assertSame($expected, $result);
+	}
+
 	public function testDefaults(): void
 	{
 		$expected = [
 			'attr'                       => 1,
+			'convert.quot'               => true,
 			'doublequote.open'           => '&#8220;',
 			'doublequote.close'          => '&#8221;',
 			'doublequote.low'            => '&#8222;',


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Our SmartyPants wrapper was converting `&quot;` into raw quotes - even inside HTML attributes. This PR removes this global replacement and uses the library’s built-in `convert_quot` flag instead, which applies only to text tokens (not tags/attributes).

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- KirbyText: Fixed Smartypants behavior of quotes inside HTML attributes (e.g. `(image: )` alt text)
 #6344

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->
- Remove warning from docs https://github.com/getkirby/getkirby.com/pull/2488/changes

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion