### PR TITLE
refact: `system.csrf`/`.title` always strings

### DIFF
--- a/panel/src/panel/system.test.ts
+++ b/panel/src/panel/system.test.ts
@@ -31,11 +31,11 @@ describe("panel.system", () => {
 
 			expect(system.state()).toStrictEqual({
 				ascii: {},
-				csrf: null,
+				csrf: "",
 				isLocal: false,
 				locales: {},
 				slugs: [],
-				title: null
+				title: ""
 			});
 		});
 	});

--- a/panel/src/panel/system.ts
+++ b/panel/src/panel/system.ts
@@ -2,21 +2,21 @@ import State from "./state";
 
 export type SystemState = {
 	ascii: Record<string, string>;
-	csrf: string | null;
+	csrf: string;
 	isLocal: boolean;
 	locales: Record<string, string>;
 	slugs: string[];
-	title: string | null;
+	title: string;
 };
 
 export function defaults(): SystemState {
 	return {
 		ascii: {},
-		csrf: null,
+		csrf: "",
 		isLocal: false,
 		locales: {},
 		slugs: [],
-		title: null
+		title: ""
 	};
 }
 


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Our code base is more consistent when these two have an exact type. The backend always provides a string too, so the `null` type was really just for the initial default value. And here we can use an empty string.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- `panel.system.csrf` and `panel.csrf.title` are always strings now (empty strings when not set)


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion