### PR TITLE
fix: Adapt i18n `direction` directive to Vue 3

### DIFF
--- a/panel/src/config/i18n.js
+++ b/panel/src/config/i18n.js
@@ -1,10 +1,10 @@
 export default {
 	install(app) {
-		const dir = (el, binding, vnode) => {
-			if (vnode.context.disabled !== true) {
+		const dir = (el, binding) => {
+			if (binding.instance.disabled !== true) {
 				el.dir = window.panel.language.direction;
 			} else {
-				el.dir = null;
+				el.removeAttribute("dir");
 			}
 		};
 
@@ -14,8 +14,8 @@ export default {
 		 * component isn't disabled
 		 */
 		app.directive("direction", {
-			bind: dir,
-			update: dir
+			beforeMount: dir,
+			updated: dir
 		});
 	}
 };

--- a/panel/src/config/i18n.test.ts
+++ b/panel/src/config/i18n.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import Panel from "@/panel/panel";
+import i18n from "./i18n";
+
+const TestComponent = {
+	props: { disabled: { type: Boolean, default: false } },
+	template: `<div v-direction></div>`
+};
+
+function mountWithDirective(disabled = false) {
+	return mount(TestComponent, {
+		props: { disabled },
+		global: { plugins: [i18n] }
+	});
+}
+
+describe("config.i18n", () => {
+	describe("v-direction directive", () => {
+		beforeEach(() => {
+			window.panel = Panel.create(app);
+		});
+
+		it("sets el.dir from Panel language when component is not disabled", () => {
+			const wrapper = mountWithDirective(false);
+			expect(wrapper.element.dir).toBe("ltr");
+		});
+
+		it("removes dir attribute when component is disabled", () => {
+			const wrapper = mountWithDirective(true);
+			expect(wrapper.element.hasAttribute("dir")).toBe(false);
+		});
+
+		it("updates el.dir when disabled changes to false", async () => {
+			const wrapper = mountWithDirective(true);
+			await wrapper.setProps({ disabled: false });
+			expect(wrapper.element.dir).toBe("ltr");
+		});
+
+		it("removes dir attribute when disabled changes to true", async () => {
+			const wrapper = mountWithDirective(false);
+			await wrapper.setProps({ disabled: true });
+			expect(wrapper.element.hasAttribute("dir")).toBe(false);
+		});
+
+		it("reflects Panel language direction", () => {
+			window.panel.language.set({ direction: "rtl" });
+			const wrapper = mountWithDirective(false);
+			expect(wrapper.element.dir).toBe("rtl");
+
+			window.panel.language.set({ direction: "ltr" });
+			expect(wrapper.element.dir).toBe("rtl");
+		});
+	});
+});

--- a/panel/src/config/i18n.ts
+++ b/panel/src/config/i18n.ts
@@ -1,7 +1,11 @@
+import type { App, DirectiveBinding } from "vue";
+
 export default {
-	install(app) {
-		const dir = (el, binding) => {
-			if (binding.instance.disabled !== true) {
+	install(app: App) {
+		const dir = (el: HTMLElement, binding: DirectiveBinding) => {
+			const instance = binding.instance as { disabled?: boolean } | null;
+
+			if (instance?.disabled !== true) {
 				el.dir = window.panel.language.direction;
 			} else {
 				el.removeAttribute("dir");


### PR DESCRIPTION
- Directive was still using old Vue 2 hooks and therefore not actually applied
- Added unit tests
- Migrated t TypeScript