### PR TITLE
perf: Excluded keys lookup set in `A::without()`

### DIFF
--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -1009,6 +1009,11 @@ class A
 
 	/**
 	 * Remove key(s) from an array
+	 *
+	 * Keys are matched using PHP's array-key semantics, so integer-like
+	 * string keys (e.g. `'1'`) and their integer counterparts (`1`) are
+	 * treated as equivalent.
+	 *
 	 * @since 3.6.5
 	 */
 	public static function without(array $array, int|string|array $keys): array

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -1017,9 +1017,11 @@ class A
 			$keys = static::wrap($keys);
 		}
 
+		$exclude = array_flip($keys);
+
 		return static::filter(
 			$array,
-			fn ($value, $key) => in_array($key, $keys, true) === false
+			fn ($value, $key) => isset($exclude[$key]) === false
 		);
 	}
 

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -1213,4 +1213,14 @@ class ATest extends TestCase
 		$this->assertSame([1 => 'dog', 2 => 'bird', 3 => 'cat', 4 => 'dog', 5 => 'bird'], A::without($indexedArray, 0));
 		$this->assertSame(['cat', 'dog', 'bird', 'cat', 'dog', 'bird'], A::without($indexedArray, -1));
 	}
+
+	public function testWithoutNumericStringKeys(): void
+	{
+		// PHP normalizes integer-like string keys to integers,
+		// so '1' and 1 refer to the same slot when used as keys
+		$array = [1 => 'a', 2 => 'b'];
+
+		$this->assertSame([2 => 'b'], A::without($array, [1]));
+		$this->assertSame([2 => 'b'], A::without($array, ['1']));
+	}
 }


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Before the filter call runs an `in_array` for each element of `$array`. `in_array()` itself goes through all of `$keys` to check for the element.

With this PR, we once create a lookup set (where the values are the keys) and then can use direct `isset()` on the lookup set.
