### PR TITLE
perf: Cache resolved Component setup per type

### DIFF
--- a/src/Toolkit/Component.php
+++ b/src/Toolkit/Component.php
@@ -25,6 +25,14 @@ class Component
 	public static array $mixins = [];
 
 	/**
+	 * Cache of fully resolved setup options, keyed by
+	 * `[static::class][$type]`. Each entry stores the source
+	 * `definition` for invalidation check
+	 * and the resolved `options`.
+	 */
+	public static array $setups = [];
+
+	/**
 	 * Registry for all component types
 	 */
 	public static array $types = [];
@@ -246,6 +254,16 @@ class Component
 	{
 		// load component definition
 		$definition = static::load($type);
+		$class      = static::class;
+
+		// return cached options if the underlying definition is
+		// still the same array we resolved from last time
+		if (
+			isset(static::$setups[$class][$type]) === true &&
+			static::$setups[$class][$type]['definition'] === $definition
+		) {
+			return static::$setups[$class][$type]['options'];
+		}
 
 		if (isset($definition['extends']) === true) {
 			// extend other definitions
@@ -277,6 +295,11 @@ class Component
 				);
 			}
 		}
+
+		static::$setups[$class][$type] = [
+			'definition' => $definition,
+			'options'    => $options,
+		];
 
 		return $options;
 	}

--- a/tests/Toolkit/ComponentTest.php
+++ b/tests/Toolkit/ComponentTest.php
@@ -20,6 +20,7 @@ class ComponentTest extends TestCase
 	{
 		Component::$types  = [];
 		Component::$mixins = [];
+		Component::$setups = [];
 	}
 
 	public function testProp(): void

--- a/tests/Toolkit/ComponentTest.php
+++ b/tests/Toolkit/ComponentTest.php
@@ -347,4 +347,84 @@ class ComponentTest extends TestCase
 		$component = new Component('test');
 		$this->assertSame([], $component->defaults());
 	}
+
+	public function testSetupCacheHit(): void
+	{
+		Component::$types = [
+			'test' => [
+				'props' => [
+					'prop' => fn ($prop) => $prop
+				]
+			]
+		];
+
+		$first = Component::setup('test');
+		$this->assertArrayHasKey('prop', $first['props']);
+
+		// poison the stored options; the next call must return
+		// the sentinel, proving the cache path was taken
+		Component::$setups[Component::class]['test']['options'] = ['poisoned' => true];
+
+		$second = Component::setup('test');
+		$this->assertSame(['poisoned' => true], $second);
+	}
+
+	public function testSetupCacheInvalidation(): void
+	{
+		Component::$types = [
+			'test' => [
+				'props' => [
+					'a' => fn ($prop) => $prop
+				]
+			]
+		];
+
+		$first = Component::setup('test');
+		$this->assertArrayHasKey('a', $first['props']);
+
+		// replace the type definition with a new array;
+		// the cached entry's definition reference no longer
+		// matches, so setup() must re-resolve
+		Component::$types['test'] = [
+			'props' => [
+				'b' => fn ($prop) => $prop
+			]
+		];
+
+		$second = Component::setup('test');
+		$this->assertArrayHasKey('b', $second['props']);
+		$this->assertArrayNotHasKey('a', $second['props']);
+	}
+
+	public function testSetupCachePerClass(): void
+	{
+		Component::$types = [
+			'test_a' => [
+				'props' => [
+					'a' => fn ($prop) => $prop
+				]
+			],
+			'test_b' => [
+				'props' => [
+					'b' => fn ($prop) => $prop
+				]
+			]
+		];
+
+		$base   = Component::setup('test_a');
+		$custom = TestComponentWithCustomProperty::setup('test_b');
+
+		$this->assertArrayHasKey('a', $base['props']);
+		$this->assertArrayHasKey('b', $custom['props']);
+
+		// each class caches under its own `static::class` slot
+		$this->assertSame(
+			['test_a'],
+			array_keys(Component::$setups[Component::class])
+		);
+		$this->assertSame(
+			['test_b'],
+			array_keys(Component::$setups[TestComponentWithCustomProperty::class])
+		);
+	}
 }


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

`Component::setup()` runs `array_replace_recursive` over defaults, the extended definition, and any mixins on every instance.

Cache the resolved options in `Component::$setups`, keyed by `[static::class][$type]` so each subclass gets its own slice. The cache stores `['definition', 'options']` and only returns the cached options when the underlying `$types[$type]` is still the same array reference, which auto-invalidates whenever a caller (e.g. plugin registration or a test) reassigns the type definition.

## Bench

```
─────────────────────────────────────────────────────────────────────────
Field type (note)            iters    Uncached      Cached    Speedup
─────────────────────────────────────────────────────────────────────────
text       (bare)            100000    91.45 ms    27.12 ms     3.4x
email      (extends text)    100000   100.21 ms    23.18 ms     4.3x
structure  (1 mixin)         100000   120.52 ms    21.98 ms     5.5x
pages      (4 mixins)        100000   194.51 ms    22.54 ms     8.6x
─────────────────────────────────────────────────────────────────────────
```

```php
<?php

use Kirby\CLI\CLI;
use Kirby\Filesystem\F;
use Kirby\Form\Field;
use SebastianBergmann\Timer\Timer;

function LEGACY_setup(string $class, string $type): array
{
	// mirror of pre-cache setup() — no $setups read/write
	$definition = $class::$types[$type];

	if (is_string($definition) === true) {
		$class::$types[$type] = $definition = F::load(
			$definition,
			allowOutput: false
		);
	}

	if (isset($definition['extends']) === true) {
		$extends = $class::$types[$definition['extends']];

		if (is_string($extends) === true) {
			$class::$types[$definition['extends']] = $extends = F::load(
				$extends,
				allowOutput: false
			);
		}

		$options = array_replace_recursive(
			$class::defaults(),
			$extends,
			$definition
		);
	} else {
		$options = array_replace_recursive($class::defaults(), $definition);
	}

	foreach ($options['mixins'] ?? [] as $mixin) {
		if (isset($class::$mixins[$mixin]) === true) {
			if (is_string($class::$mixins[$mixin]) === true) {
				$class::$mixins[$mixin] = F::load(
					$class::$mixins[$mixin],
					allowOutput: false
				);
			}

			$options = array_replace_recursive(
				$class::$mixins[$mixin],
				$options
			);
		}
	}

	return $options;
}

function run(CLI $cli, string $label, int $iterations, callable $impl): float
{
	$cli->out("\n" . $label);
	$progress = $cli->lightBlue()->progress()->total($iterations);

	$timer = new Timer;
	$timer->start();

	$tick = max(1, (int)($iterations / 100));
	for ($i = 1; $i <= $iterations; $i++) {
		if ($i % $tick === 0) {
			$progress->current($i);
		}
		$impl();
	}
	$progress->current($iterations);

	return $timer->stop()->asMilliseconds();
}

return [
	'description' => 'Benchmark Component::setup() cache',
	'command' => function (CLI $cli) {
		$iterations = 100_000;

		$cases = [
			'text'      => 'bare',
			'email'     => 'extends text',
			'structure' => '1 mixin',
			'pages'     => '4 mixins',
		];

		// warm: ensure string-path type/mixin definitions are resolved
		// into arrays so the loop measures merge cost, not file I/O
		foreach (array_keys($cases) as $type) {
			Field::setup($type);
		}

		$results = [];

		foreach ($cases as $type => $note) {
			$cached = run(
				$cli,
				"$type ($note) — cached",
				$iterations,
				fn () => Field::setup($type)
			);

			$uncached = run(
				$cli,
				"$type ($note) — uncached",
				$iterations,
				fn () => LEGACY_setup(Field::class, $type)
			);

			// sanity: both paths produce the same top-level structure
			$match = array_keys(Field::setup($type))
				=== array_keys(LEGACY_setup(Field::class, $type));

			$results["$type ($note)"] = compact('cached', 'uncached', 'match');
		}

		$cli->out('');
		$cli->out(str_repeat('─', 74));
		$cli->out(sprintf('%-26s %12s %12s %10s %8s', 'Field type', 'Uncached', 'Cached', 'Speedup', 'Match'));
		$cli->out(str_repeat('─', 74));

		foreach ($results as $label => $r) {
			$speedup = $r['cached'] > 0
				? sprintf('%.1fx', $r['uncached'] / $r['cached'])
				: 'n/a';

			$cli->out(sprintf(
				'%-26s %10.2f ms %10.2f ms %10s %8s',
				$label,
				$r['uncached'],
				$r['cached'],
				$speedup,
				$r['match'] ? 'yes' : 'NO'
			));
		}
		$cli->out(str_repeat('─', 74));
	}
];
```

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion