### PR TITLE
fix: Pass files field upload template to chunks 

### DIFF
--- a/config/fields/mixins/upload.php
+++ b/config/fields/mixins/upload.php
@@ -61,10 +61,12 @@ return [
 
 			$parent = $this->uploadParent($params['parent'] ?? null);
 
-			return $api->upload(function ($source, $filename) use ($parent, $params, $map) {
+			$template = $params['template'] ?? null;
+
+			return $api->upload(function ($source, $filename) use ($parent, $template, $map) {
 				$props = [
 					'source'   => $source,
-					'template' => $params['template'] ?? null,
+					'template' => $template,
 					'filename' => $filename,
 				];
 
@@ -78,7 +80,7 @@ return [
 				}
 
 				return $map($file, $parent);
-			});
+			}, template: $template);
 		},
 		'uploadParent' => function (string|null $parentQuery = null) {
 			$parent = $this->model();

--- a/config/fields/mixins/upload.php
+++ b/config/fields/mixins/upload.php
@@ -59,11 +59,10 @@ return [
 				);
 			}
 
-			$parent = $this->uploadParent($params['parent'] ?? null);
-
+			$parent   = $this->uploadParent($params['parent'] ?? null);
 			$template = $params['template'] ?? null;
 
-			return $api->upload(function ($source, $filename) use ($parent, $template, $map) {
+			return $api->upload(function ($source, $filename, $template) use ($parent, $map) {
 				$props = [
 					'source'   => $source,
 					'template' => $template,

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -615,8 +615,9 @@ class Api
 	public function upload(
 		Closure $callback,
 		bool $single = false,
-		bool $debug = false
+		bool $debug = false,
+		string|null $template = null
 	): array {
-		return (new Upload($this, $single, $debug))->process($callback);
+		return (new Upload($this, $single, $debug, $template))->process($callback);
 	}
 }

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -618,6 +618,13 @@ class Api
 		bool $debug = false,
 		string|null $template = null
 	): array {
-		return (new Upload($this, $single, $debug, $template))->process($callback);
+		$upload = new Upload(
+			api: $this,
+			single: $single,
+			debug: $debug,
+			template: $template
+		);
+
+		return $upload->process($callback);
 	}
 }

--- a/src/Api/Upload.php
+++ b/src/Api/Upload.php
@@ -34,7 +34,8 @@ readonly class Upload
 	public function __construct(
 		protected Api $api,
 		protected bool $single = true,
-		protected bool $debug = false
+		protected bool $debug = false,
+		protected string|null $template = null
 	) {
 	}
 
@@ -239,7 +240,7 @@ readonly class Upload
 			tmp:      $tmpRoot,
 			total:    $total,
 			offset:   $this->api->requestHeaders('Upload-Offset'),
-			template: $this->api->requestBody('template'),
+			template: $this->template ?? $this->api->requestBody('template'),
 		);
 
 		// stream chunk content and append it to partial file

--- a/src/Api/Upload.php
+++ b/src/Api/Upload.php
@@ -186,7 +186,7 @@ readonly class Upload
 				// (incomplete chunk request will return empty $source)
 				$data = match ($source) {
 					null    => null,
-					default => $callback($source, $filename)
+					default => $callback($source, $filename, $this->template)
 				};
 
 				$uploads[$upload['name']] = match (true) {

--- a/tests/Api/UploadTest.php
+++ b/tests/Api/UploadTest.php
@@ -49,12 +49,14 @@ class UploadTest extends TestCase
 	protected function upload(
 		array $api = [],
 		bool $single = true,
-		bool $debug = false
+		bool $debug = false,
+		string|null $template = null
 	): Upload {
 		return new Upload(
-			api:    $this->api($api),
-			single: $single,
-			debug:  $debug
+			api:      $this->api($api),
+			single:   $single,
+			debug:    $debug,
+			template: $template
 		);
 	}
 
@@ -583,6 +585,95 @@ class UploadTest extends TestCase
 				]
 			]
 		]);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionCode('error.file.maxsize');
+		$upload->processChunk($source, basename($source));
+	}
+
+	public function testValidateChunkWithTemplate(): void
+	{
+		$source = static::TMP . '/a.md';
+		$this->app->clone([
+			'blueprints' => [
+				'files/test' => [
+					'name'   => 'test',
+					'accept' => ['maxsize' => 100]
+				]
+			]
+		]);
+		$upload = $this->upload([
+			'requestData' => [
+				'headers' => [
+					'Upload-Length' => 120,
+					'Upload-Offset' => 0,
+					'Upload-Id'     => 'abcd'
+				]
+			]
+		], template: 'test');
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionCode('error.file.maxsize');
+		$upload->processChunk($source, basename($source));
+	}
+
+	public function testValidateChunkWithCustomTemplate(): void
+	{
+		$source = static::TMP . '/a.md';
+		F::write($source, 'abcdef');
+
+		$this->app->clone([
+			'blueprints' => [
+				'files/default' => [
+					'name'   => 'default',
+					'accept' => ['maxsize' => 100]
+				],
+				'files/custom' => [
+					'name'   => 'custom',
+					'accept' => ['maxsize' => 200]
+				]
+			]
+		]);
+		$upload = $this->upload([
+			'requestData' => [
+				'headers' => [
+					'Upload-Length' => 120,
+					'Upload-Offset' => 0,
+					'Upload-Id'     => 'abcd'
+				]
+			]
+		], template: 'custom');
+
+		$this->assertNull($upload->processChunk($source, basename($source)));
+	}
+
+	public function testValidateChunkTemplatePriority(): void
+	{
+		$source = static::TMP . '/a.md';
+		$this->app->clone([
+			'blueprints' => [
+				'files/large' => [
+					'name'   => 'large',
+					'accept' => ['maxsize' => 200]
+				],
+				'files/small' => [
+					'name'   => 'small',
+					'accept' => ['maxsize' => 100]
+				]
+			]
+		]);
+		$upload = $this->upload([
+			'requestData' => [
+				'body' => [
+					'template' => 'large'
+				],
+				'headers' => [
+					'Upload-Length' => 120,
+					'Upload-Offset' => 0,
+					'Upload-Id'     => 'abcd'
+				]
+			]
+		], template: 'small');
 
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionCode('error.file.maxsize');

--- a/tests/Form/Field/FilesFieldTest.php
+++ b/tests/Form/Field/FilesFieldTest.php
@@ -2,10 +2,48 @@
 
 namespace Kirby\Form\Field;
 
+use Closure;
+use Kirby\Cms\Api;
 use Kirby\Cms\App;
+use Kirby\Cms\File;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Cms\User;
+
+class FilesFieldTestApi extends Api
+{
+	public string|null $template = null;
+
+	public function upload(
+		Closure $callback,
+		bool $single = false,
+		bool $debug = false,
+		string|null $template = null
+	): array {
+		$this->template = $template;
+
+		return [
+			'status' => 'ok',
+			'data'   => $callback('source.txt', 'test.txt')
+		];
+	}
+}
+
+class FilesFieldTestPage extends Page
+{
+	public array $createdFile = [];
+
+	public function createFile(array $props, bool $move = false): File
+	{
+		$this->createdFile = $props;
+
+		return new File([
+			'filename' => $props['filename'],
+			'parent'   => $this,
+			'template' => $props['template']
+		]);
+	}
+}
 
 class FilesFieldTest extends TestCase
 {
@@ -276,6 +314,39 @@ class FilesFieldTest extends TestCase
 		$this->assertSame('a.jpg', $api['data'][0]['id']);
 		$this->assertSame('b.jpg', $api['data'][1]['id']);
 		$this->assertSame('c.jpg', $api['data'][2]['id']);
+	}
+
+	public function testUploadPassesTemplateToApi(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'files/custom' => [
+					'name'   => 'custom',
+					'accept' => ['extension' => 'txt']
+				]
+			]
+		]);
+		$this->app->impersonate('kirby');
+
+		$parent = new FilesFieldTestPage(['slug' => 'test']);
+
+		$field = $this->field('files', [
+			'model'   => $parent,
+			'uploads' => 'custom'
+		]);
+		$this->assertSame('.txt', $field->uploads()['accept']);
+
+		$api = new FilesFieldTestApi(['kirby' => $this->app]);
+
+		$result = $field->upload(
+			$api,
+			$field->uploads(),
+			fn ($file) => $file->template()
+		);
+
+		$this->assertSame('custom', $api->template);
+		$this->assertSame('custom', $parent->createdFile['template']);
+		$this->assertSame('custom', $result['data']);
 	}
 
 	public function testParentModel(): void

--- a/tests/Form/Field/FilesFieldTest.php
+++ b/tests/Form/Field/FilesFieldTest.php
@@ -24,7 +24,7 @@ class FilesFieldTestApi extends Api
 
 		return [
 			'status' => 'ok',
-			'data'   => $callback('source.txt', 'test.txt')
+			'data'   => $callback('source.txt', 'test.txt', $template)
 		];
 	}
 }


### PR DESCRIPTION
## Description

~Ensures files field chunked uploads send the configured upload template so chunk validation uses the correct file blueprint.~

Passes the server-side upload template into chunk validation so files field uploads use the configured file blueprint instead of falling back to default.


## Changelog 

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->

- Fixed chunked uploads using the wrong file blueprint #8086

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion