### PR TITLE
fix: Setting locale for `Site::visit()` w/o $lang

### DIFF
--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -471,9 +471,15 @@ class Site extends ModelWithContent
 		string|Page $page,
 		string|null $languageCode = null
 	): Page {
+		// always set the locale; in single-language mode this
+		// applies the locale from config, in multi-language mode
+		// it falls back to the default language when `null` is passed
+		$this->kirby()->setCurrentLanguage($languageCode);
+
+		// only set translation when explicitly passed;
+		// otherwise it would always fall back to 'en'
 		if ($languageCode !== null) {
 			$this->kirby()->setCurrentTranslation($languageCode);
-			$this->kirby()->setCurrentLanguage($languageCode);
 		}
 
 		// convert ids to a Page object

--- a/tests/Cms/Site/SiteVisitTest.php
+++ b/tests/Cms/Site/SiteVisitTest.php
@@ -93,4 +93,33 @@ class SiteVisitTest extends ModelTestCase
 		$this->assertSame($siteTitle, $site->title()->value());
 		$this->assertSame($pageTitle, $page->title()->value());
 	}
+
+	public function testVisitWithoutLanguageCode(): void
+	{
+		// create app with locale option
+		$this->app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'options' => [
+				'locale' => 'de_DE.UTF-8'
+			],
+			'site' => [
+				'children' => [
+					['slug' => 'test']
+				]
+			]
+		]);
+
+		$site = $this->app->site();
+		$site->visit('test');
+
+		// verify locale was set from config
+		$this->assertTrue(
+			in_array(
+				setlocale(LC_TIME, 0),
+				['de', 'de_DE', 'de_DE.UTF-8', 'de_DE.UTF8', 'de_DE.ISO8859-1']
+			)
+		);
+	}
 }


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Properly set the locale when passing no explicit $languageCode to `$site->visit()`
#5230


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion