### PR TITLE
refact: Some changes to `panel.content`

### DIFF
--- a/panel/src/panel/content.test.ts
+++ b/panel/src/panel/content.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it, vi, afterEach, beforeEach } from "vitest";
 import Content from "./content";
 
-const createPanel = () => ({
+const createPanel = ({ latest = {}, changes = {}, lock = {} } = {}) => ({
 	view: {
 		props: {
 			api: "/pages/test",
-			lock: { isLocked: false, modified: new Date("2024-01-01") },
+			lock: { isLocked: false, modified: new Date("2024-01-01"), ...lock },
 			versions: {
-				latest: { title: "Original" } as Record<string, unknown>,
-				changes: { title: "Original" } as Record<string, unknown>
+				latest: { title: "Original", ...latest } as Record<string, unknown>,
+				changes: { title: "Original", ...changes } as Record<string, unknown>
 			}
 		},
 		reload: vi.fn()
@@ -58,16 +58,16 @@ describe("panel.content", () => {
 		});
 
 		it("returns changed fields", () => {
-			const panel = createPanel();
-			panel.view.props.versions.changes = { title: "Updated" };
+			const panel = createPanel({ changes: { title: "Updated" } });
 			const content = Content(panel);
 			expect(content.diff()).toStrictEqual({ title: "Updated" });
 		});
 
 		it("includes null for fields absent in changes", () => {
-			const panel = createPanel();
-			panel.view.props.versions.latest = { title: "Original", slug: "test" };
-			panel.view.props.versions.changes = { title: "Original" };
+			const panel = createPanel({
+				latest: { title: "Original", slug: "test" },
+				changes: { title: "Original" }
+			});
 			const content = Content(panel);
 			expect(content.diff()).toStrictEqual({ slug: null });
 		});
@@ -99,8 +99,7 @@ describe("panel.content", () => {
 		});
 
 		it("throws when content is locked", async () => {
-			const panel = createPanel();
-			panel.view.props.lock.isLocked = true;
+			const panel = createPanel({ lock: { isLocked: true } });
 			const content = Content(panel);
 			await expect(content.discard()).rejects.toThrow(
 				"Cannot discard locked changes"
@@ -119,12 +118,13 @@ describe("panel.content", () => {
 		});
 
 		it("resets changes to latest version after discard", async () => {
-			const panel = createPanel();
-			panel.view.props.versions.latest = { title: "Published" };
-			panel.view.props.versions.changes = { title: "Draft" };
+			const panel = createPanel({
+				latest: { title: "Published" },
+				changes: { title: "Draft" }
+			});
 			const content = Content(panel);
 			await content.discard();
-			expect(panel.view.props.versions.changes).toStrictEqual({
+			expect(content.version("changes")).toStrictEqual({
 				title: "Published"
 			});
 		});
@@ -198,8 +198,7 @@ describe("panel.content", () => {
 		});
 
 		it("returns true when changes differ from latest", () => {
-			const panel = createPanel();
-			panel.view.props.versions.changes = { title: "Updated" };
+			const panel = createPanel({ changes: { title: "Updated" } });
 			const content = Content(panel);
 			expect(content.hasDiff()).toStrictEqual(true);
 		});
@@ -236,8 +235,7 @@ describe("panel.content", () => {
 		});
 
 		it("returns true when content is locked", () => {
-			const panel = createPanel();
-			panel.view.props.lock.isLocked = true;
+			const panel = createPanel({ lock: { isLocked: true } });
 			const content = Content(panel);
 			expect(content.isLocked()).toStrictEqual(true);
 		});
@@ -277,7 +275,9 @@ describe("panel.content", () => {
 			const panel = createPanel();
 			const content = Content(panel);
 			content.lockDialog({ isLocked: true, modified: new Date() });
-			const { on } = panel.dialog.open.mock.calls[0][0];
+			const { on } = vi.mocked(panel.dialog.open).mock.calls[0][0] as {
+				on: Record<string, () => void>;
+			};
 			on.close();
 			expect(panel.view.reload).toHaveBeenCalledOnce();
 		});
@@ -288,7 +288,7 @@ describe("panel.content", () => {
 			const panel = createPanel();
 			const content = Content(panel);
 			content.merge({ title: "New Title" });
-			expect(panel.view.props.versions.changes).toStrictEqual({
+			expect(content.version("changes")).toStrictEqual({
 				title: "New Title"
 			});
 		});
@@ -301,11 +301,10 @@ describe("panel.content", () => {
 		});
 
 		it("preserves existing changes when merging", () => {
-			const panel = createPanel();
-			panel.view.props.versions.changes = { title: "Draft", slug: "draft" };
+			const panel = createPanel({ changes: { title: "Draft", slug: "draft" } });
 			const content = Content(panel);
 			content.merge({ title: "Updated" });
-			expect(panel.view.props.versions.changes).toStrictEqual({
+			expect(content.version("changes")).toStrictEqual({
 				title: "Updated",
 				slug: "draft"
 			});
@@ -349,11 +348,10 @@ describe("panel.content", () => {
 		});
 
 		it("updates latest version to current changes after publish", async () => {
-			const panel = createPanel();
-			panel.view.props.versions.changes = { title: "Draft" };
+			const panel = createPanel({ changes: { title: "Draft" } });
 			const content = Content(panel);
 			await content.publish();
-			expect(panel.view.props.versions.latest).toStrictEqual({
+			expect(content.version("latest")).toStrictEqual({
 				title: "Draft"
 			});
 		});
@@ -380,9 +378,9 @@ describe("panel.content", () => {
 		it("replaces the lock's modified timestamp with a new date", () => {
 			const panel = createPanel();
 			const content = Content(panel);
-			const before = panel.view.props.lock.modified;
+			const before = content.lock().modified;
 			content.renewLock();
-			expect(panel.view.props.lock.modified).not.toBe(before);
+			expect(content.lock().modified).not.toBe(before);
 		});
 	});
 
@@ -401,9 +399,9 @@ describe("panel.content", () => {
 		it("renews lock after saving", async () => {
 			const panel = createPanel();
 			const content = Content(panel);
-			const before = panel.view.props.lock.modified;
+			const before = content.lock().modified;
 			await content.save({});
-			expect(panel.view.props.lock.modified).not.toBe(before);
+			expect(content.lock().modified).not.toBe(before);
 		});
 
 		it("emits save event with values", async () => {
@@ -511,7 +509,7 @@ describe("panel.content", () => {
 			const panel = createPanel();
 			const content = Content(panel);
 			content.updateLazy({ title: "Lazy Title" });
-			expect(panel.view.props.versions.changes).toStrictEqual({
+			expect(content.version("changes")).toStrictEqual({
 				title: "Lazy Title"
 			});
 		});
@@ -547,7 +545,8 @@ describe("panel.content", () => {
 			const panel = createPanel();
 			const content = Content(panel);
 			expect(content.version("latest")).toStrictEqual(
-				panel.view.props.versions.latest
+				(panel.view.props.versions as Record<string, Record<string, unknown>>)
+					.latest
 			);
 		});
 
@@ -555,7 +554,8 @@ describe("panel.content", () => {
 			const panel = createPanel();
 			const content = Content(panel);
 			expect(content.version("changes")).toStrictEqual(
-				panel.view.props.versions.changes
+				(panel.view.props.versions as Record<string, Record<string, unknown>>)
+					.changes
 			);
 		});
 	});

--- a/panel/src/panel/content.ts
+++ b/panel/src/panel/content.ts
@@ -7,7 +7,7 @@ import Dialog from "./dialog";
 
 type Env = {
 	api: string;
-	language: string;
+	language: string | null;
 };
 
 type Lock = {
@@ -107,7 +107,7 @@ export default function Content(panel: TODO) {
 				await this.request("discard", {}, env);
 
 				// update the props for the current view
-				panel.view.props.versions.changes = this.version("latest");
+				this.versions().changes = this.version("latest");
 
 				this.emit("discard", {}, env);
 			} catch (error) {
@@ -144,7 +144,7 @@ export default function Content(panel: TODO) {
 		 */
 		env(env: Partial<Env> = {}): Env {
 			return {
-				api: panel.view.props.api,
+				api: panel.view.props.api as string,
 				language: panel.language.code,
 				...env
 			};
@@ -188,7 +188,7 @@ export default function Content(panel: TODO) {
 				);
 			}
 
-			return panel.view.props.lock;
+			return panel.view.props.lock as Lock;
 		},
 
 		/**
@@ -234,12 +234,10 @@ export default function Content(panel: TODO) {
 				values = {};
 			}
 
-			panel.view.props.versions.changes = {
+			return (this.versions().changes = {
 				...this.version("changes"),
 				...values
-			};
-
-			return panel.view.props.versions.changes;
+			});
 		},
 
 		/**
@@ -273,7 +271,7 @@ export default function Content(panel: TODO) {
 				this.dialog?.close();
 
 				// update the props for the current view
-				panel.view.props.versions.latest = this.version("changes");
+				this.versions().latest = this.version("changes");
 
 				this.emit("publish", { values }, env);
 			} catch (error) {
@@ -299,9 +297,7 @@ export default function Content(panel: TODO) {
 			const { api, language } = this.env(env);
 
 			const options: RequestInit & { silent?: boolean } = {
-				headers: {
-					"x-language": language
-				}
+				headers: language !== null ? { "x-language": language } : {}
 			};
 
 			if (method === "save") {
@@ -309,7 +305,11 @@ export default function Content(panel: TODO) {
 				options.silent = true;
 			}
 
-			panel.api.post(api + "/changes/" + method, values, options);
+			panel.api.post(
+				api + "/changes/" + method,
+				values,
+				options as Record<string, unknown>
+			);
 		},
 
 		/**
@@ -439,7 +439,10 @@ export default function Content(panel: TODO) {
 		 * Returns all versions of the content
 		 */
 		versions(): Record<VersionId, Record<string, unknown>> {
-			return panel.view.props.versions;
+			return panel.view.props.versions as Record<
+				VersionId,
+				Record<string, unknown>
+			>;
 		}
 	});
 


### PR DESCRIPTION
- Turned `Env.language` to `string | null` as in single language setups it will be `null`
- Using `this.versions().changes` over `panel.view.props.versions.changes` as we can add typing to `this.versions()` while `panel.view.props` dives into untyped data structures and makes it hard to work with TypeScript.