### PR TITLE
docs: Mark collection first and last as nullable

### DIFF
--- a/src/Cms/LazyCollection.php
+++ b/src/Cms/LazyCollection.php
@@ -207,7 +207,7 @@ abstract class LazyCollection extends Collection
 	/**
 	 * Returns the first element
 	 *
-	 * @return TValue
+	 * @return TValue|null
 	 */
 	public function first()
 	{
@@ -337,7 +337,7 @@ abstract class LazyCollection extends Collection
 	/**
 	 * Returns the last element
 	 *
-	 * @return TValue
+	 * @return TValue|null
 	 */
 	public function last()
 	{

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -413,7 +413,7 @@ class Collection extends Iterator implements Stringable
 	/**
 	 * Returns the first element
 	 *
-	 * @return TValue
+	 * @return TValue|null
 	 */
 	public function first()
 	{
@@ -640,7 +640,7 @@ class Collection extends Iterator implements Stringable
 	/**
 	 * Returns the last element
 	 *
-	 * @return TValue
+	 * @return TValue|null
 	 */
 	public function last()
 	{

--- a/tests/Toolkit/CollectionTest.php
+++ b/tests/Toolkit/CollectionTest.php
@@ -166,6 +166,7 @@ class CollectionTest extends TestCase
 
 	public function testFirst(): void
 	{
+		$this->assertNull((new Collection())->first());
 		$this->assertSame('My first element', $this->collection->first());
 	}
 
@@ -566,6 +567,7 @@ class CollectionTest extends TestCase
 
 	public function testLast(): void
 	{
+		$this->assertNull((new Collection())->last());
 		$this->assertSame('My third element', $this->collection->last());
 	}
 


### PR DESCRIPTION
## Description

This updates the PHPDoc return types for `Collection::first()` and `Collection::last()` and their LazyCollection overrides to include null, matching the existing runtime behavior for empty collections. It also adds focused assertions for empty Collection instances so the nullable behavior is covered explicitly.

## Changelog 

### ✨ Enhancements

- Corrected `Collection::first()` and `Collection::last()` PHPDoc return types to include `null` for empty collections #8092

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion