### PR TITLE
prevent PrevNext Navigation to show in AccountView

### DIFF
--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -6,7 +6,7 @@
 		class="k-user-view"
 	>
 		<template #topbar>
-			<k-prev-next :prev="prev" :next="next" />
+			<k-prev-next v-if="$options.prevnext !== false" :prev="prev" :next="next" />
 		</template>
 
 		<k-header


### PR DESCRIPTION
- the passed parameter was ignored 

https://github.com/getkirby/kirby/issues/8153
