### PR TITLE
perf: `Str::startsWith()`/`::endsWith()` if case sensitive

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1310,7 +1310,11 @@ class Str
 			return str_starts_with($string ?? '', $needle);
 		}
 
-		return static::position($string, $needle, true) === 0;
+		$probe  = static::substr($string, 0, static::length($needle));
+		$probe  = static::lower($probe);
+		$needle = static::lower($needle);
+
+		return $needle === $probe;
 	}
 
 	/**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -428,12 +428,13 @@ class Str
 			return true;
 		}
 
-		$probe = static::substr($string, -static::length($needle));
-
-		if ($caseInsensitive === true) {
-			$needle = static::lower($needle);
-			$probe  = static::lower($probe);
+		if ($caseInsensitive === false) {
+			return str_ends_with($string ?? '', $needle);
 		}
+
+		$probe  = static::substr($string, -static::length($needle));
+		$probe  = static::lower($probe);
+		$needle = static::lower($needle);
 
 		return $needle === $probe;
 	}
@@ -1305,7 +1306,11 @@ class Str
 			return true;
 		}
 
-		return static::position($string, $needle, $caseInsensitive) === 0;
+		if ($caseInsensitive === false) {
+			return str_starts_with($string ?? '', $needle);
+		}
+
+		return static::position($string, $needle, true) === 0;
 	}
 
 	/**


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Using native PHP methods when case sensitive. 
For case-insensitive we keep the old implementation due to multi-byte handling.

#### Bench
```
  Operation                Before     After   Speedup
  ─────────────────────────────────────────────────────
  startsWith (match)       20.28 ms   13.11 ms   1.6x
  startsWith (no match)    17.23 ms   11.19 ms   1.5x
  endsWith (match)         25.34 ms   11.50 ms   2.2x
  endsWith (no match)      24.54 ms   12.10 ms   2.0x
```

