### PR TITLE
refact: `panel.t()` to use key as fallback

### DIFF
--- a/panel/src/panel/translation.test.ts
+++ b/panel/src/panel/translation.test.ts
@@ -78,10 +78,22 @@ describe("panel.translation", () => {
 			expect(translation.translate("count")).toStrictEqual(42);
 		});
 
-		it("returns the fallback when key does not exist", () => {
+		it("uses the key as fallback when key does not exist", () => {
+			const translation = Translation();
+			expect(translation.translate("missing.key")).toStrictEqual("missing.key");
+		});
+
+		it("accepts fallback as second argument", () => {
+			const translation = Translation();
+			expect(translation.translate("missing.key", "Fallback")).toStrictEqual(
+				"Fallback"
+			);
+		});
+
+		it("accepts fallback as third argument alongside data", () => {
 			const translation = Translation();
 			expect(
-				translation.translate("does-not-exist", {}, "Fallback")
+				translation.translate("missing.key", { name: "Peter" }, "Fallback")
 			).toStrictEqual("Fallback");
 		});
 

--- a/panel/src/panel/translation.test.ts
+++ b/panel/src/panel/translation.test.ts
@@ -72,12 +72,6 @@ describe("panel.translation", () => {
 			).toStrictEqual("Hello Peter");
 		});
 
-		it("returns a non-string value as-is", () => {
-			const translation = Translation();
-			translation.set({ data: { count: 42 } });
-			expect(translation.translate("count")).toStrictEqual(42);
-		});
-
 		it("uses the key as fallback when key does not exist", () => {
 			const translation = Translation();
 			expect(translation.translate("missing.key")).toStrictEqual("missing.key");

--- a/panel/src/panel/translation.ts
+++ b/panel/src/panel/translation.ts
@@ -10,6 +10,8 @@ export type TranslationState = {
 	weekday: number;
 };
 
+type Data = StringTemplateValues;
+
 export function defaults(): TranslationState {
 	return {
 		code: null,
@@ -27,6 +29,45 @@ export function defaults(): TranslationState {
  */
 export default function Translation() {
 	const parent = State("translation", defaults());
+
+	/**
+	 * Fetches a translation string by key, optionally replacing placeholders
+	 * with values from the data argument. Falls back to the given fallback
+	 * string, or the key itself if no fallback is provided.
+	 *
+	 * @example
+	 * t("key")                      // key as fallback
+	 * t("key", "fallback")          // shorthand fallback
+	 * t("key", { name: "…" })       // with placeholder
+	 * t("key", { name: "…" }, "f")  // with placeholders and fallback
+	 * t(42)                         // undefined
+	 */
+	function translate(key: string, fallback: string): string;
+	function translate(key: string, data?: Data, fallback?: string): string;
+	function translate(key: unknown, data?: Data, fallback?: string): undefined;
+	function translate(
+		this: { data: Data },
+		key: unknown,
+		data?: Data | string,
+		fallback?: string
+	): Data[string] | undefined {
+		if (typeof key !== "string") {
+			return;
+		}
+
+		if (typeof data === "string") {
+			fallback = data;
+			data = undefined;
+		}
+
+		const value = this.data[key] ?? fallback ?? key;
+
+		if (typeof value !== "string") {
+			return value;
+		}
+
+		return template(value, data);
+	}
 
 	return reactive({
 		...parent,
@@ -49,27 +90,6 @@ export default function Translation() {
 			return this.state();
 		},
 
-		/**
-		 * Fetches a translation string by key and
-		 * optionally replaces placeholders
-		 * with values from the data argument
-		 */
-		translate(
-			key: unknown,
-			data?: StringTemplateValues,
-			fallback?: string
-		): StringTemplateValues[string] | undefined {
-			if (typeof key !== "string") {
-				return;
-			}
-
-			const value = this.data[key] ?? fallback;
-
-			if (typeof value !== "string") {
-				return value;
-			}
-
-			return template(value, data);
-		}
+		translate
 	});
 }


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- `this.$panel.t()`/`window.panel.t()` now returns a string key as fallback if no matching i18n string exists and no actual fallback has been provided


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion