### PR TITLE
fix: Make offline warning visible in dark mode

### DIFF
--- a/panel/src/components/Misc/OfflineWarning.vue
+++ b/panel/src/components/Misc/OfflineWarning.vue
@@ -26,10 +26,11 @@ export default {};
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
-	background: var(--color-white);
-	box-shadow: var(--shadow);
+	background: var(--dialog-color-back);
+	color: var(--dialog-color-text);
+	box-shadow: var(--dialog-shadow);
 	padding: 0.75rem;
-	border-radius: var(--rounded);
+	border-radius: var(--dialog-rounded);
 }
 .k-offline-warning p .k-icon {
 	color: var(--color-red-400);


### PR DESCRIPTION
## Description

Before this change, the offline warning could show white text on a light background or use colors that didn’t match the other dialogs. Now it uses the same dialog color tokens as the other Panel dialogs, so the text stays readable in dark mode.

<img width="369" height="176" alt="image" src="https://github.com/user-attachments/assets/1d20ea35-ba3e-43fd-a2f2-e11d546e9182" />


<img width="351" height="183" alt="image" src="https://github.com/user-attachments/assets/77ff71de-d33a-477b-8d6a-21801e8188be" />


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Fixed the Panel offline warning dialog text in dark mode #8047 

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion