### PR TITLE
perf: Cache entities arrays in Html and Xml

### DIFF
--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -156,11 +156,22 @@ class Html extends Xml
 			return null;
 		}
 
+		// cache the keys/values arrays;
+		// invalidates if $entities changes
+		static $cached = null;
+		static $html   = [];
+		static $xml    = [];
+
 		// HTML supports named entities
 		$entities = parent::entities();
-		$html     = array_keys($entities);
-		$xml      = array_values($entities);
-		$attr     = str_replace($xml, $html, $attr);
+
+		if ($cached !== $entities) {
+			$html   = array_keys($entities);
+			$xml    = array_values($entities);
+			$cached = $entities;
+		}
+
+		$attr = str_replace($xml, $html, $attr);
 
 		if ($attr) {
 			return $before . $attr . $after;

--- a/src/Toolkit/Xml.php
+++ b/src/Toolkit/Xml.php
@@ -256,9 +256,19 @@ class Xml
 			$string = Html::encode($string, false);
 		}
 
+		// cache the keys/values arrays;
+		// invalidates if $entities changes
+		static $cached = null;
+		static $html   = [];
+		static $xml    = [];
+
 		$entities = self::entities();
-		$html = array_keys($entities);
-		$xml  = array_values($entities);
+
+		if ($cached !== $entities) {
+			$html   = array_keys($entities);
+			$xml    = array_values($entities);
+			$cached = $entities;
+		}
 
 		return str_replace($html, $xml, $string);
 	}


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Both methods called `array_keys($entities)` and `array_values($entities)` on every call against the 252-entry static table. 

Now, we cache them in local static variables. If the base table changes (e.g. cause a plugin injects something at runtime, rare), we rebuild the cached maps.
