### PR TITLE
refact: Handle Dir::remove with atomic rename

### DIFF
--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -6,6 +6,7 @@ use Kirby\Exception\Exception;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\Str;
+use Throwable;
 
 /**
  * File System Cache Driver
@@ -214,13 +215,10 @@ class FileCache extends Cache
 	 */
 	public function flush(): bool
 	{
-		if (
-			Dir::remove($this->root) === true &&
-			Dir::make($this->root) === true
-		) {
-			return true;
+		try {
+			return Dir::remove($this->root) && Dir::make($this->root);
+		} catch (Throwable) {
+			return false;
 		}
-
-		return false; // @codeCoverageIgnore
 	}
 }

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -6,7 +6,6 @@ use Kirby\Exception\Exception;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\Str;
-use Throwable;
 
 /**
  * File System Cache Driver
@@ -215,10 +214,13 @@ class FileCache extends Cache
 	 */
 	public function flush(): bool
 	{
-		try {
-			return Dir::remove($this->root) && Dir::make($this->root);
-		} catch (Throwable) {
-			return false;
+		if (
+			Dir::remove($this->root) === true &&
+			Dir::make($this->root) === true
+		) {
+			return true;
 		}
+
+		return false; // @codeCoverageIgnore
 	}
 }

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -588,7 +588,11 @@ class Dir
 			}
 		}
 
-		return rmdir($dir);
+		return Helpers::handleErrors(
+			fn (): bool => rmdir($dir),
+			fn (int $errno, string $errstr) => true,
+			fn (): never => throw new Exception('The directory could not be deleted'),
+		);
 	}
 
 	/**

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -574,6 +574,81 @@ class Dir
 			return F::unlink($dir);
 		}
 
+		// Attempt an atomic rename before deletion to prevent race conditions
+		// where concurrent processes write new files between our scandir() and
+		// rmdir() calls: once renamed, the original path is gone and concurrent
+		// writes land in a fresh directory.
+		// The system tmp dir is tried first so the OS can garbage-collect any
+		// leftovers automatically; rename() across filesystems fails immediately
+		// (e.g. Linux tmpfs), so we fall back to a same-filesystem sibling dir.
+		$tmp = null;
+
+		foreach ([sys_get_temp_dir(), dirname($dir)] as $tmpParent) {
+			$candidate = $tmpParent . '/.remove-' . uniqid('', true);
+
+			$renamed = Helpers::handleErrors(
+				fn (): bool => rename($dir, $candidate),
+				fn () => true,
+				false
+			);
+
+			if ($renamed === true) {
+				$tmp = $candidate;
+				break;
+			}
+		}
+
+		if ($tmp !== null) {
+			// Original path is atomically gone; clean up the renamed copy.
+			// A leftover tmp dir on failure is a best-effort leak; the caller
+			// already considers the target removed and returns true either way.
+			try {
+				static::removeRecursive($tmp);
+			} catch (Throwable) {
+				// ignore
+			}
+			return true;
+		}
+
+		// Rename failed (e.g. permission on parent); fall back to in-place removal.
+		// Delete all contents first, then retry rmdir to tolerate transient
+		// "directory not empty" errors caused by concurrent writes.
+		static::removeRecursive($dir);
+
+		// removeRecursive may have already removed $dir successfully;
+		// only retry if it still exists
+		if (is_dir($dir) === false) {
+			return true;
+		}
+
+		for ($attempt = 0; $attempt < 5; $attempt++) {
+			if ($attempt > 0) {
+				usleep(10_000);
+			}
+
+			// Suppress all rmdir warnings (locale-independent); success is
+			// determined by checking whether the directory still exists
+			Helpers::handleErrors(
+				fn (): bool => rmdir($dir),
+				fn () => true,
+				null
+			);
+
+			if (is_dir($dir) === false) {
+				return true;
+			}
+		}
+
+		throw new Exception('The directory could not be deleted');
+	}
+
+	/**
+	 * Recursively removes all contents of a directory and then the directory
+	 * itself; errors on the final rmdir are silently suppressed so that
+	 * partial failures (e.g. inside a renamed tmp dir) do not abort callers
+	 */
+	protected static function removeRecursive(string $dir): void
+	{
 		foreach (scandir($dir) as $childName) {
 			if (in_array($childName, ['.', '..'], true) === true) {
 				continue;
@@ -582,16 +657,16 @@ class Dir
 			$child = $dir . '/' . $childName;
 
 			if (is_dir($child) === true && is_link($child) === false) {
-				static::remove($child);
+				static::removeRecursive($child);
 			} else {
 				F::unlink($child);
 			}
 		}
 
-		return Helpers::handleErrors(
+		Helpers::handleErrors(
 			fn (): bool => rmdir($dir),
-			fn (int $errno, string $errstr) => true,
-			fn (): never => throw new Exception('The directory could not be deleted'),
+			fn () => true,
+			null
 		);
 	}
 

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -600,8 +600,8 @@ class Dir
 
 		if ($tmp !== null) {
 			// Original path is atomically gone; clean up the renamed copy.
-			// A leftover tmp dir on failure is a best-effort leak; the caller
-			// already considers the target removed and returns true either way.
+			// If cleanup fails, we still return true because the original path
+			// no longer exists and any tmp leftovers will be garbage-collected by the OS.
 			try {
 				static::removeRecursive($tmp);
 			} catch (Throwable) {
@@ -611,7 +611,7 @@ class Dir
 		}
 
 		// Rename failed (e.g. permission on parent); fall back to in-place removal.
-		// Delete all contents first, then retry rmdir to tolerate transient
+		// Delete all contents first, then retry to tolerate transient
 		// "directory not empty" errors caused by concurrent writes.
 		static::removeRecursive($dir);
 
@@ -626,13 +626,7 @@ class Dir
 				usleep(10_000);
 			}
 
-			// Suppress all rmdir warnings (locale-independent); success is
-			// determined by checking whether the directory still exists
-			Helpers::handleErrors(
-				fn (): bool => rmdir($dir),
-				fn () => true,
-				null
-			);
+			static::removeRecursive($dir);
 
 			if (is_dir($dir) === false) {
 				return true;
@@ -665,8 +659,7 @@ class Dir
 
 		Helpers::handleErrors(
 			fn (): bool => rmdir($dir),
-			fn () => true,
-			null
+			fn () => true
 		);
 	}
 

--- a/tests/Filesystem/DirTest.php
+++ b/tests/Filesystem/DirTest.php
@@ -10,6 +10,28 @@ use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
 use PHPUnit\Framework\Attributes\CoversClass;
 
+class DirFlakyRemoveRecursive extends Dir
+{
+	public static int $failCount = 0;
+
+	protected static function removeRecursive(string $dir): void
+	{
+		if (static::$failCount > 0) {
+			static::$failCount--;
+			return;
+		}
+		parent::removeRecursive($dir);
+	}
+}
+
+class DirRemoveRecursiveThrows extends Dir
+{
+	protected static function removeRecursive(string $dir): void
+	{
+		throw new \Exception('test: cleanup failure');
+	}
+}
+
 #[CoversClass(Dir::class)]
 class DirTest extends TestCase
 {
@@ -621,6 +643,32 @@ class DirTest extends TestCase
 		$this->assertTrue(Dir::remove(static::TMP . '/does-not-exist'));
 	}
 
+	public function testRemoveThrowsAfterRetryExhausted(): void
+	{
+		if (posix_getuid() === 0) {
+			$this->markTestSkipped('Cannot test permission-restricted removal as root');
+		}
+
+		$parent = static::TMP . '/locked-parent';
+		$dir    = $parent . '/locked';
+
+		Dir::make($dir . '/inner');
+
+		// Read-only parent prevents rename() from removing $dir's directory entry.
+		// Read-only $dir prevents removeRecursive() from deleting the inner subdirectory.
+		chmod($parent, 0555);
+		chmod($dir, 0555);
+
+		try {
+			$this->expectException(Exception::class);
+			$this->expectExceptionMessage('The directory could not be deleted');
+			Dir::remove($dir);
+		} finally {
+			chmod($dir, 0755);
+			chmod($parent, 0755);
+		}
+	}
+
 	public function testRemoveWithContents(): void
 	{
 		Dir::make(static::TMP . '/sub');
@@ -629,6 +677,82 @@ class DirTest extends TestCase
 
 		$this->assertTrue(Dir::remove(static::TMP));
 		$this->assertDirectoryDoesNotExist(static::TMP);
+	}
+
+	public function testRemoveWithDeeplyNested(): void
+	{
+		Dir::make(static::TMP . '/a');
+		Dir::make(static::TMP . '/a/b');
+		Dir::make(static::TMP . '/a/b/c');
+		F::write(static::TMP . '/a/file.txt', 'test');
+		F::write(static::TMP . '/a/b/file.txt', 'test');
+		F::write(static::TMP . '/a/b/c/file.txt', 'test');
+
+		$this->assertTrue(Dir::remove(static::TMP));
+		$this->assertDirectoryDoesNotExist(static::TMP);
+	}
+
+	public function testRemoveWithSymlinkChild(): void
+	{
+		$source = static::TMP . '/source';
+		$dir    = static::TMP . '/dir';
+
+		Dir::make($source);
+		Dir::make($dir);
+		symlink($source, $dir . '/link');
+
+		$this->assertTrue(Dir::remove($dir));
+		$this->assertDirectoryDoesNotExist($dir);
+		$this->assertDirectoryExists($source);
+	}
+
+	public function testRemoveCatchesCleanupError(): void
+	{
+		Dir::make(static::TMP);
+
+		// DirRemoveRecursiveThrows always throws from removeRecursive;
+		// remove() must catch it and still return true because the
+		// original path was already atomically renamed away before cleanup ran.
+		$this->assertTrue(DirRemoveRecursiveThrows::remove(static::TMP));
+		$this->assertDirectoryDoesNotExist(static::TMP);
+	}
+
+	public function testRemoveFallbackSucceedsOnFirstAttempt(): void
+	{
+		Dir::make(static::TMP . '/sub');
+		F::write(static::TMP . '/file.txt', 'test');
+
+		// Blocking rename forces the in-place fallback; the first removeRecursive
+		// call should clear all content and delete the directory.
+		FileTest::$block[] = 'rename';
+
+		try {
+			$this->assertTrue(Dir::remove(static::TMP));
+			$this->assertDirectoryDoesNotExist(static::TMP);
+		} finally {
+			FileTest::$block = [];
+		}
+	}
+
+	public function testRemoveFallbackSucceedsOnRetry(): void
+	{
+		$dir = static::TMP . '/target';
+
+		Dir::make($dir . '/inner');
+
+		// Blocking rename forces the fallback; DirFlakyRemoveRecursive is a
+		// no-op for the first two calls so the retry loop must eventually
+		// succeed and return true from inside the loop.
+		FileTest::$block[]                  = 'rename';
+		DirFlakyRemoveRecursive::$failCount = 2;
+
+		try {
+			$this->assertTrue(DirFlakyRemoveRecursive::remove($dir));
+			$this->assertDirectoryDoesNotExist($dir);
+		} finally {
+			FileTest::$block                    = [];
+			DirFlakyRemoveRecursive::$failCount = 0;
+		}
 	}
 
 	public function testRemoveLeavesNoTmpSiblings(): void

--- a/tests/Filesystem/DirTest.php
+++ b/tests/Filesystem/DirTest.php
@@ -664,6 +664,8 @@ class DirTest extends TestCase
 			$this->expectExceptionMessage('The directory could not be deleted');
 			Dir::remove($dir);
 		} finally {
+			// Dir::remove() is expected to throw (fail), so $dir still exists;
+			// restore permissions so tearDown's Dir::remove(static::TMP) can clean up.
 			chmod($dir, 0755);
 			chmod($parent, 0755);
 		}
@@ -765,23 +767,6 @@ class DirTest extends TestCase
 		// no .remove-* tmp dirs should be left in the parent
 		$leftovers = glob($parent . '/.remove-*');
 		$this->assertSame([], $leftovers);
-	}
-
-	public function testRemoveConcurrentWriteSurvives(): void
-	{
-		// Simulate the race condition: a file appears in the directory
-		// after remove() renames it away. The original path should be
-		// gone and a fresh directory at that path should be untouched.
-		Dir::make(static::TMP);
-
-		$this->assertTrue(Dir::remove(static::TMP));
-		$this->assertDirectoryDoesNotExist(static::TMP);
-
-		// Simulate what a concurrent write does: creates the dir fresh
-		Dir::make(static::TMP);
-		F::write(static::TMP . '/concurrent.txt', 'data');
-
-		$this->assertFileExists(static::TMP . '/concurrent.txt');
 	}
 
 	public function testIsReadable(): void

--- a/tests/Filesystem/DirTest.php
+++ b/tests/Filesystem/DirTest.php
@@ -616,6 +616,50 @@ class DirTest extends TestCase
 		$this->assertDirectoryDoesNotExist(static::TMP);
 	}
 
+	public function testRemoveNonExistent(): void
+	{
+		$this->assertTrue(Dir::remove(static::TMP . '/does-not-exist'));
+	}
+
+	public function testRemoveWithContents(): void
+	{
+		Dir::make(static::TMP . '/sub');
+		F::write(static::TMP . '/file.txt', 'test');
+		F::write(static::TMP . '/sub/nested.txt', 'test');
+
+		$this->assertTrue(Dir::remove(static::TMP));
+		$this->assertDirectoryDoesNotExist(static::TMP);
+	}
+
+	public function testRemoveLeavesNoTmpSiblings(): void
+	{
+		Dir::make(static::TMP);
+		$parent = dirname(static::TMP);
+
+		Dir::remove(static::TMP);
+
+		// no .remove-* tmp dirs should be left in the parent
+		$leftovers = glob($parent . '/.remove-*');
+		$this->assertSame([], $leftovers);
+	}
+
+	public function testRemoveConcurrentWriteSurvives(): void
+	{
+		// Simulate the race condition: a file appears in the directory
+		// after remove() renames it away. The original path should be
+		// gone and a fresh directory at that path should be untouched.
+		Dir::make(static::TMP);
+
+		$this->assertTrue(Dir::remove(static::TMP));
+		$this->assertDirectoryDoesNotExist(static::TMP);
+
+		// Simulate what a concurrent write does: creates the dir fresh
+		Dir::make(static::TMP);
+		F::write(static::TMP . '/concurrent.txt', 'data');
+
+		$this->assertFileExists(static::TMP . '/concurrent.txt');
+	}
+
 	public function testIsReadable(): void
 	{
 		Dir::make(static::TMP);


### PR DESCRIPTION
This is a suggestion how to solve it by atomically renaming the directory. It will try to move it to the system tmp folder first and if that fails it will keep it in the same parent folder. It will also run multiple attempts to actually delete the folder after renaming. 