### PR TITLE
fix: RedisCache flush with prefix

### DIFF
--- a/src/Cache/RedisCache.php
+++ b/src/Cache/RedisCache.php
@@ -103,11 +103,42 @@ class RedisCache extends Cache
 
 	/**
 	 * Removes keys from the database
-	 * and returns whether the operation was successful
+	 * and returns whether the operation was successful;
+	 * scoped to the configured prefix
 	 */
 	public function flush(): bool
 	{
-		return $this->connection->flushDB();
+		$prefix = $this->options['prefix'] ?? null;
+
+		// no prefix means this driver owns the whole DB anyway
+		if ($prefix === null || $prefix === '') {
+			return $this->connection->flushDB();
+		}
+
+		// fetch the normalized prefix the constructor set on the connection
+		// (so we don't have to duplicate the rtrim + '/' normalization here)
+		$prefix = $this->connection->getOption(Redis::OPT_PREFIX);
+
+		// ->scan() returns full key names with prefix already included.
+		// Clear OPT_PREFIX so ->del() doesn't double-prefix them.
+		$this->connection->setOption(Redis::OPT_PREFIX, '');
+
+		// SCAN_RETRY skips empty batches so the while-loop only exits
+		// when the iteration is genuinely done.
+		$this->connection->setOption(Redis::OPT_SCAN, Redis::SCAN_RETRY);
+
+		try {
+			$it = null;
+
+			while ($keys = $this->connection->scan($it, $prefix . '*')) {
+				$this->connection->del($keys);
+			}
+		} finally {
+			// restore the prefix to OPT_PREFIX
+			$this->connection->setOption(Redis::OPT_PREFIX, $prefix);
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/Cache/RedisCacheTest.php
+++ b/tests/Cache/RedisCacheTest.php
@@ -83,6 +83,39 @@ class RedisCacheTest extends TestCase
 		$this->assertFalse($cache->exists('c'));
 	}
 
+	public function testFlushWithPrefix(): void
+	{
+		$cache1 = new RedisCache([
+			'prefix' => 'test1:'
+		]);
+		$cache2 = new RedisCache([
+			'prefix' => 'test2:'
+		]);
+
+		$cache1->set('a', 'A basic value');
+		$cache1->set('b', 'A basic value');
+		$cache2->set('a', 'A basic value');
+		$cache2->set('b', 'A basic value');
+		$cache1->set('c/a', 'A basic value');
+		$cache2->set('c/a', 'A basic value');
+
+		$this->assertTrue($cache1->exists('a'));
+		$this->assertTrue($cache1->exists('b'));
+		$this->assertTrue($cache1->exists('c/a'));
+		$this->assertTrue($cache2->exists('a'));
+		$this->assertTrue($cache2->exists('b'));
+		$this->assertTrue($cache2->exists('c/a'));
+
+		$this->assertTrue($cache1->flush());
+
+		$this->assertFalse($cache1->exists('a'));
+		$this->assertFalse($cache1->exists('b'));
+		$this->assertFalse($cache1->exists('c/a'));
+		$this->assertTrue($cache2->exists('a'));
+		$this->assertTrue($cache2->exists('b'));
+		$this->assertTrue($cache2->exists('c/a'));
+	}
+
 	public function testOperations(): void
 	{
 		$cache = new RedisCache();


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Redis cache driver: Fixed flushing all databases even when using a prefix. Now only the Reds database for the cache with its prefix gets flushed.


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion