### PR TITLE
fix: preserve content representation extension in multilingual url component

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -399,12 +399,20 @@ return [
 
 			if ($parts[0] ?? null) {
 				$page = $kirby->site()->find($parts[0]);
+
+				// get the extension of the url, if there is one, to add it back later
+				$extension = F::extension($parts[0]);
 			} else {
 				$page = $kirby->site()->page();
 			}
 
 			if ($page) {
 				$path = $page->url($language);
+
+				// add the extension back to the url, if there was one
+				if (empty($extension) === false) {
+					$path .= '.' . $extension;
+				}
 
 				if (isset($parts[1]) === true) {
 					$path .= '#' . $parts[1];

--- a/config/components.php
+++ b/config/components.php
@@ -410,7 +410,7 @@ return [
 				$path = $page->url($language);
 
 				// add the extension back to the url, if there was one
-				if (empty($extension) === false) {
+				if ($extension !== '') {
 					$path .= '.' . $extension;
 				}
 

--- a/config/components.php
+++ b/config/components.php
@@ -410,7 +410,7 @@ return [
 				$path = $page->url($language);
 
 				// add the extension back to the url, if there was one
-				if ($extension !== '') {
+				if (isset($extension) === true && $extension !== '') {
 					$path .= '.' . $extension;
 				}
 

--- a/tests/Cms/App/AppComponentsTest.php
+++ b/tests/Cms/App/AppComponentsTest.php
@@ -384,6 +384,57 @@ class AppComponentsTest extends TestCase
 		$this->assertInstanceOf(Template::class, $this->app->template('default'));
 	}
 
+	public function testUrlPreservesExtensionOnMultilangSite(): void
+	{
+		$this->app->clone([
+			'urls' => [
+				'index' => 'https://getkirby.com'
+			],
+			'languages' => [
+				[
+					'code'    => 'en',
+					'name'    => 'English',
+					'default' => true,
+					'url'     => '/'
+				],
+				[
+					'code'    => 'de',
+					'name'    => 'Deutsch',
+					'url'     => '/de'
+				]
+			],
+			'site' => [
+				'children' => [
+					['slug' => 'articles']
+				]
+			]
+		]);
+
+		// extension is preserved for the default language
+		$this->assertSame(
+			'https://getkirby.com/articles.xml',
+			url('articles.xml')
+		);
+
+		// extension is preserved for a secondary language
+		$this->assertSame(
+			'https://getkirby.com/de/articles.xml',
+			url('articles.xml', 'de')
+		);
+
+		// works without extension as before
+		$this->assertSame(
+			'https://getkirby.com/articles',
+			url('articles')
+		);
+
+		// fragment is still appended correctly alongside the extension
+		$this->assertSame(
+			'https://getkirby.com/articles.xml#section',
+			url('articles.xml#section')
+		);
+	}
+
 	public function testUrlPlugin(): void
 	{
 		$this->app->clone([


### PR DESCRIPTION
## Description

On multilingual sites, the `url` component was dropping content representation extensions (`.xml`, `.json`, etc.) because the internal page lookup strips them and nobody put them back. This fix saves the extension before the lookup and appends it to the result.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Url::to() strips content representation extension on multilang sites #7965


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion