### PR TITLE
refact: Migrate Vue preserve mixins to TypeScript

### DIFF
--- a/panel/src/index.ts
+++ b/panel/src/index.ts
@@ -1,16 +1,16 @@
 import { createApp } from "vue";
 
-import App from "./panel/app.js";
-import Components from "./components/index.js";
+import App from "./panel/app";
+import Components from "./components/index";
 import ErrorHandling from "./config/errorhandling";
 import Helpers from "./helpers/index";
-import I18n from "./config/i18n.js";
-import Legacy from "./panel/legacy.js";
+import I18n from "./config/i18n";
+import Legacy from "./panel/legacy";
 import Libraries from "./libraries/index";
-import Panel from "./panel/panel.js";
+import Panel from "./panel/panel";
 
-import preserveDataAttrs from "./mixins/preserveDataAttrs.js";
-import preserveListeners from "./mixins/preserveListeners.js";
+import preserveDataAttrs from "./mixins/preserveDataAttrs";
+import preserveListeners from "./mixins/preserveListeners";
 
 /**
  * Global styles need to be loaded before

--- a/panel/src/mixins/preserveDataAttrs.test.ts
+++ b/panel/src/mixins/preserveDataAttrs.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import preserveDataAttrs from "./preserveDataAttrs";
+
+const ComponentWithoutInherit = {
+	mixins: [preserveDataAttrs],
+	inheritAttrs: false,
+	template: "<div />"
+};
+
+const ComponentWithInherit = {
+	mixins: [preserveDataAttrs],
+	template: "<div />"
+};
+
+describe("preserveDataAttrs", () => {
+	describe("when inheritAttrs is false", () => {
+		it("applies data- attributes to the root element", () => {
+			const wrapper = mount(ComponentWithoutInherit, {
+				attrs: { "data-foo": "bar" }
+			});
+			expect(wrapper.attributes("data-foo")).toBe("bar");
+		});
+
+		it("applies multiple data- attributes", () => {
+			const wrapper = mount(ComponentWithoutInherit, {
+				attrs: { "data-foo": "bar", "data-id": "123" }
+			});
+			expect(wrapper.attributes("data-foo")).toBe("bar");
+			expect(wrapper.attributes("data-id")).toBe("123");
+		});
+
+		it("does not apply non-data- attributes", () => {
+			const wrapper = mount(ComponentWithoutInherit, {
+				attrs: { "aria-label": "test", id: "foo" }
+			});
+			expect(wrapper.attributes("aria-label")).toBeUndefined();
+			expect(wrapper.attributes("id")).toBeUndefined();
+		});
+	});
+
+	describe("when inheritAttrs is true", () => {
+		it("does not interfere with Vue's native attr inheritance", () => {
+			const wrapper = mount(ComponentWithInherit, {
+				attrs: { "data-foo": "bar" }
+			});
+			expect(wrapper.attributes("data-foo")).toBe("bar");
+		});
+	});
+});

--- a/panel/src/mixins/preserveDataAttrs.test.ts
+++ b/panel/src/mixins/preserveDataAttrs.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import preserveDataAttrs from "./preserveDataAttrs";
+import preserveListeners from "./preserveListeners";
 
 const ComponentWithoutInherit = {
 	mixins: [preserveDataAttrs],
@@ -46,5 +47,23 @@ describe("preserveDataAttrs", () => {
 			});
 			expect(wrapper.attributes("data-foo")).toBe("bar");
 		});
+	});
+});
+
+describe("preserveDataAttrs + preserveListeners combined", () => {
+	const ComponentWithBoth = {
+		mixins: [preserveDataAttrs, preserveListeners],
+		inheritAttrs: false,
+		template: "<div />"
+	};
+
+	it("applies data- attributes and attaches event listeners", async () => {
+		const handler = vi.fn();
+		const wrapper = mount(ComponentWithBoth, {
+			attrs: { "data-id": "42", onClick: handler }
+		});
+		expect(wrapper.attributes("data-id")).toBe("42");
+		await wrapper.trigger("click");
+		expect(handler).toHaveBeenCalledOnce();
 	});
 });

--- a/panel/src/mixins/preserveDataAttrs.ts
+++ b/panel/src/mixins/preserveDataAttrs.ts
@@ -1,3 +1,5 @@
+import type { ComponentOptions } from "vue";
+
 /**
  * Ensures that even when a component prohibits to
  * inherit non-prop attributes, all `data-` attributes
@@ -14,4 +16,4 @@ export default {
 			}
 		}
 	}
-};
+} satisfies ComponentOptions;

--- a/panel/src/mixins/preserveListeners.test.ts
+++ b/panel/src/mixins/preserveListeners.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import preserveListeners from "./preserveListeners";
+
+const ComponentWithoutInherit = {
+	mixins: [preserveListeners],
+	inheritAttrs: false,
+	template: "<div />"
+};
+
+describe("preserveListeners", () => {
+	describe("when inheritAttrs is false", () => {
+		it("attaches event listeners to the root element", async () => {
+			const handler = vi.fn();
+			const wrapper = mount(ComponentWithoutInherit, {
+				attrs: { onClick: handler }
+			});
+			await wrapper.trigger("click");
+			expect(handler).toHaveBeenCalledOnce();
+		});
+
+		it("attaches multiple listeners for the same event", async () => {
+			const handlerA = vi.fn();
+			const handlerB = vi.fn();
+			const wrapper = mount(ComponentWithoutInherit, {
+				attrs: { onClick: [handlerA, handlerB] }
+			});
+			await wrapper.trigger("click");
+			expect(handlerA).toHaveBeenCalledOnce();
+			expect(handlerB).toHaveBeenCalledOnce();
+		});
+
+		it("does not attach non-event attributes as listeners", async () => {
+			const wrapper = mount(ComponentWithoutInherit, {
+				attrs: { "data-foo": "bar" }
+			});
+			expect(wrapper.attributes("data-foo")).toBeUndefined();
+		});
+
+		it("removes listeners when unmounted", async () => {
+			const handler = vi.fn();
+			const wrapper = mount(ComponentWithoutInherit, {
+				attrs: { onClick: handler }
+			});
+			wrapper.unmount();
+			wrapper.element.dispatchEvent(new Event("click"));
+			expect(handler).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/panel/src/mixins/preserveListeners.test.ts
+++ b/panel/src/mixins/preserveListeners.test.ts
@@ -31,10 +31,12 @@ describe("preserveListeners", () => {
 		});
 
 		it("does not attach non-event attributes as listeners", async () => {
+			const handler = vi.fn();
 			const wrapper = mount(ComponentWithoutInherit, {
-				attrs: { "data-foo": "bar" }
+				attrs: { "data-foo": handler }
 			});
-			expect(wrapper.attributes("data-foo")).toBeUndefined();
+			await wrapper.trigger("click");
+			expect(handler).not.toHaveBeenCalled();
 		});
 
 		it("removes listeners when unmounted", async () => {

--- a/panel/src/mixins/preserveListeners.ts
+++ b/panel/src/mixins/preserveListeners.ts
@@ -1,3 +1,4 @@
+import type { ComponentOptions } from "vue";
 import { wrap } from "@/helpers/array.js";
 
 /**
@@ -40,4 +41,4 @@ export default {
 	unmounted() {
 		this.__listenersController.abort();
 	}
-};
+} satisfies ComponentOptions;

--- a/panel/src/mixins/preserveListeners.ts
+++ b/panel/src/mixins/preserveListeners.ts
@@ -1,5 +1,5 @@
 import type { ComponentOptions } from "vue";
-import { wrap } from "@/helpers/array.js";
+import { wrap } from "@/helpers/array";
 
 /**
  * Ensures that even when a component prohibits to

--- a/panel/vite.config.ts
+++ b/panel/vite.config.ts
@@ -148,7 +148,7 @@ export default defineConfig(({ mode }) => {
 			rolldownOptions: {
 				checks: { pluginTimings: false },
 				external: ["vue"],
-				input: "./src/index.js",
+				input: "./src/index.ts",
 				output: {
 					entryFileNames: "js/[name].min.js",
 					chunkFileNames: "js/[name].min.js",


### PR DESCRIPTION
- Migrated `preserveDataAttrs` and `preserveListeners` to TypeScript
- Added unit tests for both