### PR TITLE
fix: `Lock::for()` with no active lock

### DIFF
--- a/src/Content/Lock.php
+++ b/src/Content/Lock.php
@@ -59,8 +59,12 @@ class Lock
 				}
 			}
 
-			// return the last lock if no lock was found
-			return $lock;
+			// no language has an active lock:
+			// fall back to the lock for the current language,
+			// so that the user and modification timestamp
+			// reflect the current version and not the
+			// arbitrary last-iterated language
+			return static::for($version, Language::ensure());
 		}
 
 		$language = Language::ensure($language);

--- a/src/Content/VersionRules.php
+++ b/src/Content/VersionRules.php
@@ -56,9 +56,11 @@ class VersionRules
 		Version $version,
 		Language $language
 	): void {
-		if ($version->isLocked('*') === true) {
+		$lock = $version->lock('*');
+
+		if ($lock->isLocked() === true) {
 			throw new LockedContentException(
-				lock: $version->lock('*'),
+				lock: $lock,
 				key: 'content.lock.delete'
 			);
 		}
@@ -74,17 +76,21 @@ class VersionRules
 		static::ensure($fromVersion, $fromLanguage);
 
 		// check if the source version is locked in any language
-		if ($fromVersion->isLocked('*') === true) {
+		$fromLock = $fromVersion->lock('*');
+
+		if ($fromLock->isLocked() === true) {
 			throw new LockedContentException(
-				lock: $fromVersion->lock('*'),
+				lock: $fromLock,
 				key: 'content.lock.move'
 			);
 		}
 
 		// check if the target version is locked in any language
-		if ($toVersion->isLocked('*') === true) {
+		$toLock = $toVersion->lock('*');
+
+		if ($toLock->isLocked() === true) {
 			throw new LockedContentException(
-				lock: $toVersion->lock('*'),
+				lock: $toLock,
 				key: 'content.lock.update'
 			);
 		}
@@ -105,9 +111,11 @@ class VersionRules
 		static::ensure($version, $language);
 
 		// check if the version is locked in any language
-		if ($version->isLocked('*') === true) {
+		$lock = $version->lock('*');
+
+		if ($lock->isLocked() === true) {
 			throw new LockedContentException(
-				lock: $version->lock('*'),
+				lock: $lock,
 				key: 'content.lock.publish'
 			);
 		}
@@ -129,9 +137,11 @@ class VersionRules
 		static::ensure($version, $language);
 
 		// check if the version is locked in any language
-		if ($version->isLocked('*') === true) {
+		$lock = $version->lock('*');
+
+		if ($lock->isLocked() === true) {
 			throw new LockedContentException(
-				lock: $version->lock('*'),
+				lock: $lock,
 				key: 'content.lock.replace'
 			);
 		}
@@ -151,9 +161,11 @@ class VersionRules
 	): void {
 		static::ensure($version, $language);
 
-		if ($version->isLocked('*') === true) {
+		$lock = $version->lock('*');
+
+		if ($lock->isLocked() === true) {
 			throw new LockedContentException(
-				lock: $version->lock('*'),
+				lock: $lock,
 				key: 'content.lock.update'
 			);
 		}

--- a/tests/Content/LockTest.php
+++ b/tests/Content/LockTest.php
@@ -142,6 +142,46 @@ class LockTest extends TestCase
 		$this->assertSame('admin', $lock->user()->id());
 	}
 
+	public function testForWithLanguageWildcardNoActiveLocked(): void
+	{
+		$this->app = $this->app->clone([
+			'languages' => [
+				[
+					'code'    => 'en',
+					'default' => true
+				],
+				[
+					'code' => 'de'
+				]
+			]
+		]);
+
+		$this->app->impersonate('admin');
+
+		// admin has an unsaved draft in the current (en) language only;
+		// the de version intentionally does not exist
+		$this->createLatestVersion('en');
+		$this->createChangesVersion('en');
+
+		$changes = $this->app->page('test')->version('changes');
+		$lock    = $changes->lock('*');
+
+		// nothing is locked (admin is the current user), so the wildcard
+		// must fall back to the current language's lock and not to an
+		// arbitrary last-iterated language (de) without a version
+		$this->assertFalse($lock->isLocked());
+		$this->assertSame('admin', $lock->user()->id());
+		$this->assertNotNull($lock->modified());
+
+		// switching the current language to de (no draft there) must be
+		// reflected in the fallback as well
+		$this->app->setCurrentLanguage('de');
+		$lock = $changes->lock('*');
+
+		$this->assertFalse($lock->isLocked());
+		$this->assertNull($lock->modified());
+	}
+
 	public function testForWithLegacyLock(): void
 	{
 		$page = $this->app->page('test');

--- a/tests/Content/VersionRulesTest.php
+++ b/tests/Content/VersionRulesTest.php
@@ -18,9 +18,14 @@ class ExistingVersion extends Version
 
 class LockedVersion extends Version
 {
-	public function isLocked(Language|string $language = 'default'): bool
+	public function lock(Language|string $language = 'default'): Lock
 	{
-		return true;
+		return new class () extends Lock {
+			public function isLocked(): bool
+			{
+				return true;
+			}
+		};
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

We use the `Lock` class for two purposes:
- a boolean state that we use model-wide (is locked anywhere?) 
- per-version display info (editor + timestamp)

Previously, those two would match in the case of an active lock. But if no active lock exists, `Lock::for()` fell back to the last `$lock` from the loop - so belonging to the last language, which is fine for the boolean state (model is not actively locked anywhere) but could produce wrong information or the user/modified timestamp to show up in `k-form-controls`. 

This PR now uses `Language::ensure()` to create a `Lock` object for the current language instead.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Fixed content meta data (editor & modified timestamp) to fall back to the current language when no active lock exists (`Kirby\Content\Lock::for()` uses current language for fallback)

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion