### PR TITLE
fix: Blocks becoming unresponsive when apps steal focus (closes #6700)

### DIFF
--- a/panel/src/components/Forms/Blocks/Blocks.vue
+++ b/panel/src/components/Forms/Blocks/Blocks.vue
@@ -469,11 +469,11 @@ export default {
 
 			return true;
 		},
-		onBlur() {
-			// resets multi selecting on tab change
-			// keep only if there are already multiple selections
-			// triggers `blur` event when tab changed
-			if (this.selected.length === 0) {
+		onBlur(e) {
+			// reset multi-select key when focus leaves the document entirely
+			// (e.g., switching apps, screenshot tools capturing focus)
+			// but preserve state if multiple blocks are already selected
+			if (!e.relatedTarget && this.selected.length <= 1) {
 				this.isMultiSelectKey = false;
 			}
 		},


### PR DESCRIPTION
## Description
When screenshot tools or other applications captured focus while a modifier key was pressed, `isMultiSelectKey` would remain true (since keyup never fired), causing `pointer-events: none` to stay applied to all block children.

AI Disclosure: Written with Claude Code + Opus 4.5 :)

## Changelog 

### 🐛 Bug fixes
- Fix blocks becoming unresponsive when external apps steal focus (#6700)

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion