### PR TITLE
refact: New `Cms\Inventory` class

### DIFF
--- a/src/Cms/HasChildren.php
+++ b/src/Cms/HasChildren.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Filesystem\Dir;
 use Kirby\Toolkit\Str;
 
 /**
@@ -91,7 +90,7 @@ trait HasChildren
 		$kirby = $this->kirby();
 
 		// create the inventory for all drafts
-		$inventory = Dir::inventory(
+		$inventory = Inventory::for(
 			$this->root() . '/_drafts',
 			$kirby->contentExtension(),
 			$kirby->contentIgnore(),

--- a/src/Cms/Inventory.php
+++ b/src/Cms/Inventory.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\Filesystem\Dir;
+
+/**
+ * Scans a directory for the contents of a page, site or user:
+ * children, files, content files and the resolved template/model
+ *
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     5.5.0
+ */
+class Inventory
+{
+	/**
+	 * Separator between num and slug in page directory names
+	 * (e.g. `1_about` → num: 1, slug: 'about')
+	 */
+	public static string $numSeparator = '_';
+
+	/**
+	 * Scans the directory and analyzes files,
+	 * content, meta info and children
+	 */
+	public static function for(
+		string $dir,
+		string $extension = 'txt',
+		array|null $ignore = null,
+		bool $multilang = false
+	): array {
+		$inventory = [
+			'children' => [],
+			'files'    => [],
+			'template' => 'default',
+		];
+
+		$dir = realpath($dir);
+
+		if ($dir === false) {
+			return $inventory;
+		}
+
+		// a temporary store for all content files
+		$content = [];
+
+		// read and sort all items naturally to avoid sorting issues later
+		$items = Dir::read($dir, $ignore);
+		natsort($items);
+
+		// loop through all directory items and collect all relevant information
+		foreach ($items as $item) {
+			// ignore all items with a leading dot or underscore
+			if (
+				str_starts_with($item, '.') ||
+				str_starts_with($item, '_')
+			) {
+				continue;
+			}
+
+			$root = $dir . '/' . $item;
+
+			// collect all directories as children
+			if (is_dir($root) === true) {
+				$inventory['children'][] = static::child(
+					$item,
+					$root,
+					$extension,
+					$multilang
+				);
+				continue;
+			}
+
+			$itemExt = pathinfo($item, PATHINFO_EXTENSION);
+
+			// don't track files with these extensions
+			if (in_array($itemExt, ['htm', 'html', 'php'], true) === true) {
+				continue;
+			}
+
+			// collect all content files separately,
+			// not as inventory entries
+			if ($itemExt === $extension) {
+				$filename = pathinfo($item, PATHINFO_FILENAME);
+
+				// remove the language codes from all content filenames
+				if ($multilang === true) {
+					$filename = pathinfo($filename, PATHINFO_FILENAME);
+				}
+
+				$content[] = $filename;
+				continue;
+			}
+
+			// collect all other files
+			$inventory['files'][$item] = [
+				'filename'  => $item,
+				'extension' => $itemExt,
+				'root'      => $root,
+			];
+		}
+
+		$content = array_unique($content);
+
+		$inventory['template'] = static::template(
+			$content,
+			$inventory['files']
+		);
+
+		return $inventory;
+	}
+
+	/**
+	 * Collect information for a child for the inventory
+	 */
+	protected static function child(
+		string $item,
+		string $root,
+		string $extension = 'txt',
+		bool $multilang = false
+	): array {
+		// extract the slug and num of the directory
+		if ($separator = strpos($item, static::$numSeparator)) {
+			$num  = (int)substr($item, 0, $separator);
+			$slug = substr($item, $separator + 1);
+		}
+
+		// determine the model
+		if (Page::$models !== []) {
+			if ($multilang === true) {
+				$code = App::instance()->defaultLanguage()->code();
+				$extension = $code . '.' . $extension;
+			}
+
+			// look if a content file can be found
+			// for any of the available models
+			foreach (Page::$models as $name => $class) {
+				if (is_file($root . '/' . $name . '.' . $extension) === true) {
+					$model = $name;
+					break;
+				}
+			}
+		}
+
+		return [
+			'dirname' => $item,
+			'model'   => $model ?? null,
+			'num'     => $num ?? null,
+			'root'    => $root,
+			'slug'    => $slug ?? $item,
+		];
+	}
+
+	/**
+	 * Determines the main template for the inventory
+	 * from all collected content files, ignoring meta files
+	 */
+	protected static function template(
+		array $content,
+		array $files,
+	): string {
+		foreach ($content as $name) {
+			// is a meta file corresponding to an actual file, i.e. cover.jpg
+			if (isset($files[$name]) === true) {
+				continue;
+			}
+
+			// it's most likely the template
+			// (will overwrite and use the last match for historic reasons)
+			$template = $name;
+		}
+
+		return $template ?? 'default';
+	}
+}

--- a/src/Cms/Inventory.php
+++ b/src/Cms/Inventory.php
@@ -121,7 +121,8 @@ class Inventory
 		bool $multilang = false
 	): array {
 		// extract the slug and num of the directory
-		if ($separator = strpos($item, static::$numSeparator)) {
+		// TODO: Switch to static::$numSeparator in v6
+		if ($separator = strpos($item, Dir::$numSeparator)) {
 			$num  = (int)substr($item, 0, $separator);
 			$slug = substr($item, $separator + 1);
 		}

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -8,7 +8,6 @@ use Kirby\Content\VersionId;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
-use Kirby\Filesystem\Dir;
 use Kirby\Http\Response;
 use Kirby\Panel\Page as Panel;
 use Kirby\Template\Template;
@@ -372,7 +371,7 @@ class Page extends ModelWithContent
 		}
 
 		if ($this->num() !== null) {
-			return $this->dirname = $this->num() . Dir::$numSeparator . $this->uid();
+			return $this->dirname = $this->num() . Inventory::$numSeparator . $this->uid();
 		}
 
 		return $this->dirname = $this->uid();
@@ -485,7 +484,7 @@ class Page extends ModelWithContent
 
 		$kirby = $this->kirby();
 
-		return $this->inventory = Dir::inventory(
+		return $this->inventory = Inventory::for(
 			$this->root(),
 			$kirby->contentExtension(),
 			$kirby->contentIgnore(),

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -256,7 +256,7 @@ class Site extends ModelWithContent
 
 		$kirby = $this->kirby();
 
-		return $this->inventory = Dir::inventory(
+		return $this->inventory = Inventory::for(
 			$this->root(),
 			$kirby->contentExtension(),
 			$kirby->contentIgnore(),

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -8,7 +8,6 @@ use Kirby\Content\Field;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Exception\PermissionException;
-use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Panel\User as Panel;
 use Kirby\Session\Session;
@@ -274,7 +273,7 @@ class User extends ModelWithContent
 
 		$kirby = $this->kirby();
 
-		return $this->inventory = Dir::inventory(
+		return $this->inventory = Inventory::for(
 			$this->root(),
 			$kirby->contentExtension(),
 			$kirby->contentIgnore(),

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -3,8 +3,8 @@
 namespace Kirby\Filesystem;
 
 use Exception;
-use Kirby\Cms\App;
 use Kirby\Cms\Helpers;
+use Kirby\Cms\Inventory;
 use Kirby\Cms\Page;
 use Kirby\Toolkit\Str;
 use Throwable;
@@ -229,150 +229,14 @@ class Dir
 		array|null $contentIgnore = null,
 		bool $multilang = false
 	): array {
-		$inventory = [
-			'children' => [],
-			'files'    => [],
-			'template' => 'default',
-		];
+		Helpers::deprecated('`Kirby\Filesystem\Dir::inventory()` has been deprecated. Please use `Kirby\Cms\Inventory::for()` instead.', 'dir-inventory');
 
-		$dir = realpath($dir);
-
-		if ($dir === false) {
-			return $inventory;
-		}
-
-		// a temporary store for all content files
-		$content = [];
-
-		// read and sort all items naturally to avoid sorting issues later
-		$items = static::read($dir, $contentIgnore);
-		natsort($items);
-
-		// loop through all directory items and collect all relevant information
-		foreach ($items as $item) {
-			// ignore all items with a leading dot or underscore
-			if (
-				str_starts_with($item, '.') ||
-				str_starts_with($item, '_')
-			) {
-				continue;
-			}
-
-			$root = $dir . '/' . $item;
-
-			// collect all directories as children
-			if (is_dir($root) === true) {
-				$inventory['children'][] = static::inventoryChild(
-					$item,
-					$root,
-					$contentExtension,
-					$multilang
-				);
-				continue;
-			}
-
-			$extension = pathinfo($item, PATHINFO_EXTENSION);
-
-			// don't track files with these extensions
-			if (in_array($extension, ['htm', 'html', 'php'], true) === true) {
-				continue;
-			}
-
-			// collect all content files separately,
-			// not as inventory entries
-			if ($extension === $contentExtension) {
-				$filename = pathinfo($item, PATHINFO_FILENAME);
-
-				// remove the language codes from all content filenames
-				if ($multilang === true) {
-					$filename = pathinfo($filename, PATHINFO_FILENAME);
-				}
-
-				$content[] = $filename;
-				continue;
-			}
-
-			// collect all other files
-			$inventory['files'][$item] = [
-				'filename'  => $item,
-				'extension' => $extension,
-				'root'      => $root,
-			];
-		}
-
-		$content = array_unique($content);
-
-		$inventory['template'] = static::inventoryTemplate(
-			$content,
-			$inventory['files']
+		return Inventory::for(
+			$dir,
+			$contentExtension,
+			$contentIgnore,
+			$multilang
 		);
-
-		return $inventory;
-	}
-
-	/**
-	 * Collect information for a child for the inventory
-	 * @deprecated 5.5.0
-	 */
-	protected static function inventoryChild(
-		string $item,
-		string $root,
-		string $contentExtension = 'txt',
-		bool $multilang = false
-	): array {
-		// extract the slug and num of the directory
-		if ($separator = strpos($item, static::$numSeparator)) {
-			$num  = (int)substr($item, 0, $separator);
-			$slug = substr($item, $separator + 1);
-		}
-
-		// determine the model
-		if (Page::$models !== []) {
-			if ($multilang === true) {
-				$code = App::instance()->defaultLanguage()->code();
-				$contentExtension = $code . '.' . $contentExtension;
-			}
-
-			// look if a content file can be found
-			// for any of the available models
-			foreach (Page::$models as $modelName => $modelClass) {
-				if (is_file($root . '/' . $modelName . '.' . $contentExtension) === true) {
-					$model = $modelName;
-					break;
-				}
-			}
-		}
-
-		return [
-			'dirname' => $item,
-			'model'   => $model ?? null,
-			'num'     => $num ?? null,
-			'root'    => $root,
-			'slug'    => $slug ?? $item,
-		];
-	}
-
-	/**
-	 * Determines the main template for the inventory
-	 * from all collected content files, ignore file meta files
-	 * @deprecated 5.5.0
-	 */
-	protected static function inventoryTemplate(
-		array $content,
-		array $files,
-	): string {
-		foreach ($content as $name) {
-			// is a meta file corresponding to an actual file, i.e. cover.jpg
-			if (isset($files[$name]) === true) {
-				continue;
-			}
-
-			// it's most likely the template
-			// (will overwrite and use the last match for historic reasons)
-			$template = $name;
-		}
-
-		return $template ?? 'default';
 	}
 
 	/**

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -44,6 +44,10 @@ class Dir
 		'@eaDir'
 	];
 
+	/**
+	 * @deprecated 5.5.0 Will be changed to `Kirby\Cms\Inventory::$numSeparator` in v6
+	 * @todo Migrate in v6
+	 */
 	public static string $numSeparator = '_';
 
 	/**

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -216,6 +216,8 @@ class Dir
 	 * relevant information.
 	 *
 	 * Don't use outside the Cms context.
+	 *
+	 * @deprecated 5.5.0 Use `Kirby\Cms\Inventory::for()` instead. Will be removed in Kirby 6.
 	 */
 	public static function inventory(
 		string $dir,
@@ -306,6 +308,7 @@ class Dir
 
 	/**
 	 * Collect information for a child for the inventory
+	 * @deprecated 5.5.0
 	 */
 	protected static function inventoryChild(
 		string $item,
@@ -348,6 +351,7 @@ class Dir
 	/**
 	 * Determines the main template for the inventory
 	 * from all collected content files, ignore file meta files
+	 * @deprecated 5.5.0
 	 */
 	protected static function inventoryTemplate(
 		array $content,

--- a/tests/Cms/InventoryTest.php
+++ b/tests/Cms/InventoryTest.php
@@ -1,0 +1,300 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Kirby\Filesystem\Dir;
+use Kirby\Filesystem\F;
+use Kirby\TestCase;
+use Kirby\Toolkit\A;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Inventory::class)]
+class InventoryTest extends TestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Cms.Inventory';
+
+	protected function setUp(): void
+	{
+		static::setUpTmp();
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+		static::tearDownTmp();
+		Page::$models = [];
+	}
+
+	protected function create(array $items): void
+	{
+		foreach ($items as $item) {
+			$root = static::TMP . '/' . $item;
+
+			if (F::extension($item)) {
+				F::write($root, '');
+			} else {
+				Dir::make($root);
+			}
+		}
+	}
+
+	public function testFor(): void
+	{
+		$this->create([
+			'1_project-a',
+			'2_project-b',
+			'cover.jpg',
+			'cover.jpg.txt',
+			'projects.txt',
+			'_ignore.txt',
+			'.invisible'
+		]);
+
+		$inventory = Inventory::for(static::TMP);
+
+		$this->assertSame('project-a', $inventory['children'][0]['slug']);
+		$this->assertSame(1, $inventory['children'][0]['num']);
+
+		$this->assertSame('project-b', $inventory['children'][1]['slug']);
+		$this->assertSame(2, $inventory['children'][1]['num']);
+
+		$this->assertSame('cover.jpg', $inventory['files']['cover.jpg']['filename']);
+		$this->assertSame('jpg', $inventory['files']['cover.jpg']['extension']);
+		$this->assertArrayNotHasKey('_ignore.txt', $inventory['files']);
+		$this->assertArrayNotHasKey('.invisible', $inventory['files']);
+
+		$this->assertSame('projects', $inventory['template']);
+	}
+
+	public function testForWithSkippedFiles(): void
+	{
+		$this->create([
+			'valid.jpg',
+			'skipped.html',
+			'skipped.htm',
+			'skipped.php'
+		]);
+
+		$inventory = Inventory::for(static::TMP);
+
+		$this->assertSame(['valid.jpg'], A::pluck($inventory['files'], 'filename'));
+	}
+
+	public function testForChildSorting(): void
+	{
+		$this->create([
+			'1_project-c',
+			'10_project-b',
+			'11_project-a',
+		]);
+
+		$inventory = Inventory::for(static::TMP);
+
+		$this->assertSame('project-c', $inventory['children'][0]['slug']);
+		$this->assertSame('project-b', $inventory['children'][1]['slug']);
+		$this->assertSame('project-a', $inventory['children'][2]['slug']);
+	}
+
+	public function testForChildWithLeadingZero(): void
+	{
+		$this->create([
+			'01_project-c',
+			'02_project-b',
+			'03_project-a',
+		]);
+
+		$inventory = Inventory::for(static::TMP);
+
+		$this->assertSame('project-c', $inventory['children'][0]['slug']);
+		$this->assertSame(1, $inventory['children'][0]['num']);
+
+		$this->assertSame('project-b', $inventory['children'][1]['slug']);
+		$this->assertSame(2, $inventory['children'][1]['num']);
+
+		$this->assertSame('project-a', $inventory['children'][2]['slug']);
+		$this->assertSame(3, $inventory['children'][2]['num']);
+	}
+
+	public function testForFileSorting(): void
+	{
+		$this->create([
+			'1-c.jpg',
+			'10-b.jpg',
+			'11-a.jpg',
+		]);
+
+		$inventory = Inventory::for(static::TMP);
+		$files     = array_values($inventory['files']);
+
+		$this->assertSame('1-c.jpg', $files[0]['filename']);
+		$this->assertSame('10-b.jpg', $files[1]['filename']);
+		$this->assertSame('11-a.jpg', $files[2]['filename']);
+	}
+
+	public function testForMissingTemplate(): void
+	{
+		$this->create([
+			'cover.jpg',
+			'cover.jpg.txt'
+		]);
+
+		$inventory = Inventory::for(static::TMP);
+
+		$this->assertSame('cover.jpg', $inventory['files']['cover.jpg']['filename']);
+		$this->assertSame('default', $inventory['template']);
+	}
+
+	public function testForTemplateWithDotInFilename(): void
+	{
+		$this->create([
+			'cover.jpg',
+			'cover.jpg.txt',
+			'article.video.txt'
+		]);
+
+		$inventory = Inventory::for(static::TMP);
+
+		$this->assertSame('cover.jpg', $inventory['files']['cover.jpg']['filename']);
+		$this->assertSame('article.video', $inventory['template']);
+	}
+
+	public function testForExtension(): void
+	{
+		$this->create([
+			'cover.jpg',
+			'cover.jpg.md',
+			'article.md'
+		]);
+
+		$inventory = Inventory::for(static::TMP, 'md');
+
+		$this->assertSame('cover.jpg', $inventory['files']['cover.jpg']['filename']);
+		$this->assertSame('article', $inventory['template']);
+	}
+
+	public function testForIgnore(): void
+	{
+		$this->create([
+			'cover.jpg',
+			'article.txt'
+		]);
+
+		$inventory = Inventory::for(static::TMP, 'txt', ['cover.jpg']);
+
+		$this->assertCount(0, $inventory['files']);
+		$this->assertSame('article', $inventory['template']);
+	}
+
+	public function testForMultilang(): void
+	{
+		$this->create([
+			'cover.jpg',
+			'cover.jpg.en.txt',
+			'article.en.txt',
+			'article.de.txt'
+		]);
+
+		$inventory = Inventory::for(static::TMP, 'txt', null, true);
+
+		$this->assertSame('cover.jpg', $inventory['files']['cover.jpg']['filename']);
+		$this->assertSame('article', $inventory['template']);
+	}
+
+	public function testForChildModels(): void
+	{
+		Page::$models = [
+			'a' => 'A',
+			'b' => 'A'
+		];
+
+		$this->create([
+			'child-with-model-a/a.txt',
+			'child-with-model-b/b.txt',
+			'child-without-model-c/c.txt'
+		]);
+
+		$inventory = Inventory::for(static::TMP);
+
+		$this->assertSame('a', $inventory['children'][0]['model']);
+		$this->assertSame('b', $inventory['children'][1]['model']);
+		$this->assertNull($inventory['children'][2]['model']);
+	}
+
+	public function testForNonExistingDir(): void
+	{
+		$inventory = Inventory::for('/does-not-exist-' . uniqid());
+
+		$this->assertSame([
+			'children' => [],
+			'files'    => [],
+			'template' => 'default',
+		], $inventory);
+	}
+
+	public function testForChildWithoutNum(): void
+	{
+		$this->create([
+			'about/about.txt',
+		]);
+
+		$inventory = Inventory::for(static::TMP);
+
+		$this->assertSame('about', $inventory['children'][0]['dirname']);
+		$this->assertSame('about', $inventory['children'][0]['slug']);
+		$this->assertNull($inventory['children'][0]['num']);
+	}
+
+	public function testForTemplateLastWins(): void
+	{
+		// when multiple content files have no matching file in $files,
+		// the last one wins (historical behaviour)
+		$this->create([
+			'article.txt',
+			'note.txt',
+		]);
+
+		$inventory = Inventory::for(static::TMP);
+
+		$this->assertSame('note', $inventory['template']);
+	}
+
+	public function testForChildMultilangModels(): void
+	{
+		new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'languages' => [
+				[
+					'code'    => 'en',
+					'name'    => 'English',
+					'default' => true
+				],
+				[
+					'code'    => 'de',
+					'name'    => 'Deutsch',
+				]
+			]
+		]);
+
+		Page::$models = [
+			'a' => 'A',
+			'b' => 'A'
+		];
+
+		$this->create([
+			'child-with-model-a/a.de.txt',
+			'child-with-model-a/a.en.txt',
+			'child-with-model-b/b.de.txt',
+			'child-with-model-b/b.en.txt',
+			'child-without-model-c/c.de.txt',
+			'child-without-model-c/c.en.txt'
+		]);
+
+		$inventory = Inventory::for(static::TMP, 'txt', null, true);
+
+		$this->assertSame('a', $inventory['children'][0]['model']);
+		$this->assertSame('b', $inventory['children'][1]['model']);
+		$this->assertNull($inventory['children'][2]['model']);
+	}
+}


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

`Dir::inventory()` has a weird coupling to the `Cms` namespace. I would propose moving that logic into a new `Cms\Inventory` class instead.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- New `Kirby\Cms\Inventory` class used for page, site and user content dir inventories

### ☠️ Deprecated
- `Kirby\Filesystem\Dir::inventory()` has been deprecated. Use `Kirby\Cms\Inventory`  instead



## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion