### PR TITLE
doc: Improve description for `Str::trim()`

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -651,10 +651,17 @@ class Str
 	}
 
 	/**
-	 * Safe ltrim alternative
+	 * Sequence-based ltrim alternative.
+	 * For character list trimming, use PHP's native `ltrim()` function.
+	 *
+	 * ```php
+	 * Str::ltrim('abababaC', 'ab'); // 'aC'
+	 * ```
 	 */
-	public static function ltrim(string $string, string $trim = ' '): string
-	{
+	public static function ltrim(
+		string $string,
+		string $trim = ' '
+	): string {
 		return preg_replace('!^(' . preg_quote($trim) . ')+!', '', $string);
 	}
 
@@ -997,10 +1004,17 @@ class Str
 	}
 
 	/**
-	 * Safe rtrim alternative
+	 * Sequence-based rtrim alternative.
+	 * For character list trimming, use PHP's native `rtrim()` function.
+	 *
+	 * ```php
+	 * Str::rtrim('Cabababa', 'ab'); // 'Ca'
+	 * ```
 	 */
-	public static function rtrim(string $string, string $trim = ' '): string
-	{
+	public static function rtrim(
+		string $string,
+		string $trim = ' '
+	): string {
 		return preg_replace('!(' . preg_quote($trim) . ')+$!', '', $string);
 	}
 
@@ -1425,11 +1439,20 @@ class Str
 	}
 
 	/**
-	 * Safe trim alternative
+	 * Sequence-based trim alternative.
+	 * For character list trimming, use PHP's native `trim()` function.
+	 *
+	 * ```php
+	 * Str::trim('abababaC', 'ab'); // 'aC'
+	 * ```
 	 */
-	public static function trim(string $string, string $trim = ' '): string
-	{
-		return static::rtrim(static::ltrim($string, $trim), $trim);
+	public static function trim(
+		string $string,
+		string $trim = ' '
+	): string {
+		$string = static::ltrim($string, $trim, true);
+		$string = static::rtrim($string, $trim, true);
+		return $string;
 	}
 
 	/**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -651,7 +651,7 @@ class Str
 	}
 
 	/**
-	 * Sequence-based ltrim alternative.
+	 * Trims away a fixed sequence at the beginning of the string.
 	 * For character list trimming, use PHP's native `ltrim()` function.
 	 *
 	 * ```php
@@ -1004,11 +1004,11 @@ class Str
 	}
 
 	/**
-	 * Sequence-based rtrim alternative.
+	 * Trims away a fixed sequence at the end of the string.
 	 * For character list trimming, use PHP's native `rtrim()` function.
 	 *
 	 * ```php
-	 * Str::rtrim('Cabababa', 'ab'); // 'Ca'
+	 * Str::rtrim('Cabababa', 'ba'); // 'Ca'
 	 * ```
 	 */
 	public static function rtrim(
@@ -1439,11 +1439,11 @@ class Str
 	}
 
 	/**
-	 * Sequence-based trim alternative.
+	 * Trims away a fixed sequence at the beginning and end of the string.
 	 * For character list trimming, use PHP's native `trim()` function.
 	 *
 	 * ```php
-	 * Str::trim('abababaC', 'ab'); // 'aC'
+	 * Str::trim('ababaCbabab', 'ab'); // 'aCb'
 	 * ```
 	 */
 	public static function trim(

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1450,8 +1450,8 @@ class Str
 		string $string,
 		string $trim = ' '
 	): string {
-		$string = static::ltrim($string, $trim, true);
-		$string = static::rtrim($string, $trim, true);
+		$string = static::ltrim($string, $trim);
+		$string = static::rtrim($string, $trim);
 		return $string;
 	}
 


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

https://github.com/getkirby/kirby/issues/5033 has been stale for way too long. I have looked again into adding support for character list based trimming. But in the end that's additional parameters and inside we call the native PHP `trim()` anyways. In that case, I think one should directly just use the native PHP functions and not `Str::trim()`. I propose therefore to update the docs for the `Str` trim methods to make clearer what they do and advise developers to use the native PHP functions if they need character list based trimming.

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion