### PR TITLE
perf: Reduce requests triggered by link field

### DIFF
--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -58,32 +58,32 @@
 			</div>
 
 			<!-- Page or file browser -->
-			<div
-				v-if="currentType.id === 'page'"
-				v-show="expanded"
-				data-type="page"
-				class="k-link-input-body"
-			>
-				<div class="k-page-browser">
-					<k-page-tree
-						:current="$helper.link.getPageUUID(value)"
-						:root="false"
+			<template v-if="expanded">
+				<div
+					v-if="currentType.id === 'page'"
+					data-type="page"
+					class="k-link-input-body"
+				>
+					<div class="k-page-browser">
+						<k-page-tree
+							:current="$helper.link.getPageUUID(value)"
+							:root="false"
+							@select="selectModel($event)"
+						/>
+					</div>
+				</div>
+				<div
+					v-else-if="currentType.id === 'file'"
+					data-type="file"
+					class="k-link-input-body"
+				>
+					<k-file-browser
+						:opened="$panel.view.props.model.uuid ?? $panel.view.props.model.id"
+						:selected="$helper.link.getFileUUID(value)"
 						@select="selectModel($event)"
 					/>
 				</div>
-			</div>
-			<div
-				v-else-if="currentType.id === 'file'"
-				v-show="expanded"
-				data-type="file"
-				class="k-link-input-body"
-			>
-				<k-file-browser
-					:opened="$panel.view.props.model.uuid ?? $panel.view.props.model.id"
-					:selected="$helper.link.getFileUUID(value)"
-					@select="selectModel($event)"
-				/>
-			</div>
+			</template>
 		</k-input>
 	</k-field>
 </template>

--- a/panel/src/components/Navigation/PageTree.vue
+++ b/panel/src/components/Navigation/PageTree.vue
@@ -83,6 +83,15 @@ export default {
 			this.$set(item, "loading", false);
 		},
 		async preselect(page) {
+			// skip the parents API call
+			// if the page is already in the loaded items
+			const existing = this.findItem(page);
+
+			if (existing) {
+				this.$emit("select", existing);
+				return;
+			}
+
 			// get array of parent uuids/ids
 			const response = await this.$panel.get("site/tree/parents", {
 				query: {
@@ -90,8 +99,8 @@ export default {
 					root: this.root
 				}
 			});
-			const parents = response.data;
 
+			const parents = response.data;
 			let tree = this;
 
 			// go through all parents, try to find the matching item,


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

- PageTree/FileBrowser in the LinkField are only mounted when `expanded = true`. This avoids firing all the load requests from the page tree, even if the link field isn't even expanded. Downside is that when collapsing and expanding again, the page tree is fully loaded again - previous state of the page tree resets.

- Small optimization that if the page tree already has the page in its data, preselect doesn't cause another backend request.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- Link field: reduced the amount of backend request fired directly when mounted (thx @tobimori)



## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion