### PR TITLE
refact: Remove dead checks

### DIFF
--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -233,7 +233,7 @@ class User extends ModelWithContent
 		#[SensitiveParameter]
 		string|null $password = null
 	): string|null {
-		if ($password !== null && $password !== '' && $password !== false) {
+		if ($password !== null && $password !== '') {
 			$password = password_hash($password, PASSWORD_DEFAULT);
 		}
 
@@ -247,7 +247,7 @@ class User extends ModelWithContent
 	public function hasPassword(): bool
 	{
 		$password = $this->password();
-		return $password === '' || $password === null || $password === false ? false : true;
+		return $password === '' || $password === null ? false : true;
 	}
 
 	/**

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -247,7 +247,7 @@ class User extends ModelWithContent
 	public function hasPassword(): bool
 	{
 		$password = $this->password();
-		return $password === '' || $password === null ? false : true;
+		return $password !== '' && $password !== null;
 	}
 
 	/**


### PR DESCRIPTION
Follow-up to #7869:

`$password` and `$user->password()` can never be `false` as they are type-hinted `string|null`.