### PR TITLE
refact: Use more modern first class callables

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -216,7 +216,7 @@ return [
 			}
 
 			if (empty($options['fields']) === false) {
-				$fields = array_map('strtolower', $options['fields']);
+				$fields = array_map(strtolower(...), $options['fields']);
 				$keys   = array_intersect($keys, $fields);
 			}
 

--- a/config/fields/mixins/picker.php
+++ b/config/fields/mixins/picker.php
@@ -126,10 +126,7 @@ return [
 			]);
 		},
 		'toItems' => function (array $models) {
-			return A::map(
-				$models,
-				fn ($model) => $this->toItem($model)
-			);
+			return A::map($models, $this->toItem(...));
 		},
 		'toModel' => function (string $id) {
 			throw new Exception(message: 'toModel() is not implemented on ' . $this->type() . ' field');

--- a/src/Cms/Responder.php
+++ b/src/Cms/Responder.php
@@ -313,7 +313,8 @@ class Responder implements Stringable
 				if (isset($injectedHeaders['Vary']) === true) {
 					// split CORS Vary into individual values
 					// to avoid duplication
-					$corsVaryValues = array_map('trim', explode(',', $injectedHeaders['Vary']));
+					$corsVaryValues = explode(',', $injectedHeaders['Vary']);
+					$corsVaryValues = array_map(trim(...), $corsVaryValues);
 					array_push($vary, ...$corsVaryValues);
 				}
 

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -99,10 +99,10 @@ class Dir
 		bool $absolute = false
 	): array {
 		$scan   = static::read($dir, $ignore, true);
-		$result = array_values(array_filter($scan, 'is_dir'));
+		$result = array_values(array_filter($scan, is_dir(...)));
 
 		if ($absolute !== true) {
-			$result = array_map('basename', $result);
+			$result = array_map(basename(...), $result);
 		}
 
 		return $result;
@@ -130,10 +130,10 @@ class Dir
 		bool $absolute = false
 	): array {
 		$scan   = static::read($dir, $ignore, true);
-		$result = array_values(array_filter($scan, 'is_file'));
+		$result = array_values(array_filter($scan, is_file(...)));
 
 		if ($absolute !== true) {
-			$result = array_map('basename', $result);
+			$result = array_map(basename(...), $result);
 		}
 
 		return $result;

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -68,7 +68,7 @@ class Router
 			$patterns = A::wrap($props['pattern']);
 			$methods  = A::map(
 				explode('|', strtoupper($props['method'] ?? 'GET')),
-				'trim'
+				trim(...)
 			);
 
 			if ($methods === ['ALL']) {

--- a/src/Http/VolatileHeaders.php
+++ b/src/Http/VolatileHeaders.php
@@ -62,7 +62,7 @@ class VolatileHeaders
 
 		foreach ($corsHeaders as $name => $value) {
 			if ($name === 'Vary') {
-				$corsVaryValues = array_map('trim', explode(',', $value));
+				$corsVaryValues = array_map(trim(...), explode(',', $value));
 				$this->append($name, $corsVaryValues, $volatile);
 				continue;
 			}
@@ -87,7 +87,7 @@ class VolatileHeaders
 	 */
 	protected function normalizeVaryValues(string $value): array
 	{
-		$values = A::map(explode(',', $value), 'trim');
+		$values = A::map(explode(',', $value), trim(...));
 		$values = A::filter($values, static fn ($entry) => $entry !== '');
 
 		return array_values(array_unique($values));
@@ -98,7 +98,7 @@ class VolatileHeaders
 	 */
 	protected function removeVaryValues(array $values, array $remove): array
 	{
-		$removeLower = A::map($remove, 'strtolower');
+		$removeLower = A::map($remove, strtolower(...));
 
 		return array_values(A::filter(
 			$values,

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -286,7 +286,7 @@ class Plugin
 			);
 
 			// sort the matches by key length (with longest key first)
-			$keys = array_map('strlen', array_keys($option));
+			$keys = array_map(strlen(...), array_keys($option));
 			array_multisort($keys, SORT_DESC, $option);
 
 			if ($option !== []) {

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -194,7 +194,7 @@ class KirbyTag
 		// convert it to arrays of keys and values
 		$chunks = array_chunk($search, 2);
 		$keys   = array_column($chunks, 0);
-		$values = array_map('trim', array_column($chunks, 1));
+		$values = array_map(trim(...), array_column($chunks, 1));
 
 		// ensure that there is a value for each key
 		// otherwise combining won't work

--- a/tests/Toolkit/ATest.php
+++ b/tests/Toolkit/ATest.php
@@ -356,7 +356,7 @@ class ATest extends TestCase
 		$array    = [' A ', 'B ', ' C'];
 		$expected = ['A', 'B', 'C'];
 
-		$this->assertSame($expected, A::map($array, 'trim'));
+		$this->assertSame($expected, A::map($array, trim(...)));
 	}
 
 	public function testMapWithClassMethod(): void


### PR DESCRIPTION
I think it would be great if we move more to this code style. Especially in this case where it replaces strings - the new syntax is much better with IDEs etc., e.g. immediately noticing if there would be a typo and we are passing a function that doesn't exists.