### PR TITLE
perf: Cache parameter list in `Controller`

### DIFF
--- a/src/Toolkit/Controller.php
+++ b/src/Toolkit/Controller.php
@@ -20,6 +20,12 @@ use ReflectionFunction;
  */
 class Controller
 {
+	/**
+	 * Cached parameter list of the wrapped closure;
+	 * @var \ReflectionParameter[]|null
+	 */
+	protected array|null $params = null;
+
 	public function __construct(
 		protected Closure $function
 	) {
@@ -27,10 +33,11 @@ class Controller
 
 	public function arguments(array $data = []): array
 	{
-		$info = new ReflectionFunction($this->function);
+		$this->params ??= (new ReflectionFunction($this->function))->getParameters();
+
 		$args = [];
 
-		foreach ($info->getParameters() as $param) {
+		foreach ($this->params as $param) {
 			$name = $param->getName();
 
 			if ($param->isVariadic() === true) {


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Accounts in my bench test for 10-20% performance improvement for `$controller->call()`. Not huge, but I think still wort it considering the small change and how much we use it for page controllers, hooks etc.

`$function` is immutable inside the controller, so caching the parameters should be fine.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🏎️ Performance
<!-- 
e.g. Method X has been removed
-->
- Improved performance of `Kirby\Toolkit\Controller`



## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion