### PR TITLE
fix: Prevent duplicate draft when changing status in `page.create:after` hook

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -491,7 +491,12 @@ trait PageActions
 			$page = $page->changeStatus('listed', $props['num']);
 		}
 
-		$page->uuid()?->populate();
+		// only populate UUID cache if the page still exists at its
+		// expected location; a hook may have changed the status and
+		// moved the draft directory, making the page object stale
+		if ($page->exists() === true) {
+			$page->uuid()?->populate();
+		}
 
 		return $page;
 	}

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -491,12 +491,11 @@ trait PageActions
 			$page = $page->changeStatus('listed', $props['num']);
 		}
 
-		// only populate UUID cache if the page still exists at its
-		// expected location; a hook may have changed the status and
-		// moved the draft directory, making the page object stale
-		if ($page->exists() === true) {
-			$page->uuid()?->populate();
-		}
+		// resolve the page from parent's collection to get the
+		// up-to-date object (a hook may have modified it)
+		$page = $page->parentModel()->findPageOrDraft($page->id()) ?? $page;
+
+		$page->uuid()?->populate();
 
 		return $page;
 	}

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -482,7 +482,11 @@ trait PageActions
 			],
 			function ($page) use ($storage) {
 				// move to final storage
-				return $page->changeStorage($storage);
+				$page->changeStorage($storage);
+
+				$page->uuid()?->populate();
+
+				return $page;
 			}
 		);
 
@@ -490,12 +494,6 @@ trait PageActions
 		if (isset($props['num']) === true) {
 			$page = $page->changeStatus('listed', $props['num']);
 		}
-
-		// resolve the page from parent's collection to get the
-		// up-to-date object (a hook may have modified it)
-		$page = $page->parentModel()->findPageOrDraft($page->id()) ?? $page;
-
-		$page->uuid()?->populate();
 
 		return $page;
 	}

--- a/tests/Cms/Page/PageCreateTest.php
+++ b/tests/Cms/Page/PageCreateTest.php
@@ -474,12 +474,9 @@ class PageCreateTest extends ModelTestCase
 	}
 
 	/**
-	 * Calling changeStatus() inside page.create:after should not
-	 * recreate the draft directory (which was the bug in 5.3.0/5.3.1:
-	 * uuid()->populate() on a stale page object was writing a new file
-	 * back to the moved draft location)
+	 * Changing status in page.create:after should not recreate the draft.
 	 */
-	public function testCreateWithChangeStatusInAfterHookNoDuplicateDraft(): void
+	public function testAfterCreateHookChangeStatusDoesNotDuplicateDraft(): void
 	{
 		$app = $this->app->clone([
 			'hooks' => [
@@ -498,18 +495,21 @@ class PageCreateTest extends ModelTestCase
 
 		// exactly one page should exist — no duplicate
 		$this->assertCount(1, $app->site()->childrenAndDrafts());
+		$this->assertCount(0, $app->site()->drafts());
+		$this->assertCount(1, $app->site()->children());
 	}
 
 	/**
-	 * After calling changeStatus() inside page.create:after, the UUID
-	 * cache must be populated with the correct UUID of the listed page —
-	 * not a newly generated one written to the recreated draft directory
+	 * Changing status in page.create:after should keep UUID cache valid.
 	 */
-	public function testCreateWithChangeStatusInAfterHookUuidPopulated(): void
+	public function testAfterCreateHookChangeStatusKeepsUuidCacheValid(): void
 	{
+		$uuidWasCachedInAfterHook = false;
+
 		$app = $this->app->clone([
 			'hooks' => [
-				'page.create:after' => function (Page $page) {
+				'page.create:after' => function (Page $page) use (&$uuidWasCachedInAfterHook) {
+					$uuidWasCachedInAfterHook = $page->uuid()->isCached();
 					$page->changeStatus('listed');
 				}
 			]
@@ -518,6 +518,8 @@ class PageCreateTest extends ModelTestCase
 		$app->impersonate('kirby');
 
 		Page::create(['slug' => 'test']);
+
+		$this->assertTrue($uuidWasCachedInAfterHook);
 
 		// get the actual listed page
 		$page = $app->site()->children()->first();

--- a/tests/Cms/Page/PageCreateTest.php
+++ b/tests/Cms/Page/PageCreateTest.php
@@ -474,10 +474,12 @@ class PageCreateTest extends ModelTestCase
 	}
 
 	/**
-	 * Changing status in the page.create:after hook should
-	 * not create a duplicate draft directory
+	 * Calling changeStatus() inside page.create:after should not
+	 * recreate the draft directory (which was the bug in 5.3.0/5.3.1:
+	 * uuid()->populate() on a stale page object was writing a new file
+	 * back to the moved draft location)
 	 */
-	public function testCreateWithChangeStatusInAfterHook(): void
+	public function testCreateWithChangeStatusInAfterHookNoDuplicateDraft(): void
 	{
 		$app = $this->app->clone([
 			'hooks' => [
@@ -489,22 +491,21 @@ class PageCreateTest extends ModelTestCase
 
 		$app->impersonate('kirby');
 
-		$page = Page::create([
-			'slug' => 'test',
-		]);
+		Page::create(['slug' => 'test']);
 
-		// the draft directory should not exist anymore
+		// the draft directory must not be recreated after being moved by publish()
 		$this->assertDirectoryDoesNotExist(static::TMP . '/content/_drafts/test');
 
-		// the listed page directory should exist (with sorting number)
-		$this->assertDirectoryExists(static::TMP . '/content/1_test');
+		// exactly one page should exist — no duplicate
+		$this->assertCount(1, $app->site()->childrenAndDrafts());
 	}
 
 	/**
-	 * Changing status in the page.create:after hook should
-	 * not create a second page with a different UUID
+	 * After calling changeStatus() inside page.create:after, the UUID
+	 * cache must be populated with the correct UUID of the listed page —
+	 * not a newly generated one written to the recreated draft directory
 	 */
-	public function testCreateWithChangeStatusInAfterHookUuid(): void
+	public function testCreateWithChangeStatusInAfterHookUuidPopulated(): void
 	{
 		$app = $this->app->clone([
 			'hooks' => [
@@ -516,11 +517,15 @@ class PageCreateTest extends ModelTestCase
 
 		$app->impersonate('kirby');
 
-		Page::create([
-			'slug' => 'test',
-		]);
+		Page::create(['slug' => 'test']);
 
-		// there should be exactly one page, no duplicate draft
-		$this->assertCount(1, $app->site()->childrenAndDrafts());
+		// get the actual listed page
+		$page = $app->site()->children()->first();
+
+		// UUID cache must be populated with the listed page's UUID
+		$this->assertTrue($page->uuid()->isCached());
+
+		// resolving the cached UUID must return the same page
+		$this->assertSame($page->id(), $page->uuid()->model()->id());
 	}
 }


### PR DESCRIPTION
## Description

When `changeStatus()` is called inside a `page.create:after` hook, the draft directory gets moved to the published location. However, the `$page` object returned from `commit('create')` still points to the old draft path. The subsequent `$page->uuid()->populate()` call then fails to read the content (file no longer exists), generates a new UUID, and writes it to disk — recreating the draft directory with only a UUID field.

This adds an `$page->exists()` check before calling `populate()` to skip UUID cache population when the page no longer exists at its expected location.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes

- Duplicate draft created when using page.create:after hook (Kirby 5.3.x) #7957


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion