### PR TITLE
fix: Keep form controls visible when view buttons are empty

### DIFF
--- a/panel/lab/components/buttons/7_view-buttons/index.php
+++ b/panel/lab/components/buttons/7_view-buttons/index.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'docs' => 'k-view-buttons',
+];

--- a/panel/lab/components/buttons/7_view-buttons/index.vue
+++ b/panel/lab/components/buttons/7_view-buttons/index.vue
@@ -1,0 +1,63 @@
+<template>
+	<k-lab-examples>
+		<k-lab-example label="View Buttons: buttons & slot">
+			<k-header>
+				Home
+				<template slot="buttons">
+					<k-view-buttons :buttons="viewButtons">
+						<template #after>
+							<k-form-controls
+								:has-diff="true"
+								editor="editor@getkirby.com"
+								modified="2024-10-01T17:00:00"
+								@discard="log('discard')"
+								@submit="log('submit')"
+							/>
+						</template>
+					</k-view-buttons>
+				</template>
+			</k-header>
+		</k-lab-example>
+		<k-lab-example label="View Buttons: no buttons & slot">
+			<k-header>
+				Home
+				<template slot="buttons">
+					<k-view-buttons :buttons="[]">
+						<template #after>
+							<k-form-controls
+								:has-diff="true"
+								editor="editor@getkirby.com"
+								modified="2024-10-01T17:00:00"
+								@discard="log('discard')"
+								@submit="log('submit')"
+							/>
+						</template>
+					</k-view-buttons>
+				</template>
+			</k-header>
+		</k-lab-example>
+	</k-lab-examples>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			viewButtons: [
+				{
+					key: "open",
+					props: {
+						icon: "open",
+						title: "Open"
+					}
+				}
+			]
+		};
+	},
+	methods: {
+		log(action) {
+			alert(action);
+		}
+	}
+};
+</script>

--- a/panel/lab/components/formcontrols/index.vue
+++ b/panel/lab/components/formcontrols/index.vue
@@ -58,6 +58,42 @@
 				@submit="log('submit')"
 			/>
 		</k-lab-example>
+		<k-lab-example label="View Buttons: Empty">
+			<k-header>
+				Home
+				<template slot="buttons">
+					<k-view-buttons :buttons="[]">
+						<template #after>
+							<k-form-controls
+								:has-diff="true"
+								editor="editor@getkirby.com"
+								modified="2024-10-01T17:00:00"
+								@discard="log('discard')"
+								@submit="log('submit')"
+							/>
+						</template>
+					</k-view-buttons>
+				</template>
+			</k-header>
+		</k-lab-example>
+		<k-lab-example label="View Buttons: Mixed">
+			<k-header>
+				Home
+				<template slot="buttons">
+					<k-view-buttons :buttons="viewButtons">
+						<template #after>
+							<k-form-controls
+								:has-diff="true"
+								editor="editor@getkirby.com"
+								modified="2024-10-01T17:00:00"
+								@discard="log('discard')"
+								@submit="log('submit')"
+							/>
+						</template>
+					</k-view-buttons>
+				</template>
+			</k-header>
+		</k-lab-example>
 		<k-lab-example label="Saving">
 			<k-form-controls :has-diff="true" :is-processing="true" />
 		</k-lab-example>
@@ -79,7 +115,16 @@ export default {
 	data() {
 		return {
 			hasDiff: false,
-			isLocked: false
+			isLocked: false,
+			viewButtons: [
+				{
+					key: "open",
+					props: {
+						icon: "open",
+						title: "Open"
+					}
+				}
+			]
 		};
 	},
 	methods: {

--- a/panel/lab/components/formcontrols/index.vue
+++ b/panel/lab/components/formcontrols/index.vue
@@ -58,42 +58,6 @@
 				@submit="log('submit')"
 			/>
 		</k-lab-example>
-		<k-lab-example label="View Buttons: Empty">
-			<k-header>
-				Home
-				<template slot="buttons">
-					<k-view-buttons :buttons="[]">
-						<template #after>
-							<k-form-controls
-								:has-diff="true"
-								editor="editor@getkirby.com"
-								modified="2024-10-01T17:00:00"
-								@discard="log('discard')"
-								@submit="log('submit')"
-							/>
-						</template>
-					</k-view-buttons>
-				</template>
-			</k-header>
-		</k-lab-example>
-		<k-lab-example label="View Buttons: Mixed">
-			<k-header>
-				Home
-				<template slot="buttons">
-					<k-view-buttons :buttons="viewButtons">
-						<template #after>
-							<k-form-controls
-								:has-diff="true"
-								editor="editor@getkirby.com"
-								modified="2024-10-01T17:00:00"
-								@discard="log('discard')"
-								@submit="log('submit')"
-							/>
-						</template>
-					</k-view-buttons>
-				</template>
-			</k-header>
-		</k-lab-example>
 		<k-lab-example label="Saving">
 			<k-form-controls :has-diff="true" :is-processing="true" />
 		</k-lab-example>

--- a/panel/src/components/View/Buttons/Buttons.vue
+++ b/panel/src/components/View/Buttons/Buttons.vue
@@ -1,5 +1,5 @@
 <template>
-	<nav v-if="buttons.length" class="k-view-buttons">
+	<nav v-if="hasContent" class="k-view-buttons">
 		<slot name="before" />
 
 		<k-button-group v-for="(group, index) in groups" :key="index">
@@ -34,6 +34,9 @@ export default {
 	},
 	emits: ["action"],
 	computed: {
+		hasContent() {
+			return this.buttons.length > 0 || this.$slots.before || this.$slots.after;
+		},
 		groups() {
 			return this.$helper.array.split(this.buttons, "-");
 		}

--- a/src/Panel/Lab/Doc.php
+++ b/src/Panel/Lab/Doc.php
@@ -10,6 +10,7 @@ use Kirby\Panel\Lab\Doc\Prop;
 use Kirby\Panel\Lab\Doc\Slot;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
+use Throwable;
 
 /**
  * Documentation for a single Vue component
@@ -68,7 +69,12 @@ class Doc
 			$file = static::file($name, 'dist');
 		}
 
-		$data = Data::read($file);
+		try {
+			$data = Data::read($file);
+		} catch (Throwable) {
+			return null;
+		}
+
 
 		// filter internal components
 		if (isset($data['tags']['internal']) === true) {


### PR DESCRIPTION
## Description

When the home page has `preview: false`, the site view can end up with no view buttons. In that case, `k-view-buttons` was not rendered at all, so the `save` and `discard` form controls inside its slot also disappeared.

`k-view-buttons` now also renders when it has slot content, even if the `buttons` array is empty. This keeps the form controls visible while still hiding preview-related buttons.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Fixed site view buttons when home preview is false #8046 

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion