### PR TITLE
fix: `Str::toByte()` support for fractional sizes

### DIFF
--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1400,7 +1400,7 @@ class Str
 					}
 				}
 
-				// wihtout a result, keep the original placeholder
+				// without a result, keep the original placeholder
 				return $result ?? $match[0];
 			},
 			$string
@@ -1409,13 +1409,14 @@ class Str
 
 	/**
 	 * Converts a filesize string with shortcuts
-	 * like M, G or K to an integer value
+	 * like M, G or K to an integer value.
+	 * Fractional sizes are supported (e.g. `1.5G` returns 1.5 GiB).
 	 */
 	public static function toBytes(string $size): int
 	{
 		$size = trim($size);
 		$last = strtolower($size[strlen($size) - 1] ?? '');
-		$size = (int)$size;
+		$size = (float)$size;
 
 		$size *= match ($last) {
 			'g'     => 1024 * 1024 * 1024,
@@ -1424,7 +1425,7 @@ class Str
 			default => 1
 		};
 
-		return $size;
+		return (int)$size;
 	}
 
 	/**

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -1347,6 +1347,11 @@ class StrTest extends TestCase
 		$this->assertSame(2 * 1024 * 1024, Str::toBytes('2m'));
 		$this->assertSame(2 * 1024 * 1024 * 1024, Str::toBytes('2G'));
 		$this->assertSame(2 * 1024 * 1024 * 1024, Str::toBytes('2g'));
+
+		// fractional sizes
+		$this->assertSame((int)(1.5 * 1024), Str::toBytes('1.5K'));
+		$this->assertSame((int)(1.5 * 1024 * 1024), Str::toBytes('1.5M'));
+		$this->assertSame((int)(1.5 * 1024 * 1024 * 1024), Str::toBytes('1.5G'));
 	}
 
 	public function testToType(): void


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Fixed fractional support for `Kirby\Toolkit|Str::toBytes()`


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion