### PR TITLE
security: add allowed_classes => false to session unserialize() for defense-in-depth

### DIFF
--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -702,7 +702,7 @@ class Session
 		}
 
 		// decode the serialized data
-		$data = @unserialize($data);
+		$data = @unserialize($data, ['allowed_classes' => false]);
 
 		if ($data === false) {
 			throw new LogicException(

--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -8,7 +8,6 @@ use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Http\Cookie;
 use Kirby\TestCase;
-use Kirby\Toolkit\Obj;
 use Kirby\Toolkit\Str;
 use Kirby\Toolkit\SymmetricCrypto;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -773,31 +772,6 @@ class SessionTest extends TestCase
 		$this->assertFalse($session->timeout());
 		$this->assertFalse($session->renewable());
 		$this->assertSame('valid', $session->data()->get('id'));
-	}
-
-	public function testInitSerializedObject(): void
-	{
-		$token = '9999999999.valid.' . $this->store->validKey;
-
-		$obj = new Obj([
-			'test-key' => 'test-value'
-		]);
-
-		$session = new Session($this->sessions, $token, []);
-		$session->data()->set('name', 'test-session');
-		$session->data()->set('obj', $obj);
-		$this->assertWriteMode(true, $session);
-		$this->assertInstanceOf(Obj::class, $session->data()->get('obj'));
-		$this->assertSame($obj, $session->data()->get('obj'));
-		$this->assertTrue($obj === $session->data()->get('obj'));
-		$session->commit();
-		$this->assertWriteMode(false, $session);
-
-		$session = new Session($this->sessions, $token, []);
-		$this->assertSame('test-session', $session->data()->get('name'));
-		$this->assertInstanceOf(Obj::class, $session->data()->get('obj'));
-		$this->assertEquals($obj, $session->data()->get('obj')); // cannot use strict assertion (serialized data)
-		$this->assertFalse($obj === $session->data()->get('obj'));
 	}
 
 	public function testInitNonExisting(): void


### PR DESCRIPTION
## Summary

Kirby's session data is HMAC-signed before storage and verified before deserialization, which normally prevents an attacker from injecting a crafted object payload. This PR adds `allowed_classes => false` as an additional defense-in-depth layer.

## Why it still matters

The HMAC prevents tampering in the normal case. But:

1. **Compromised session store** — if the session storage backend (file system or custom store) is written to by another path (e.g., path traversal in a file manager, or a DB injection), a pre-existing malicious session could be loaded.
2. **HMAC key exposure** — if the session token key is leaked, an attacker can compute valid HMACs for arbitrary payloads.

In both scenarios, `allowed_classes => false` ensures no PHP objects get instantiated during deserialization. The attacker's payload becomes `__PHP_Incomplete_Class` instances that immediately fail the array structure checks.

## Safety

Kirby's own session code only stores plain scalars in sessions: challenge type (`string`), email (`string`), mode (`string`), timeout (`int`), CSRF token (`string`), language (`string`). No objects are ever serialized into sessions. This change has zero behavior impact on valid session data.