### PR TITLE
fix: Add a labels to the blocks field options button and the form controls more button

### DIFF
--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -19,6 +19,7 @@
 					@click="$refs.blocks.choose(value.length)"
 				/>
 				<k-button
+					:title="$t('options')"
 					icon="dots"
 					variant="filled"
 					size="xs"

--- a/panel/src/components/Forms/FormControls.vue
+++ b/panel/src/components/Forms/FormControls.vue
@@ -108,6 +108,7 @@ export default {
 						click: () => this.$emit("submit")
 					},
 					{
+						title: this.$t("options"),
 						theme: "notice",
 						icon: "dots",
 						click: () => this.$refs.dropdown.toggle()


### PR DESCRIPTION
## Description
closes [8035](https://github.com/getkirby/kirby/issues/8035)

### 🐛 Bug fixes
This PR adds missing button labels for an icon buttons