### PR TITLE
fix: `LazyCollection` regression fixes

### DIFF
--- a/config/methods.php
+++ b/config/methods.php
@@ -251,6 +251,9 @@ return function (App $app) {
 			Field $field,
 			string $separator = 'yaml'
 		) use ($app): Pages {
+			// always pass at least two arguments even if the
+			// data is empty so that `$site->find()` always
+			// returns a collection, not a single page
 			return $app->site()->find(
 				false,
 				false,
@@ -320,6 +323,9 @@ return function (App $app) {
 			Field $field,
 			string $separator = 'yaml'
 		) use ($app): Users {
+			// always pass at least two arguments even if the
+			// data is empty so that `$users->find()` always
+			// returns a collection, not a single user
 			return $app->users()->find(
 				false,
 				false,

--- a/src/Cms/LazyCollection.php
+++ b/src/Cms/LazyCollection.php
@@ -159,6 +159,28 @@ abstract class LazyCollection extends Collection
 	}
 
 	/**
+	 * Find one or multiple elements by id
+	 *
+	 * @param string ...$keys
+	 * @return TValue|static
+	 */
+	public function find(...$keys)
+	{
+		$result = parent::find(...$keys);
+
+		// when the result is a cloned collection (multiple keys),
+		// mark it as initialized to prevent it from initializing
+		// all of its elements again after we filtered it above
+		// (relevant when finding elements in a collection that
+		// has not been (fully) initialized yet)
+		if ($result instanceof static && $result !== $this) {
+			$result->initialized = true;
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Returns the elements in reverse order
 	 */
 	public function flip(): static

--- a/src/Cms/LazyCollection.php
+++ b/src/Cms/LazyCollection.php
@@ -143,6 +143,22 @@ abstract class LazyCollection extends Collection
 	}
 
 	/**
+	 * Clone and remove all elements from the collection
+	 */
+	public function empty(): static
+	{
+		$empty = parent::empty();
+
+		// prevent new collection from initializing its
+		// elements into the now empty collection
+		// (relevant when emptying a collection that
+		// has not been (fully) initialized yet)
+		$empty->initialized = true;
+
+		return $empty;
+	}
+
+	/**
 	 * Returns the elements in reverse order
 	 */
 	public function flip(): static

--- a/src/Cms/LazyCollection.php
+++ b/src/Cms/LazyCollection.php
@@ -379,6 +379,26 @@ abstract class LazyCollection extends Collection
 	}
 
 	/**
+	 * Prepends an element to the data array
+	 *
+	 * ```php
+	 * $collection->prepend('key', $value);
+	 * $collection->prepend($value);
+	 * ```
+	 *
+	 * @param string|TValue ...$args
+	 * @return $this
+	 */
+	public function prepend(...$args): static
+	{
+		// prepending to an uninitialized collection would
+		// destroy the order on later initialization
+		$this->initialize();
+
+		return parent::prepend(...$args);
+	}
+
+	/**
 	 * Moves the cursor to the previous element
 	 * and returns it
 	 * @deprecated

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -153,6 +153,12 @@ class Users extends LazyCollection
 			throw new LogicException('Cannot hydrate user "' . $key . '" with missing root'); // @codeCoverageIgnore
 		}
 
+		// ignore empty keys to avoid matching the `accounts` root
+		// directory itself (e.g. from `false` values coerced to `""`)
+		if ($key === '') {
+			return null;
+		}
+
 		// check if the user directory exists if not all keys have been
 		// populated in the collection, otherwise we can assume that
 		// this method will only be called on "unhydrated" user IDs

--- a/src/Content/Changes.php
+++ b/src/Content/Changes.php
@@ -118,6 +118,10 @@ class Changes
 	{
 		/**
 		 * @var \Kirby\Cms\Pages $pages
+		 *
+		 * Always pass at least two arguments even if the
+		 * data is empty so that `$site->find()` always
+		 * returns a collection, not a single page
 		 */
 		$pages = $this->kirby->site()->find(
 			false,
@@ -185,6 +189,10 @@ class Changes
 	{
 		/**
 		 * @var \Kirby\Cms\Users $users
+		 *
+		 * Always pass at least two arguments even if the
+		 * data is empty so that `$users->find()` always
+		 * returns a collection, not a single user
 		 */
 		$users = $this->kirby->users()->find(
 			false,

--- a/tests/Cms/Collections/LazyCollectionTest.php
+++ b/tests/Cms/Collections/LazyCollectionTest.php
@@ -580,6 +580,40 @@ class LazyCollectionTest extends TestCase
 		$this->assertTrue($collection->initialized);
 	}
 
+	public function testPrepend(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->data = [
+			'b' => new Obj(['id' => 'b', 'type' => 'static']),
+			'c' => null
+		];
+
+		$collection->prepend(new Obj(['id' => 'a', 'type' => 'prepended']));
+
+		$this->assertSame([
+			'a' => ['id' => 'a', 'type' => 'prepended'],
+			'b' => ['id' => 'b', 'type' => 'static'],
+			'c' => ['id' => 'c', 'type' => 'hydrated']
+		], $collection->toArray());
+	}
+
+	public function testPrependUnitialized(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->targetData = [
+			'b' => new Obj(['id' => 'b', 'type' => 'initialized']),
+			'c' => null
+		];
+
+		$collection->prepend(new Obj(['id' => 'a', 'type' => 'prepended']));
+
+		$this->assertSame([
+			'a' => ['id' => 'a', 'type' => 'prepended'],
+			'b' => ['id' => 'b', 'type' => 'initialized'],
+			'c' => ['id' => 'c', 'type' => 'hydrated']
+		], $collection->toArray());
+	}
+
 	public function testRandom(): void
 	{
 		$collection = new MockLazyCollectionWithInitialization();

--- a/tests/Cms/Collections/LazyCollectionTest.php
+++ b/tests/Cms/Collections/LazyCollectionTest.php
@@ -128,6 +128,32 @@ class LazyCollectionTest extends TestCase
 		$this->assertFalse($collection2->iterated);
 	}
 
+	public function testEmpty(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->data = [
+			'a' => new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null
+		];
+
+		$newCollection = $collection->empty();
+
+		$this->assertSame([], $newCollection->toArray());
+	}
+
+	public function testEmptyUnitialized(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->targetData = [
+			'a' => new Obj(['id' => 'a', 'type' => 'initialized']),
+			'b' => null
+		];
+
+		$newCollection = $collection->empty();
+
+		$this->assertSame([], $newCollection->toArray());
+	}
+
 	public function testGet(): void
 	{
 		$collection = new MockLazyCollection();

--- a/tests/Cms/Collections/LazyCollectionTest.php
+++ b/tests/Cms/Collections/LazyCollectionTest.php
@@ -154,6 +154,47 @@ class LazyCollectionTest extends TestCase
 		$this->assertSame([], $newCollection->toArray());
 	}
 
+	public function testFind(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->data = [
+			'a' => $a = new Obj(['id' => 'a', 'type' => 'static']),
+			'b' => null,
+			'c' => null
+		];
+
+		$objectResult     = $collection->find('a');
+		$collectionResult = $collection->find('a', 'b');
+
+		$this->assertSame($a, $objectResult);
+
+		$this->assertSame([
+			'a' => ['id' => 'a', 'type' => 'static'],
+			'b' => ['id' => 'b', 'type' => 'hydrated']
+		], $collectionResult->toArray());
+	}
+
+	public function testFindUnitialized(): void
+	{
+		$collection = new MockLazyCollectionWithInitialization();
+		$collection->targetData = [
+			'a' => new Obj(['id' => 'a', 'type' => 'initialized']),
+			'b' => null,
+			'c' => null
+		];
+
+		$objectResult     = $collection->find('a');
+		$collectionResult = $collection->find('a', 'b');
+
+		$this->assertSame('a', $objectResult->id);
+		$this->assertSame('hydrated', $objectResult->type);
+
+		$this->assertSame([
+			'a' => ['id' => 'a', 'type' => 'hydrated'],
+			'b' => ['id' => 'b', 'type' => 'hydrated']
+		], $collectionResult->toArray());
+	}
+
 	public function testGet(): void
 	{
 		$collection = new MockLazyCollection();


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

This PR fixes several shortcomings of `LazyCollection` when in lazy initialization mode. First and foremost the regression in #7943 but also similar issues I found while researching and implementing the fix.

Thanks to @afbora for his great help with debugging.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Using `$users->find()` with more than one argument or `$field->toUsers()`/`$field->toUser()` no longer results in unfiltered collections. #7943
- Calling `$users->find(false)` no longer loads an invalid empty user object.
- `$lazyCollection->prepend()` and `$users->prepend()` ensure the intended element order even if the collection was not initialized before
- `$lazyCollection->empty()` and `$users->empty()` no longer result in populated collections if the original collection was not initialized before

### 🧹 Housekeeping
<!-- 
e.g. Update JS dependencies
-->

- Add missing code comments on the behavior of `$collection->find(false, false, ...$data)`

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion