### PR TITLE
[Auth] refact: Allow auth methods without email

### DIFF
--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -56,7 +56,7 @@ class Auth
 	 */
 	public function authenticate(
 		string $method,
-		string $email,
+		string|null $email,
 		#[SensitiveParameter]
 		string|null $password = null,
 		bool $long = false

--- a/src/Auth/Method.php
+++ b/src/Auth/Method.php
@@ -35,7 +35,7 @@ abstract class Method
 	 * a pending status if a challenge is required.
 	 */
 	abstract public function authenticate(
-		string $email,
+		string|null $email,
 		#[SensitiveParameter]
 		string|null $password = null,
 		bool $long = false

--- a/src/Auth/Method/BasicAuthMethod.php
+++ b/src/Auth/Method/BasicAuthMethod.php
@@ -26,7 +26,7 @@ class BasicAuthMethod extends Method
 	 * @throws \Kirby\Exception\InvalidArgumentException If the password is missing
 	 */
 	public function authenticate(
-		string $email,
+		string|null $email,
 		#[SensitiveParameter]
 		string|null $password = null,
 		bool $long = false

--- a/src/Auth/Method/CodeMethod.php
+++ b/src/Auth/Method/CodeMethod.php
@@ -21,7 +21,7 @@ use Kirby\Panel\Ui\Component;
 class CodeMethod extends Method
 {
 	public function authenticate(
-		string $email,
+		string|null $email,
 		string|null $password = null,
 		bool $long = false
 	): Status {

--- a/src/Auth/Method/PasswordMethod.php
+++ b/src/Auth/Method/PasswordMethod.php
@@ -25,7 +25,7 @@ class PasswordMethod extends Method
 	 * @throws \Kirby\Exception\InvalidArgumentException If the password is missing
 	 */
 	public function authenticate(
-		string $email,
+		string|null $email,
 		#[SensitiveParameter]
 		string|null $password = null,
 		bool $long = false

--- a/src/Auth/Method/PasswordResetMethod.php
+++ b/src/Auth/Method/PasswordResetMethod.php
@@ -17,7 +17,7 @@ use Kirby\Panel\Ui\Component;
 class PasswordResetMethod extends CodeMethod
 {
 	public function authenticate(
-		string $email,
+		string|null $email,
 		string|null $password = null,
 		bool $long = false
 	): Status {

--- a/src/Auth/Methods.php
+++ b/src/Auth/Methods.php
@@ -40,7 +40,7 @@ class Methods
 	 */
 	public function authenticate(
 		string $type,
-		string $email,
+		string|null $email,
 		string|null $password = null,
 		bool $long = false
 	): User|Status {

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -39,7 +39,7 @@ class DummyChallenge extends Challenge
 class DummyAuthMethod extends Method
 {
 	public function authenticate(
-		string $email,
+		string|null $email,
 		string|null $password = null,
 		bool $long = false
 	): Status|User {


### PR DESCRIPTION
E.g. to allow a passkey method - that could look something like this then

```php
public function authenticate(
	string|null $email,
	#[SensitiveParameter]
	string|null $password = null,
	bool $long = false
): User|Status {
	$kirby     = $this->auth->kirby();
	$challenge = $kirby->session()->pull('kirby.webauthn.login');
	$user      = $this->findUserByCredentialId($password);
	$webauthn  = Webauthn::for($user);

	$webauthn->verifyLogin(
		$user->secret('webauthn') ?? [],
		$password,
		$challenge
	);

	$user->loginPasswordless(['createMode' => 'cookie', 'long' => $long]);
	return $user;
}
```

### Merge first

- [x] https://github.com/getkirby/kirby/pull/8122