### PR TITLE
fix: Spread args in `LazyValue::unwrap()`

### DIFF
--- a/src/Toolkit/LazyValue.php
+++ b/src/Toolkit/LazyValue.php
@@ -36,7 +36,7 @@ class LazyValue
 	public static function unwrap(mixed $data, mixed ...$args): mixed
 	{
 		if (is_array($data) === true) {
-			return A::map($data, fn ($value) => static::unwrap($value, $args));
+			return A::map($data, fn ($value) => static::unwrap($value, ...$args));
 		}
 
 		if ($data instanceof static) {

--- a/tests/Toolkit/LazyValueTest.php
+++ b/tests/Toolkit/LazyValueTest.php
@@ -35,4 +35,21 @@ class LazyValueTest extends TestCase
 		$value = LazyValue::unwrap([$lazy, 'b', 'c']);
 		$this->assertSame($expected, $value);
 	}
+
+	public function testUnwrapArgs(): void
+	{
+		$captured = null;
+		$lazy = new LazyValue(function (...$args) use (&$captured) {
+			$captured = $args;
+			return 'resolved';
+		});
+
+		LazyValue::unwrap([$lazy], 'a', 'b');
+		$this->assertSame(['a', 'b'], $captured);
+
+		$lazy = new LazyValue(fn (string $prefix) => $prefix . '-resolved');
+
+		$result = LazyValue::unwrap([[$lazy, 'plain']], 'deep');
+		$this->assertSame([['deep-resolved', 'plain']], $result);
+	}
 }


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

`LazyValue::unwrap(mixed $data, mixed ...$args)` declares variadic args parameter, but the array recursion branch passed `$args` as a single argument. So the recursive call sees e.g. `[['a','b']]` instead of `['a','b']`.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- `Kirby\Toolkit\LayzValue`: fixed passing variadic arguments

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion