### PR TITLE
fix: Preserving profiles in Imagick driver

### DIFF
--- a/src/Image/Darkroom/Imagick.php
+++ b/src/Image/Darkroom/Imagick.php
@@ -181,9 +181,11 @@ class Imagick extends Darkroom
 			}
 		}
 
-		$image->thumbnailImage(
+		$image->resizeImage(
 			$options['width'],
 			$options['height'],
+			Image::FILTER_LANCZOS,
+			1,
 			true
 		);
 

--- a/tests/Image/Darkroom/ImagickTest.php
+++ b/tests/Image/Darkroom/ImagickTest.php
@@ -407,5 +407,29 @@ class ImagickTest extends TestCase
 		$meta = shell_exec('identify -verbose ' . escapeshellarg($file));
 		$this->assertStringNotContainsString('photoshop:CaptionWriter', $meta);
 		$this->assertStringNotContainsString('GPS', $meta);
+		$this->assertStringNotContainsString('Profile-iptc', $meta);
+	}
+
+	public function testStripPreservesProfileFromOption(): void
+	{
+		$fixture = static::FIXTURES . '/image/onigiri-adobe-rgb-gps.jpg';
+
+		// confirm the fixture has IPTC data before processing
+		$command = 'identify -verbose ' . escapeshellarg($fixture) . ' 2>/dev/null';
+		$this->assertStringContainsString('Profile-iptc', shell_exec($command));
+
+		// IPTC is preserved when listed in profiles option
+		copy($fixture, $file = static::TMP . '/onigiri-iptc-preserved.jpg');
+		$imagick = new Imagick(['profiles' => ['icc', 'iptc'], 'width' => 250]);
+		$imagick->process($file);
+		$meta = shell_exec('identify -verbose ' . escapeshellarg($file) . ' 2>/dev/null');
+		$this->assertStringContainsString('Profile-iptc', $meta);
+
+		// IPTC is stripped when not listed in profiles option
+		copy($fixture, $file = static::TMP . '/onigiri-iptc-stripped.jpg');
+		$imagick = new Imagick(['width' => 250]);
+		$imagick->process($file);
+		$meta = shell_exec('identify -verbose ' . escapeshellarg($file) . ' 2>/dev/null');
+		$this->assertStringNotContainsString('Profile-iptc', $meta);
 	}
 }


### PR DESCRIPTION

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Imagick thumb driver: fixed preserving profiles listed in `profiles` option
#8066


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion