### PR TITLE
fix: treat post_max_size=0 as unlimited

### DIFF
--- a/src/Api/Upload.php
+++ b/src/Api/Upload.php
@@ -62,9 +62,15 @@ readonly class Upload
 	public static function chunkSize(): int
 	{
 		$max = [
-			Str::toBytes(ini_get('upload_max_filesize')),
-			Str::toBytes(ini_get('post_max_size'))
+			Str::toBytes(ini_get('upload_max_filesize'))
 		];
+
+		$postMaxSize = Str::toBytes(ini_get('post_max_size'));
+
+		// in PHP, post_max_size=0 means "no limit", so it must not be treated
+		if ($postMaxSize > 0) {
+			$max[] = $postMaxSize;
+		}
 
 		// consider cloudflare proxy limit, if detected
 		if (isset($_SERVER['HTTP_CF_CONNECTING_IP']) === true) {
@@ -412,11 +418,12 @@ readonly class Upload
 			$postMaxSize       = Str::toBytes(ini_get('post_max_size'));
 			$uploadMaxFileSize = Str::toBytes(ini_get('upload_max_filesize'));
 
+			// in PHP, post_max_size=0 means "no limit", so it must not be treated
+			// as smaller than upload_max_filesize.
 			// @codeCoverageIgnoreStart
-			if ($postMaxSize < $uploadMaxFileSize) {
+			if ($postMaxSize > 0 && $postMaxSize < $uploadMaxFileSize) {
 				throw new Exception(
-					message:
-					I18n::translate(
+					message: I18n::translate(
 						'upload.error.iniPostSize',
 						'The uploaded file exceeds the post_max_size directive in php.ini'
 					)
@@ -425,8 +432,7 @@ readonly class Upload
 			// @codeCoverageIgnoreEnd
 
 			throw new Exception(
-				message:
-				I18n::translate(
+				message: I18n::translate(
 					'upload.error.noFiles',
 					'No files were uploaded'
 				)

--- a/tests/Api/UploadTest.php
+++ b/tests/Api/UploadTest.php
@@ -94,6 +94,17 @@ class UploadTest extends TestCase
 		);
 	}
 
+	public function testChunkSizeWithUnlimitedPostMaxSize(): void
+	{
+		ini_set('upload_max_filesize', '10M');
+		ini_set('post_max_size', '0');
+
+		$this->assertSame(
+			(int)floor(10 * 1024 * 1024 * 0.95),
+			Upload::chunkSize()
+		);
+	}
+
 	public function testCleanTmpDir(): void
 	{
 		$dir = static::TMP . '/site/cache/.uploads';
@@ -615,6 +626,19 @@ class UploadTest extends TestCase
 	{
 		ini_set('upload_max_filesize', '10M');
 		ini_set('post_max_size', '20M');
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('No files were uploaded');
+
+		$upload = $this->upload();
+		$upload->process(function () {
+		});
+	}
+
+	public function testValidateFilesEmptyWithUnlimitedPostMaxSize(): void
+	{
+		ini_set('upload_max_filesize', '10M');
+		ini_set('post_max_size', '0');
 
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('No files were uploaded');


### PR DESCRIPTION
## Description

In PHP, `post_max_size=0` means that the POST size limit is disabled.

Kirby currently interprets this value as a literal `0`, which causes uploads to fail because the calculated chunk size becomes `0` and the upload validation may throw the wrong error.

This PR treats `post_max_size=0` as unlimited and ignores it when determining the effective upload size.

## Changelog 

### 🐛 Bug fixes

- Disabiling PHP's post_max_size causes uploads to fail. #8022


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion