### PR TITLE
fix: Prevent repeated load of config files

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1034,7 +1034,7 @@ class App
 
 		// load the main config options
 		$root    = $this->root('config');
-		$options = F::load($root . '/config.php', [], allowOutput: false);
+		$options = F::load($root . '/config.php', [], allowOutput: false, cache: true);
 
 		// merge into one clean options array
 		return $this->options = array_replace_recursive(Config::$data, $options);
@@ -1049,7 +1049,7 @@ class App
 		$root = $this->root('config');
 
 		// first load `config/env.php` to access its `url` option
-		$envOptions = F::load($root . '/env.php', [], allowOutput: false);
+		$envOptions = F::load($root . '/env.php', [], allowOutput: false, cache: true);
 
 		// use the option from the main `config.php`,
 		// but allow the `env.php` to override it

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -123,6 +123,11 @@ class F
 	];
 
 	/**
+	 * Cache for loaded files when using `load()` with `cache: true`
+	 */
+	public static array $loadCache = [];
+
+	/**
 	 * Appends new content to an existing file
 	 *
 	 * @param string $file The path for the file
@@ -358,8 +363,14 @@ class F
 		string $file,
 		mixed $fallback = null,
 		array $data = [],
-		bool $allowOutput = true
+		bool $allowOutput = true,
+		bool $cache = false
 	) {
+		// return cached result if available
+		if ($cache === true && array_key_exists($file, static::$loadCache)) {
+			return static::$loadCache[$file];
+		}
+
 		if (is_file($file) === false) {
 			return $fallback;
 		}
@@ -382,6 +393,11 @@ class F
 			gettype($result) !== gettype($fallback)
 		) {
 			return $fallback;
+		}
+
+		// cache the result if requested
+		if ($cache === true) {
+			static::$loadCache[$file] = $result;
 		}
 
 		return $result;

--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -809,7 +809,8 @@ class Environment
 			$configCli = F::load(
 				file: $root . '/config.cli.php',
 				fallback: [],
-				allowOutput: false
+				allowOutput: false,
+				cache: true
 			);
 		}
 
@@ -821,7 +822,8 @@ class Environment
 			$configHost = F::load(
 				file: $path,
 				fallback: [],
-				allowOutput: false
+				allowOutput: false,
+				cache: true
 			);
 		}
 
@@ -833,7 +835,8 @@ class Environment
 			$configAddr = F::load(
 				file: $path,
 				fallback: [],
-				allowOutput: false
+				allowOutput: false,
+				cache: true
 			);
 		}
 


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- `Kirby\Filesystem\F::load()` has a new `cache` parameter which will return the file content from cache or add the loaded file content to a cache on the first time its loaded

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Fixed repeated loading of config files when cloning App object 
#4286


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion