### PR TITLE
perf: Use reverse MIME -> extensions map in `Mime`

### DIFF
--- a/src/Filesystem/Mime.php
+++ b/src/Filesystem/Mime.php
@@ -137,6 +137,11 @@ class Mime
 	];
 
 	/**
+	 * Lazy-built reverse map of $types (MIME type → extensions[])
+	 */
+	protected static array|null $mimes = null;
+
+	/**
 	 * Fixes an invalid MIME type guess for the given file
 	 */
 	public static function fix(
@@ -294,20 +299,13 @@ class Mime
 	 */
 	public static function toExtension(string|null $mime = null): string|false
 	{
-		foreach (static::$types as $key => $value) {
-			if (
-				is_array($value) === true &&
-				in_array($mime, $value, true) === true
-			) {
-				return $key;
-			}
-
-			if ($value === $mime) {
-				return $key;
-			}
+		if ($mime === null) {
+			return false;
 		}
 
-		return false;
+		static::$mimes ??= A::flip(static::$types);
+
+		return static::$mimes[$mime][0] ?? false;
 	}
 
 	/**
@@ -317,31 +315,25 @@ class Mime
 		string|null $mime = null,
 		bool $matchWildcards = false
 	): array {
-		// get all extensions
-		$extensions = array_keys(static::$types);
+		if ($mime === null) {
+			return [];
+		}
 
-		// filter extensions for given MIME type
-		$extensions = A::filter(
-			$extensions,
-			function ($extension) use ($mime, $matchWildcards) {
-				// get corresponding MIME types as array
-				$mimes = A::wrap(static::$types[$extension]);
+		static::$mimes ??= A::flip(static::$types);
 
-				if ($matchWildcards === true) {
-					// check if at least one MIME type with wildcards matches
-					return A::some(
-						$mimes,
-						fn (string $v): bool => static::matches($v, $mime)
-					);
-				}
+		if ($matchWildcards === false) {
+			return static::$mimes[$mime] ?? [];
+		}
 
-				// check if at least one MIME type matches exactly
-				return in_array($mime, $mimes, true);
+		$extensions = [];
+
+		foreach (static::$mimes as $registered => $exts) {
+			if (static::matches($registered, $mime) === true) {
+				array_push($extensions, ...$exts);
 			}
-		);
+		}
 
-		// renumber array with consecutive keys
-		return array_values($extensions);
+		return array_values(array_unique($extensions));
 	}
 
 	/**

--- a/tests/Filesystem/MimeTest.php
+++ b/tests/Filesystem/MimeTest.php
@@ -161,6 +161,12 @@ class MimeTest extends TestCase
 		$this->assertSame('css', $extensions);
 	}
 
+	public function testToExtensionNotFound(): void
+	{
+		$this->assertFalse(Mime::toExtension('nonexistent/type'));
+		$this->assertFalse(Mime::toExtension(null));
+	}
+
 	public function testToExtensions(): void
 	{
 		$extensions = Mime::toExtensions('image/jpeg');
@@ -192,6 +198,11 @@ class MimeTest extends TestCase
 		foreach (['js', 'pdf', 'zip', 'docx'] as $ext) {
 			$this->assertNotContains($ext, $extensions);
 		}
+	}
+
+	public function testToExtensionsNull(): void
+	{
+		$this->assertSame([], Mime::toExtensions(null));
 	}
 
 	public function testTypeWithOptimizedSvg(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->
Both methods currently iterate the entire `$types` map (~110 entries) on every call. The alternative builds a reverse MIME → extensions[] map once via the new `A::flip()`, turning exact-match lookups into O(1). The wildcard branch still scans the whole map (same size, ~107 entries) but tests each MIME type once instead of once per extension.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🏎️ Performance
<!-- 
e.g. New feature X which helps users to …
-->
- Improved performance of `Kirby\Filesystem\Mime::toExtension()` and `Kirby\Filesystem\Mime::toExtensions()`


## Bench
```
────────────────────────────────────────────────────────────────────────────────
  Case                                                    Current     Proposed    Speedup
  ────────────────────────────────────────────────────────────────────────────────
  toExtension  (common,   application/zip)               172.95 ms       9.91 ms      17.5x
  toExtension  (miss,     nonexistent/type)              169.24 ms       9.66 ms      17.5x
  toExtensions (exact,    image/jpeg)                    491.21 ms      10.41 ms      47.2x
  toExtensions (wildcard, image/*)                      1656.25 ms     431.85 ms       3.8x
  ────────────────────────────────────────────────────────────────────────────────
```

You can use the following Kirby CLI command to run the performance test yourself. Do not run it on this branch but on e.g. `feat/a-flip` so it can compare the existing implementation vs. the new proposed implementation (which is included in the command).

E.g. put the file in our sandbox in `public/site/commands/sandbox/bench/mime-toextension` and run via `kirby sandbox:bench:mime-toextension`
 
```php
<?php

use Kirby\CLI\CLI;
use Kirby\Filesystem\Mime;
use Kirby\Toolkit\A;
use SebastianBergmann\Timer\Timer;

function bench_reverse(): array
{
	static $reverse = null;
	return $reverse ??= A::flip(Mime::$types);
}

function NEW_mimeToExtension(string|null $mime = null): string|false
{
	if ($mime === null) {
		return false;
	}

	return bench_reverse()[$mime][0] ?? false;
}

function NEW_mimeToExtensions(
	string|null $mime = null,
	bool $matchWildcards = false
): array {
	if ($mime === null) {
		return [];
	}

	$reverse = bench_reverse();

	if ($matchWildcards === false) {
		return $reverse[$mime] ?? [];
	}

	$extensions = [];

	foreach ($reverse as $registered => $exts) {
		if (Mime::matches($registered, $mime) === true) {
			array_push($extensions, ...$exts);
		}
	}

	return array_values(array_unique($extensions));
}

function run(
	CLI $cli,
	string $label,
	int $iterations,
	callable $impl
): float {
	$cli->out("\n" . $label);
	$progress = $cli->lightBlue()->progress()->total($iterations);
	$step     = max(1, (int)($iterations / 100));

	$timer = new Timer;
	$timer->start();

	for ($i = 1; $i <= $iterations; $i++) {
		if ($i % $step === 0) {
			$progress->current($i);
		}
		$impl();
	}
	$progress->current($iterations);

	return $timer->stop()->asMilliseconds();
}

return [
	'command' => function (CLI $cli) {
		$iterations = 50000;

		$cases = [
			'toExtension  (common,   application/zip)'  => [
				fn () => Mime::toExtension('application/zip'),
				fn () => NEW_mimeToExtension('application/zip'),
			],
			'toExtension  (miss,     nonexistent/type)' => [
				fn () => Mime::toExtension('nonexistent/type'),
				fn () => NEW_mimeToExtension('nonexistent/type'),
			],
			'toExtensions (exact,    image/jpeg)'       => [
				fn () => Mime::toExtensions('image/jpeg'),
				fn () => NEW_mimeToExtensions('image/jpeg'),
			],
			'toExtensions (wildcard, image/*)'          => [
				fn () => Mime::toExtensions('image/*', true),
				fn () => NEW_mimeToExtensions('image/*', true),
			],
		];

		$results = [];

		foreach ($cases as $label => [$currentImpl, $proposedImpl]) {
			$header = sprintf('%s, %d iterations', $label, $iterations);

			$current  = run($cli, $header . ' — current',  $iterations, $currentImpl);
			$proposed = run($cli, $header . ' — proposed', $iterations, $proposedImpl);

			$results[$label] = [
				'current'  => $current,
				'proposed' => $proposed,
			];
		}

		$cli->out('');
		$cli->out(str_repeat('─', 80));
		$cli->out(sprintf('%-50s %12s %12s %10s', 'Case', 'Current', 'Proposed', 'Speedup'));
		$cli->out(str_repeat('─', 80));

		foreach ($results as $label => $r) {
			$speedup = $r['proposed'] > 0
				? sprintf('%.1fx', $r['current'] / $r['proposed'])
				: 'n/a';

			$cli->out(sprintf(
				'%-50s %10.2f ms %10.2f ms %10s',
				$label,
				$r['current'],
				$r['proposed'],
				$speedup
			));
		}

		$cli->out(str_repeat('─', 80));
	}
];
```


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion