### PR TITLE
[Auth] feat: Switch between auth challenges

### DIFF
--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -356,7 +356,7 @@ class Auth
 		$this->user()?->logout();
 
 		// clear the pending challenge
-		$this->challenges->clear();
+		$this->challenges->clear($this->kirby->session());
 
 		// clear the status cache
 		$this->status = null;

--- a/src/Auth/Challenges.php
+++ b/src/Auth/Challenges.php
@@ -69,9 +69,8 @@ class Challenges
 		);
 	}
 
-	public function clear(): void
+	public function clear(Session $session): void
 	{
-		$session = $this->kirby->session();
 		$session->remove('kirby.challenge.data');
 		$session->remove('kirby.challenge.email');
 		$session->remove('kirby.challenge.mode');
@@ -109,18 +108,7 @@ class Challenges
 
 		// try to find a challenge that is available for that user
 		if ($challenge = $this->firstAvailable($user, $mode)) {
-			$data      = $challenge->create();
-			$timeout   = $this->timeout();
-
-			$session->set('kirby.challenge.email', $email);
-			$session->set('kirby.challenge.type', $challenge->type());
-			$session->set('kirby.challenge.mode', $mode);
-			$session->set('kirby.challenge.timeout', time() + $timeout);
-
-			if ($data !== null) {
-				$session->set('kirby.challenge.data', $data->toArray());
-			}
-
+			$this->store($session, $challenge, $email, $mode);
 			return $challenge;
 		}
 
@@ -190,11 +178,7 @@ class Challenges
 			// clear stale challenge data before throwing
 			// so that even if the exception is swallowed upstream,
 			// the expired challenge cannot be reused
-			$session->remove('kirby.challenge.data');
-			$session->remove('kirby.challenge.email');
-			$session->remove('kirby.challenge.mode');
-			$session->remove('kirby.challenge.timeout');
-			$session->remove('kirby.challenge.type');
+			$this->clear($session);
 			throw new ChallengeTimeoutException();
 		}
 
@@ -241,6 +225,80 @@ class Challenges
 			mode:    $mode,
 			timeout: $timeout
 		);
+	}
+
+	/**
+	 * Writes challenge state into the session
+	 */
+	protected function store(
+		Session $session,
+		Challenge $challenge,
+		string $email,
+		string $mode
+	): void {
+		$data    = $challenge->create();
+		$timeout = $this->timeout();
+
+		$session->set('kirby.challenge.email', $email);
+		$session->set('kirby.challenge.type', $challenge->type());
+		$session->set('kirby.challenge.mode', $mode);
+		$session->set('kirby.challenge.timeout', time() + $timeout);
+
+		if ($data !== null) {
+			$session->set('kirby.challenge.data', $data->toArray());
+		}
+	}
+
+	/**
+	 * Switches the active challenge within an existing pending session
+	 */
+	public function switch(Session $session, string $type): Challenge
+	{
+		$this->ensureNotTimeout($session);
+
+		$email = $session->get('kirby.challenge.email');
+		$mode  = $session->get('kirby.challenge.mode');
+
+		if (is_string($email) !== true || is_string($mode) !== true) {
+			throw new InvalidArgumentException(
+				fallback: 'No authentication challenge is active'
+			);
+		}
+
+		$user = $this->kirby->user($email);
+
+		if ($user === null) {
+			throw new UserNotFoundException(name: $email);
+		}
+
+		// keep existing challenge if the requested type is same
+		if ($session->get('kirby.challenge.type') === $type) {
+			return $this->get($type, $user, $mode);
+		}
+
+		// rate-limiting:
+		// each switch can trigger side effects (e.g. email sends),
+		// so it must consume budget just like ::create()
+		$this->auth->limits()->ensure($email);
+		$this->auth->limits()->track($email, triggerHook: false);
+
+		// check if new challenge is available for the user and mode
+		$available = $this->available($user, $mode);
+
+		if (in_array($type, $available) === false) {
+			throw new InvalidArgumentException(
+				fallback: 'The requested challenge is not available'
+			);
+		}
+
+		// clear existing challenge
+		$this->clear($session);
+
+		// create new challenge and store in session
+		$challenge = $this->get($type, $user, $mode);
+		$this->store($session, $challenge, $email, $mode);
+
+		return $challenge;
 	}
 
 	public function timeout(): int|null

--- a/tests/Auth/ChallengesTest.php
+++ b/tests/Auth/ChallengesTest.php
@@ -66,6 +66,26 @@ class DummyChallenge extends Challenge
 	}
 }
 
+class DummyChallenge2 extends Challenge
+{
+	public static bool $available = true;
+
+	public static function isAvailable(User $user, string $mode): bool
+	{
+		return static::$available;
+	}
+
+	public function create(): Pending|null
+	{
+		return null;
+	}
+
+	public function verify(mixed $input, Pending $data): bool
+	{
+		return true;
+	}
+}
+
 #[CoversClass(Challenges::class)]
 class ChallengesTest extends TestCase
 {
@@ -78,13 +98,15 @@ class ChallengesTest extends TestCase
 	{
 		parent::setUp();
 
-		DummyChallenge::$available = true;
-		DummyChallenge::$enabled   = true;
-		DummyChallenge::$created   = [];
-		DummyChallenge::$verified  = [];
-		DummyChallenge::$pending   = null;
+		DummyChallenge::$available  = true;
+		DummyChallenge::$enabled    = true;
+		DummyChallenge::$created    = [];
+		DummyChallenge::$verified   = [];
+		DummyChallenge::$pending    = null;
+		DummyChallenge2::$available = true;
 
 		Challenges::$challenges['dummy'] = DummyChallenge::class;
+		Challenges::$challenges['dummy2'] = DummyChallenge2::class;
 
 		$this->app = $this->app->clone([
 			'options' => [
@@ -107,7 +129,8 @@ class ChallengesTest extends TestCase
 	protected function tearDown(): void
 	{
 		parent::tearDown();
-		unset(Challenges::$challenges['dummy']);
+		unset(Challenges::$challenges['dummy'], Challenges::$challenges['dummy2']);
+
 	}
 
 	protected function session(): Session
@@ -151,7 +174,7 @@ class ChallengesTest extends TestCase
 		$session->set('kirby.challenge.timeout', time() + 1000);
 		$session->set('kirby.challenge.type', 'dummy');
 
-		$this->challenges->clear();
+		$this->challenges->clear($session);
 
 		$this->assertNull($session->get('kirby.challenge.data'));
 		$this->assertNull($session->get('kirby.challenge.email'));
@@ -234,6 +257,117 @@ class ChallengesTest extends TestCase
 		$this->assertSame($user, $challenge->user());
 		$this->assertSame('login', $challenge->mode());
 		$this->assertSame(123, $challenge->timeout());
+	}
+
+	public function testSwitch(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'auth' => [
+					'challenges' => ['dummy', 'dummy2']
+				]
+			]
+		]);
+
+		$this->challenges = new Challenges($this->app->auth(), $this->app);
+
+		$session = $this->app->session();
+		$session->set('kirby.challenge.email', 'marge@simpsons.com');
+		$session->set('kirby.challenge.mode', 'login');
+		$session->set('kirby.challenge.type', 'dummy');
+		$session->set('kirby.challenge.timeout', time() + 1000);
+		$session->set('kirby.challenge.data', ['public' => 'x', 'secret' => 'y']);
+
+		$challenge = $this->challenges->switch($session, 'dummy2');
+
+		$this->assertInstanceOf(DummyChallenge2::class, $challenge);
+		$this->assertSame('dummy2', $session->get('kirby.challenge.type'));
+		$this->assertSame('marge@simpsons.com', $session->get('kirby.challenge.email'));
+		$this->assertSame('login', $session->get('kirby.challenge.mode'));
+		$this->assertSame(MockTime::$time + $this->challenges->timeout(), $session->get('kirby.challenge.timeout'));
+
+		// dummy2::create() returns null, so no data should be written
+		$this->assertNull($session->get('kirby.challenge.data'));
+	}
+
+	public function testSwitchSameType(): void
+	{
+		$session = $this->session();
+		$session->set('kirby.challenge.email', 'marge@simpsons.com');
+		$session->set('kirby.challenge.mode', 'login');
+		$session->set('kirby.challenge.type', 'dummy');
+		$timeout = time() + 1000;
+		$session->set('kirby.challenge.timeout', $timeout);
+		$session->set('kirby.challenge.data', ['public' => 'x', 'secret' => 'y']);
+
+		$challenge = $this->challenges->switch($session, 'dummy');
+
+		$this->assertInstanceOf(DummyChallenge::class, $challenge);
+
+		// session must remain untouched
+		$this->assertSame('dummy', $session->get('kirby.challenge.type'));
+		$this->assertSame($timeout, $session->get('kirby.challenge.timeout'));
+		$this->assertSame(['public' => 'x', 'secret' => 'y'], $session->get('kirby.challenge.data'));
+	}
+
+	public function testSwitchTimeout(): void
+	{
+		$session = $this->session();
+		$session->set('kirby.challenge.email', 'marge@simpsons.com');
+		$session->set('kirby.challenge.mode', 'login');
+		$session->set('kirby.challenge.type', 'dummy');
+		$session->set('kirby.challenge.timeout', time() - 10);
+
+		$this->expectException(ChallengeTimeoutException::class);
+
+		$this->challenges->switch($session, 'dummy');
+	}
+
+	public function testSwitchNoActiveChallenge(): void
+	{
+		$session = $this->session();
+
+		$this->expectException(InvalidArgumentException::class);
+
+		$this->challenges->switch($session, 'dummy');
+	}
+
+	public function testSwitchUnavailable(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'auth' => [
+					'challenges' => ['dummy', 'dummy2']
+				]
+			]
+		]);
+
+		$this->challenges = new Challenges($this->app->auth(), $this->app);
+
+		DummyChallenge2::$available = false;
+
+		$session = $this->app->session();
+		$session->set('kirby.challenge.email', 'marge@simpsons.com');
+		$session->set('kirby.challenge.mode', 'login');
+		$session->set('kirby.challenge.type', 'dummy');
+		$session->set('kirby.challenge.timeout', time() + 1000);
+
+		$this->expectException(InvalidArgumentException::class);
+
+		$this->challenges->switch($session, 'dummy2');
+	}
+
+	public function testSwitchUserNotFound(): void
+	{
+		$session = $this->session();
+		$session->set('kirby.challenge.email', 'unknown@example.com');
+		$session->set('kirby.challenge.mode', 'login');
+		$session->set('kirby.challenge.type', 'dummy');
+		$session->set('kirby.challenge.timeout', time() + 1000);
+
+		$this->expectException(UserNotFoundException::class);
+
+		$this->challenges->switch($session, 'dummy');
 	}
 
 	public function testVerify(): void


### PR DESCRIPTION
- Adding a new `$auth->challenges()->switch($type)` method that allows switching an existing challenge over to a different type of challenge that is available for the user and mode.
- Keeping code DRY-er in the `Challenges` class by introducing new `::clear()` and `:store()` methods that add/remove challenge data from the session.