### PR TITLE
fix: Do not pass icon prop to choice input

### DIFF
--- a/panel/src/components/Forms/Input/ChoiceInput.vue
+++ b/panel/src/components/Forms/Input/ChoiceInput.vue
@@ -2,7 +2,6 @@
 	<label
 		:aria-disabled="disabled"
 		:class="['k-choice-input', $attrs.class]"
-		:data-has-icon="Boolean(icon)"
 		:style="$attrs.style"
 	>
 		<input

--- a/panel/src/components/Forms/Input/ToggleInput.vue
+++ b/panel/src/components/Forms/Input/ToggleInput.vue
@@ -4,6 +4,7 @@
 		:checked="value"
 		:class="['k-toggle-input', $attrs.class]"
 		:disabled="disabled"
+		:icon="undefined"
 		:label="labelText"
 		:style="$attrs.style"
 		type="checkbox"


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

We need to force-unset the `icon` prop when using `k-choice-input` in `k-toggle-input`, otherwise the icon is rendered twice (by `k-input` and by `k-choice-input`).

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Toggle field: Fixed duplicate display of field icon
#7939

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion