### PR TITLE
fix: support normalized blueprint field lookups

### DIFF
--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -30,6 +30,7 @@ class Blueprint
 	public static array $loaded = [];
 
 	protected array $fields = [];
+	protected array|null $fieldsLower = null;
 	protected ModelWithContent $model;
 	protected array $props;
 	protected array $sections = [];
@@ -371,8 +372,8 @@ class Blueprint
 		}
 
 		// field objects use normalized lowercase keys
-		$fields = array_change_key_case($this->fields);
-		return $fields[Str::lower($name)] ?? null;
+		$this->fieldsLower ??= array_change_key_case($this->fields);
+		return $this->fieldsLower[Str::lower($name)] ?? null;
 	}
 
 	/**

--- a/src/Cms/Blueprint.php
+++ b/src/Cms/Blueprint.php
@@ -366,7 +366,13 @@ class Blueprint
 	 */
 	public function field(string $name): array|null
 	{
-		return $this->fields[$name] ?? null;
+		if (isset($this->fields[$name]) === true) {
+			return $this->fields[$name];
+		}
+
+		// field objects use normalized lowercase keys
+		$fields = array_change_key_case($this->fields);
+		return $fields[Str::lower($name)] ?? null;
 	}
 
 	/**

--- a/tests/Cms/Blueprints/BlueprintTest.php
+++ b/tests/Cms/Blueprints/BlueprintTest.php
@@ -682,6 +682,43 @@ class BlueprintTest extends TestCase
 		$this->assertSame($fields['test'], $blueprint->field('test'));
 	}
 
+	public function testFieldWithNormalizedName(): void
+	{
+		$blueprint = new Blueprint([
+			'model' => $this->model,
+			'fields' => $fields = [
+				'mixedCasing' => [
+					'type'  => 'text',
+					'name'  => 'mixedCasing',
+					'label' => 'Mixed Casing',
+					'width' => '1/1'
+				]
+			]
+		]);
+
+		$this->assertSame($fields['mixedCasing'], $blueprint->field('mixedCasing'));
+		$this->assertSame($fields['mixedCasing'], $blueprint->field('mixedcasing'));
+	}
+
+	public function testFieldWithDuplicateNormalizedName(): void
+	{
+		$blueprint = new Blueprint([
+			'model' => $this->model,
+			'fields' => [
+				'mixedCasing' => [
+					'type'  => 'text',
+					'label' => 'First'
+				],
+				'MixedCasing' => [
+					'type'  => 'textarea',
+					'label' => 'Last'
+				]
+			]
+		]);
+
+		$this->assertSame('Last', $blueprint->field('MIXEDCASING')['label']);
+	}
+
 	public function testNestedFields(): void
 	{
 		$blueprint = new Blueprint([


### PR DESCRIPTION
## Description

`Field::key()` returns normalized lowercase field keys, while blueprint field definitions keep their original casing. This caused `Blueprint::field($field->key())` to fail for mixed-case field names. `Blueprint::field()` now keeps exact-case lookups unchanged and falls back to a normalized lowercase lookup, matching the behavior used by form fields.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
- Fixed blueprint field lookups with normalized field keys for mixed-case field names #8171

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion