### PR TITLE
fix: Generate thumbs in temp file and move atomically

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -358,11 +358,31 @@ return [
 			$kirby->option('thumbs.driver', 'gd'),
 			$kirby->option('thumbs', [])
 		);
-		$options = $darkroom->preprocess($src, $options);
-		$root    = (new Filename($src, $dst, $options))->toString();
+		$options   = $darkroom->preprocess($src, $options);
+		$root      = (new Filename($src, $dst, $options))->toString();
+		$extension = F::extension($root);
 
-		F::copy($src, $root, true);
-		$darkroom->process($root, $options);
+		// generate the thumb in a temp file so broken output never appears at the final path
+		$tempRoot  = F::dirname($root) . '/' . F::name($root) . '.tmp-' . uniqid();
+
+		// keep the original extension so the darkroom can infer the output format.
+		if ($extension !== '') {
+			$tempRoot .= '.' . $extension;
+		}
+
+		F::copy($src, $tempRoot, true);
+
+		try {
+			$darkroom->process($tempRoot, $options);
+
+			// move the finished file into place so the final path
+			// only appears once generation succeeded
+			F::move($tempRoot, $root, true);
+		} catch (Throwable $e) {
+			// clean up the temp file so failed jobs don't leave broken output behind
+			F::remove($tempRoot);
+			throw $e;
+		}
 
 		return $root;
 	},

--- a/tests/Cms/Media/MediaTest.php
+++ b/tests/Cms/Media/MediaTest.php
@@ -8,6 +8,18 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Http\Response;
+use Kirby\Image\Darkroom;
+
+class MediaTestTrackingDarkroom extends Darkroom
+{
+	public static string|null $processedFile = null;
+
+	public function process(string $file, array $options = []): array
+	{
+		static::$processedFile = $file;
+		return $options;
+	}
+}
 
 class MediaTest extends TestCase
 {
@@ -305,6 +317,49 @@ class MediaTest extends TestCase
 		$this->expectExceptionMessage('File not found');
 
 		Media::thumb($site, $file->mediaHash(), $file->filename());
+	}
+
+	public function testThumbComponentUsesTempFile(): void
+	{
+		$originalDarkroomTypes = Darkroom::$types;
+		Darkroom::$types['tracking-test'] = MediaTestTrackingDarkroom::class;
+		MediaTestTrackingDarkroom::$processedFile = null;
+
+		App::destroy();
+		$this->app = new App([
+			'options' => [
+				'thumbs.driver' => 'tracking-test'
+			],
+			'roots'   => [
+				'index' => static::TMP
+			]
+		]);
+
+		Dir::make(static::TMP . '/content');
+		Dir::make(static::TMP . '/media');
+		F::copy(static::FIXTURES . '/files/test.jpg', $source = static::TMP . '/content/test.jpg');
+
+		try {
+			$this->assertSame(
+				$destination = static::TMP . '/media/test.jpg',
+				$this->app->thumb($source, $destination, [
+					'width'  => 64,
+					'height' => 64,
+					'crop'   => 'center'
+				])
+			);
+		} finally {
+			Darkroom::$types = $originalDarkroomTypes;
+			$processedFile = MediaTestTrackingDarkroom::$processedFile;
+			MediaTestTrackingDarkroom::$processedFile = null;
+		}
+
+		$this->assertNotNull($processedFile);
+		$this->assertNotSame($destination, $processedFile);
+		$this->assertStringStartsWith(static::TMP . '/media/test.tmp-', $processedFile);
+		$this->assertStringEndsWith('.jpg', $processedFile);
+		$this->assertFileExists($destination);
+		$this->assertFileDoesNotExist($processedFile);
 	}
 
 	public function testThumbStringModel(): void


### PR DESCRIPTION
## Description

This updates the default thumb component to generate thumbnails in a temporary file first and only move them to the final destination after processing succeeds. Previously, thumbs were processed directly at the final path, which could leave behind a broken thumbnail if generation failed halfway through. With this change, the final thumb path only appears once generation has completed successfully. 

A unit test was added to verify that the thumb component processes a temporary file instead of writing directly to the final destination.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes

- Improve thumbnail generation reliability by writing thumbs #4632 


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion