### PR TITLE
fix: Continue table index across paginated section tables

### DIFF
--- a/panel/lab/components/collections/4_table/index.vue
+++ b/panel/lab/components/collections/4_table/index.vue
@@ -1,0 +1,56 @@
+<template>
+	<k-lab-examples>
+		<k-lab-example label="table">
+			<k-collection
+				:columns="columns"
+				:items="tableItems"
+				:empty="empty"
+				layout="table"
+			/>
+		</k-lab-example>
+
+		<k-lab-example label="table pagination index">
+			<k-collection
+				:columns="columns"
+				:items="tableItems"
+				:empty="empty"
+				layout="table"
+				:pagination="tablePagination"
+			/>
+		</k-lab-example>
+	</k-lab-examples>
+</template>
+
+<script>
+export default {
+	props: {
+		empty: Object,
+		items: Array,
+		pagination: Object
+	},
+	computed: {
+		columns() {
+			return {
+				title: {
+					label: "Title"
+				},
+				info: {
+					label: "Info"
+				}
+			};
+		},
+		tableItems() {
+			return this.items.slice(0, 8).map((item, index) => ({
+				title: item.text ?? `Item ${index + 1}`,
+				info: item.info ?? "Some info text"
+			}));
+		},
+		tablePagination() {
+			return {
+				...this.pagination,
+				offset: 16
+			};
+		}
+	}
+};
+</script>

--- a/panel/lab/components/items/4_table/index.vue
+++ b/panel/lab/components/items/4_table/index.vue
@@ -8,6 +8,9 @@
 				layout="table"
 			/>
 		</k-lab-example>
+		<k-lab-example label="custom start index">
+			<k-items :columns="columns" :items="items" :index="17" layout="table" />
+		</k-lab-example>
 		<k-lab-example label="Selectable">
 			<k-items
 				:columns="columns"

--- a/panel/src/components/Collection/Collection.vue
+++ b/panel/src/components/Collection/Collection.vue
@@ -12,6 +12,7 @@
 			v-bind="{
 				columns,
 				fields,
+				index: resolvedIndex,
 				items,
 				layout,
 				link,
@@ -101,6 +102,9 @@ export default {
 				};
 			}
 			return {};
+		},
+		resolvedIndex() {
+			return (this.paginationOptions.offset ?? this.index - 1) + 1;
 		},
 		paginationOptions() {
 			const options =

--- a/panel/src/components/Collection/Items.vue
+++ b/panel/src/components/Collection/Items.vue
@@ -92,6 +92,13 @@ export const props = {
 			default: () => []
 		},
 		/**
+		 * Index number for first row in table layout
+		 */
+		index: {
+			type: Number,
+			default: 1
+		},
+		/**
 		 * Enable/disable that each item is a clickable link
 		 */
 		link: {
@@ -157,6 +164,7 @@ export default {
 			return {
 				columns: this.columns,
 				fields: this.fields,
+				index: this.index,
 				rows: this.items,
 				selecting: this.selecting,
 				sortable: this.sortable


### PR DESCRIPTION
## Description

Fix table index numbering in Panel section tables when pagination is enabled.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes

- Pages section table index resets to 1 on each pagination page #8002


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion