### PR TITLE
feat: Allow custom field options for create dialog

### DIFF
--- a/src/Panel/Controller/Dialog/ModelCreateDialogController.php
+++ b/src/Panel/Controller/Dialog/ModelCreateDialogController.php
@@ -58,14 +58,22 @@ abstract class ModelCreateDialogController extends DialogController
 		$custom = [];
 		$fields = $this->blueprint()->fields();
 		$ignore = $this->customFieldsIgnore();
+		$create = $this->blueprint()->create()['fields'] ?? [];
 
-		foreach ($this->blueprint()->create()['fields'] ?? [] as $name) {
-			$field = $fields[$name] ?? null;
+		foreach ($create as $key => $value) {
+			$name    = is_int($key) ? $value : $key;
+			$options = is_int($key) ? [] : (is_array($value) ? $value : []);
+			$field   = $fields[$name] ?? null;
 
 			if ($field === null) {
 				throw new InvalidArgumentException(
 					message: 'Unknown field  "' . $name . '" in create dialog'
 				);
+			}
+
+			// merge override options with base field definition
+			if ($options !== []) {
+				$field = array_replace_recursive($field, $options);
 			}
 
 			if (in_array($field['type'], static::$fieldTypes, true) === false) {

--- a/tests/Panel/Controller/Dialog/PageCreateDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/PageCreateDialogControllerTest.php
@@ -325,6 +325,40 @@ class PageCreateDialogControllerTest extends TestCase
 		$this->assertSame('1/1', $props['fields']['foo']['width']);
 	}
 
+	public function testLoadWithCustomFieldOptions(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/default' => [
+					'create' => [
+						'fields' => [
+							'foo' => [
+								'label'    => 'Custom Label',
+								'required' => false
+							]
+						]
+					],
+					'fields' => [
+						'foo' => [
+							'type'     => 'text',
+							'label'    => 'Original Label',
+							'required' => true
+						]
+					]
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		$controller = new PageCreateDialogController();
+		$props      = $controller->load()->props();
+
+		$this->assertArrayHasKey('foo', $props['fields']);
+		$this->assertSame('Custom Label', $props['fields']['foo']['label']);
+		$this->assertFalse($props['fields']['foo']['required']);
+	}
+
 	public function testModel(): void
 	{
 		$this->app = $this->app->clone([


### PR DESCRIPTION
## Description

💥 Facing the issue that when creating directly as published, the dialog will throw errors when some validation has been disabled via the `create` option. Cause for validating, the dialog uses the temporary model - and its blueprint - and that of course considers the regular field options. This could be considered as intended (validation options can only be customized when creating as draft as the main validations will be enforced when publishing too - and during that step the custom options don't matter)... but this of course could be confusing. I need another opinion @bastianallgeier 

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- Page create dialog: Override field options just for the create dialog. This allows you to e.g. disable certain validations during page creation.
https://github.com/getkirby/kirby/issues/7079

```yml
create:
  fields:
    fieldA:
      required: false
      
fields:
  fieldA:
    type: text
    required: true
```


### For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful):
https://github.com/getkirby/sandbox/pull/26
- [ ] Add changes & docs to release notes draft in Notion