### PR TITLE
test: Improve database and sql coverage

### DIFF
--- a/tests/Database/DatabaseTest.php
+++ b/tests/Database/DatabaseTest.php
@@ -79,6 +79,18 @@ class DatabaseTest extends TestCase
 		], array_values(Database::instances()));
 	}
 
+	public function testInstanceById(): void
+	{
+		$database = new Database([
+			'database' => ':memory:',
+			'type'     => 'sqlite',
+			'id'       => 'custom'
+		]);
+
+		$this->assertSame($database, Database::instance('custom'));
+		$this->assertNull(Database::instance('missing'));
+	}
+
 	public function testAffected(): void
 	{
 		$this->database->table('users')->delete();
@@ -103,6 +115,53 @@ class DatabaseTest extends TestCase
 	{
 		$result = $this->database->table('users')->select('*')->all();
 		$this->assertSame($result, $this->database->lastResult());
+	}
+
+	public function testQueryWithArrayResultsAndTrace(): void
+	{
+		$result = $this->database->query(
+			'SELECT * FROM users WHERE username = :username',
+			['username' => 'john'],
+			[
+				'fetch'    => 'array',
+				'iterator' => 'array'
+			]
+		);
+
+		$this->assertSame('john', $result[0]['username']);
+		$this->assertSame($result, $this->database->lastResult());
+
+		$trace = $this->database->trace();
+		$this->assertSame('SELECT * FROM users WHERE username = :username', $trace[array_key_last($trace)]['query']);
+		$this->assertSame(['username' => 'john'], $trace[array_key_last($trace)]['bindings']);
+		$this->assertNull($trace[array_key_last($trace)]['error']);
+	}
+
+	public function testQueryWithFetchClosureForSingleResult(): void
+	{
+		$result = $this->database->query(
+			'SELECT * FROM users WHERE username = :username',
+			['username' => 'john'],
+			[
+				'method'   => 'fetch',
+				'fetch'    => fn (array $row) => $row['fname'] . ' ' . $row['lname'],
+				'iterator' => 'array'
+			]
+		);
+
+		$this->assertSame('John Lennon', $result);
+
+		$result = $this->database->query(
+			'SELECT * FROM users WHERE username = :username',
+			['username' => 'nobody'],
+			[
+				'method'   => 'fetch',
+				'fetch'    => fn (array $row) => $row['fname'] . ' ' . $row['lname'],
+				'iterator' => 'array'
+			]
+		);
+
+		$this->assertFalse($result);
 	}
 
 	public function testLastError(): void
@@ -156,6 +215,25 @@ class DatabaseTest extends TestCase
 		$this->assertTrue($this->database->dropTable('users'));
 	}
 
+	public function testValidateColumnAndTableCaches(): void
+	{
+		$this->assertTrue($this->database->validateColumn('users', 'username'));
+		$this->assertFalse($this->database->validateColumn('missing', 'username'));
+
+		$this->assertTrue($this->database->createTable('accounts', [
+			'id' => [
+				'type' => 'int'
+			],
+			'email' => [
+				'type' => 'varchar'
+			]
+		]));
+		$this->assertTrue($this->database->validateTable('accounts'));
+		$this->assertTrue($this->database->validateColumn('accounts', 'email'));
+		$this->assertTrue($this->database->dropTable('accounts'));
+		$this->assertFalse($this->database->validateTable('accounts'));
+	}
+
 	public function testMagicCall(): void
 	{
 		$this->assertCount(3, $this->database->users()->all());
@@ -164,6 +242,24 @@ class DatabaseTest extends TestCase
 	public function testType(): void
 	{
 		$this->assertSame('sqlite', $this->database->type());
+	}
+
+	public function testPrefixAndSql(): void
+	{
+		$database = new Database([
+			'database' => ':memory:',
+			'type'     => 'sqlite',
+			'prefix'   => 'kirby_'
+		]);
+
+		$database->execute('CREATE TABLE "kirby_users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE)');
+
+		$this->assertSame('kirby_', $database->prefix());
+		$this->assertInstanceOf(\Kirby\Database\Sql\Sqlite::class, $database->sql());
+		$this->assertSame(
+			'SELECT * FROM "kirby_users"',
+			$database->table('users')->build('select')['query']
+		);
 	}
 
 	public function testEscape(): void

--- a/tests/Database/SqlTest.php
+++ b/tests/Database/SqlTest.php
@@ -490,6 +490,125 @@ class SqlTest extends TestCase
 		], $this->sql->having('test < :value'));
 	}
 
+	public function testSelect(): void
+	{
+		$this->database->createTable('users', [
+			'id'   => ['type' => 'int'],
+			'name' => ['type' => 'varchar']
+		]);
+		$this->database->createTable('roles', [
+			'id' => ['type' => 'int']
+		]);
+
+		$select = $this->sql->select([
+			'table'    => 'users',
+			'columns'  => ['users.id', 'name'],
+			'distinct' => true,
+			'join'     => [[
+				'type'  => 'left join',
+				'table' => 'roles',
+				'on'    => 'roles.id = users.id'
+			]],
+			'where'    => ['users.id' => 1],
+			'group'    => 'users.id',
+			'having'   => 'COUNT(*) > 0',
+			'order'    => 'users.id DESC',
+			'offset'   => 5,
+			'limit'    => 10,
+			'bindings' => []
+		]);
+
+		$this->assertStringContainsString('SELECT DISTINCT `users`.`id`, `users`.`name`', $select['query']);
+		$this->assertStringContainsString('FROM `users`', $select['query']);
+		$this->assertStringContainsString('LEFT JOIN `roles` ON roles.id = users.id', $select['query']);
+		$this->assertStringContainsString('WHERE users.id = ', $select['query']);
+		$this->assertStringContainsString('GROUP BY users.id', $select['query']);
+		$this->assertStringContainsString('HAVING COUNT(*) > 0', $select['query']);
+		$this->assertStringContainsString('ORDER BY users.id DESC', $select['query']);
+		$this->assertStringContainsString('LIMIT ', $select['query']);
+		$this->assertCount(3, $select['bindings']);
+	}
+
+	public function testInsertUpdateAndDelete(): void
+	{
+		$this->database->createTable('users', [
+			'id'      => ['type' => 'int'],
+			'name'    => ['type' => 'varchar'],
+			'meta'    => ['type' => 'text'],
+			'updated' => ['type' => 'timestamp']
+		]);
+
+		$insert = $this->sql->insert([
+			'table'    => 'users',
+			'values'   => [
+				'name'    => 'John Doe',
+				'meta'    => ['role' => 'admin'],
+				'updated' => 'NOW()'
+			],
+			'bindings' => []
+		]);
+
+		$this->assertStringStartsWith('INSERT INTO `users` (`users`.`name`, `users`.`meta`, `users`.`updated`) VALUES (', $insert['query']);
+		$this->assertCount(2, $insert['bindings']);
+		$this->assertSame('John Doe', array_values($insert['bindings'])[0]);
+		$this->assertSame('{"role":"admin"}', array_values($insert['bindings'])[1]);
+
+		$update = $this->sql->update([
+			'table'    => 'users',
+			'values'   => [
+				'name'    => 'Jane Doe',
+				'updated' => null
+			],
+			'where'    => ['id' => 1],
+			'bindings' => []
+		]);
+
+		$this->assertStringContainsString('UPDATE `users` SET `users`.`name` = ', $update['query']);
+		$this->assertStringContainsString('`users`.`updated` = null', $update['query']);
+		$this->assertStringContainsString('WHERE id = ', $update['query']);
+		$this->assertCount(2, $update['bindings']);
+		$this->assertSame('Jane Doe', array_values($update['bindings'])[0]);
+		$this->assertSame(1, array_values($update['bindings'])[1]);
+
+		$delete = $this->sql->delete([
+			'table'    => 'users',
+			'where'    => 'id = :id',
+			'bindings' => ['id' => 1]
+		]);
+
+		$this->assertSame('DELETE FROM `users` WHERE id = :id', $delete['query']);
+		$this->assertSame(['id' => 1], $delete['bindings']);
+	}
+
+	public function testSelectHelpers(): void
+	{
+		$this->database->createTable('users', [
+			'name' => ['type' => 'varchar']
+		]);
+
+		$this->assertSame('*', $this->sql->selected('users'));
+		$this->assertSame('COUNT(*)', $this->sql->selected('users', 'COUNT(*)'));
+		$this->assertSame('`users`.`name`', $this->sql->selected('users', ['name']));
+		$this->assertSame([
+			'query'    => null,
+			'bindings' => []
+		], $this->sql->order());
+		$this->assertSame([
+			'query'    => null,
+			'bindings' => []
+		], $this->sql->limit());
+		$this->assertSame('table`name', $this->sql->unquoteIdentifier('`table``name`'));
+		$this->assertSame('table"name', $this->sql->unquoteIdentifier('"table""name"'));
+	}
+
+	public function testJoinInvalid(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid join type SIDEWAYS JOIN');
+
+		$this->sql->join('SIDEWAYS JOIN', 'test', 'test.id = another.id');
+	}
+
 	public function testValueSet(): void
 	{
 		$this->database->createTable('users', [


### PR DESCRIPTION
## Description

Added missing database unit test cases. 

Database namespace coverage:
- Before: 73.31%
- After: 92.25%

**`Database`**
- `instance()`: retrieving an instance by ID and returning `null` for an unknown ID
- `query()`: returning results with `fetch => 'array'` and `iterator => 'array'`
- `query()`: handling single-row fetches with a closure
- `trace()`: recording the latest query, bindings, and error state
- `validateColumn()`: handling existing and missing table/column checks
- `validateTable()`: updating the cached table list after create/drop operations
- `prefix()`: returning the configured table prefix
- `sql()`: returning the correct SQL driver instance
- `table()`: resolving prefixed table names correctly

**`Sql`**
- `select()`: building queries with `distinct`, `join`, `where`, `group`, `having`, `order`, and `limit`
- `insert()`: building insert queries with literals and JSON-encoded values
- `update()`: building update queries with bound values and `null` literals
- `delete()`: building delete queries with where bindings
- `selected()`: handling `*`, raw strings, and validated column lists
- `order()`: early return for empty input
- `limit()`: early return when no limit/offset is provided
- `unquoteIdentifier()`: unescaping quoted identifiers with escaped quotes/backticks
- `join()`: throwing an exception for invalid join types


## Changelog 

### 🧹 Housekeeping

- Improve database and sql coverage

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion