### PR TITLE
feat: Optional Frontmatter support

### DIFF
--- a/src/Content/FrontmatterStorage.php
+++ b/src/Content/FrontmatterStorage.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\File;
+use Kirby\Cms\Language;
+use Kirby\Data\Frontmatter;
+use Kirby\Exception\Exception;
+use Kirby\Filesystem\F;
+
+/**
+ * Content storage handler using plain text files
+ * with YAML frontmatter format
+ *
+ * @package   Kirby Content
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.4.0
+ */
+class FrontmatterStorage extends PlainTextStorage
+{
+	/**
+	 * Returns the stored content fields
+	 *
+	 * @return array<string, string>
+	 */
+	public function read(VersionId $versionId, Language $language): array
+	{
+		$contentFile = $this->contentFile($versionId, $language);
+
+		if (file_exists($contentFile) === true) {
+			return Frontmatter::decode(F::read($contentFile));
+		}
+
+		return [];
+	}
+
+	/**
+	 * Writes the content fields of an existing version
+	 *
+	 * @param array<string, string> $fields Content fields
+	 *
+	 * @throws \Kirby\Exception\Exception If the content cannot be written
+	 */
+	protected function write(VersionId $versionId, Language $language, array $fields): void
+	{
+		// only store non-null value fields
+		$fields = array_filter($fields, fn ($field) => $field !== null);
+
+		// for file models with no fields, clean up rather than write an empty file
+		if ($this->model instanceof File && $fields === []) {
+			$this->delete($versionId, $language);
+			return;
+		}
+
+		$success = F::write(
+			$this->contentFile($versionId, $language),
+			Frontmatter::encode($fields)
+		);
+
+		// @codeCoverageIgnoreStart
+		if ($success !== true) {
+			throw new Exception(message: 'Could not write the content file');
+		}
+		// @codeCoverageIgnoreEnd
+	}
+}

--- a/src/Data/Frontmatter.php
+++ b/src/Data/Frontmatter.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Kirby\Data;
+
+/**
+ * Reads and writes YAML frontmatter format:
+ *
+ * ---
+ * title: My Title
+ * uuid: abc123
+ * ---
+ * Optional body stored as `text` field
+ *
+ * @package   Kirby Data
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class Frontmatter extends Handler
+{
+	/**
+	 * The field name used to store the body content
+	 * that appears after the closing --- delimiter
+	 */
+	public const BODY_KEY = 'text';
+
+	public static function decode($string): array
+	{
+		if ($string === null || $string === '') {
+			return [];
+		}
+
+		if (is_array($string) === true) {
+			return $string;
+		}
+
+		// parse standard frontmatter block: opening ---, YAML, closing ---,
+		// and optional body text after the closing delimiter
+		if (preg_match('/^---\r?\n(.*?)\r?\n---\r?\n?(.*)?$/s', $string, $matches)) {
+			$fields = Yaml::decode($matches[1]);
+			$body   = trim($matches[2] ?? '');
+
+			if ($body !== '') {
+				$fields[static::BODY_KEY] = $body;
+			}
+
+			return $fields;
+		}
+
+		// fall back to plain YAML for files without delimiters
+		return Yaml::decode($string);
+	}
+
+	public static function encode($data): string
+	{
+		$body = $data[static::BODY_KEY] ?? null;
+
+		// remove the body key from the frontmatter fields
+		unset($data[static::BODY_KEY]);
+
+		$frontmatter = "---\n" . rtrim(Yaml::encode($data)) . "\n---\n";
+
+		if ($body !== null && trim($body) !== '') {
+			return $frontmatter . $body . "\n";
+		}
+
+		return $frontmatter;
+	}
+}

--- a/src/Data/Frontmatter.php
+++ b/src/Data/Frontmatter.php
@@ -16,6 +16,7 @@ namespace Kirby\Data;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ * @since     5.4.0
  */
 class Frontmatter extends Handler
 {

--- a/tests/Content/FrontmatterStorageTest.php
+++ b/tests/Content/FrontmatterStorageTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Kirby\Content;
+
+use Kirby\Cms\File;
+use Kirby\Cms\Language;
+use Kirby\Data\Frontmatter;
+use Kirby\Filesystem\F;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(FrontmatterStorage::class)]
+class FrontmatterStorageTest extends TestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Content.FrontmatterStorage';
+
+	protected $storage;
+
+	public function setUpMultiLanguage(
+		array|null $site = null
+	): void {
+		parent::setUpMultiLanguage(site: $site);
+
+		$this->storage = new FrontmatterStorage($this->model);
+	}
+
+	public function setUpSingleLanguage(
+		array|null $site = null
+	): void {
+		parent::setUpSingleLanguage(site: $site);
+
+		$this->storage = new FrontmatterStorage($this->model);
+	}
+
+	public function testCreateChangesMultiLang(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$fields = [
+			'title' => 'Foo',
+			'text'  => 'Bar'
+		];
+
+		$this->storage->create(VersionId::changes(), $this->app->language('en'), $fields);
+
+		$contentFile = $this->model->root() . '/_changes/article.en.txt';
+		$this->assertFileExists($contentFile);
+		$this->assertSame($fields, Frontmatter::decode(F::read($contentFile)));
+		$this->assertStringContainsString('---', F::read($contentFile));
+	}
+
+	public function testCreateChangesSingleLang(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$fields = [
+			'title' => 'Foo',
+			'text'  => 'Bar'
+		];
+
+		$this->storage->create(VersionId::changes(), Language::single(), $fields);
+
+		$contentFile = $this->model->root() . '/_changes/article.txt';
+		$this->assertFileExists($contentFile);
+		$this->assertSame($fields, Frontmatter::decode(F::read($contentFile)));
+		$this->assertStringContainsString('---', F::read($contentFile));
+	}
+
+	public function testCreateLatestMultiLang(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$fields = [
+			'title' => 'Foo',
+			'text'  => 'Bar'
+		];
+
+		$this->storage->create(VersionId::latest(), $this->app->language('en'), $fields);
+
+		$contentFile = $this->model->root() . '/article.en.txt';
+		$this->assertFileExists($contentFile);
+		$this->assertSame($fields, Frontmatter::decode(F::read($contentFile)));
+		$this->assertStringContainsString('---', F::read($contentFile));
+	}
+
+	public function testCreateLatestSingleLang(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$fields = [
+			'title' => 'Foo',
+			'text'  => 'Bar'
+		];
+
+		$this->storage->create(VersionId::latest(), Language::single(), $fields);
+
+		$contentFile = $this->model->root() . '/article.txt';
+		$this->assertFileExists($contentFile);
+		$this->assertSame($fields, Frontmatter::decode(F::read($contentFile)));
+		$this->assertStringContainsString('---', F::read($contentFile));
+	}
+
+	public function testRead(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$fields      = ['title' => 'Foo', 'text' => 'Bar'];
+		$contentFile = $this->model->root() . '/article.txt';
+
+		F::write($contentFile, Frontmatter::encode($fields));
+
+		$this->assertSame($fields, $this->storage->read(VersionId::latest(), Language::single()));
+	}
+
+	public function testReadMissingFile(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$this->assertSame([], $this->storage->read(VersionId::latest(), Language::single()));
+	}
+
+	public function testUpdateForFileWithMetaData(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$file = new File([
+			'parent'   => $this->app->site(),
+			'filename' => 'image.jpg'
+		]);
+
+		$storage = new FrontmatterStorage($file);
+		$content = ['alt' => 'Test'];
+
+		$storage->update(VersionId::latest(), Language::single(), $content);
+
+		$contentFile = $file->parent()->root() . '/image.jpg.txt';
+		$this->assertFileExists($contentFile);
+		$this->assertSame($content, Frontmatter::decode(F::read($contentFile)));
+	}
+
+	public function testUpdateForFileWithoutMetaData(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$file = new File([
+			'parent'   => $this->app->site(),
+			'filename' => 'image.jpg'
+		]);
+
+		$storage = new FrontmatterStorage($file);
+		$storage->update(VersionId::latest(), Language::single(), []);
+
+		$this->assertFileDoesNotExist($file->parent()->root() . '/image.jpg.txt');
+	}
+}

--- a/tests/Data/FrontmatterTest.php
+++ b/tests/Data/FrontmatterTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Kirby\Data;
+
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Frontmatter::class)]
+class FrontmatterTest extends TestCase
+{
+	public function testDecodeEmpty(): void
+	{
+		$this->assertSame([], Frontmatter::decode(null));
+		$this->assertSame([], Frontmatter::decode(''));
+	}
+
+	public function testDecodeWithArray(): void
+	{
+		$this->assertSame(
+			['this is' => 'an array'],
+			Frontmatter::decode(['this is' => 'an array'])
+		);
+	}
+
+	public function testDecodeStandardFrontmatter(): void
+	{
+		$string = "---\ntitle: My Title\nuuid: abc123\n---\n";
+
+		$this->assertSame([
+			'title' => 'My Title',
+			'uuid'  => 'abc123'
+		], Frontmatter::decode($string));
+	}
+
+	public function testDecodeWithBody(): void
+	{
+		$string = "---\ntitle: My Title\n---\nThis is the body text.\nIt can contain **Markdown**.\n";
+
+		$this->assertSame([
+			'title' => 'My Title',
+			'text'  => "This is the body text.\nIt can contain **Markdown**."
+		], Frontmatter::decode($string));
+	}
+
+	public function testDecodeWithBodyAndTextField(): void
+	{
+		// body after closing --- wins over text field in YAML block
+		$string = "---\ntitle: My Title\ntext: from yaml\n---\nThis is the body.\n";
+
+		$this->assertSame([
+			'title' => 'My Title',
+			'text'  => 'This is the body.'
+		], Frontmatter::decode($string));
+	}
+
+	public function testDecodeEmptyBody(): void
+	{
+		// empty body should not produce a text key
+		$string = "---\ntitle: My Title\n---\n";
+
+		$this->assertSame([
+			'title' => 'My Title'
+		], Frontmatter::decode($string));
+	}
+
+	public function testDecodeFallback(): void
+	{
+		// string without --- delimiters falls back to plain YAML
+		$string = "title: My Title\nuuid: abc123\n";
+
+		$this->assertSame([
+			'title' => 'My Title',
+			'uuid'  => 'abc123'
+		], Frontmatter::decode($string));
+	}
+
+	public function testEncode(): void
+	{
+		$data = [
+			'title' => 'My Title',
+			'uuid'  => 'abc123'
+		];
+
+		$this->assertSame(
+			"---\ntitle: My Title\nuuid: abc123\n---\n",
+			Frontmatter::encode($data)
+		);
+	}
+
+	public function testEncodeWithBody(): void
+	{
+		$data = [
+			'title' => 'My Title',
+			'text'  => 'This is the body.'
+		];
+
+		$this->assertSame(
+			"---\ntitle: My Title\n---\nThis is the body.\n",
+			Frontmatter::encode($data)
+		);
+	}
+
+	public function testEncodeWithEmptyBody(): void
+	{
+		$data = [
+			'title' => 'My Title',
+			'text'  => ''
+		];
+
+		$this->assertSame(
+			"---\ntitle: My Title\n---\n",
+			Frontmatter::encode($data)
+		);
+	}
+
+	public function testRoundtrip(): void
+	{
+		$data = [
+			'title' => 'My Title',
+			'uuid'  => 'abc123'
+		];
+
+		$this->assertSame($data, Frontmatter::decode(Frontmatter::encode($data)));
+
+		$dataWithBody = [
+			'title' => 'My Title',
+			'text'  => 'This is the body text.'
+		];
+
+		$this->assertSame($dataWithBody, Frontmatter::decode(Frontmatter::encode($dataWithBody)));
+	}
+}


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements

- New `Kirby\Data\Frontmatter` handler
- New `Kirby\Content\FrontmatterStorage` handler

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

Frontmatter support can now be activated by overwriting the storage component in a simple plugin: 

```php
// site/plugins/frontmatter/index.php

use Kirby\Cms\App;
use Kirby\Cms\ModelWithContent;
use Kirby\Content\FrontmatterStorage;

App::plugin('getkirby/frontmatter', [
  'components' => [
	'storage' => function (
		App $kirby,
		ModelWithContent $model
	): Storage {
		return new FrontmatterStorage(model: $model);
	},
  ] 
]);
```

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion