### PR TITLE
feat: Allow all extensions to be defined in the config

### DIFF
--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -762,12 +762,15 @@ trait AppPlugins
 	 */
 	protected function extensionsFromOptions(): void
 	{
-		// register routes and hooks from options
+		// directly register api components, routes and hooks from options.
 		$this->extend([
 			'api'    => $this->options['api']    ?? [],
 			'routes' => $this->options['routes'] ?? [],
 			'hooks'  => $this->options['hooks']  ?? []
 		]);
+
+		// register everything under the extensions key
+		$this->extend($this->options['extensions'] ?? []);
 	}
 
 	/**


### PR DESCRIPTION
## Description

This is based on feedback from our partners office hour. 

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements

It's now possible to define any extension directly in your config, to be able to set site-specific extensions without creating a helper plugin. 

```php
// /site/config/config.php

return [
  'extensions' => [
    'pageModels' => [
      // ...
    ],
    'blueprints' => [
      // ...
    ]
  ]
];

```

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion