### PR TITLE
Fix #8067 filteredOptions returning undefined when search.min is set

### DIFF
--- a/panel/src/components/Forms/Input/PicklistInput.vue
+++ b/panel/src/components/Forms/Input/PicklistInput.vue
@@ -169,7 +169,7 @@ export default {
 		filteredOptions() {
 			// min length for the search to kick in
 			if (this.query.length < (this.search.min ?? 0)) {
-				return;
+				return this.options;
 			}
 			// include the info field in the search if the user has set the option to true...
 			if (this.search.info) {


### PR DESCRIPTION
With this fix the multiselect field search starts filtering after the min characters number is matched/passed. I tested this with Kirby 5.3.3. I hope this PR was done correctly. Targets issue #8067 