### PR TITLE
fix: read Forwarded `for=` field from parsed fields, not host parts

### DIFF
--- a/src/Http/Environment.php
+++ b/src/Http/Environment.php
@@ -360,8 +360,9 @@ class Environment
 
 		// prefer the standardized `Forwarded` header if defined
 		if ($forwarded = $this->get('HTTP_FORWARDED')) {
-			// only use the first (outermost) proxy by using the first set of values
-			// before the first comma (but only a comma outside of quotes)
+			// only use the first (outermost) proxy by using
+			// the first set of values before the first comma
+			// (but only a comma outside of quotes)
 			if (Str::contains($forwarded, ',') === true) {
 				$forwarded = preg_split('/"[^"]*"(*SKIP)(*F)|,/', $forwarded)[0];
 			}
@@ -372,6 +373,7 @@ class Environment
 
 			// split key and value into an associative array
 			$fields = [];
+
 			foreach ($rawFields as $field) {
 				$key   = Str::lower(Str::before($field, '='));
 				$value = Str::after($field, '=');
@@ -399,7 +401,7 @@ class Environment
 				$data['port'] ??= 443;
 			}
 
-			$data['for'] = $parts['for'] ?? null;
+			$data['for'] = $fields['for'] ?? null;
 
 			return $data;
 		}

--- a/tests/Http/EnvironmentTest.php
+++ b/tests/Http/EnvironmentTest.php
@@ -963,6 +963,43 @@ class EnvironmentTest extends TestCase
 		$this->assertSame($expected, $env->isLocal());
 	}
 
+	public function testIsLocalWithForwardedForOnly(): void
+	{
+		// HTTP_FORWARDED carries a localhost `for=` value as the only IP signal.
+		// isLocal() must treat the request as local, just like it does for
+		// HTTP_X_FORWARDED_FOR with the same value.
+		$env = new Environment(null, [
+			'HTTP_FORWARDED' => 'for=127.0.0.1',
+		]);
+
+		$this->assertTrue($env->isLocal());
+	}
+
+	public function testIsLocalWithForwardedForExternalIp(): void
+	{
+		// REMOTE_ADDR is local, but HTTP_FORWARDED says the original client
+		// is external. isLocal() must return false. A non-local IP from any
+		// source disqualifies the request.
+		$env = new Environment(null, [
+			'REMOTE_ADDR'    => '127.0.0.1',
+			'HTTP_FORWARDED' => 'for=1.2.3.4',
+		]);
+
+		$this->assertFalse($env->isLocal());
+	}
+
+	public function testIsLocalWithForwardedForAndHost(): void
+	{
+		// Even when the Forwarded header also carries host/proto fields,
+		// the for= value must be extracted.
+		$env = new Environment(null, [
+			'REMOTE_ADDR'    => '127.0.0.1',
+			'HTTP_FORWARDED' => 'for=1.2.3.4;host=example.com;proto=https',
+		]);
+
+		$this->assertFalse($env->isLocal());
+	}
+
 	public static function isLocalWithServerNameProvider(): array
 	{
 		return [


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

In `Http/Environment`, `::detectForwarded()` was reading the client IP from the wrong variable when parsing the standardized `Forwarded` header:

```php
$data['for'] = $parts['for'] ?? null;   // before
$data['for'] = $fields['for'] ?? null;  // after
```

`$parts` is the return value of `::detectPortInHost(])`, which only ever contains `host` and `port` keys, never `for`. As a result, `$data['for']` was always `null`. The correct source is `$fields`, which holds the parsed `key=value` pairs from the header itself.

Behind a proxy that only emits `Forwarded`, `::isLocal()` could return the wrong answer.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Fixed: `Kirby\Http\Environment` now correctly extracts the `for=` value from the standardized `Forwarded` header, fixing `::isLocal()` detection behind certain proxies.

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion