### PR TITLE
fix: Preserve existing input ids in validator

### DIFF
--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -1,7 +1,7 @@
 <template>
 	<k-field
 		v-bind="$props"
-		:input="id"
+		:input="false"
 		:class="['k-blocks-field', $attrs.class]"
 		:style="$attrs.style"
 	>
@@ -30,7 +30,7 @@
 		</template>
 
 		<k-input-validator
-			v-bind="{ id, min, max, required }"
+			v-bind="{ min, max, required }"
 			:value="JSON.stringify(value)"
 		>
 			<k-blocks

--- a/panel/src/components/Forms/Field/EntriesField.vue
+++ b/panel/src/components/Forms/Field/EntriesField.vue
@@ -1,7 +1,7 @@
 <template>
 	<k-field
 		v-bind="$props"
-		:input="id"
+		:input="false"
 		:class="['k-entries-field', $attrs.class]"
 		:style="$attrs.style"
 		@click.native.stop
@@ -31,7 +31,7 @@
 		</template>
 
 		<k-input-validator
-			v-bind="{ id, min, max, required }"
+			v-bind="{ min, max, required }"
 			:value="JSON.stringify(entries)"
 		>
 			<!-- Empty State -->

--- a/panel/src/components/Forms/Field/LayoutField.vue
+++ b/panel/src/components/Forms/Field/LayoutField.vue
@@ -1,7 +1,7 @@
 <template>
 	<k-field
 		v-bind="$props"
-		:input="id"
+		:input="false"
 		:class="['k-layout-field', $attrs.class]"
 		:style="$attrs.style"
 	>
@@ -27,7 +27,7 @@
 		</template>
 
 		<k-input-validator
-			v-bind="{ id, min, max, required }"
+			v-bind="{ min, max, required }"
 			:value="JSON.stringify(value)"
 		>
 			<k-layouts

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -2,7 +2,7 @@
 	<k-field
 		v-bind="$props"
 		:class="['k-structure-field', $attrs.class]"
-		:input="id"
+		:input="false"
 		:style="$attrs.style"
 		@click.native.stop
 	>
@@ -57,7 +57,7 @@
 		</template>
 
 		<k-input-validator
-			v-bind="{ id, min, max, required }"
+			v-bind="{ min, max, required }"
 			:value="JSON.stringify(items)"
 		>
 			<template v-if="hasFields">

--- a/panel/src/components/Forms/Input/Validator.js
+++ b/panel/src/components/Forms/Input/Validator.js
@@ -4,23 +4,29 @@
  */
 export default class InputValidator extends HTMLElement {
 	static formAssociated = true;
+	/** @type {ElementInternals} */
+	internals = this.attachInternals();
+	/** @type {Array<unknown>} */
+	entries = [];
+	/** @type {number | null} */
+	max = null;
+	/** @type {number | null} */
+	min = null;
+	/** @type {boolean} */
+	required = false;
 
 	static get observedAttributes() {
 		return ["min", "max", "required", "value"];
 	}
 
 	attributeChangedCallback(attribute, oldValue, newValue) {
-		this[attribute] = newValue;
-	}
-
-	constructor() {
-		super();
-		this.internals = this.attachInternals();
-		this.entries = [];
-
-		this.max = null;
-		this.min = null;
-		this.required = false;
+		if (attribute === "required") {
+			this.required = newValue !== null && newValue !== "false";
+		} else if (attribute === "min" || attribute === "max") {
+			this[attribute] = newValue === null ? null : parseInt(newValue);
+		} else {
+			this[attribute] = newValue;
+		}
 	}
 
 	connectedCallback() {
@@ -60,29 +66,22 @@ export default class InputValidator extends HTMLElement {
 	}
 
 	validate() {
-		const max = parseInt(this.getAttribute("max"));
-		const min = parseInt(this.getAttribute("min"));
-
-		const required =
-			this.hasAttribute("required") &&
-			this.getAttribute("required") !== "false";
-
-		if (required && this.entries.length === 0) {
+		if (this.required && this.entries.length === 0) {
 			this.internals.setValidity(
 				{ valueMissing: true },
 				window.panel.t("error.validation.required"),
 				this.input
 			);
-		} else if (this.hasAttribute("min") && this.entries.length < min) {
+		} else if (this.min !== null && this.entries.length < this.min) {
 			this.internals.setValidity(
 				{ rangeUnderflow: true },
-				window.panel.t("error.validation.min", { min }),
+				window.panel.t("error.validation.min", { min: this.min }),
 				this.input
 			);
-		} else if (this.hasAttribute("max") && this.entries.length > max) {
+		} else if (this.max !== null && this.entries.length > this.max) {
 			this.internals.setValidity(
 				{ rangeOverflow: true },
-				window.panel.t("error.validation.max", { max }),
+				window.panel.t("error.validation.max", { max: this.max }),
 				this.input
 			);
 		} else {

--- a/panel/src/components/Forms/Input/Validator.js
+++ b/panel/src/components/Forms/Input/Validator.js
@@ -24,21 +24,6 @@ export default class InputValidator extends HTMLElement {
 	}
 
 	connectedCallback() {
-		this.tabIndex = 0;
-
-		// pass-through the id attribute
-		const id = this.getAttribute("id");
-
-		if (id && this.input) {
-			if (this.input.hasAttribute("id") === false) {
-				this.input.setAttribute("id", id);
-			}
-
-			// always strip own id to avoid duplicate ids in the DOM,
-			// even when the transfer was skipped because the child already has one
-			this.removeAttribute("id");
-		}
-
 		this.validate();
 	}
 

--- a/panel/src/components/Forms/Input/Validator.js
+++ b/panel/src/components/Forms/Input/Validator.js
@@ -47,10 +47,6 @@ export default class InputValidator extends HTMLElement {
 		);
 	}
 
-	get isEmpty() {
-		return this.selected.length === 0;
-	}
-
 	get name() {
 		return this.getAttribute("name");
 	}

--- a/panel/src/components/Forms/Input/Validator.js
+++ b/panel/src/components/Forms/Input/Validator.js
@@ -30,7 +30,10 @@ export default class InputValidator extends HTMLElement {
 		const id = this.getAttribute("id");
 
 		if (id) {
-			this.input.setAttribute("id", id);
+			if (this.input.hasAttribute("id") === false) {
+				this.input.setAttribute("id", id);
+			}
+
 			this.removeAttribute("id");
 		}
 

--- a/panel/src/components/Forms/Input/Validator.js
+++ b/panel/src/components/Forms/Input/Validator.js
@@ -89,19 +89,19 @@ export default class InputValidator extends HTMLElement {
 		if (required && this.entries.length === 0) {
 			this.internals.setValidity(
 				{ valueMissing: true },
-				window.panel.$t("error.validation.required"),
+				window.panel.t("error.validation.required"),
 				this.input
 			);
 		} else if (this.hasAttribute("min") && this.entries.length < min) {
 			this.internals.setValidity(
 				{ rangeUnderflow: true },
-				window.panel.$t("error.validation.min", { min }),
+				window.panel.t("error.validation.min", { min }),
 				this.input
 			);
 		} else if (this.hasAttribute("max") && this.entries.length > max) {
 			this.internals.setValidity(
 				{ rangeOverflow: true },
-				window.panel.$t("error.validation.max", { max }),
+				window.panel.t("error.validation.max", { max }),
 				this.input
 			);
 		} else {

--- a/panel/src/components/Forms/Input/Validator.js
+++ b/panel/src/components/Forms/Input/Validator.js
@@ -29,11 +29,13 @@ export default class InputValidator extends HTMLElement {
 		// pass-through the id attribute
 		const id = this.getAttribute("id");
 
-		if (id) {
+		if (id && this.input) {
 			if (this.input.hasAttribute("id") === false) {
 				this.input.setAttribute("id", id);
 			}
 
+			// always strip own id to avoid duplicate ids in the DOM,
+			// even when the transfer was skipped because the child already has one
 			this.removeAttribute("id");
 		}
 

--- a/panel/src/components/Forms/Input/Validator.test.js
+++ b/panel/src/components/Forms/Input/Validator.test.js
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import InputValidator from "./Validator.js";
+
+const TAG = "k-input-validator-test";
+
+beforeAll(() => {
+	customElements.define(TAG, InputValidator);
+});
+
+afterEach(() => {
+	document.body.innerHTML = "";
+});
+
+function mount(attrs = {}, child = null) {
+	const validator = document.createElement(TAG);
+
+	// jsdom does not fully implement ElementInternals.setValidity;
+	// stub validate so connectedCallback does not throw unhandled errors
+	validator.validate = () => {};
+
+	for (const [key, value] of Object.entries(attrs)) {
+		validator.setAttribute(key, value);
+	}
+
+	if (child) {
+		validator.appendChild(child);
+	}
+
+	document.body.appendChild(validator);
+
+	return validator;
+}
+
+describe("InputValidator", () => {
+	describe("connectedCallback", () => {
+		it("transfers its id to a child without an existing id", () => {
+			const input = document.createElement("input");
+			const validator = mount({ id: "myField" }, input);
+
+			expect(input.getAttribute("id")).toBe("myField");
+			expect(validator.hasAttribute("id")).toBe(false);
+		});
+
+		it("does not overwrite the existing id on the child", () => {
+			const input = document.createElement("input");
+			input.setAttribute("id", "myField-0");
+			mount({ id: "myField" }, input);
+
+			expect(input.getAttribute("id")).toBe("myField-0");
+		});
+
+		it("removes its own id even when the transfer was skipped", () => {
+			const input = document.createElement("input");
+			input.setAttribute("id", "myField-0");
+			const validator = mount({ id: "myField" }, input);
+
+			expect(validator.hasAttribute("id")).toBe(false);
+		});
+
+		it("does not throw when there is no child input", () => {
+			expect(() => mount({ id: "myField" })).not.toThrow();
+		});
+	});
+});

--- a/panel/src/components/Forms/Input/Validator.test.js
+++ b/panel/src/components/Forms/Input/Validator.test.js
@@ -2,67 +2,300 @@
  * @vitest-environment jsdom
  */
 
-import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import InputValidator from "./Validator.js";
+
+/**
+ * @typedef {InputValidator & HTMLElement} InputValidatorEl
+ */
 
 const TAG = "k-input-validator-test";
 
 beforeAll(() => {
 	customElements.define(TAG, InputValidator);
+
+	// jsdom does not implement ElementInternals.setValidity. Stub it on the
+	// prototype so validate() can run end-to-end and we can spy on calls.
+	const proto = window.ElementInternals.prototype;
+	proto.setValidity ??= () => {};
+	proto.checkValidity ??= () => true;
+	proto.reportValidity ??= () => true;
+
+	// Minimal panel.t shim used by validate()
+	window.panel ??= {};
+	window.panel.t = (key, params) =>
+		params ? `${key}:${JSON.stringify(params)}` : key;
 });
 
 afterEach(() => {
 	document.body.innerHTML = "";
+	vi.restoreAllMocks();
 });
 
-function mount(attrs = {}, child = null) {
-	const validator = document.createElement(TAG);
-
-	// jsdom does not fully implement ElementInternals.setValidity;
-	// stub validate so connectedCallback does not throw unhandled errors
-	validator.validate = () => {};
+/**
+ * Creates a validator element with the given attributes and children
+ * and appends it to the document body so connectedCallback fires.
+ *
+ * @param {Record<string, string>} [attrs]
+ * @param {HTMLElement | HTMLElement[]} [children]
+ * @returns {InputValidatorEl}
+ */
+function mount(attrs = {}, children = []) {
+	const validator = /** @type {InputValidatorEl} */ (
+		document.createElement(TAG)
+	);
 
 	for (const [key, value] of Object.entries(attrs)) {
 		validator.setAttribute(key, value);
 	}
 
-	if (child) {
+	for (const child of [].concat(children)) {
 		validator.appendChild(child);
 	}
 
 	document.body.appendChild(validator);
-
 	return validator;
 }
 
+/**
+ * @param {Record<string, string>} [attrs]
+ * @returns {HTMLInputElement}
+ */
+function input(attrs = {}) {
+	const el = document.createElement("input");
+	for (const [key, value] of Object.entries(attrs)) {
+		el.setAttribute(key, value);
+	}
+	return el;
+}
+
 describe("InputValidator", () => {
-	describe("connectedCallback", () => {
-		it("transfers its id to a child without an existing id", () => {
-			const input = document.createElement("input");
-			const validator = mount({ id: "myField" }, input);
+	describe("attributeChangedCallback", () => {
+		it("coerces min and max to numbers", () => {
+			const validator = mount();
 
-			expect(input.getAttribute("id")).toBe("myField");
-			expect(validator.hasAttribute("id")).toBe(false);
+			expect(validator.min).toBeNull();
+			expect(validator.max).toBeNull();
+
+			validator.setAttribute("min", "1");
+			validator.setAttribute("max", "5");
+
+			expect(validator.min).toBe(1);
+			expect(validator.max).toBe(5);
 		});
 
-		it("does not overwrite the existing id on the child", () => {
-			const input = document.createElement("input");
-			input.setAttribute("id", "myField-0");
-			mount({ id: "myField" }, input);
+		it("resets min and max to null when the attributes are removed", () => {
+			const validator = mount({ min: "2", max: "8" });
 
-			expect(input.getAttribute("id")).toBe("myField-0");
+			expect(validator.min).toBe(2);
+			expect(validator.max).toBe(8);
+
+			validator.removeAttribute("min");
+			validator.removeAttribute("max");
+
+			expect(validator.min).toBeNull();
+			expect(validator.max).toBeNull();
 		});
 
-		it("removes its own id even when the transfer was skipped", () => {
-			const input = document.createElement("input");
-			input.setAttribute("id", "myField-0");
-			const validator = mount({ id: "myField" }, input);
-
-			expect(validator.hasAttribute("id")).toBe(false);
+		it("treats required as a boolean: present → true", () => {
+			const validator = mount();
+			expect(validator.required).toBe(false);
+			validator.setAttribute("required", "true");
+			expect(validator.required).toBe(true);
 		});
 
-		it("does not throw when there is no child input", () => {
-			expect(() => mount({ id: "myField" })).not.toThrow();
+		it("treats required='false' as not required", () => {
+			const validator = mount({ required: "true" });
+			expect(validator.required).toBe(true);
+			validator.setAttribute("required", "false");
+			expect(validator.required).toBe(false);
+		});
+
+		it("resets required to false when the attribute is removed", () => {
+			const validator = mount({ required: "true" });
+			expect(validator.required).toBe(true);
+			validator.removeAttribute("required");
+			expect(validator.required).toBe(false);
+		});
+	});
+
+	describe("has", () => {
+		it("returns true when the value is in entries", () => {
+			const validator = mount();
+			validator.value = JSON.stringify(["red", "blue"]);
+			expect(validator.has("red")).toBe(true);
+		});
+
+		it("returns false when the value is not in entries", () => {
+			const validator = mount();
+			validator.value = JSON.stringify(["red"]);
+			expect(validator.has("blue")).toBe(false);
+		});
+	});
+
+	describe("input", () => {
+		it("returns the element matching the anchor selector", () => {
+			const target = input({ class: "preferred" });
+			const other = input();
+			const validator = mount({ anchor: ".preferred" }, [other, target]);
+			expect(validator.input).toBe(target);
+		});
+
+		it("falls back to the first focusable descendant", () => {
+			const wrapper = document.createElement("div");
+			const button = document.createElement("button");
+			wrapper.appendChild(button);
+			const validator = mount({}, wrapper);
+			expect(validator.input).toBe(button);
+		});
+
+		it("matches input, textarea, select and button", () => {
+			for (const tag of ["input", "textarea", "select", "button"]) {
+				const child = document.createElement(tag);
+				const validator = mount({}, child);
+				expect(validator.input).toBe(child);
+				document.body.innerHTML = "";
+			}
+		});
+
+		it("falls back to the first direct child when nothing focusable exists", () => {
+			const wrapper = document.createElement("div");
+			const validator = mount({}, wrapper);
+			expect(validator.input).toBe(wrapper);
+		});
+
+		it("returns null when there are no children", () => {
+			const validator = mount();
+			expect(validator.input).toBeNull();
+		});
+	});
+
+	describe("name", () => {
+		it("reflects the name attribute", () => {
+			const validator = mount({ name: "tags" });
+			expect(validator.name).toBe("tags");
+		});
+
+		it("returns null when name is not set", () => {
+			const validator = mount();
+			expect(validator.name).toBeNull();
+		});
+	});
+
+	describe("type", () => {
+		it("returns the local element name", () => {
+			const validator = mount();
+			expect(validator.type).toBe(TAG);
+		});
+	});
+
+	describe("validate", () => {
+		it("flags valueMissing when required and entries are empty", () => {
+			const validator = mount({ required: "true" }, input());
+			const spy = vi.spyOn(validator.internals, "setValidity");
+
+			validator.validate();
+
+			expect(spy).toHaveBeenCalledWith(
+				{ valueMissing: true },
+				"error.validation.required",
+				validator.input
+			);
+		});
+
+		it("treats required='false' as not required", () => {
+			const validator = mount({ required: "false" }, input());
+			const spy = vi.spyOn(validator.internals, "setValidity");
+
+			validator.validate();
+
+			expect(spy).toHaveBeenCalledWith({});
+		});
+
+		it("flags rangeUnderflow when entries are below min", () => {
+			const validator = mount({ min: "3" }, input());
+			validator.value = JSON.stringify(["a", "b"]);
+			const spy = vi.spyOn(validator.internals, "setValidity");
+
+			validator.validate();
+
+			expect(spy).toHaveBeenCalledWith(
+				{ rangeUnderflow: true },
+				expect.stringContaining("error.validation.min"),
+				validator.input
+			);
+		});
+
+		it("flags rangeOverflow when entries are above max", () => {
+			const validator = mount({ max: "2" }, input());
+			validator.value = JSON.stringify(["a", "b", "c"]);
+			const spy = vi.spyOn(validator.internals, "setValidity");
+
+			validator.validate();
+
+			expect(spy).toHaveBeenCalledWith(
+				{ rangeOverflow: true },
+				expect.stringContaining("error.validation.max"),
+				validator.input
+			);
+		});
+
+		it("clears validity when constraints are satisfied", () => {
+			const validator = mount({ min: "1", max: "3" }, input());
+			validator.value = JSON.stringify(["a", "b"]);
+			const spy = vi.spyOn(validator.internals, "setValidity");
+
+			validator.validate();
+
+			expect(spy).toHaveBeenCalledWith({});
+		});
+
+		it("prefers valueMissing over min when both could apply", () => {
+			const validator = mount({ required: "true", min: "2" }, input());
+			const spy = vi.spyOn(validator.internals, "setValidity");
+
+			validator.validate();
+
+			expect(spy).toHaveBeenCalledWith(
+				{ valueMissing: true },
+				expect.any(String),
+				validator.input
+			);
+		});
+	});
+
+	describe("value", () => {
+		it("parses a JSON-encoded array into entries", () => {
+			const validator = mount();
+			validator.value = JSON.stringify(["a", "b"]);
+			expect(validator.entries).toEqual(["a", "b"]);
+		});
+
+		it("falls back to an empty array for non-string input", () => {
+			const validator = mount();
+			validator.value = null;
+			expect(validator.entries).toEqual([]);
+		});
+
+		it("serializes entries back to a JSON string via the getter", () => {
+			const validator = mount();
+			validator.value = JSON.stringify([1, 2, 3]);
+			expect(validator.value).toBe("[1,2,3]");
+		});
+
+		it("returns an empty array as JSON when entries are missing", () => {
+			const validator = mount();
+			validator.entries = null;
+			expect(validator.value).toBe("[]");
+		});
+
+		it("re-runs validation when set", () => {
+			const validator = mount({ required: "true" }, input());
+			const spy = vi.spyOn(validator.internals, "setValidity");
+
+			validator.value = JSON.stringify(["x"]);
+
+			expect(spy).toHaveBeenCalledWith({});
 		});
 	});
 });


### PR DESCRIPTION
## Description

This fixes an issue where the first option of a `toggles` field inside a block could not be selected after reload. The problem was caused by `k-input-validator` passing its own `id` attribute through to the first nested input. For grouped inputs like toggles, that overwrote the first radio input's generated `id`, while the label still pointed to the original `for` value.

The fix keeps the validator's existing id pass-through behavior, but only applies it when the target input does not already have an `id`. This preserves explicit `id`/`for` relationships created by grouped inputs while keeping the previous behavior for inputs that rely on the validator-provided id.


### Additional notes

As a follow-up, we should decouple `k-input-validator` from input ID management entirely. The validator currently mutates the first nested input by passing its own `id` attribute through to it, which can interfere with components that manage their own `id`/`for` relationships, such as grouped radio-style inputs.

A more robust long-term solution would be to make validation targeting explicit, e.g. through the existing `anchor` attribute, and let each input component remain responsible for its own IDs and labels. This would keep `k-input-validator` focused on validity state only and avoid unexpected DOM mutations.


## Changelog 

### 🐛 Bug fixes

- Fixed first toggles option in blocks not being selectable #8093 

## Docs

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion