### PR TITLE
build: Workflow to attach Lab as ZIP to release

### DIFF
--- a/.github/workflows/lab.yml
+++ b/.github/workflows/lab.yml
@@ -1,0 +1,60 @@
+name: Panel Lab docs
+
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release to attach the Panel Lab docs to (e.g. 6.1.0)"
+        required: true
+      dry_run:
+        description: "Skip uploading to the release (for testing)"
+        type: boolean
+        default: false
+
+jobs:
+  build-and-upload:
+    name: "Build & upload Lab JSON docs"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    permissions:
+      contents: write # required to upload release assets
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Set up Node.js and cache npm dependencies
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # pin@v4
+        with:
+          cache: "npm"
+          cache-dependency-path: panel/package-lock.json
+
+      - name: Install npm dependencies
+        run: npm ci
+        working-directory: panel
+
+      - name: Build Lab JSON docs
+        run: npm run build:docs
+        working-directory: panel
+
+      - name: Create ZIP archive
+        run: |
+          VERSION="${{ github.event.release.tag_name || inputs.tag }}"
+          zip "lab-${VERSION}.zip" *.json
+        working-directory: panel/dist/ui
+
+      - name: Upload Lab ZIP to release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ github.event.release.tag_name || inputs.tag }}"
+          gh release upload "${VERSION}" \
+            "panel/dist/ui/lab-${VERSION}.zip" \
+            --clobber


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Adds a new "Panel Lab docs" workflow that automatically builds and attaches the Lab docs JSONs as ZIP to each GitHub Release. That way we could finally offer instructions at https://getkirby.com/docs/reference/plugins/ui#access-the-panel-lab-locally

1. Download `Lab.zip` from release.
2. Unzip all files into `panel/dist/ui/`

### Testing
The workflow can also be triggered manually via `workflow_dispatch`. A `dry_run` option is available to run the full build and packaging pipeline without uploading anything to a release. At least something, but I haven't thought of a real good way to know/test whether this all works as imagined.