### PR TITLE
fix: Redirect repeated slashes in page URLs to canonical paths

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -1238,6 +1238,36 @@ class App
 		// set the current locale
 		$this->setCurrentLanguage($language);
 
+		// canonicalize repeated slashes only in page resolution
+		// read the original request, not `$path`, because upstream parsing
+		// may already have collapsed duplicate slashes
+		$requestUri = $this->environment()->get('REQUEST_URI');
+
+		if (is_string($requestUri) === true) {
+			[$requestPath, $requestQuery] = array_pad(
+				explode('?', $requestUri, 2),
+				2,
+				null
+			);
+
+			if (Str::contains($requestPath, '//') === true) {
+				// collapse repeated slashes in the path to a single slash
+				// and keep the query string unchanged
+				$normalizedPath = preg_replace('!/{2,}!', '/', $requestPath);
+
+				if ($normalizedPath !== $requestPath) {
+					// send clients to the canonical page URL to avoid duplicate content
+					$location = $normalizedPath ?: '/';
+
+					if ($requestQuery !== null && $requestQuery !== '') {
+						$location .= '?' . $requestQuery;
+					}
+
+					return Response::redirect($location, 301);
+				}
+			}
+		}
+
 		// directly prevent path with incomplete content representation
 		if (Str::endsWith($path, '.') === true) {
 			return null;

--- a/tests/Cms/App/AppResolveTest.php
+++ b/tests/Cms/App/AppResolveTest.php
@@ -32,6 +32,65 @@ class AppResolveTest extends TestCase
 		$this->assertTrue($result->isHomePage());
 	}
 
+	public function testResolveRedirectsLeadingRepeatedSlashes(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'test'
+					]
+				]
+			],
+			'server' => [
+				'REQUEST_URI' => '//test?foo=bar'
+			],
+			'urls' => [
+				'index' => 'https://getkirby.test'
+			]
+		]);
+
+		$response = $app->resolve(null);
+
+		$this->assertSame(301, $response->code());
+		$this->assertSame('/test?foo=bar', $response->headers()['Location']->toString());
+	}
+
+	public function testResolveRedirectsInnerRepeatedSlashes(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'test',
+						'children' => [
+							[
+								'slug' => 'subpage'
+							]
+						]
+					]
+				]
+			],
+			'server' => [
+				'REQUEST_URI' => '/test//subpage?foo=bar'
+			],
+			'urls' => [
+				'index' => 'https://getkirby.test'
+			]
+		]);
+
+		$response = $app->resolve('test/subpage');
+
+		$this->assertSame(301, $response->code());
+		$this->assertSame('/test/subpage?foo=bar', $response->headers()['Location']->toString());
+	}
+
 	public function testResolveMainPage(): void
 	{
 		$app = new App([


### PR DESCRIPTION
## Description

After a long wait, this appears to finally provide a fix for the 4-year-old issue around repeated slashes in page URLs 🎉 

This fixes the issue where page requests with repeated slashes like `//page` or `/page//child` could be resolved inconsistently and sometimes return the homepage with a `200` response.

The fix handles this in `App::resolve()` by reading the raw `REQUEST_URI`, collapsing repeated slashes in the path, preserving the query string, and redirecting the request to the canonical single-slash URL with a `301` response.

This keeps the behavior scoped to page resolution instead of applying a global normalization rule in the router or environment layer.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements

- Improves page URL handling by redirecting repeated slashes to canonical paths #4801 


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion