### PR TITLE
feat: Auto-unlock when leaving the view

### DIFF
--- a/config/api/routes/changes.php
+++ b/config/api/routes/changes.php
@@ -34,4 +34,13 @@ return [
 			);
 		}
 	],
+	[
+		'pattern' => '(:all)/changes/unlock',
+		'method'  => 'POST',
+		'action'  => function (string $path) {
+			return Changes::unlock(
+				model: Find::parent($path),
+			);
+		}
+	],
 ];

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -301,6 +301,7 @@
 	"error.version.discard.permission": "You are not allowed to discard this version",
 	"error.version.publish.permission": "You are not allowed to publish this version",
 	"error.version.save.permission": "You are not allowed to change this version",
+	"error.version.unlock.permission": "You are not allowed to unlock this version",
 
 	"expand": "Expand",
 	"expand.all": "Expand all",

--- a/panel/src/components/Views/ModelView.vue
+++ b/panel/src/components/Views/ModelView.vue
@@ -62,6 +62,14 @@ export default {
 			return this.lock.modified;
 		}
 	},
+	watch: {
+		api(newApi, oldApi) {
+			// the api has changed when the editor navigated to a view
+			// with the same view component, but a different model. In this
+			// case, we need to unlock view for the old model.
+			this.unlock(oldApi);
+		}
+	},
 	mounted() {
 		this.$events.on("beforeunload", this.onBeforeUnload);
 		this.$events.on("content.save", this.onContentSave);
@@ -77,12 +85,23 @@ export default {
 		this.$events.off("keydown.right", this.toNext);
 		this.$events.off("model.reload", this.$reload);
 		this.$events.off("view.save", this.onViewSave);
+
+		// the view component gets discarded when a different view
+		// is being opened, so let's unlock this view.
+		if (this.isLocked === false) {
+			this.unlock(this.api);
+		}
 	},
 	methods: {
 		onBeforeUnload(e) {
 			if (this.$panel.content.isProcessing === true || this.isSaved === false) {
 				e.preventDefault();
 				e.returnValue = "";
+			}
+
+			// the window or tab is closed, so let's unlock this view.
+			if (this.isLocked === false) {
+				this.unlock(this.api);
 			}
 		},
 		onContentSave({ api, language }) {
@@ -142,6 +161,12 @@ export default {
 			if (this.prev && e.target.localName === "body") {
 				this.$go(this.prev.link);
 			}
+		},
+		unlock(api) {
+			this.$panel.content.unlock({
+				api: api,
+				language: this.$panel.language.code
+			});
 		}
 	}
 };

--- a/panel/src/panel/content.js
+++ b/panel/src/panel/content.js
@@ -324,6 +324,45 @@ export default (panel) => {
 		saveAbortController: null,
 
 		/**
+		 * Releases the content lock without discarding changes.
+		 * Called when the editor navigates away from the view.
+		 */
+		unlock(env = {}) {
+			// Cancel any pending saves first to avoid race conditions
+			this.cancelSaving();
+
+			const { api, language } = this.env(env);
+
+			// Build the URL with csrf and language as query params.
+			// sendBeacon cannot set custom headers.
+			const url = panel.url(`${panel.api.endpoint}${api}/changes/unlock`, {
+				csrf: panel.api.csrf,
+				language: language
+			});
+
+			// Use sendBeacon for reliability during page unload. Browsers
+			// guarantee delivery even when the page is being closed.
+			// Returns true if the request was successfully queued.
+			if (navigator.sendBeacon(url) === true) {
+				return;
+			}
+
+			// Fall back to a regular request if sendBeacon wasn't queued
+			panel.api
+				.post(
+					api + "/changes/unlock",
+					{},
+					{
+						headers: { "x-language": language },
+						silent: true
+					}
+				)
+				.catch(() => {
+					// Silently ignore errors. The lock will expire after 10 minutes anyway.
+				});
+		},
+
+		/**
 		 * Updates the form values of the current view
 		 */
 		async update(values = {}, env = {}) {

--- a/src/Api/Controller/Changes.php
+++ b/src/Api/Controller/Changes.php
@@ -153,4 +153,22 @@ class Changes
 			'status' => 'ok'
 		];
 	}
+
+	/**
+	 * Releases the content lock without discarding changes
+	 */
+	public static function unlock(ModelWithContent $model): array
+	{
+		if ($model->permissions()->can('update') === false) {
+			throw new PermissionException(
+				key: 'version.unlock.permission',
+			);
+		}
+
+		$model->version('changes')->unlock('current');
+
+		return [
+			'status' => 'ok'
+		];
+	}
 }

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -581,6 +581,35 @@ class Version
 	}
 
 	/**
+	 * Removes the lock from the changes version without discarding changes
+	 */
+	public function unlock(Language|string $language = 'default'): void
+	{
+		$language = Language::ensure($language);
+
+		if ($this->exists($language) === false) {
+			return;
+		}
+
+		$fields = $this->read($language);
+
+		// only remove the lock if the current user holds it
+		if (($fields['lock'] ?? null) !== $this->model->kirby()->user()?->id()) {
+			return;
+		}
+
+		unset($fields['lock']);
+
+		$this->model->storage()->update(
+			versionId: $this->id,
+			language:  $language,
+			fields:    $fields
+		);
+
+		VersionCache::remove($this, $language);
+	}
+
+	/**
 	 * Updates the content fields of an existing version
 	 *
 	 * @param array<string, string> $fields Content fields

--- a/tests/Api/Controller/ChangesTest.php
+++ b/tests/Api/Controller/ChangesTest.php
@@ -206,4 +206,34 @@ class ChangesTest extends TestCase
 
 		Changes::save($this->page, []);
 	}
+
+	public function testUnlock(): void
+	{
+		$this->app->impersonate('kirby');
+
+		Data::write($file = $this->page->root() . '/_changes/article.txt', [
+			'title' => 'Test',
+			'uuid'  => 'test',
+			'lock'  => 'kirby'
+		]);
+
+		$response = Changes::unlock($this->page);
+
+		$this->assertSame(['status' => 'ok'], $response);
+
+		$changes = Data::read($file);
+
+		$this->assertSame([
+			'title' => 'Test',
+			'uuid'  => 'test',
+		], $changes);
+	}
+
+	public function testUnlockWithoutPermissions(): void
+	{
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('You are not allowed to unlock this version');
+
+		Changes::unlock($this->page);
+	}
 }

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -1390,6 +1390,69 @@ class VersionTest extends TestCase
 		$this->assertGreaterThanOrEqual($minTime, filemtime($root));
 	}
 
+	public function testUnlockSingleLanguage(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$this->app->impersonate('kirby');
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::changes()
+		);
+
+		$file = $this->contentFile(versionId: VersionId::changes());
+		Data::write($file, [
+			'title' => 'Test',
+			'lock'  => 'kirby'
+		]);
+
+		$version->unlock();
+
+		$this->assertSame(['title' => 'Test'], Data::read($file));
+	}
+
+	public function testUnlockWhenLockedByAnotherUser(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$this->app->impersonate('kirby');
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::changes()
+		);
+
+		$file = $this->contentFile(versionId: VersionId::changes());
+		Data::write($file, [
+			'title' => 'Test',
+			'lock'  => 'another-user'
+		]);
+
+		$version->unlock();
+
+		// lock must remain because the current user doesn't hold it
+		$this->assertSame([
+			'title' => 'Test',
+			'lock'  => 'another-user'
+		], Data::read($file));
+	}
+
+	public function testUnlockWhenNotExists(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$version = new Version(
+			model: $this->model,
+			id: VersionId::changes()
+		);
+
+		// should not throw, just return early
+		$version->unlock();
+
+		$this->assertContentFileDoesNotExist(versionId: VersionId::changes());
+	}
+
 	public function testUpdateMultiLanguage(): void
 	{
 		$this->setUpMultiLanguage();


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements

- A model view will now automatically be unlocked, as soon as the editor leaves the view or closes the tab/window. This will make sure that content-editing is not unnecessarily blocked for other editors. 
  - New `Version::unlock()` method
  - New `panel.content.unlock()` method
  - New `/api/(:all)/changes/unlock` route

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion