### PR TITLE
fix: Wrap header title on larger screens

### DIFF
--- a/panel/src/components/Layout/Header.vue
+++ b/panel/src/components/Layout/Header.vue
@@ -83,14 +83,21 @@ export default {
 	margin-bottom: 0;
 }
 
+/* On larger screens, keep title and buttons on a single line */
+@media screen and (min-width: 70rem) {
+	.k-header {
+		flex-wrap: nowrap;
+	}
+}
+
 .k-header-title {
 	font-size: var(--text-h1);
 	font-weight: var(--font-h1);
 	line-height: var(--leading-h1);
 	margin-bottom: var(--header-padding-block);
 	min-width: 0;
+	flex: 1 1 auto;
 }
-
 .k-header-title-button {
 	display: inline-flex;
 	text-align: start;
@@ -99,12 +106,10 @@ export default {
 	max-width: 100%;
 	outline: 0;
 }
-
 .k-header-title-text {
 	overflow-x: clip;
 	text-overflow: ellipsis;
 }
-
 .k-header-title-icon {
 	--icon-color: var(--color-text-dimmed);
 	border-radius: var(--rounded);
@@ -128,8 +133,8 @@ export default {
 	display: flex;
 	gap: var(--spacing-2);
 	margin-bottom: var(--header-padding-block);
+	flex-shrink: 0;
 }
-
 .k-header:has(.k-header-buttons) {
 	position: sticky;
 	top: var(--scroll-top);


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Panel: the header title and buttons stay side by side on larger screens, no matter how long the title is
#7643


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion