### PR TITLE
fix: Add noreferrer to _blank links in Html::rel

### DIFF
--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -380,7 +380,7 @@ class Html extends Xml
 	}
 
 	/**
-	 * Add noreferrer to rels when target is `_blank`
+	 * Adds noreferrer to rels when target is `_blank`
 	 *
 	 * @param string|null $rel Current `rel` value
 	 * @param string|null $target Current `target` value
@@ -392,15 +392,18 @@ class Html extends Xml
 	): string|null {
 		$rel = trim($rel ?? '');
 
-		if ($target === '_blank') {
-			if (empty($rel) === false) {
-				return $rel;
-			}
-
-			return trim($rel . ' noreferrer', ' ');
+		if ($target !== '_blank') {
+			return $rel ?: null;
 		}
 
-		return $rel ?: null;
+		// don't duplicate noreferrer if it's already in the rel list
+		$tokens = preg_split('/\s+/', $rel, -1, PREG_SPLIT_NO_EMPTY);
+
+		if (in_array('noreferrer', $tokens, true) === true) {
+			return $rel;
+		}
+
+		return trim($rel . ' noreferrer');
 	}
 
 	/**

--- a/tests/Toolkit/HtmlTest.php
+++ b/tests/Toolkit/HtmlTest.php
@@ -78,7 +78,7 @@ class HtmlTest extends TestCase
 	public function testAWithTargetAndRel(): void
 	{
 		$html = Html::a('https://getkirby.com', 'Kirby', ['target' => '_blank', 'rel' => 'noopener']);
-		$expected = '<a href="https://getkirby.com" rel="noopener" target="_blank">Kirby</a>';
+		$expected = '<a href="https://getkirby.com" rel="noopener noreferrer" target="_blank">Kirby</a>';
 		$this->assertSame($expected, $html);
 	}
 
@@ -288,17 +288,23 @@ class HtmlTest extends TestCase
 
 	public function testRel(): void
 	{
-		$html = Html::rel('me');
-		$expected = 'me';
-		$this->assertSame($expected, $html);
+		// non-_blank target: rel passes through untouched
+		$this->assertSame('me', Html::rel('me'));
+		$this->assertNull(Html::rel(null));
+		$this->assertNull(Html::rel(''));
 
-		$html = Html::rel(null, '_blank');
-		$expected = 'noreferrer';
-		$this->assertSame($expected, $html);
+		// _blank target without existing rel: adds noreferrer
+		$this->assertSame('noreferrer', Html::rel(null, '_blank'));
+		$this->assertSame('noreferrer', Html::rel('', '_blank'));
 
-		$html = Html::rel('noopener', '_blank');
-		$expected = 'noopener';
-		$this->assertSame($expected, $html);
+		// _blank target with existing rel: appends noreferrer
+		$this->assertSame('noopener noreferrer', Html::rel('noopener', '_blank'));
+		$this->assertSame('nofollow noreferrer', Html::rel('nofollow', '_blank'));
+
+		// _blank target where noreferrer is already present: no duplicate
+		$this->assertSame('noreferrer', Html::rel('noreferrer', '_blank'));
+		$this->assertSame('noopener noreferrer', Html::rel('noopener noreferrer', '_blank'));
+		$this->assertSame('noreferrer noopener', Html::rel('noreferrer noopener', '_blank'));
 	}
 
 	public function testTel(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Starting this based on the previous docblock description of `Html::rel()`:

```
Add noreferrer to rels when target is `_blank`
```

But the actual code hasn't been doing that: `Html::rel('nofollow', '_blank')` returns 'nofollow' without appending `noreferrer`.

The PR implements a fix that actually does what the docblock says it does. I hope that is really the idea here to always add it for `_blank`?

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- `Kirby\Toolkit\Html::rel()`: Always add `noreferrer`, even with existing `rel` values. 

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion