### PR TITLE
fix: prevent empty slug from leaking parent field values into new child pages

### DIFF
--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -123,7 +123,7 @@ class Page extends ModelWithContent
 	 */
 	public function __construct(array $props)
 	{
-		if (isset($props['slug']) === false) {
+		if (isset($props['slug']) === false || $props['slug'] === '') {
 			throw new InvalidArgumentException(
 				message: 'The page slug is required'
 			);

--- a/src/Panel/PageCreateDialog.php
+++ b/src/Panel/PageCreateDialog.php
@@ -273,7 +273,7 @@ class PageCreateDialog
 		}
 
 		$props = [
-			'slug'     => $this->slug ?? '__new__',
+			'slug'     => $this->slug ?: '__new__',
 			'template' => $this->template,
 			'model'    => $this->template,
 			'parent'   => $this->parent instanceof Page ? $this->parent : null,

--- a/tests/Cms/Page/PageSlugTest.php
+++ b/tests/Cms/Page/PageSlugTest.php
@@ -94,4 +94,12 @@ class PageSlugTest extends ModelTestCase
 
 		new Page(['slug' => null]);
 	}
+
+	public function testSlugWithEmptyString(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('The page slug is required');
+
+		new Page(['slug' => '']);
+	}
 }

--- a/tests/Panel/PageCreateDialogTest.php
+++ b/tests/Panel/PageCreateDialogTest.php
@@ -366,6 +366,45 @@ class PageCreateDialogTest extends AreaTestCase
 		$this->assertInstanceOf(PageUuid::class, $model->uuid());
 	}
 
+	public function testModelSlugFallsBackToNewWhenNull(): void
+	{
+		$dialog = new PageCreateDialog(
+			null,
+			null,
+			'test',
+			null,
+			null // slug = null
+		);
+
+		$this->assertSame('__new__', $dialog->model()->slug());
+	}
+
+	public function testModelSlugFallsBackToNewWhenEmpty(): void
+	{
+		$dialog = new PageCreateDialog(
+			null,
+			null,
+			'test',
+			null,
+			'' // slug = empty string
+		);
+
+		$this->assertSame('__new__', $dialog->model()->slug());
+	}
+
+	public function testModelSlugUsesProvidedSlug(): void
+	{
+		$dialog = new PageCreateDialog(
+			null,
+			null,
+			'test',
+			null,
+			'my-article' // slug = valid slug
+		);
+
+		$this->assertSame('my-article', $dialog->model()->slug());
+	}
+
 	public function testModelUuidDisabled(): void
 	{
 		$this->app([

--- a/tests/Panel/PageCreateDialogTest.php
+++ b/tests/Panel/PageCreateDialogTest.php
@@ -482,4 +482,146 @@ class PageCreateDialogTest extends AreaTestCase
 		$this->assertSame('bar-slug', $page->slug());
 		$this->assertSame('bar-slug', $page->bar()->value());
 	}
+
+	public function testSubmitDefault(): void
+	{
+		$app = $this->app([
+			'blueprints' => [
+				'pages/article' => [
+					'fields' => [
+						'text' => ['type' => 'text']
+					]
+				]
+			]
+		]);
+		$app->impersonate('kirby');
+
+		$dialog = new PageCreateDialog(
+			null,
+			null,
+			'article',
+			null,
+			'my-article',
+			'My Article'
+		);
+
+		$dialog->submit([]);
+		$page = $app->page('my-article');
+
+		$this->assertSame('my-article', $page->slug());
+		$this->assertSame('My Article', $page->title()->value());
+		$this->assertSame('', $page->text()->value());
+	}
+
+	public function testSubmitWithSlugFromTemplate(): void
+	{
+		// slug field is hidden when create.slug is set; Panel submits slug: ''
+		$app = $this->app([
+			'blueprints' => [
+				'pages/article' => [
+					'create' => [
+						'slug' => 'art-{{ page.category }}'
+					],
+					'fields' => [
+						'category' => ['type' => 'text']
+					]
+				]
+			]
+		]);
+		$app->impersonate('kirby');
+
+		$dialog = new PageCreateDialog(
+			null,
+			null,
+			'article',
+			null,
+			'',          // empty string – simulates hidden slug field
+			'My Article'
+		);
+
+		$dialog->submit(['category' => 'photo']);
+		$page = $app->page('art-photo');
+
+		$this->assertSame('art-photo', $page->slug());
+		$this->assertSame('My Article', $page->title()->value());
+	}
+
+	public function testSubmitWithTitleAndSlugFromTemplate(): void
+	{
+		$app = $this->app([
+			'blueprints' => [
+				'pages/article' => [
+					'create' => [
+						'title'  => 'New: {{ page.category }}',
+						'slug'   => 'cat-{{ page.category }}',
+						'fields' => ['category']
+					],
+					'fields' => [
+						'category' => ['type' => 'text']
+					]
+				]
+			]
+		]);
+		$app->impersonate('kirby');
+
+		$dialog = new PageCreateDialog(
+			null,
+			null,
+			'article',
+			null
+		);
+
+		$dialog->submit(['category' => 'photo']);
+		$page = $app->page('cat-photo');
+
+		$this->assertSame('cat-photo', $page->slug());
+		$this->assertSame('New: photo', $page->title()->value());
+		$this->assertSame('photo', $page->category()->value());
+	}
+
+	public function testSubmitDoesNotLeakParentContent(): void
+	{
+		$app = $this->app([
+			'blueprints' => [
+				'pages/parent-page' => [
+					'fields' => [
+						'text' => ['type' => 'text']
+					]
+				],
+				'pages/article' => [
+					'create' => [
+						'slug' => 'child-{{ page.category }}'
+					],
+					'fields' => [
+						'text'     => ['type' => 'text'],
+						'category' => ['type' => 'text']
+					]
+				]
+			]
+		]);
+		$app->impersonate('kirby');
+
+		Page::create([
+			'slug'     => 'parent',
+			'template' => 'parent-page',
+			'content'  => ['title' => 'Parent', 'text' => 'Parent content']
+		]);
+
+		// parentId uses the pages/id format required by Find::parent()
+		$dialog = new PageCreateDialog(
+			'pages/parent',
+			null,
+			'article',
+			null,
+			'',       // empty string – simulates hidden slug field
+			'Child'
+		);
+
+		$dialog->submit(['category' => 'test']);
+		$child = $app->page('parent/child-test');
+
+		$this->assertSame('child-test', $child->slug());
+		$this->assertSame('Child', $child->title()->value());
+		$this->assertSame('', $child->text()->value());
+	}
 }

--- a/tests/Panel/PageCreateDialogTest.php
+++ b/tests/Panel/PageCreateDialogTest.php
@@ -585,7 +585,7 @@ class PageCreateDialogTest extends AreaTestCase
 			'blueprints' => [
 				'pages/parent-page' => [
 					'fields' => [
-						'text' => ['type' => 'text']
+						'summary' => ['type' => 'text']
 					]
 				],
 				'pages/article' => [
@@ -593,7 +593,6 @@ class PageCreateDialogTest extends AreaTestCase
 						'slug' => 'child-{{ page.category }}'
 					],
 					'fields' => [
-						'text'     => ['type' => 'text'],
 						'category' => ['type' => 'text']
 					]
 				]
@@ -604,7 +603,7 @@ class PageCreateDialogTest extends AreaTestCase
 		Page::create([
 			'slug'     => 'parent',
 			'template' => 'parent-page',
-			'content'  => ['title' => 'Parent', 'text' => 'Parent content']
+			'content'  => ['title' => 'Parent', 'summary' => 'Parent content']
 		]);
 
 		// parentId uses the pages/id format required by Find::parent()
@@ -622,6 +621,13 @@ class PageCreateDialogTest extends AreaTestCase
 
 		$this->assertSame('child-test', $child->slug());
 		$this->assertSame('Child', $child->title()->value());
-		$this->assertSame('', $child->text()->value());
+		$this->assertFalse($child->summary()->exists());
+
+		// read the content file directly to verify no parent data was written to disk
+		$contentFile = $child->version('latest')->contentFile();
+		$content = file_get_contents($contentFile);
+
+		$this->assertStringNotContainsString('Summary', $content);
+		$this->assertStringNotContainsString('Parent content', $content);
 	}
 }


### PR DESCRIPTION
## Description

When `create.slug` is defined in a blueprint, the slug field is hidden and the Panel submits `slug: ''`. The `??` operator doesn't guard against empty strings, so the temp model was created with an empty slug — causing its `root()` to resolve to the `_drafts/` directory, which exists on disk. This made `exists()` return `true` and triggered parent field values to leak into the new child's content file.

**Changes:**
- `PageCreateDialog::model()`: use `?:` instead of `??` to fall back to `'__new__'` for both `null` and `''`
- `Page::__construct()`: also reject empty string slugs, not just `null`

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes

- Child page content file includes parent page field values after save in Panel #7940


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion