### PR TITLE
fix: Handle UUID cache misses without crashing

### DIFF
--- a/src/Uuid/Uuid.php
+++ b/src/Uuid/Uuid.php
@@ -347,9 +347,13 @@ abstract class Uuid implements Stringable
 
 		if ($lazy === false) {
 			if (App::instance()->option('content.uuid.index') === false) {
-				throw new NotFoundException(
-					message: 'Model for UUID ' . $this->uri->toString() . ' could not be found without searching in the site index'
-				);
+				if (App::instance()->option('debug') === true) {
+					throw new NotFoundException(
+						message: 'Model for UUID ' . $this->uri->toString() . ' could not be found without searching in the site index'
+					);
+				}
+
+				return null;
 			}
 
 			if ($this->model = $this->findByIndex()) {

--- a/tests/Cms/App/AppTest.php
+++ b/tests/Cms/App/AppTest.php
@@ -861,6 +861,24 @@ class AppTest extends TestCase
 		$this->assertIsFile($file, $app->file('file://my-file'));
 	}
 
+	public function testFindFileByDeadUuidNoIndex(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'options' => [
+				'content' => [
+					'uuid' => [
+						'index' => false
+					]
+				]
+			]
+		]);
+
+		$this->assertNull($app->file('file://does-not-exist'));
+	}
+
 	public function testBlueprints(): void
 	{
 		$app = new App([

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -459,6 +459,22 @@ class PagesTest extends TestCase
 		$this->assertIsPage('c/d', $app->page('page://test-d'));
 	}
 
+	public function testFindByDeadUuidNoIndex(): void
+	{
+		$app = $this->app->clone([
+			'options' => [
+				'content' => [
+					'uuid' => [
+						'index' => false
+					]
+				]
+			]
+		]);
+
+		$this->assertNull($app->site()->find('page://does-not-exist'));
+		$this->assertNull($app->page('page://does-not-exist'));
+	}
+
 	public function testFindChildren(): void
 	{
 		$site = new Site([

--- a/tests/Content/FieldMethodsTest.php
+++ b/tests/Content/FieldMethodsTest.php
@@ -230,6 +230,36 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame('cover.jpg', $page->coverid()->toFile()->filename());
 	}
 
+	public function testToFileDeadUuidNoIndex(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'options' => [
+				'content' => [
+					'uuid' => [
+						'index' => false
+					]
+				]
+			],
+			'site' => [
+				'children' => [
+					[
+						'content' => [
+							'cover' => 'file://does-not-exist'
+						],
+						'slug' => 'test'
+					]
+				]
+			]
+		]);
+
+		$page = $app->page('test');
+		$this->assertNull($page->cover()->toFile());
+		$this->assertSame([], $page->cover()->toFiles()->data());
+	}
+
 	public function testToFiles(): void
 	{
 		$page = new Page([
@@ -379,6 +409,27 @@ class FieldMethodsTest extends TestCase
 		$this->assertSame($a, $this->field(Yaml::encode(['a']))->toPage());
 		$this->assertSame($b, $this->field(Yaml::encode(['b', 'a']))->toPage());
 		$this->assertSame($c, $this->field(Yaml::encode(['page://uuid-c', 'b', 'a']))->toPage());
+	}
+
+	public function testToPageDeadUuidNoIndex(): void
+	{
+		new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'options' => [
+				'content' => [
+					'uuid' => [
+						'index' => false
+					]
+				]
+			]
+		]);
+
+		$value = Yaml::encode(['page://does-not-exist']);
+
+		$this->assertNull($this->field('page://does-not-exist')->toPage());
+		$this->assertSame([], $this->field($value)->toPages()->data());
 	}
 
 	public function testToPages(): void
@@ -640,6 +691,27 @@ class FieldMethodsTest extends TestCase
 
 		$this->assertSame($a, $this->field(Yaml::encode(['a@company.com']))->toUser());
 		$this->assertSame($b, $this->field(Yaml::encode(['b@company.com', 'a@company.com']))->toUser());
+	}
+
+	public function testToUserDeadUuidNoIndex(): void
+	{
+		new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'options' => [
+				'content' => [
+					'uuid' => [
+						'index' => false
+					]
+				]
+			]
+		]);
+
+		$value = Yaml::encode(['user://does-not-exist']);
+
+		$this->assertNull($this->field('user://does-not-exist')->toUser());
+		$this->assertSame([], $this->field($value)->toUsers()->data());
 	}
 
 	public function testToUsers(): void

--- a/tests/Uuid/UuidTest.php
+++ b/tests/Uuid/UuidTest.php
@@ -369,12 +369,37 @@ class UuidTest extends TestCase
 		$this->assertNull(Uuid::for('file://something')->model());
 	}
 
-	public function testModelNotFoundIndexLookupDisabled(): void
+	public function testModelNotFoundNoIndex(): void
 	{
 		$this->app->clone(['options' => ['content' => ['uuid' => ['index' => false]]]]);
+		$this->assertNull(Uuid::for('page://something')->model());
+		$this->assertNull(Uuid::for('user://something')->model());
+		$this->assertNull(Uuid::for('file://something')->model());
+	}
+
+	public function testModelNotFoundNoIndexDebug(): void
+	{
+		$this->app->clone(['options' => [
+			'content' => ['uuid' => ['index' => false]],
+			'debug'   => true
+		]]);
+
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Model for UUID page://something could not be found without searching in the site index');
 		Uuid::for('page://something')->model();
+	}
+
+	public function testModelStaleFileParentNoIndex(): void
+	{
+		$this->app->clone(['options' => ['content' => ['uuid' => ['index' => false]]]]);
+
+		$uuid = Uuid::for('file://my-file');
+		Uuids::cache()->set($uuid->key(), [
+			'parent'   => 'page://something',
+			'filename' => 'test.pdf'
+		]);
+
+		$this->assertNull($uuid->model());
 	}
 
 	public function testPopulateGenerate(): void


### PR DESCRIPTION
## Description

This updates UUID resolution with `content.uuid.index = false` so cache misses return `null` in non-debug mode instead of crashing Panel or frontend renders with a `NotFoundException`. In debug mode, the exception is preserved to make stale or missing UUID cache entries easier to diagnose. Regression tests cover direct UUID lookup, stale cached file-parent references, field resolvers, page lookup, and file lookup.

## Changelog 

### 🐛 Bug fixes

- Fixed UUID cache misses with `content.uuid.index = false` #8103 


## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion