### PR TITLE
fix: Remove pagination bottom margin to visible in the file-browser dialog

### DIFF
--- a/panel/src/components/Navigation/FileBrowser.vue
+++ b/panel/src/components/Navigation/FileBrowser.vue
@@ -154,6 +154,10 @@ export default {
 	justify-content: end;
 }
 
+.k-file-browser-pagination .k-pagination {
+	margin-bottom: 0;
+}
+
 @container (max-width: 30rem) {
 	.k-file-browser-layout {
 		grid-template-columns: minmax(0, 1fr);


### PR DESCRIPTION
## Description

Add a CSS rule (with overwritten) in FileBrowser.vue to set `.k-file-browser-pagination .k-pagination { margin-bottom: 0; }` to eliminate unwanted spacing under the pagination controls and tighten up the file browser layout.

### Before
<img width="486" height="171" alt="image" src="https://github.com/user-attachments/assets/41a0ae5b-f6fd-404c-9a36-9431b2c59a6b" />

### After
<img width="490" height="206" alt="image" src="https://github.com/user-attachments/assets/5ea77248-c33e-4f8d-b3ed-0cb5e51fab05" />



## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes

- Pagination is now visible in the file-browser dialog #8080 


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion