### PR TITLE
fix: Move picker search props into shared models dialog mixin

### DIFF
--- a/panel/src/components/Dialogs/ModelsDialog.vue
+++ b/panel/src/components/Dialogs/ModelsDialog.vue
@@ -46,6 +46,7 @@ import Dialog from "@/mixins/dialog.js";
 import Search from "@/mixins/search.js";
 
 export const props = {
+	mixins: [Search],
 	props: {
 		endpoint: String,
 		empty: Object,
@@ -71,7 +72,7 @@ export const props = {
 };
 
 export default {
-	mixins: [Dialog, Search, props],
+	mixins: [Dialog, props],
 	emits: ["cancel", "fetched", "submit"],
 	data() {
 		return {


### PR DESCRIPTION
## Description

This fixes `search: false` for picker fields like `files`, `pages`, and `users`.

The problem was that the search prop got lost in the wrapper dialogs before it reached the shared models dialog. I fixed it by moving the `Search` mixin into the shared props export in `ModelsDialog.vue`, so the wrapper dialogs receive it as well.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes

- Fixed picker dialogs so the `search: false` option now works as expected  #8053 

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion