### PR TITLE
test: Cover remaining helper functions

### DIFF
--- a/config/helpers.php
+++ b/config/helpers.php
@@ -202,7 +202,7 @@ if (Helpers::hasOverride('go') === false) { // @codeCoverageIgnore
 	 */
 	function go(string $url = '/', int $code = 302): never
 	{
-		Response::go($url, $code);
+		Response::go($url, $code); // @codeCoverageIgnore
 	}
 }
 

--- a/tests/Cms/Helpers/HelperFunctionsTest.php
+++ b/tests/Cms/Helpers/HelperFunctionsTest.php
@@ -246,6 +246,20 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame($gist, $expected);
 	}
 
+	public function testGet(): void
+	{
+		$this->app->clone([
+			'request' => [
+				'query' => [
+					'foo' => 'bar'
+				]
+			]
+		]);
+
+		$this->assertSame('bar', get('foo'));
+		$this->assertSame('fallback', get('does-not-exist', 'fallback'));
+	}
+
 	public function testH(): void
 	{
 		$html = h('Guns & Roses');
@@ -624,6 +638,9 @@ class HelperFunctionsTest extends HelpersTestCase
 
 		$pages = pages('a', 'b');
 		$this->assertCount(2, $pages);
+
+		$pages = pages(['a', 'b']);
+		$this->assertCount(2, $pages);
 	}
 
 	public function testParam(): void
@@ -950,6 +967,20 @@ class HelperFunctionsTest extends HelpersTestCase
 		$this->assertSame('1.234.567 Autos', tc('car', 1234567, 'de'));
 		$this->assertSame('1.234.567 Autos', tc('car', 1234567, 'de', true));
 		$this->assertSame('1234567 Autos', tc('car', 1234567, 'de', false));
+	}
+
+	public function testTt(): void
+	{
+		$this->app->clone([
+			'translations' => [
+				'en' => [
+					'welcome' => 'Welcome {name}'
+				]
+			]
+		]);
+
+		$this->assertSame('Welcome Kirby', tt('welcome', ['name' => 'Kirby']));
+		$this->assertSame('Hello Kirby', tt('does-not-exist', 'Hello {name}', ['name' => 'Kirby']));
 	}
 
 	public function testUrl(): void


### PR DESCRIPTION
Adds focused unit coverage for the remaining helper function branches in `config/helpers.php`, including request query access via `get()`, array argument normalization in `pages()`, and template translation fallback handling in `tt()`. The untestable `go()` redirect helper line is excluded from coverage because it terminates execution through `Response::go()`.