### PR TITLE
fix: `::filterBy()` with non-default separator

### DIFF
--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -452,7 +452,7 @@ class Collection extends Iterator implements Stringable
 	public function getAttribute(
 		array|object $item,
 		string $attribute,
-		bool $split = false,
+		bool|string $split = false,
 		$related = null
 	) {
 		$value = $this->{'getAttributeFrom' . gettype($item)}(
@@ -1177,7 +1177,7 @@ Collection::$filters['=='] = function (
 	Collection $collection,
 	string $field,
 	$test,
-	bool $split = false
+	bool|string $split = false
 ): Collection {
 	foreach ($collection->data as $key => $item) {
 		$value = $collection->getAttribute($item, $field, $split, $test);
@@ -1201,7 +1201,7 @@ Collection::$filters['!='] = function (
 	Collection $collection,
 	string $field,
 	$test,
-	bool $split = false
+	bool|string $split = false
 ): Collection {
 	foreach ($collection->data as $key => $item) {
 		$value = $collection->getAttribute($item, $field, $split, $test);

--- a/tests/Toolkit/CollectionFilterTest.php
+++ b/tests/Toolkit/CollectionFilterTest.php
@@ -106,13 +106,22 @@ class CollectionFilterTest extends TestCase
 				'split'      => false
 			],
 
-			// split strings
+			// split strings with comma/default separator
 			[
 				'attributes' => ['a' => 'a, b', 'b' => 'b, c', 'c' => 'c, d'],
 				'operator'   =>  '==',
 				'test'       => 'b',
 				'expected'   => ['a', 'b'],
-				'split'      => ','
+				'split'      => true
+			],
+
+			// split strings with non-comma separator
+			[
+				'attributes' => ['a' => 'a; b', 'b' => 'b; c', 'c' => 'c; d'],
+				'operator'   =>  '==',
+				'test'       => 'b',
+				'expected'   => ['a', 'b'],
+				'split'      => ';'
 			],
 
 			// booleans
@@ -180,13 +189,22 @@ class CollectionFilterTest extends TestCase
 				'split'      => false
 			],
 
-			// split strings
+			// split strings with comma/default separator
 			[
 				'attributes' => ['a' => 'a, b', 'b' => 'b, c', 'c' => 'c, d'],
 				'operator'   =>  '!=',
 				'test'       => 'b',
 				'expected'   => ['c'],
-				'split'      => ','
+				'split'      => true
+			],
+
+			// split strings with non-comma separator
+			[
+				'attributes' => ['a' => 'a; b', 'b' => 'b; c', 'c' => 'c; d'],
+				'operator'   =>  '!=',
+				'test'       => 'b',
+				'expected'   => ['c'],
+				'split'      => ';'
 			],
 
 			// booleans

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -192,9 +192,22 @@ class CollectionTest extends TestCase
 		$this->assertSame('Homer', $collection->getAttribute($collection->first(), 'username'));
 		$this->assertSame('Marge', $collection->getAttribute($collection->last(), 'username'));
 
-		// split
+		// split with default comma separator (bool true)
 		$this->assertSame(['simpson', 'male'], $collection->getAttribute($collection->first(), 'tags', true));
 		$this->assertSame(['simpson', 'female'], $collection->getAttribute($collection->last(), 'tags', true));
+
+		// split with explicit comma separator (string ',')
+		$this->assertSame(['simpson', 'male'], $collection->getAttribute($collection->first(), 'tags', ','));
+		$this->assertSame(['simpson', 'female'], $collection->getAttribute($collection->last(), 'tags', ','));
+
+		// split with non-comma separator
+		$collection2 = new Collection([
+			'a' => ['username' => 'Homer', 'tags' => 'simpson; male'],
+			'b' => ['username' => 'Marge', 'tags' => 'simpson; female'],
+		]);
+
+		$this->assertSame(['simpson', 'male'], $collection2->getAttribute($collection2->first(), 'tags', ';'));
+		$this->assertSame(['simpson', 'female'], $collection2->getAttribute($collection2->last(), 'tags', ';'));
 	}
 
 	public function testGetAttributeFromObject(): void


### PR DESCRIPTION

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Fixed using `::filter()`/`::filterBy()` with non-default separators
#8062

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion