### PR TITLE
feat: New Frontmatter Data Handler

### DIFF
--- a/src/Data/Frontmatter.php
+++ b/src/Data/Frontmatter.php
@@ -23,7 +23,7 @@ class Frontmatter extends Handler
 	 * The field name used to store the body content
 	 * that appears after the closing --- delimiter
 	 */
-	public const BODY_KEY = 'text';
+	public static string $body = 'text';
 
 	public static function decode($string): array
 	{
@@ -42,7 +42,7 @@ class Frontmatter extends Handler
 			$body   = trim($matches[2] ?? '');
 
 			if ($body !== '') {
-				$fields[static::BODY_KEY] = $body;
+				$fields[static::$body] = $body;
 			}
 
 			return $fields;
@@ -54,10 +54,10 @@ class Frontmatter extends Handler
 
 	public static function encode($data): string
 	{
-		$body = $data[static::BODY_KEY] ?? null;
+		$body = $data[static::$body] ?? null;
 
 		// remove the body key from the frontmatter fields
-		unset($data[static::BODY_KEY]);
+		unset($data[static::$body]);
 
 		$frontmatter = "---\n" . rtrim(Yaml::encode($data)) . "\n---\n";
 

--- a/src/Data/Frontmatter.php
+++ b/src/Data/Frontmatter.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Kirby\Data;
+
+/**
+ * Reads and writes YAML frontmatter format:
+ *
+ * ---
+ * title: My Title
+ * uuid: abc123
+ * ---
+ * Optional body stored as `text` field
+ *
+ * @package   Kirby Data
+ * @author    Bastian Allgeier <bastian@getkirby.com>
+ * @link      https://getkirby.com
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class Frontmatter extends Handler
+{
+	/**
+	 * The field name used to store the body content
+	 * that appears after the closing --- delimiter
+	 */
+	public const BODY_KEY = 'text';
+
+	public static function decode($string): array
+	{
+		if ($string === null || $string === '') {
+			return [];
+		}
+
+		if (is_array($string) === true) {
+			return $string;
+		}
+
+		// parse standard frontmatter block: opening ---, YAML, closing ---,
+		// and optional body text after the closing delimiter
+		if (preg_match('/^---\r?\n(.*?)\r?\n---\r?\n?(.*)?$/s', $string, $matches)) {
+			$fields = Yaml::decode($matches[1]);
+			$body   = trim($matches[2] ?? '');
+
+			if ($body !== '') {
+				$fields[static::BODY_KEY] = $body;
+			}
+
+			return $fields;
+		}
+
+		// fall back to plain YAML for files without delimiters
+		return Yaml::decode($string);
+	}
+
+	public static function encode($data): string
+	{
+		$body = $data[static::BODY_KEY] ?? null;
+
+		// remove the body key from the frontmatter fields
+		unset($data[static::BODY_KEY]);
+
+		$frontmatter = "---\n" . rtrim(Yaml::encode($data)) . "\n---\n";
+
+		if ($body !== null && trim($body) !== '') {
+			return $frontmatter . $body . "\n";
+		}
+
+		return $frontmatter;
+	}
+}

--- a/tests/Data/FrontmatterTest.php
+++ b/tests/Data/FrontmatterTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Kirby\Data;
+
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Frontmatter::class)]
+class FrontmatterTest extends TestCase
+{
+	public function testDecodeEmpty(): void
+	{
+		$this->assertSame([], Frontmatter::decode(null));
+		$this->assertSame([], Frontmatter::decode(''));
+	}
+
+	public function testDecodeWithArray(): void
+	{
+		$this->assertSame(
+			['this is' => 'an array'],
+			Frontmatter::decode(['this is' => 'an array'])
+		);
+	}
+
+	public function testDecodeStandardFrontmatter(): void
+	{
+		$string = "---\ntitle: My Title\nuuid: abc123\n---\n";
+
+		$this->assertSame([
+			'title' => 'My Title',
+			'uuid'  => 'abc123'
+		], Frontmatter::decode($string));
+	}
+
+	public function testDecodeWithBody(): void
+	{
+		$string = "---\ntitle: My Title\n---\nThis is the body text.\nIt can contain **Markdown**.\n";
+
+		$this->assertSame([
+			'title' => 'My Title',
+			'text'  => "This is the body text.\nIt can contain **Markdown**."
+		], Frontmatter::decode($string));
+	}
+
+	public function testDecodeWithBodyAndTextField(): void
+	{
+		// body after closing --- wins over text field in YAML block
+		$string = "---\ntitle: My Title\ntext: from yaml\n---\nThis is the body.\n";
+
+		$this->assertSame([
+			'title' => 'My Title',
+			'text'  => 'This is the body.'
+		], Frontmatter::decode($string));
+	}
+
+	public function testDecodeEmptyBody(): void
+	{
+		// empty body should not produce a text key
+		$string = "---\ntitle: My Title\n---\n";
+
+		$this->assertSame([
+			'title' => 'My Title'
+		], Frontmatter::decode($string));
+	}
+
+	public function testDecodeFallback(): void
+	{
+		// string without --- delimiters falls back to plain YAML
+		$string = "title: My Title\nuuid: abc123\n";
+
+		$this->assertSame([
+			'title' => 'My Title',
+			'uuid'  => 'abc123'
+		], Frontmatter::decode($string));
+	}
+
+	public function testEncode(): void
+	{
+		$data = [
+			'title' => 'My Title',
+			'uuid'  => 'abc123'
+		];
+
+		$this->assertSame(
+			"---\ntitle: My Title\nuuid: abc123\n---\n",
+			Frontmatter::encode($data)
+		);
+	}
+
+	public function testEncodeWithBody(): void
+	{
+		$data = [
+			'title' => 'My Title',
+			'text'  => 'This is the body.'
+		];
+
+		$this->assertSame(
+			"---\ntitle: My Title\n---\nThis is the body.\n",
+			Frontmatter::encode($data)
+		);
+	}
+
+	public function testEncodeWithEmptyBody(): void
+	{
+		$data = [
+			'title' => 'My Title',
+			'text'  => ''
+		];
+
+		$this->assertSame(
+			"---\ntitle: My Title\n---\n",
+			Frontmatter::encode($data)
+		);
+	}
+
+	public function testRoundtrip(): void
+	{
+		$data = [
+			'title' => 'My Title',
+			'uuid'  => 'abc123'
+		];
+
+		$this->assertSame($data, Frontmatter::decode(Frontmatter::encode($data)));
+
+		$dataWithBody = [
+			'title' => 'My Title',
+			'text'  => 'This is the body text.'
+		];
+
+		$this->assertSame($dataWithBody, Frontmatter::decode(Frontmatter::encode($dataWithBody)));
+	}
+}

--- a/tests/Data/FrontmatterTest.php
+++ b/tests/Data/FrontmatterTest.php
@@ -74,6 +74,26 @@ class FrontmatterTest extends TestCase
 		], Frontmatter::decode($string));
 	}
 
+	public function testDecodeWithWhitespaceOnlyBody(): void
+	{
+		// whitespace-only body after closing --- should not produce a text key
+		$string = "---\ntitle: My Title\n---\n   \n";
+
+		$this->assertSame([
+			'title' => 'My Title'
+		], Frontmatter::decode($string));
+	}
+
+	public function testDecodeWithWindowsLineEndings(): void
+	{
+		$string = "---\r\ntitle: My Title\r\nuuid: abc123\r\n---\r\n";
+
+		$this->assertSame([
+			'title' => 'My Title',
+			'uuid'  => 'abc123'
+		], Frontmatter::decode($string));
+	}
+
 	public function testEncode(): void
 	{
 		$data = [
@@ -105,6 +125,19 @@ class FrontmatterTest extends TestCase
 		$data = [
 			'title' => 'My Title',
 			'text'  => ''
+		];
+
+		$this->assertSame(
+			"---\ntitle: My Title\n---\n",
+			Frontmatter::encode($data)
+		);
+	}
+
+	public function testEncodeWithWhitespaceOnlyBody(): void
+	{
+		$data = [
+			'title' => 'My Title',
+			'text'  => '   '
 		];
 
 		$this->assertSame(


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🎉 Features

New Frontmatter Data handler, which can be used to import or export frontmatter into Kirby. 

#### Decoding

```php
use Kirby\Data\Frontmatter;

$md = <<<MD
---
title: My new article
date: '2026-03-12'
---
# Hello world

This is my brand new article written in **Frontmatter/Markdown**
MD;

$result = Frontmatter::decode($md);

// [
//  'title' => 'My new article',
//  'date' => '2026-03-12',
//  'text' => '# Hello world ...'
// ]
```

#### Encoding

```php
use Kirby\Data\Frontmatter;

$result = Frontmatter::encode([
  'title' => 'My new article',
  'date' => '2026-03-12',
  'text' => '# Hello world …'
]);

// ---
// title: My new article
// date: 2026-03-12 
// ---
// # Hello world …
```





## For review team
<!--
We will take care of the following before merging the PR.
-->
- [x] Add changes & docs to release notes draft in Notion