### PR TITLE
fix: Split `V::minWords()`/`::maxWords()` on any whitespace

### DIFF
--- a/src/Toolkit/V.php
+++ b/src/Toolkit/V.php
@@ -504,14 +504,14 @@ V::$validators = [
 	 * Checks if the number of words in the value equals or is below the given maximum
 	 */
 	'maxWords' => function (string|null $value, $max): bool {
-		return V::max(explode(' ', trim($value)), $max) === true;
+		return V::max(preg_split('/\s+/', trim($value ?? ''), -1, PREG_SPLIT_NO_EMPTY), $max) === true;
 	},
 
 	/**
-	 * Checks if the number of words in the value equals or is below the given maximum
+	 * Checks if the number of words in the value equals or is above the given minimum
 	 */
 	'minWords' => function (string|null $value, $min): bool {
-		return V::min(explode(' ', trim($value)), $min) === true;
+		return V::min(preg_split('/\s+/', trim($value ?? ''), -1, PREG_SPLIT_NO_EMPTY), $min) === true;
 	},
 
 	/**

--- a/tests/Toolkit/VTest.php
+++ b/tests/Toolkit/VTest.php
@@ -521,6 +521,20 @@ class VTest extends TestCase
 		$this->assertTrue(V::maxWords('This is Kirby ', 3));
 
 		$this->assertFalse(V::maxWords('This is Kirby', 2));
+
+		// double spaces don't introduce a third word
+		$this->assertTrue(V::maxWords('hello  world', 2));
+
+		// tabs and newlines count as separators
+		$this->assertTrue(V::maxWords("hello\tworld", 2));
+		$this->assertTrue(V::maxWords("hello\nworld", 2));
+
+		// mixed whitespace
+		$this->assertTrue(V::maxWords("foo  bar\t\tbaz", 3));
+
+		// empty string has zero words
+		$this->assertTrue(V::maxWords('', 0));
+		$this->assertTrue(V::maxWords('   ', 0));
 	}
 
 	public function testMinWords(): void
@@ -530,6 +544,20 @@ class VTest extends TestCase
 
 		$this->assertFalse(V::minWords('This is Kirby', 4));
 		$this->assertFalse(V::minWords('This is Kirby ', 4));
+
+		// double spaces don't introduce a third word
+		$this->assertFalse(V::minWords('hello  world', 3));
+
+		// tabs and newlines count as separators
+		$this->assertTrue(V::minWords("hello\tworld", 2));
+		$this->assertTrue(V::minWords("hello\nworld", 2));
+
+		// mixed whitespace
+		$this->assertTrue(V::minWords("foo  bar\t\tbaz", 3));
+
+		// empty string has zero words
+		$this->assertFalse(V::minWords('', 1));
+		$this->assertFalse(V::minWords('   ', 1));
 	}
 
 	public function testMore(): void


### PR DESCRIPTION
### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Fixed `minWords`/`maxWords` validators for non-single whitespace

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion