### PR TITLE
refact: Improve Permission class

### DIFF
--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -674,7 +674,7 @@ class Blueprint
 
 		// set all options to false
 		if ($options === false) {
-			return array_map(fn () => false, $defaults);
+			return array_fill_keys(array_keys($defaults), false);
 		}
 
 		// extend options if possible

--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -32,6 +32,9 @@ class Helpers
 		// The internal `$model->contentFile*()` methods have been deprecated
 		'model-content-file' => true,
 
+		// Passing `$category = null` to `Permissions::for()` is not supported
+		'permissions-for-category-null' => true,
+
 		// Passing an `info` array inside the `extends` array
 		// has been deprecated. Pass the individual entries (e.g. root, version)
 		// directly as named arguments.

--- a/src/Cms/Permissions.php
+++ b/src/Cms/Permissions.php
@@ -177,16 +177,20 @@ class Permissions
 
 	protected function get(string $category, string|null $action = null): mixed
 	{
-		return is_string($action) === true
-			? $this->actions[$category][$action]
-			: $this->actions[$category];
+		if (is_string($action) === true) {
+			return $this->actions[$category][$action];
+		}
+		
+		return $this->actions[$category];
 	}
 
 	protected function has(string $category, string|null $action = null): bool
 	{
-		return is_string($action) === true
-			? isset($this->actions[$category][$action])
-			: isset($this->actions[$category]);
+		if (is_string($action) === true) {
+			return isset($this->actions[$category][$action]);
+		}
+		
+		return isset($this->actions[$category]);
 	}
 
 	protected function normalize(

--- a/src/Cms/Permissions.php
+++ b/src/Cms/Permissions.php
@@ -186,7 +186,7 @@ class Permissions
 		if (is_string($action) === true) {
 			return $this->actions[$category][$action];
 		}
-		
+
 		return $this->actions[$category];
 	}
 
@@ -198,7 +198,7 @@ class Permissions
 		if (is_string($action) === true) {
 			return isset($this->actions[$category][$action]);
 		}
-		
+
 		return isset($this->actions[$category]);
 	}
 

--- a/src/Cms/Permissions.php
+++ b/src/Cms/Permissions.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\LogicException;
 
 /**
  * Handles permission definition in each user
@@ -19,17 +20,17 @@ class Permissions
 {
 	public static array $extendedActions = [];
 
-	protected array $actions = [
+	protected array $defaults = [
 		'access' => [
 			'account'   => true,
 			'languages' => true,
 			'panel'     => true,
 			'site'      => true,
 			'system'    => true,
-			'users'     => true,
+			'users'     => true
 		],
 		'files' => [
-			'access'     	 => true,
+			'access'         => true,
 			'changeName'     => true,
 			'changeTemplate' => true,
 			'create'         => true,
@@ -46,7 +47,7 @@ class Permissions
 			'update' => true
 		],
 		'pages' => [
-			'access'     	 => true,
+			'access'         => true,
 			'changeSlug'     => true,
 			'changeStatus'   => true,
 			'changeTemplate' => true,
@@ -86,6 +87,8 @@ class Permissions
 		]
 	];
 
+	protected array $actions;
+
 	/**
 	 * Permissions constructor
 	 *
@@ -93,125 +96,120 @@ class Permissions
 	 */
 	public function __construct(array|bool|null $settings = [])
 	{
+		$defaults = $this->defaults;
+
 		// dynamically register the extended actions
 		foreach (static::$extendedActions as $key => $actions) {
-			if (isset($this->actions[$key]) === true) {
+			if (isset($defaults[$key]) === true) {
 				throw new InvalidArgumentException(
 					message: 'The action ' . $key . ' is already a core action'
 				);
 			}
 
-			$this->actions[$key] = $actions;
+			$defaults[$key] = $actions;
 		}
 
-		if (is_array($settings) === true) {
-			return $this->setCategories($settings);
-		}
-
-		if (is_bool($settings) === true) {
-			return $this->setAll($settings);
-		}
+		$this->actions = $this->normalize(
+			settings: $settings,
+			defaults: $defaults
+		);
 	}
 
+	protected function expand(
+		array|bool|null $values,
+		array $defaults = []
+	): array {
+		if (is_bool($values) === true) {
+			$values = ['*' => $values];
+		}
+
+		if (is_array($values) === false) {
+			return [];
+		}
+
+		if (array_key_exists('*', $values) === true) {
+			$values += array_fill_keys(
+				array_keys($defaults),
+				$values['*']
+			);
+
+			unset($values['*']);
+		}
+
+		return $values;
+	}
+
+	/**
+	 * @todo Replace first param with `string $category` in v6
+	 */
 	public function for(
 		string|null $category = null,
 		string|null $action = null,
 		bool $default = false
 	): bool {
-		if ($action === null) {
-			if ($this->hasCategory($category) === false) {
-				return $default;
-			}
+		if (is_null($category) === true) {
+			Helpers::deprecated(
+				'Passing `$category = null` to `Permissions::for()` is not supported',
+				'permissions-for-category-null'
+			);
 
-			return $this->actions[$category];
-		}
-
-		if ($this->hasAction($category, $action) === false) {
 			return $default;
 		}
 
-		return $this->actions[$category][$action];
-	}
-
-	protected function hasAction(string $category, string $action): bool
-	{
-		return
-			$this->hasCategory($category) === true &&
-			array_key_exists($action, $this->actions[$category]) === true;
-	}
-
-	protected function hasCategory(string $category): bool
-	{
-		return array_key_exists($category, $this->actions) === true;
-	}
-
-	/**
-	 * @return $this
-	 */
-	protected function setAction(
-		string $category,
-		string $action,
-		$setting
-	): static {
-		// wildcard to overwrite the entire category
-		if ($action === '*') {
-			return $this->setCategory($category, $setting);
+		if ($this->has($category, $action) === false) {
+			return $default;
 		}
 
-		$this->actions[$category][$action] = $setting;
+		$permission = $this->get($category, $action);
 
-		return $this;
-	}
+		if (is_bool($permission) === false) {
+			$key = is_string($action) === true
+				? $category . '.' . $action
+				: $category;
 
-	/**
-	 * @return $this
-	 */
-	protected function setAll(bool $setting): static
-	{
-		foreach ($this->actions as $categoryName => $actions) {
-			$this->setCategory($categoryName, $setting);
+			throw new LogicException(
+				message: 'The value for the permission "' . $key . '" must be of type bool, ' . gettype($permission) . ' given'
+			);
 		}
 
-		return $this;
+		return $permission;
 	}
 
-	/**
-	 * @return $this
-	 */
-	protected function setCategories(array $settings): static
+	protected function get(string $category, string|null $action = null): mixed
 	{
-		foreach ($settings as $name => $actions) {
-			if (is_bool($actions) === true) {
-				$this->setCategory($name, $actions);
+		return is_string($action) === true
+			? $this->actions[$category][$action]
+			: $this->actions[$category];
+	}
+
+	protected function has(string $category, string|null $action = null): bool
+	{
+		return is_string($action) === true
+			? isset($this->actions[$category][$action])
+			: isset($this->actions[$category]);
+	}
+
+	protected function normalize(
+		array|bool|null $settings,
+		array $defaults = []
+	): array {
+		$categories = $this->expand($settings, $defaults);
+
+		foreach ($categories as $category => $actions) {
+			if (isset($defaults[$category]) === false) {
+				continue;
 			}
 
-			if (is_array($actions) === true) {
-				foreach ($actions as $action => $setting) {
-					$this->setAction($name, $action, $setting);
+			$actions = $this->expand($actions, $defaults[$category]);
+
+			foreach ($actions as $key => $value) {
+				if (isset($defaults[$category][$key]) === true) {
+					$defaults[$category][$key] = (bool)$value;
 				}
 			}
 		}
 
-		return $this;
-	}
-
-	/**
-	 * @return $this
-	 * @throws \Kirby\Exception\InvalidArgumentException
-	 */
-	protected function setCategory(string $category, bool $setting): static
-	{
-		if ($this->hasCategory($category) === false) {
-			throw new InvalidArgumentException(
-				message: 'Invalid permissions category'
-			);
-		}
-
-		foreach ($this->actions[$category] as $action => $actionSetting) {
-			$this->actions[$category][$action] = $setting;
-		}
-
-		return $this;
+		return $defaults;
 	}
 
 	public function toArray(): array

--- a/src/Cms/Permissions.php
+++ b/src/Cms/Permissions.php
@@ -115,6 +115,9 @@ class Permissions
 		);
 	}
 
+	/**
+	 * Expands a bool or null shorthand into a full actions array
+	 */
 	protected function expand(
 		array|bool|null $values,
 		array $defaults = []
@@ -175,6 +178,9 @@ class Permissions
 		return $permission;
 	}
 
+	/**
+	 * Returns the permission value for a category or a specific action
+	 */
 	protected function get(string $category, string|null $action = null): mixed
 	{
 		if (is_string($action) === true) {
@@ -184,6 +190,9 @@ class Permissions
 		return $this->actions[$category];
 	}
 
+	/**
+	 * Checks whether a category or specific action exists in the actions array
+	 */
 	protected function has(string $category, string|null $action = null): bool
 	{
 		if (is_string($action) === true) {
@@ -193,6 +202,9 @@ class Permissions
 		return isset($this->actions[$category]);
 	}
 
+	/**
+	 * Normalizes the permission settings against the defaults
+	 */
 	protected function normalize(
 		array|bool|null $settings,
 		array $defaults = []
@@ -216,6 +228,9 @@ class Permissions
 		return $defaults;
 	}
 
+	/**
+	 * Returns all permissions as an array
+	 */
 	public function toArray(): array
 	{
 		return $this->actions;

--- a/src/Cms/Permissions.php
+++ b/src/Cms/Permissions.php
@@ -220,7 +220,13 @@ class Permissions
 
 			foreach ($actions as $key => $value) {
 				if (isset($defaults[$category][$key]) === true) {
-					$defaults[$category][$key] = (bool)$value;
+					if (is_bool($value) === false) {
+						throw new LogicException(
+							message: 'The value for the permission "' . $category . '.' . $key . '" must be of type bool, ' . gettype($value) . ' given'
+						);
+					}
+
+					$defaults[$category][$key] = $value;
 				}
 			}
 		}

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -703,6 +703,19 @@ class BlueprintTest extends TestCase
 		$this->assertArrayNotHasKey('child-field', $blueprint->fields());
 	}
 
+	public function testNormalizeOptionsFalse(): void
+	{
+		$blueprint = new PageBlueprint([
+			'model'   => $this->model,
+			'options' => false,
+		]);
+
+		// all keys from defaults are present and every value is false, not null
+		foreach ($blueprint->options() as $key => $value) {
+			$this->assertFalse($value, "Option '$key' should be false");
+		}
+	}
+
 	public function testInvalidSectionType(): void
 	{
 		$blueprint = new Blueprint([

--- a/tests/Cms/Permissions/PermissionsTest.php
+++ b/tests/Cms/Permissions/PermissionsTest.php
@@ -260,6 +260,16 @@ class PermissionsTest extends TestCase
 		restore_error_handler();
 	}
 
+	public function testForWithNonBoolValueThrowsException(): void
+	{
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage(
+			'The value for the permission "pages.read" must be of type bool, string given'
+		);
+
+		new Permissions(['pages' => ['read' => 'yes']]);
+	}
+
 	public function testForWithoutActionThrowsException(): void
 	{
 		$p = new Permissions();

--- a/tests/Cms/Permissions/PermissionsTest.php
+++ b/tests/Cms/Permissions/PermissionsTest.php
@@ -140,7 +140,7 @@ class PermissionsTest extends TestCase
 		$this->assertTrue($p->for('pages', 'read'));
 		$this->assertFalse($p->for('pages', 'update'));
 		$this->assertFalse($p->for('pages', 'delete'));
-		
+
 		// explicit value also takes precedence if defined before wildcard
 		$p = new Permissions(['pages' => ['read' => true, '*' => false]]);
 		$this->assertTrue($p->for('pages', 'read'));
@@ -197,7 +197,7 @@ class PermissionsTest extends TestCase
 				'another'     => false
 			]
 		];
-		
+
 		// defaults are used if not overridden
 		$p = new Permissions();
 		$this->assertTrue($p->for('test-category', 'test-action'));

--- a/tests/Cms/Permissions/PermissionsTest.php
+++ b/tests/Cms/Permissions/PermissionsTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\LogicException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -68,6 +69,22 @@ class PermissionsTest extends TestCase
 		];
 	}
 
+	public function testActionIsolation(): void
+	{
+		// disabling a single action leaves the rest of the category intact
+		$p = new Permissions(['pages' => ['delete' => false]]);
+		$this->assertFalse($p->for('pages', 'delete'));
+		$this->assertTrue($p->for('pages', 'read'));
+		$this->assertTrue($p->for('pages', 'update'));
+		$this->assertTrue($p->for('pages', 'create'));
+
+		// disabling an entire category does not affect other categories
+		$p = new Permissions(['pages' => false]);
+		$this->assertFalse($p->for('pages', 'read'));
+		$this->assertTrue($p->for('files', 'read'));
+		$this->assertTrue($p->for('site', 'update'));
+	}
+
 	#[DataProvider('actionsProvider')]
 	public function testActions(string $category, $action): void
 	{
@@ -104,6 +121,25 @@ class PermissionsTest extends TestCase
 		]);
 
 		$this->assertTrue($p->for($category, $action));
+	}
+
+	public function testActionWildcard(): void
+	{
+		// wildcard disables all actions in a category
+		$p = new Permissions(['pages' => ['*' => false]]);
+		$this->assertFalse($p->for('pages', 'read'));
+		$this->assertFalse($p->for('pages', 'update'));
+		$this->assertFalse($p->for('pages', 'delete'));
+
+		// other categories are unaffected
+		$this->assertTrue($p->for('files', 'read'));
+		$this->assertTrue($p->for('site', 'update'));
+
+		// explicit value after wildcard takes precedence
+		$p = new Permissions(['pages' => ['*' => false, 'read' => true]]);
+		$this->assertTrue($p->for('pages', 'read'));
+		$this->assertFalse($p->for('pages', 'update'));
+		$this->assertFalse($p->for('pages', 'delete'));
 	}
 
 	public function testExtendActions(): void
@@ -147,6 +183,26 @@ class PermissionsTest extends TestCase
 		new Permissions();
 	}
 
+	public function testExtendActionsWithCategoryBool(): void
+	{
+		Permissions::$extendedActions = [
+			'test-category' => [
+				'test-action' => true,
+				'another'     => true
+			]
+		];
+
+		// category-level false disables all extended actions
+		$p = new Permissions(['test-category' => false]);
+		$this->assertFalse($p->for('test-category', 'test-action'));
+		$this->assertFalse($p->for('test-category', 'another'));
+
+		// category-level true keeps all extended actions enabled
+		$p = new Permissions(['test-category' => true]);
+		$this->assertTrue($p->for('test-category', 'test-action'));
+		$this->assertTrue($p->for('test-category', 'another'));
+	}
+
 	public function testForDefault(): void
 	{
 		// exists
@@ -168,5 +224,110 @@ class PermissionsTest extends TestCase
 		// action does not exist with custom default
 		$p = new Permissions();
 		$this->assertTrue($p->for('access', 'foo', default:true));
+	}
+
+	public function testForNullCategory(): void
+	{
+		$p       = new Permissions();
+		$message = null;
+
+		set_error_handler(function (int $errno, string $errstr) use (&$message) {
+			$message = $errstr;
+			return true;
+		}, E_USER_DEPRECATED);
+
+		// returns false default and triggers deprecation
+		$this->assertFalse($p->for(null));
+		$this->assertSame(
+			'Passing `$category = null` to `Permissions::for()` is not supported',
+			$message
+		);
+
+		// returns custom default
+		$this->assertTrue($p->for(null, default: true));
+
+		restore_error_handler();
+	}
+
+	public function testForWithoutActionThrowsException(): void
+	{
+		$p = new Permissions();
+
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage(
+			'The value for the permission "pages" must be of type bool, array given'
+		);
+
+		$p->for('pages');
+	}
+
+	public function testMixedSettings(): void
+	{
+		$p = new Permissions([
+			'pages' => false,
+			'files' => ['delete' => false],
+		]);
+
+		// all page actions disabled
+		$this->assertFalse($p->for('pages', 'read'));
+		$this->assertFalse($p->for('pages', 'update'));
+		$this->assertFalse($p->for('pages', 'delete'));
+
+		// only files.delete disabled, rest untouched
+		$this->assertFalse($p->for('files', 'delete'));
+		$this->assertTrue($p->for('files', 'read'));
+		$this->assertTrue($p->for('files', 'update'));
+
+		// unrelated categories unaffected
+		$this->assertTrue($p->for('site', 'update'));
+		$this->assertTrue($p->for('users', 'create'));
+	}
+
+	public function testNullSettings(): void
+	{
+		// null behaves identically to empty array — all defaults apply
+		$p = new Permissions(null);
+		$this->assertTrue($p->for('pages', 'read'));
+		$this->assertTrue($p->for('files', 'update'));
+		$this->assertTrue($p->for('site', 'changeTitle'));
+		$this->assertTrue($p->for('users', 'create'));
+	}
+
+	public function testToArray(): void
+	{
+		// default: all core categories present
+		$p     = new Permissions();
+		$array = $p->toArray();
+
+		$this->assertArrayHasKey('access', $array);
+		$this->assertArrayHasKey('files', $array);
+		$this->assertArrayHasKey('languages', $array);
+		$this->assertArrayHasKey('pages', $array);
+		$this->assertArrayHasKey('site', $array);
+		$this->assertArrayHasKey('user', $array);
+		$this->assertArrayHasKey('users', $array);
+
+		// default values are true
+		$this->assertTrue($array['pages']['read']);
+		$this->assertTrue($array['site']['update']);
+
+		// modified permissions are reflected
+		$p     = new Permissions(['pages' => ['delete' => false]]);
+		$array = $p->toArray();
+		$this->assertFalse($array['pages']['delete']);
+		$this->assertTrue($array['pages']['read']);
+	}
+
+	public function testUnknownSettingsIgnored(): void
+	{
+		// unknown category is silently ignored, all defaults kept
+		$p = new Permissions(['nonexistent' => false]);
+		$this->assertTrue($p->for('pages', 'read'));
+		$this->assertTrue($p->for('files', 'update'));
+
+		// unknown action is silently ignored, known actions kept
+		$p = new Permissions(['pages' => ['nonexistent' => false]]);
+		$this->assertTrue($p->for('pages', 'read'));
+		$this->assertTrue($p->for('pages', 'update'));
 	}
 }

--- a/tests/Cms/Permissions/PermissionsTest.php
+++ b/tests/Cms/Permissions/PermissionsTest.php
@@ -140,6 +140,12 @@ class PermissionsTest extends TestCase
 		$this->assertTrue($p->for('pages', 'read'));
 		$this->assertFalse($p->for('pages', 'update'));
 		$this->assertFalse($p->for('pages', 'delete'));
+		
+		// explicit value also takes precedence if defined before wildcard
+		$p = new Permissions(['pages' => ['read' => true, '*' => false]]);
+		$this->assertTrue($p->for('pages', 'read'));
+		$this->assertFalse($p->for('pages', 'update'));
+		$this->assertFalse($p->for('pages', 'delete'));
 	}
 
 	public function testExtendActions(): void
@@ -188,9 +194,14 @@ class PermissionsTest extends TestCase
 		Permissions::$extendedActions = [
 			'test-category' => [
 				'test-action' => true,
-				'another'     => true
+				'another'     => false
 			]
 		];
+		
+		// defaults are used if not overridden
+		$p = new Permissions();
+		$this->assertTrue($p->for('test-category', 'test-action'));
+		$this->assertFalse($p->for('test-category', 'another'));
 
 		// category-level false disables all extended actions
 		$p = new Permissions(['test-category' => false]);


### PR DESCRIPTION
## Description

This PR extracts work from @lukaskleinschmidt's PR https://github.com/getkirby/kirby/pull/7896 to isolate the Permission class refactoring, simplify review and add new tests.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ♻️ Refactored

- Renamed `Permissions::$actions` property to `$defaults`; added separate protected array `$actions` populated by the constructor
- Replaced 6 old methods (`Permissions::setAll`, `Permissions::setCategory`, `Permissions::setCategories`, `Permissions::setAction`, `Permissions::hasAction`, `Permissions::hasCategory`) with 4 cleaner ones: `Permissions::normalize()`, `Permissions::expand()`, `Permissions::get()`, `Permissions::has()`
- `Permissions::normalize()` and `Permissions::expand()` handle all four input shapes: `null`, `bool`, `['cat' => bool]`, `['cat' => ['action' => bool]]`,  including `*` wildcard at both levels.
- `Permissions::for()` now deprecates `$category = null` via `Helpers::deprecated()` and throws `LogicException` if a stored value is somehow not a bool
- Slightly refactored the Blueprint class: `array_fill_keys(array_keys($defaults), false)` instead of `array_map(fn () => false, $defaults)`.

### 🧹Housekeeping

- New Unit tests for the Permissions class
- New Unit test for the new option normalization in the Blueprint class

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion