### PR TITLE
fix: Prevent stale page writes from recreating moved page directories

### DIFF
--- a/src/Content/PlainTextStorage.php
+++ b/src/Content/PlainTextStorage.php
@@ -262,8 +262,16 @@ class PlainTextStorage extends Storage
 	}
 
 	/**
-	 * Prevent stale page instances from recreating a moved page directory
-	 * during concurrent reorder or move operations.
+	 * Prevents stale page instances from recreating moved page directories.
+	 *
+	 * During a concurrent reorder, a page directory may be moved while another
+	 * stale page instance still points to the old root path. If that stale
+	 * instance writes content afterwards, the write path may recreate the missing
+	 * directory and produce a ghost or duplicate page folder.
+	 *
+	 * To avoid that, this method re-resolves the page from the current app state
+	 * when the expected root no longer exists. If the page was moved in the
+	 * meantime, the write is aborted instead of recreating the old path.
 	 */
 	protected function ensureCurrentPageRoot(VersionId $versionId): void
 	{

--- a/src/Content/PlainTextStorage.php
+++ b/src/Content/PlainTextStorage.php
@@ -262,6 +262,40 @@ class PlainTextStorage extends Storage
 	}
 
 	/**
+	 * Prevent stale page instances from recreating a moved page directory
+	 * during concurrent reorder or move operations.
+	 */
+	protected function ensureCurrentPageRoot(VersionId $versionId): void
+	{
+		if (
+			$this->model instanceof Page === false ||
+			$versionId->is('latest') === false
+		) {
+			return;
+		}
+
+		$staleRoot = $this->contentDirectory($versionId);
+
+		if (is_dir($staleRoot) === true) {
+			return;
+		}
+
+		// `$this->model` may still point to a stale root after a concurrent move,
+		// so we re-resolve the page from the current app state.
+		$currentPage = $this->model->kirby()->page($this->model->id());
+
+		if (
+			$currentPage !== null &&
+			$currentPage->root() !== null &&
+			$currentPage->root() !== $staleRoot
+		) {
+			throw new LogicException(
+				message: 'The page was moved during a concurrent operation. Please retry the write with a fresh page instance.'
+			);
+		}
+	}
+
+	/**
 	 * Returns the stored content fields
 	 *
 	 * @return array<string, string>
@@ -318,6 +352,8 @@ class PlainTextStorage extends Storage
 			$this->delete($versionId, $language);
 			return;
 		}
+
+		$this->ensureCurrentPageRoot($versionId);
 
 		$success = Data::write($this->contentFile($versionId, $language), $fields);
 

--- a/tests/Cms/Page/PageChangeSortTest.php
+++ b/tests/Cms/Page/PageChangeSortTest.php
@@ -152,4 +152,32 @@ class PageChangeSortTest extends ModelTestCase
 		$this->assertDirectoryExists(static::TMP . '/content/2_c');
 		$this->assertDirectoryExists(static::TMP . '/content/1_d');
 	}
+
+	public function testFreshPageRemainsWritableAfterChangeSort(): void
+	{
+		Page::create([
+			'slug' => 'a',
+			'num'  => 1,
+		]);
+
+		Page::create([
+			'slug' => 'b',
+			'num'  => 2,
+		]);
+
+		Page::create([
+			'slug' => 'c',
+			'num'  => 3,
+		]);
+
+		$page = $this->site()->find('b')->changeSort(3);
+		$page = $page->update([
+			'headline' => 'Sorted'
+		]);
+
+		$this->assertSame('Sorted', $page->headline()->value());
+		$this->assertSame(3, $page->num());
+		$this->assertDirectoryExists(static::TMP . '/content/3_b');
+		$this->assertFileExists(static::TMP . '/content/3_b/default.txt');
+	}
 }

--- a/tests/Cms/Page/PageUpdateTest.php
+++ b/tests/Cms/Page/PageUpdateTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Exception\LogicException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -228,6 +229,46 @@ class PageUpdateTest extends ModelTestCase
 		$updated = $updated->update(['test' => null]);
 
 		$this->assertNull($updated->test()->value());
+	}
+
+	public function testUpdateFailsForStalePageAfterConcurrentMove(): void
+	{
+		Page::create([
+			'slug' => 'a',
+			'num'  => 1,
+		]);
+
+		Page::create([
+			'slug' => 'b',
+			'num'  => 2,
+		]);
+
+		Page::create([
+			'slug' => 'c',
+			'num'  => 3,
+		]);
+
+		$stalePage = $this->app->site()->find('b')->clone();
+		$freshPage = $this->app->site()->find('b');
+
+		$this->assertSame(static::TMP . '/content/2_b', $stalePage->root());
+
+		$freshPage = $freshPage->changeSort(3);
+
+		$this->assertSame(static::TMP . '/content/3_b', $freshPage->root());
+		$this->assertDirectoryExists(static::TMP . '/content/3_b');
+		$this->assertDirectoryDoesNotExist(static::TMP . '/content/2_b');
+
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('The page was moved during a concurrent operation.');
+
+		try {
+			$stalePage->update(['headline' => 'Test']);
+		} finally {
+			$this->assertDirectoryDoesNotExist(static::TMP . '/content/2_b');
+			$this->assertDirectoryExists(static::TMP . '/content/3_b');
+			$this->assertFileDoesNotExist(static::TMP . '/content/2_b/default.txt');
+		}
 	}
 
 }

--- a/tests/Content/PlainTextStorageTest.php
+++ b/tests/Content/PlainTextStorageTest.php
@@ -7,6 +7,7 @@ use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\Cms\User;
 use Kirby\Data\Data;
+use Kirby\Exception\LogicException;
 use Kirby\Filesystem\Dir;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -579,6 +580,64 @@ class PlainTextStorageTest extends TestCase
 
 		$this->storage->update(VersionId::latest(), Language::single(), $fields);
 		$this->assertSame($fields, Data::read($this->model->root() . '/article.txt'));
+	}
+
+	public function testUpdateLatestSingleLangFailsForStalePageAfterMove(): void
+	{
+		$this->setUpSingleLanguage([
+			'children' => [
+				[
+					'slug'     => 'a-page',
+					'template' => 'article',
+				],
+				[
+					'slug'     => 'a',
+					'template' => 'article',
+					'num'      => 1,
+				],
+				[
+					'slug'     => 'b',
+					'template' => 'article',
+					'num'      => 2,
+				],
+				[
+					'slug'     => 'c',
+					'template' => 'article',
+					'num'      => 3,
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		Data::write($this->app->page('a')->root() . '/article.txt', []);
+		Data::write($this->app->page('b')->root() . '/article.txt', []);
+		Data::write($this->app->page('c')->root() . '/article.txt', []);
+
+		$stalePage = $this->app->page('b')->clone();
+		$freshPage = $this->app->page('b');
+		$storage   = new PlainTextStorage($stalePage);
+
+		$this->assertSame(static::TMP . '/content/2_b', $stalePage->root());
+
+		$freshPage = $freshPage->changeSort(3);
+
+		$this->assertSame(static::TMP . '/content/3_b', $freshPage->root());
+		$this->assertDirectoryExists(static::TMP . '/content/3_b');
+		$this->assertDirectoryDoesNotExist(static::TMP . '/content/2_b');
+
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('The page was moved during a concurrent operation.');
+
+		try {
+			$storage->update(VersionId::latest(), Language::single(), [
+				'title' => 'Updated'
+			]);
+		} finally {
+			$this->assertDirectoryDoesNotExist(static::TMP . '/content/2_b');
+			$this->assertDirectoryExists(static::TMP . '/content/3_b');
+			$this->assertFileDoesNotExist(static::TMP . '/content/2_b/article.txt');
+		}
 	}
 
 	public function testUpdateForFileWithMetaData(): void


### PR DESCRIPTION
## Description

This fixes a race condition where a stale page instance could still write to an old page path after the page had been moved during reordering.

When that happened, the write path could recreate the missing directory and produce ghost or duplicate page folders.

The fix adds a guard before writing page content. If the original root no longer exists, Kirby resolves the page again from the current app state. If the page was moved in the meantime, the write now fails instead of recreating the old path.

I've implemented the suggestion in my previous comment. I hope you like it:
https://github.com/getkirby/kirby/issues/7964#issuecomment-4054666897

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements

- Prevents ghost duplicate page folders caused by stale concurrent writes after page reordering #7964 

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion