### PR TITLE
fix: Preserve falsy values in `A::implode()`

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -372,21 +372,15 @@ class A
 		array $array,
 		string $separator = ''
 	): string {
-		$result = '';
+		$parts = [];
 
 		foreach ($array as $value) {
-			if (empty($result) === false) {
-				$result .= $separator;
-			}
-
-			if (is_array($value) === true) {
-				$value = static::implode($value, $separator);
-			}
-
-			$result .= $value;
+			$parts[] = is_array($value) === true
+				? static::implode($value, $separator)
+				: $value;
 		}
 
-		return $result;
+		return implode($separator, $parts);
 	}
 
 	/**

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -319,6 +319,18 @@ class ATest extends TestCase
 
 		$array = ['a' => 'A', 'b' => 'B', 'c' => ['C', 'D']];
 		$this->assertSame('ABCD', A::implode($array));
+
+		// '0' as first element must not swallow the next separator
+		$this->assertSame('0-b-c', A::implode(['0', 'b', 'c'], '-'));
+		$this->assertSame('a-0-b', A::implode(['a', '0', 'b'], '-'));
+
+		// leading empty strings should produce leading separators
+		$this->assertSame('-b-c', A::implode(['', 'b', 'c'], '-'));
+		$this->assertSame('a--c', A::implode(['a', '', 'c'], '-'));
+
+		// '0' inside nested arrays must round-trip
+		$this->assertSame('x-0-b', A::implode([['x'], '0', 'b'], '-'));
+		$this->assertSame('0-x-y', A::implode([['0'], 'x', 'y'], '-'));
 	}
 
 	public function testMap(): void


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- `Kirby\Toolkit\A::implode()`: preserve falsy values when imploding array

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion