### PR TITLE
refact: Backport new license enum cases

### DIFF
--- a/src/Cms/LicenseStatus.php
+++ b/src/Cms/LicenseStatus.php
@@ -21,6 +21,13 @@ enum LicenseStatus: string
 	case Active = 'active';
 
 	/**
+	 * Compliance with the conditional license
+	 * requirements has been confirmed
+	 * @since 5.4.0
+	 */
+	case Acknowledged = 'acknowledged';
+
+	/**
 	 * Only used for the demo instance
 	 */
 	case Demo = 'demo';
@@ -57,10 +64,11 @@ enum LicenseStatus: string
 	public function activatable(): bool
 	{
 		return match ($this) {
-			static::Active,
-			static::Inactive,
-			static::Legacy    => true,
-			default           => false
+			static::Active       => true,
+			static::Acknowledged => true,
+			static::Inactive     => true,
+			static::Legacy       => true,
+			default              => false
 		};
 	}
 
@@ -84,12 +92,13 @@ enum LicenseStatus: string
 	public function icon(): string
 	{
 		return match ($this) {
-			static::Active   => 'check',
-			static::Demo     => 'preview',
-			static::Inactive => 'clock',
-			static::Legacy   => 'alert',
-			static::Missing  => 'key',
-			static::Unknown  => 'question',
+			static::Active       => 'check',
+			static::Acknowledged => 'shield',
+			static::Demo         => 'preview',
+			static::Inactive     => 'clock',
+			static::Legacy       => 'alert',
+			static::Missing      => 'key',
+			static::Unknown      => 'question',
 		};
 	}
 
@@ -118,9 +127,10 @@ enum LicenseStatus: string
 	public function renewable(): bool
 	{
 		return match ($this) {
-			static::Active,
-			static::Demo => false,
-			default      => true
+			static::Active       => false,
+			static::Acknowledged => false,
+			static::Demo         => false,
+			default              => true
 		};
 	}
 
@@ -132,12 +142,13 @@ enum LicenseStatus: string
 	public function theme(): string
 	{
 		return match ($this) {
-			static::Active   => 'positive',
-			static::Demo     => 'notice',
-			static::Inactive => 'notice',
-			static::Legacy   => 'negative',
-			static::Missing  => 'love',
-			static::Unknown  => 'passive',
+			static::Active       => 'positive',
+			static::Acknowledged => 'passive',
+			static::Demo         => 'notice',
+			static::Inactive     => 'notice',
+			static::Legacy       => 'negative',
+			static::Missing      => 'love',
+			static::Unknown      => 'passive',
 		};
 	}
 

--- a/src/Cms/LicenseType.php
+++ b/src/Cms/LicenseType.php
@@ -27,6 +27,12 @@ enum LicenseType: string
 	case Enterprise = 'enterprise';
 
 	/**
+	 * Develop/private installation
+	 * @since 5.4.0
+	 */
+	case Free = 'free';
+
+	/**
 	 * Invalid license codes
 	 */
 	case Invalid = 'invalid';
@@ -44,6 +50,7 @@ enum LicenseType: string
 		return match (true) {
 			static::Basic->isValidCode($code)      => static::Basic,
 			static::Enterprise->isValidCode($code) => static::Enterprise,
+			static::Free->isValidCode($code)       => static::Free,
 			static::Legacy->isValidCode($code)     => static::Legacy,
 			default                                => static::Invalid
 		};
@@ -70,6 +77,7 @@ enum LicenseType: string
 		return match ($this) {
 			static::Basic      => 38,
 			static::Enterprise => 38,
+			static::Free       => strlen(static::Free->prefix()),
 			static::Legacy     => 39,
 			static::Invalid    => 0,
 		};
@@ -83,6 +91,7 @@ enum LicenseType: string
 		return match ($this) {
 			static::Basic      => 'Kirby Basic',
 			static::Enterprise => 'Kirby Enterprise',
+			static::Free       => I18n::translate('license.free.label'),
 			static::Legacy     => 'Kirby 3',
 			static::Invalid    => I18n::translate('license.unregistered.label'),
 		};
@@ -96,6 +105,7 @@ enum LicenseType: string
 		return match ($this) {
 			static::Basic      => 'K-BAS-',
 			static::Enterprise => 'K-ENT-',
+			static::Free       => 'FREE',
 			static::Legacy     => 'K3-PRO-',
 			static::Invalid    => null,
 		};


### PR DESCRIPTION
Backported from v5.4 to 5.3.2 - so that we can update the license hub with less problems. 