### PR TITLE
feat: New string.sanitizeHTML helper method

### DIFF
--- a/panel/lab/internals/helpers/string/index.vue
+++ b/panel/lab/internals/helpers/string/index.vue
@@ -207,6 +207,27 @@
 			<!-- @code-end -->
 		</k-lab-example>
 
+		<k-lab-example label="$helper.string.sanitizeHTML()" script="html">
+			<k-text>
+				<p>Sanitizes HTML:</p>
+				<!-- prettier-ignore -->
+				<k-code language="javascript">this.$helper.string.sanitizeHTML(html): string</k-code>
+			</k-text>
+			<!-- @code -->
+			<k-grid variant="fields">
+				<k-column width="1/2">
+					<h2>Input</h2>
+					<k-input type="text" :value="html" @input="html = $event" />
+				</k-column>
+				<k-column width="1/2">
+					<h2>Result</h2>
+					<k-code language="html">{{ $helper.string.sanitizeHTML(html) }}</k-code>
+				</k-column>
+			</k-grid>
+			<!-- @code-end -->
+		</k-lab-example>
+
+
 		<k-lab-example label="$helper.string.slug()" script="slug">
 			<k-text>
 				<p>Convert string to ASCII slug:</p>

--- a/panel/src/components/Forms/Input/WriterInput.vue
+++ b/panel/src/components/Forms/Input/WriterInput.vue
@@ -262,7 +262,7 @@ export default {
 			let nodes = this.nodes;
 
 			// convert array to object format to add options
-			if (Array.isArray(nodes)) {
+			if (Array.isArray(nodes) === true) {
 				nodes = Object.fromEntries(nodes.map((n) => [n, true]));
 			}
 

--- a/panel/src/components/Forms/Writer/Marks/index.js
+++ b/panel/src/components/Forms/Writer/Marks/index.js
@@ -1,0 +1,12 @@
+import Bold from "./Bold";
+import Clear from "./Clear";
+import Code from "./Code";
+import Email from "./Email";
+import Italic from "./Italic";
+import Link from "./Link";
+import Strike from "./Strike";
+import Sub from "./Sub";
+import Sup from "./Sup";
+import Underline from "./Underline";
+
+export { Bold, Clear, Code, Email, Italic, Link, Strike, Sub, Sup, Underline };

--- a/panel/src/components/Forms/Writer/Nodes/index.js
+++ b/panel/src/components/Forms/Writer/Nodes/index.js
@@ -1,3 +1,13 @@
-export { default as Doc } from "./Doc";
-export { default as Paragraph } from "./Paragraph";
-export { default as Text } from "./Text";
+import BulletList from "./BulletList";
+import Doc from "./Doc";
+import HardBreak from "./HardBreak";
+import Heading from "./Heading";
+import HorizontalRule from "./HorizontalRule";
+import ListDoc from "./ListDoc";
+import ListItem from "./ListItem";
+import OrderedList from "./OrderedList";
+import Paragraph from "./Paragraph";
+import Quote from "./Quote";
+import Text from "./Text";
+
+export { BulletList, Doc, HardBreak, Heading, HorizontalRule, ListDoc, ListItem, OrderedList, Paragraph, Quote, Text };

--- a/panel/src/helpers/index.js
+++ b/panel/src/helpers/index.js
@@ -18,6 +18,7 @@ import string from "./string.js";
 import throttle from "./throttle.js";
 import upload from "./upload.js";
 import url from "./url.js";
+import writer from "./writer.js";
 
 import "./regex.js";
 
@@ -47,7 +48,8 @@ export default {
 			throttle,
 			upload,
 			url,
-			uuid: string.uuid
+			uuid: string.uuid,
+			writer
 		};
 
 		app.prototype.$esc = string.escapeHTML;

--- a/panel/src/helpers/string.js
+++ b/panel/src/helpers/string.js
@@ -1,9 +1,7 @@
 import { DOMParser, DOMSerializer, Schema } from "prosemirror-model";
 
-import { Bold, Code, Italic, Link, Strike, Sub, Sup, Underline } from "../components/Forms/Writer/Marks";
-import { Doc, Text } from "../components/Forms/Writer/Nodes";
-
 import "./regex";
+import { createMarks, createNodes } from "./writer";
 
 const escapingMap = {
 	"&": "&amp;",
@@ -175,29 +173,38 @@ export function rtrim(string = "", replace = "") {
  * @returns {string}
  */
 export function sanitizeHTML(html, options = {}) {
-	// Instantiate marks and nodes to extract their schema definitions
-	const marks = options.marks ?? [
-		new Bold(),
-		new Code(),
-		new Italic(),
-		new Link(),
-		new Strike(),
-		new Sub(),
-		new Sup(),
-		new Underline()
-	];
+	const marks = createMarks(
+		options.marks ?? [
+			"bold",
+			"code",
+			"italic",
+			"link",
+			"strike",
+			"sub",
+			"sup",
+			"underline"
+		]
+	);
 
-	const nodes = options.nodes ?? [new Doc({ inline: true }), new Text()];
+	const nodes = createNodes(
+		options.nodes ?? { doc: { inline: true }, text: true },
+		["doc", "text", "paragraph"]
+	);
 
 	// Build schema from the extracted definitions
 	const sanitizeSchema = new Schema({
-		marks: Object.fromEntries(marks.map((m) => [m.name, m.schema])),
-		nodes: Object.fromEntries(nodes.map((n) => [n.name, n.schema]))
+		marks: Object.fromEntries(
+			Object.values(marks).map((m) => [m.name, m.schema])
+		),
+		nodes: Object.fromEntries(
+			Object.values(nodes).map((n) => [n.name, n.schema])
+		)
 	});
 
-	const dom = new window.DOMParser()
-		.parseFromString(`<div>${html}</div>`, "text/html")
-		.body.firstElementChild;
+	const dom = new window.DOMParser().parseFromString(
+		`<div>${html}</div>`,
+		"text/html"
+	).body.firstElementChild;
 
 	const doc = DOMParser.fromSchema(sanitizeSchema).parse(dom);
 	const div = document.createElement("div");

--- a/panel/src/helpers/string.sanitizeHTML.test.js
+++ b/panel/src/helpers/string.sanitizeHTML.test.js
@@ -3,8 +3,6 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { Bold, Italic } from "../components/Forms/Writer/Marks";
-import { Doc, Paragraph, Text } from "../components/Forms/Writer/Nodes";
 import { sanitizeHTML } from "./string.js";
 
 describe.concurrent("$helper.string.sanitizeHTML", () => {
@@ -21,9 +19,7 @@ describe.concurrent("$helper.string.sanitizeHTML", () => {
 	});
 
 	it("should preserve bold with strong tag", () => {
-		expect(sanitizeHTML("<strong>bold</strong>")).toBe(
-			"<strong>bold</strong>"
-		);
+		expect(sanitizeHTML("<strong>bold</strong>")).toBe("<strong>bold</strong>");
 	});
 
 	it("should preserve bold with b tag", () => {
@@ -77,7 +73,7 @@ describe.concurrent("$helper.string.sanitizeHTML", () => {
 	});
 
 	it("should restrict to custom marks", () => {
-		const marks = [new Bold(), new Italic()];
+		const marks = ["bold", "italic"];
 		expect(sanitizeHTML("<strong>bold</strong>", { marks })).toBe(
 			"<strong>bold</strong>"
 		);
@@ -86,18 +82,16 @@ describe.concurrent("$helper.string.sanitizeHTML", () => {
 	});
 
 	it("should support custom nodes with block content", () => {
-		const nodes = [new Doc(), new Paragraph(), new Text()];
+		const nodes = ["doc", "paragraph", "text"];
 		expect(sanitizeHTML("<p>hello</p>", { nodes })).toBe("<p>hello</p>");
 		expect(sanitizeHTML("hello", { nodes })).toBe("<p>hello</p>");
 	});
 
 	it("should combine custom marks and nodes", () => {
-		const marks = [new Bold()];
-		const nodes = [new Doc(), new Paragraph(), new Text()];
 		expect(
 			sanitizeHTML("<p><strong>bold</strong> <em>italic</em></p>", {
-				marks,
-				nodes
+				marks: ["bold"],
+				nodes: ["doc", "paragraph", "text"]
 			})
 		).toBe("<p><strong>bold</strong> italic</p>");
 	});

--- a/panel/src/helpers/string.sanitizeHTML.test.js
+++ b/panel/src/helpers/string.sanitizeHTML.test.js
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from "vitest";
+import { Bold, Italic } from "../components/Forms/Writer/Marks";
+import { Doc, Paragraph, Text } from "../components/Forms/Writer/Nodes";
+import { sanitizeHTML } from "./string.js";
+
+describe.concurrent("$helper.string.sanitizeHTML", () => {
+	it("should strip script tags", () => {
+		expect(sanitizeHTML("<script>alert('xss')</script>")).toBe("");
+	});
+
+	it("should strip disallowed block elements but keep text", () => {
+		expect(sanitizeHTML("<div>hello</div>")).toBe("hello");
+	});
+
+	it("should strip disallowed inline elements but keep text", () => {
+		expect(sanitizeHTML("<span>hello</span>")).toBe("hello");
+	});
+
+	it("should preserve bold with strong tag", () => {
+		expect(sanitizeHTML("<strong>bold</strong>")).toBe(
+			"<strong>bold</strong>"
+		);
+	});
+
+	it("should preserve bold with b tag", () => {
+		expect(sanitizeHTML("<b>bold</b>")).toBe("<strong>bold</strong>");
+	});
+
+	it("should preserve italic with em tag", () => {
+		expect(sanitizeHTML("<em>italic</em>")).toBe("<em>italic</em>");
+	});
+
+	it("should preserve italic with i tag", () => {
+		expect(sanitizeHTML("<i>italic</i>")).toBe("<em>italic</em>");
+	});
+
+	it("should preserve underline", () => {
+		expect(sanitizeHTML("<u>underline</u>")).toBe("<u>underline</u>");
+	});
+
+	it("should preserve links with attributes", () => {
+		const html =
+			'<a href="https://example.com" target="_blank" title="Example">link</a>';
+		expect(sanitizeHTML(html)).toBe(
+			'<a href="https://example.com" target="_blank" title="Example">link</a>'
+		);
+	});
+
+	it("should preserve strike, code, sub, sup marks", () => {
+		expect(sanitizeHTML("<s>strike</s>")).toBe("<s>strike</s>");
+		expect(sanitizeHTML("<code>code</code>")).toBe("<code>code</code>");
+		expect(sanitizeHTML("<sub>sub</sub>")).toBe("<sub>sub</sub>");
+		expect(sanitizeHTML("<sup>sup</sup>")).toBe("<sup>sup</sup>");
+	});
+
+	it("should strip unsupported elements", () => {
+		expect(sanitizeHTML("<font>text</font>")).toBe("text");
+		expect(sanitizeHTML("<mark>text</mark>")).toBe("text");
+	});
+
+	it("should handle empty string", () => {
+		expect(sanitizeHTML("")).toBe("");
+	});
+
+	it("should handle plain text", () => {
+		expect(sanitizeHTML("just text")).toBe("just text");
+	});
+
+	it("should handle nested allowed marks", () => {
+		expect(sanitizeHTML("<strong><em>bold italic</em></strong>")).toBe(
+			"<strong><em>bold italic</em></strong>"
+		);
+	});
+
+	it("should restrict to custom marks", () => {
+		const marks = [new Bold(), new Italic()];
+		expect(sanitizeHTML("<strong>bold</strong>", { marks })).toBe(
+			"<strong>bold</strong>"
+		);
+		expect(sanitizeHTML("<u>underline</u>", { marks })).toBe("underline");
+		expect(sanitizeHTML("<code>code</code>", { marks })).toBe("code");
+	});
+
+	it("should support custom nodes with block content", () => {
+		const nodes = [new Doc(), new Paragraph(), new Text()];
+		expect(sanitizeHTML("<p>hello</p>", { nodes })).toBe("<p>hello</p>");
+		expect(sanitizeHTML("hello", { nodes })).toBe("<p>hello</p>");
+	});
+
+	it("should combine custom marks and nodes", () => {
+		const marks = [new Bold()];
+		const nodes = [new Doc(), new Paragraph(), new Text()];
+		expect(
+			sanitizeHTML("<p><strong>bold</strong> <em>italic</em></p>", {
+				marks,
+				nodes
+			})
+		).toBe("<p><strong>bold</strong> italic</p>");
+	});
+});

--- a/panel/src/helpers/writer.js
+++ b/panel/src/helpers/writer.js
@@ -1,0 +1,193 @@
+import Mark from "@/components/Forms/Writer/Mark";
+import Node from "@/components/Forms/Writer/Node";
+
+// Marks
+import {
+	Bold,
+	Clear,
+	Code,
+	Email,
+	Italic,
+	Link,
+	Strike,
+	Sup,
+	Sub,
+	Underline
+} from "@/components/Forms/Writer/Marks";
+
+// Nodes
+import {
+	BulletList,
+	Doc,
+	HardBreak,
+	Heading,
+	HorizontalRule,
+	ListItem,
+	OrderedList,
+	Quote,
+	Paragraph,
+	Text
+} from "@/components/Forms/Writer/Nodes";
+
+export const allowedExtensions = (available, allowed) => {
+	if (allowed === false) {
+		return [];
+	}
+
+	if (allowed === true) {
+		return Object.keys(available);
+	}
+
+	if (Array.isArray(allowed)) {
+		return allowed;
+	}
+
+	if (typeof allowed === "object" && allowed !== null) {
+		return Object.keys(allowed).filter((key) => allowed[key] !== false);
+	}
+
+	return Object.keys(available);
+};
+
+export const availableMarks = (options = {}) => {
+	return {
+		bold: new Bold(options.bold ?? {}),
+		clear: new Clear(options.clear ?? {}),
+		code: new Code(options.code ?? {}),
+		email: new Email(options.email ?? {}),
+		italic: new Italic(options.italic ?? {}),
+		link: new Link(options.link ?? {}),
+		strike: new Strike(options.strike ?? {}),
+		sup: new Sup(options.sup ?? {}),
+		sub: new Sub(options.sub ?? {}),
+		underline: new Underline(options.underline ?? {}),
+		...availableMarksFromPlugins()
+	};
+};
+
+export const availableMarksFromPlugins = () => {
+	return createExtensionsFromPlugins(
+		window?.panel?.plugins?.writerMarks ?? {},
+		Mark.prototype
+	);
+};
+
+export const availableNodes = (options = {}) => {
+	return {
+		bulletList: new BulletList(options.bulletList ?? {}),
+		doc: new Doc(options.doc ?? {}),
+		hardBreak: new HardBreak(options.hardBreak ?? {}),
+		heading: new Heading(options.heading ?? {}),
+		horizontalRule: new HorizontalRule(options.horizontalRule ?? {}),
+		listItem: new ListItem(options.listItem ?? {}),
+		orderedList: new OrderedList(options.orderedList ?? {}),
+		paragraph: new Paragraph(options.paragraph ?? {}),
+		quote: new Quote(options.quote ?? {}),
+		text: new Text(options.text ?? {}),
+		...availableNodesFromPlugins()
+	};
+};
+
+export const availableNodesFromPlugins = () => {
+	return createExtensionsFromPlugins(
+		window?.panel?.plugins?.writerNodes ?? {},
+		Node.prototype
+	);
+};
+
+export const createExtensionsFromPlugins = (plugins, proto) => {
+	const extensions = {};
+
+	// take each extension object and turn
+	// it into an instance that extends the Node or Mark class
+	for (const name in plugins) {
+		extensions[name] = Object.create(
+			proto,
+			Object.getOwnPropertyDescriptors({ name, ...plugins[name] })
+		);
+	}
+
+	return extensions;
+};
+
+export const createMarks = (marks, required = []) => {
+	const options = extensionOptions(marks);
+	const available = availableMarks(options);
+	const installed = filterExtensions(available, marks);
+
+	// re-install all required extensions
+	for (const extension of required) {
+		installed[extension] = available[extension];
+	}
+
+	return installed;
+};
+
+export const createNodes = (nodes, required = []) => {
+	const options = extensionOptions(nodes);
+	const available = availableNodes(options);
+	const installed = filterExtensions(available, nodes);
+
+	// re-install all required extensions
+	for (const extension of required) {
+		installed[extension] = available[extension];
+	}
+
+	// always install the list item node if there's a bullet list or ordered list
+	if (installed.bulletList || installed.orderedList) {
+		installed.listItem = available.listItem;
+	}
+
+	return installed;
+};
+
+export const extensionOptions = (allowed) => {
+	if (
+		typeof allowed !== "object" ||
+		allowed === null ||
+		Array.isArray(allowed)
+	) {
+		return {};
+	}
+
+	const options = {};
+
+	for (const [name, value] of Object.entries(allowed)) {
+		if (typeof value === "object" && value !== null) {
+			options[name] = value;
+		}
+	}
+
+	return options;
+};
+
+export const filterExtensions = (available, allowed) => {
+	allowed = allowedExtensions(available, allowed);
+
+	let installed = {};
+
+	for (const extension in available) {
+		if (allowed.includes(extension)) {
+			installed[extension] = available[extension];
+		}
+	}
+
+	return installed;
+};
+
+export const keepInlineNodes = (nodes) => {
+	return nodes.filter((node) => node.schema.inline === true);
+};
+
+export default {
+	allowedExtensions,
+	availableMarks,
+	availableMarksFromPlugins,
+	availableNodes,
+	availableNodesFromPlugins,
+	createMarks,
+	createNodes,
+	extensionOptions,
+	filterExtensions,
+	keepInlineNodes
+};

--- a/panel/src/helpers/writer.js
+++ b/panel/src/helpers/writer.js
@@ -1,5 +1,6 @@
 import Mark from "@/components/Forms/Writer/Mark";
 import Node from "@/components/Forms/Writer/Node";
+import { isObject } from "./object";
 
 // Marks
 import {
@@ -42,7 +43,7 @@ export const allowedExtensions = (available, allowed) => {
 		return allowed;
 	}
 
-	if (typeof allowed === "object" && allowed !== null) {
+	if (isObject(allowed) === true) {
 		return Object.keys(allowed).filter((key) => allowed[key] !== false);
 	}
 
@@ -143,9 +144,9 @@ export const createNodes = (nodes, required = []) => {
 
 export const extensionOptions = (allowed) => {
 	if (
-		typeof allowed !== "object" ||
-		allowed === null ||
-		Array.isArray(allowed)
+		Array.isArray(allowed) === true ||
+		isObject(allowed) === false ||
+		allowed === null
 	) {
 		return {};
 	}

--- a/panel/src/helpers/writer.js
+++ b/panel/src/helpers/writer.js
@@ -38,7 +38,7 @@ export const allowedExtensions = (available, allowed) => {
 		return Object.keys(available);
 	}
 
-	if (Array.isArray(allowed)) {
+	if (Array.isArray(allowed) === true) {
 		return allowed;
 	}
 

--- a/panel/src/helpers/writer.test.js
+++ b/panel/src/helpers/writer.test.js
@@ -1,0 +1,488 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	allowedExtensions,
+	availableMarks,
+	availableMarksFromPlugins,
+	availableNodes,
+	availableNodesFromPlugins,
+	createExtensionsFromPlugins,
+	createMarks,
+	createNodes,
+	extensionOptions,
+	filterExtensions,
+	keepInlineNodes
+} from "./writer.js";
+import Mark from "@/components/Forms/Writer/Mark";
+import Node from "@/components/Forms/Writer/Node";
+
+const allMarkNames = [
+	"bold",
+	"clear",
+	"code",
+	"email",
+	"italic",
+	"link",
+	"strike",
+	"sup",
+	"sub",
+	"underline"
+];
+
+const allNodeNames = [
+	"bulletList",
+	"doc",
+	"hardBreak",
+	"heading",
+	"horizontalRule",
+	"listItem",
+	"orderedList",
+	"paragraph",
+	"quote",
+	"text"
+];
+
+describe("allowedExtensions", () => {
+	const available = { a: 1, b: 2, c: 3 };
+
+	it("should return empty array for false", () => {
+		expect(allowedExtensions(available, false)).toEqual([]);
+	});
+
+	it("should return all keys for true", () => {
+		expect(allowedExtensions(available, true)).toEqual(["a", "b", "c"]);
+	});
+
+	it("should return the array as-is", () => {
+		expect(allowedExtensions(available, ["a", "c"])).toEqual(["a", "c"]);
+	});
+
+	it("should return empty array for empty array", () => {
+		expect(allowedExtensions(available, [])).toEqual([]);
+	});
+
+	it("should return enabled keys from object", () => {
+		expect(
+			allowedExtensions(available, { a: true, b: false, c: true })
+		).toEqual(["a", "c"]);
+	});
+
+	it("should treat object values as enabled", () => {
+		expect(
+			allowedExtensions(available, {
+				a: { option: "value" },
+				b: true,
+				c: false
+			})
+		).toEqual(["a", "b"]);
+	});
+
+	it("should return all keys for null", () => {
+		expect(allowedExtensions(available, null)).toEqual(["a", "b", "c"]);
+	});
+
+	it("should return all keys for undefined", () => {
+		expect(allowedExtensions(available, undefined)).toEqual(["a", "b", "c"]);
+	});
+});
+
+describe("extensionOptions", () => {
+	it("should return empty object for true", () => {
+		expect(extensionOptions(true)).toEqual({});
+	});
+
+	it("should return empty object for false", () => {
+		expect(extensionOptions(false)).toEqual({});
+	});
+
+	it("should return empty object for null", () => {
+		expect(extensionOptions(null)).toEqual({});
+	});
+
+	it("should return empty object for array", () => {
+		expect(extensionOptions(["a", "b"])).toEqual({});
+	});
+
+	it("should extract object values", () => {
+		expect(
+			extensionOptions({
+				a: { level: 1 },
+				b: true,
+				c: { inline: true },
+				d: false
+			})
+		).toEqual({
+			a: { level: 1 },
+			c: { inline: true }
+		});
+	});
+
+	it("should return empty object when no options exist", () => {
+		expect(extensionOptions({ a: true, b: false })).toEqual({});
+	});
+});
+
+describe("availableMarks", () => {
+	it("should return all built-in marks", () => {
+		const marks = availableMarks();
+		expect(Object.keys(marks).sort()).toEqual([...allMarkNames].sort());
+	});
+
+	it("should return instances with correct names", () => {
+		const marks = availableMarks();
+		for (const name of allMarkNames) {
+			expect(marks[name].name).toBe(name);
+		}
+	});
+
+	it("should pass options to constructors", () => {
+		const marks = availableMarks({ bold: { custom: "value" } });
+		expect(marks.bold.options.custom).toBe("value");
+	});
+
+	it("should use defaults without options", () => {
+		const marks = availableMarks();
+		expect(marks.bold.options).toEqual({});
+	});
+});
+
+describe("availableMarksFromPlugins", () => {
+	it("should return empty object without plugins", () => {
+		expect(availableMarksFromPlugins()).toEqual({});
+	});
+});
+
+describe("availableNodes", () => {
+	it("should return all built-in nodes", () => {
+		const nodes = availableNodes();
+		expect(Object.keys(nodes).sort()).toEqual([...allNodeNames].sort());
+	});
+
+	it("should return instances with correct names", () => {
+		const nodes = availableNodes();
+		for (const name of allNodeNames) {
+			expect(nodes[name].name).toBe(name);
+		}
+	});
+
+	it("should pass options to constructors", () => {
+		const nodes = availableNodes({ heading: { levels: [1, 2] } });
+		expect(nodes.heading.options.levels).toEqual([1, 2]);
+	});
+
+	it("should use defaults without options", () => {
+		const nodes = availableNodes();
+		expect(nodes.heading.options.levels).toEqual([1, 2, 3, 4, 5, 6]);
+		expect(nodes.hardBreak.options.enter).toBe(false);
+		expect(nodes.hardBreak.options.text).toBe(false);
+		expect(nodes.doc.options.inline).toBe(false);
+	});
+
+	it("should pass doc inline option", () => {
+		const nodes = availableNodes({ doc: { inline: true } });
+		expect(nodes.doc.options.inline).toBe(true);
+	});
+
+	it("should pass hardBreak options", () => {
+		const nodes = availableNodes({
+			hardBreak: { enter: true, text: true }
+		});
+		expect(nodes.hardBreak.options.enter).toBe(true);
+		expect(nodes.hardBreak.options.text).toBe(true);
+	});
+});
+
+describe("availableNodesFromPlugins", () => {
+	it("should return empty object without plugins", () => {
+		expect(availableNodesFromPlugins()).toEqual({});
+	});
+});
+
+describe("createExtensionsFromPlugins", () => {
+	it("should return empty object for empty plugins", () => {
+		expect(createExtensionsFromPlugins({}, Mark.prototype)).toEqual({});
+	});
+
+	it("should create mark instances from plugin definitions", () => {
+		const plugins = {
+			highlight: {
+				get schema() {
+					return {
+						parseDOM: [{ tag: "mark" }],
+						toDOM: () => ["mark", 0]
+					};
+				}
+			}
+		};
+
+		const result = createExtensionsFromPlugins(plugins, Mark.prototype);
+		expect(result.highlight).toBeDefined();
+		expect(result.highlight.name).toBe("highlight");
+		expect(result.highlight.schema.parseDOM).toEqual([{ tag: "mark" }]);
+	});
+
+	it("should create node instances from plugin definitions", () => {
+		const plugins = {
+			customBlock: {
+				get schema() {
+					return {
+						content: "inline*",
+						group: "block",
+						parseDOM: [{ tag: "div.custom" }],
+						toDOM: () => ["div", { class: "custom" }, 0]
+					};
+				}
+			}
+		};
+
+		const result = createExtensionsFromPlugins(plugins, Node.prototype);
+		expect(result.customBlock).toBeDefined();
+		expect(result.customBlock.name).toBe("customBlock");
+		expect(result.customBlock.schema.group).toBe("block");
+	});
+
+	it("should handle multiple plugins", () => {
+		const plugins = {
+			foo: { get schema() { return {}; } },
+			bar: { get schema() { return {}; } }
+		};
+
+		const result = createExtensionsFromPlugins(plugins, Mark.prototype);
+		expect(Object.keys(result)).toEqual(["foo", "bar"]);
+	});
+});
+
+describe("filterExtensions", () => {
+	const available = {
+		a: { name: "a" },
+		b: { name: "b" },
+		c: { name: "c" }
+	};
+
+	it("should return all extensions for true", () => {
+		const result = filterExtensions(available, true);
+		expect(Object.keys(result)).toEqual(["a", "b", "c"]);
+	});
+
+	it("should return no extensions for false", () => {
+		const result = filterExtensions(available, false);
+		expect(Object.keys(result)).toEqual([]);
+	});
+
+	it("should filter by array", () => {
+		const result = filterExtensions(available, ["a", "c"]);
+		expect(Object.keys(result)).toEqual(["a", "c"]);
+	});
+
+	it("should filter by object", () => {
+		const result = filterExtensions(available, {
+			a: true,
+			b: false,
+			c: { option: 1 }
+		});
+		expect(Object.keys(result)).toEqual(["a", "c"]);
+	});
+
+	it("should ignore unknown extensions in array", () => {
+		const result = filterExtensions(available, ["a", "unknown"]);
+		expect(Object.keys(result)).toEqual(["a"]);
+	});
+
+	it("should ignore unknown extensions in object", () => {
+		const result = filterExtensions(available, {
+			a: true,
+			unknown: true
+		});
+		expect(Object.keys(result)).toEqual(["a"]);
+	});
+
+	it("should preserve extension references", () => {
+		const result = filterExtensions(available, ["a"]);
+		expect(result.a).toBe(available.a);
+	});
+});
+
+describe("createMarks", () => {
+	it("should create all marks with true", () => {
+		const marks = createMarks(true);
+		expect(Object.keys(marks).sort()).toEqual([...allMarkNames].sort());
+	});
+
+	it("should create no marks with false", () => {
+		const marks = createMarks(false);
+		expect(Object.keys(marks)).toEqual([]);
+	});
+
+	it("should filter marks by array", () => {
+		const marks = createMarks(["bold", "italic"]);
+		expect(Object.keys(marks).sort()).toEqual(["bold", "italic"]);
+	});
+
+	it("should filter marks by object", () => {
+		const marks = createMarks({
+			bold: true,
+			italic: true,
+			strike: false
+		});
+		expect(Object.keys(marks).sort()).toEqual(["bold", "italic"]);
+	});
+
+	it("should pass options from object values", () => {
+		const marks = createMarks({
+			bold: { custom: "test" },
+			italic: true
+		});
+		expect(marks.bold.options.custom).toBe("test");
+		expect(Object.keys(marks).sort()).toEqual(["bold", "italic"]);
+	});
+
+	it("should re-install required marks", () => {
+		const marks = createMarks(["bold"], ["italic"]);
+		expect(marks.bold).toBeDefined();
+		expect(marks.italic).toBeDefined();
+	});
+
+	it("should re-install required marks even with false", () => {
+		const marks = createMarks(false, ["bold"]);
+		expect(Object.keys(marks)).toEqual(["bold"]);
+	});
+
+	it("should re-install required marks even when disabled in object", () => {
+		const marks = createMarks({ bold: false }, ["bold"]);
+		expect(marks.bold).toBeDefined();
+	});
+
+	it("should return instances with correct names", () => {
+		const marks = createMarks(["bold", "italic"]);
+		expect(marks.bold.name).toBe("bold");
+		expect(marks.italic.name).toBe("italic");
+	});
+});
+
+describe("createNodes", () => {
+	it("should create all nodes with true", () => {
+		const nodes = createNodes(true);
+		expect(Object.keys(nodes).sort()).toEqual([...allNodeNames].sort());
+	});
+
+	it("should create no nodes with false", () => {
+		const nodes = createNodes(false);
+		expect(Object.keys(nodes)).toEqual([]);
+	});
+
+	it("should filter nodes by array", () => {
+		const nodes = createNodes(["doc", "text", "paragraph"]);
+		expect(Object.keys(nodes).sort()).toEqual(["doc", "paragraph", "text"]);
+	});
+
+	it("should filter nodes by object", () => {
+		const nodes = createNodes({
+			doc: true,
+			text: true,
+			paragraph: true,
+			heading: false
+		});
+		expect(Object.keys(nodes).sort()).toEqual(["doc", "paragraph", "text"]);
+	});
+
+	it("should pass options from object values", () => {
+		const nodes = createNodes({
+			doc: { inline: true },
+			text: true
+		});
+		expect(nodes.doc.options.inline).toBe(true);
+	});
+
+	it("should pass heading levels via object", () => {
+		const nodes = createNodes({
+			heading: { levels: [1, 2] },
+			doc: true,
+			text: true,
+			paragraph: true
+		});
+		expect(nodes.heading.options.levels).toEqual([1, 2]);
+	});
+
+	it("should pass hardBreak options via object", () => {
+		const nodes = createNodes({
+			hardBreak: { enter: true, text: true },
+			doc: true,
+			text: true,
+			paragraph: true
+		});
+		expect(nodes.hardBreak.options.enter).toBe(true);
+		expect(nodes.hardBreak.options.text).toBe(true);
+	});
+
+	it("should re-install required nodes", () => {
+		const nodes = createNodes(["doc"], ["text", "paragraph"]);
+		expect(nodes.doc).toBeDefined();
+		expect(nodes.text).toBeDefined();
+		expect(nodes.paragraph).toBeDefined();
+	});
+
+	it("should re-install required nodes even with false", () => {
+		const nodes = createNodes(false, ["doc", "text"]);
+		expect(Object.keys(nodes).sort()).toEqual(["doc", "text"]);
+	});
+
+	it("should auto-install listItem for bulletList", () => {
+		const nodes = createNodes(["bulletList", "doc", "text", "paragraph"]);
+		expect(nodes.listItem).toBeDefined();
+	});
+
+	it("should auto-install listItem for orderedList", () => {
+		const nodes = createNodes(["orderedList", "doc", "text", "paragraph"]);
+		expect(nodes.listItem).toBeDefined();
+	});
+
+	it("should auto-install listItem for bulletList in object format", () => {
+		const nodes = createNodes({
+			bulletList: true,
+			doc: true,
+			text: true,
+			paragraph: true
+		});
+		expect(nodes.listItem).toBeDefined();
+	});
+
+	it("should not install listItem without lists", () => {
+		const nodes = createNodes(["doc", "text", "paragraph"]);
+		expect(nodes.listItem).toBeUndefined();
+	});
+
+	it("should return instances with correct names", () => {
+		const nodes = createNodes(["doc", "text", "paragraph"]);
+		expect(nodes.doc.name).toBe("doc");
+		expect(nodes.text.name).toBe("text");
+		expect(nodes.paragraph.name).toBe("paragraph");
+	});
+});
+
+describe("keepInlineNodes", () => {
+	it("should keep only inline nodes", () => {
+		const nodes = [
+			{ schema: { inline: true } },
+			{ schema: { inline: false } },
+			{ schema: { inline: true } },
+			{ schema: {} }
+		];
+
+		const result = keepInlineNodes(nodes);
+		expect(result).toHaveLength(2);
+		expect(result[0]).toBe(nodes[0]);
+		expect(result[1]).toBe(nodes[2]);
+	});
+
+	it("should return empty array when no inline nodes exist", () => {
+		const nodes = [{ schema: { group: "block" } }, { schema: {} }];
+		expect(keepInlineNodes(nodes)).toEqual([]);
+	});
+
+	it("should return empty array for empty input", () => {
+		expect(keepInlineNodes([])).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features

You can now use `this.$helper.string.sanitizeHTML()` in the Panel to create a clean HTML string with configurable marks and nodes. By default, the sanitizer will only keep inline marks (bold, code, italic, link, strike, sub, sup, underline)

```js
this.$helper.string.sanitizeHTML('<p><marquee><strong onclick="alert(\'boo\')">Foo</strong></marquee></p>')
// returns: <strong>Foo</strong>
```

To set custom writer marks and nodes, you can pass an options object: 

```js
this.$helper.string.sanitizeHTML(unsanitizedHTML, {
  marks: [new Bold()],
  nodes: [new Doc(), new Paragraph(), new Text()]
});
```

### For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion