### PR TITLE
feat: `HtmlString` classes

### DIFF
--- a/panel/src/panel/html.test.ts
+++ b/panel/src/panel/html.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import html, { HtmlString } from "./html";
+
+describe("HtmlString class", () => {
+	describe("instance", () => {
+		it("extends String", () => {
+			const html = new HtmlString("<b>safe</b>");
+			expect(html).toBeInstanceOf(HtmlString);
+			expect(html).toBeInstanceOf(String);
+		});
+
+		it("returns its raw content via toString()", () => {
+			expect(new HtmlString("<b>safe</b>").toString()).toBe("<b>safe</b>");
+		});
+
+		it("returns its raw content via String()", () => {
+			expect(String(new HtmlString("<b>x</b>"))).toBe("<b>x</b>");
+		});
+
+		it("serializes to JSON as a plain string", () => {
+			expect(JSON.stringify(new HtmlString("<b>x</b>"))).toBe('"<b>x</b>"');
+		});
+
+		it("concatenates like a string", () => {
+			expect("a" + new HtmlString("b")).toBe("ab");
+		});
+	});
+
+	describe("resolve()", () => {
+		it("rewraps top-level <key> into HtmlString and strips brackets", () => {
+			const result = HtmlString.resolve({
+				title: "plain",
+				"<body>": "<p>html</p>"
+			}) as unknown as { title: string; body: HtmlString };
+
+			expect(result.title).toBe("plain");
+			expect(result.body).toBeInstanceOf(HtmlString);
+			expect(result.body.toString()).toBe("<p>html</p>");
+		});
+
+		it("recurses into nested objects", () => {
+			const result = HtmlString.resolve({
+				view: {
+					props: {
+						"<help>": "<em>hi</em>",
+						name: "plain"
+					}
+				}
+			}) as unknown as { view: { props: { help: HtmlString; name: string } } };
+
+			expect(result.view.props.help).toBeInstanceOf(HtmlString);
+			expect(result.view.props.name).toBe("plain");
+		});
+
+		it("recurses into arrays of objects", () => {
+			const result = HtmlString.resolve({
+				options: [
+					{ "<text>": "<b>Bold</b>", value: "a" },
+					{ text: "Plain", value: "b" }
+				]
+			}) as unknown as {
+				options: Array<{ text: string | HtmlString; value: string }>;
+			};
+
+			expect(result.options[0].text).toBeInstanceOf(HtmlString);
+			expect(result.options[1].text).toBe("Plain");
+		});
+
+		it("does not touch plain objects/arrays", () => {
+			const input = { a: 1, b: [{ c: 2 }] };
+			const result = HtmlString.resolve(input);
+			expect(result).toEqual(input);
+		});
+
+		it("does not mutate the input", () => {
+			const input = { "<body>": "<p>x</p>" };
+			HtmlString.resolve(input);
+			expect(input).toEqual({ "<body>": "<p>x</p>" });
+		});
+
+		it("passes primitives through unchanged", () => {
+			expect(HtmlString.resolve("plain")).toBe("plain");
+			expect(HtmlString.resolve(42)).toBe(42);
+			expect(HtmlString.resolve(null)).toBe(null);
+			expect(HtmlString.resolve(undefined)).toBe(undefined);
+		});
+
+		it("ignores single-char angle pairs and empty bracket strings", () => {
+			// "<>" alone is not a meaningful key wrapper
+			const result = HtmlString.resolve({ "<>": "x" }) as Record<
+				string,
+				unknown
+			>;
+			expect(result["<>"]).toBe("x");
+			expect(result["<>"] instanceof HtmlString).toBe(false);
+		});
+
+		it("warns on collision between key and <key> in the same object", () => {
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+			HtmlString.resolve({
+				foo: "untrusted",
+				"<foo>": "<b>trusted</b>"
+			});
+			expect(warn).toHaveBeenCalledOnce();
+			expect(warn.mock.calls[0][0]).toMatch(/foo/);
+			warn.mockRestore();
+		});
+
+		it("wraps non-string values under <key> by recursing", () => {
+			// Pragmatic edge case: if backend wraps an array under <key>,
+			// don't blindly stringify - recurse into it.
+			const result = HtmlString.resolve({
+				"<items>": [{ "<text>": "<b>x</b>" }]
+			}) as unknown as { items: Array<{ text: HtmlString }> };
+
+			expect(Array.isArray(result.items)).toBe(true);
+			expect(result.items[0].text).toBeInstanceOf(HtmlString);
+		});
+	});
+});
+
+describe("$html()", () => {
+	it("wraps a plain string in HtmlString", () => {
+		const result = html("<b>x</b>");
+		expect(result).toBeInstanceOf(HtmlString);
+		expect(result.toString()).toBe("<b>x</b>");
+	});
+
+	it("returns an HtmlString unchanged (same identity)", () => {
+		const safe = new HtmlString("<b>x</b>");
+		expect(html(safe)).toBe(safe);
+	});
+
+	it("coerces null to an empty HtmlString", () => {
+		expect(html(null).toString()).toBe("");
+	});
+
+	it("coerces undefined to an empty HtmlString", () => {
+		expect(html(undefined).toString()).toBe("");
+	});
+
+	it("coerces a number to its string form", () => {
+		expect(html(42).toString()).toBe("42");
+	});
+});

--- a/panel/src/panel/html.ts
+++ b/panel/src/panel/html.ts
@@ -1,0 +1,87 @@
+/**
+ * Wraps and marks a string as trusted, pre-escaped HTML.
+ *
+ * A plain string flowing through Panel state is treated as untrusted and
+ * should get escaped at the render site. An `HtmlString` instance can be
+ *  passed through unchanged, so it can be rendered via `v-html`/
+ * `v-safe-html` without further escaping.
+ *
+ * The backend signals safety by emitting JSON with the parent key wrapped
+ * in `<…>`, e.g. `"<help>": "<b>html</b>"`. `HtmlString.resolve()` walks
+ * incoming state, finds those keys, rewraps their values, and strips the
+ * brackets. `Kirby\Toolkit\HtmlString::resolve()` does the inverse on the
+ * PHP side.
+ *
+ * Since the class extends `String`, instances behave like strings in
+ * almost every context (template interpolation, attribute binding,
+ * concatenation, `JSON.stringify`), and `instanceof` survives Vue's
+ * `reactive()` proxy and prop type validation.
+ *
+ * @since 6.0.0
+ */
+export class HtmlString extends String {
+	constructor(value: string) {
+		super(value);
+	}
+
+	/**
+	 * Recursively walks `data` and rewraps any value whose parent key
+	 * matches `<key>` into an `HtmlString`, stripping the brackets. Plain
+	 * keys are kept as-is. Arrays are walked element by element.
+	 *
+	 * Returns a new object/array; does not mutate the input.
+	 */
+	static resolve<T>(data: T): T {
+		if (Array.isArray(data) === true) {
+			return data.map((value) => HtmlString.resolve(value)) as T;
+		}
+
+		if (data !== null && typeof data === "object") {
+			const result: Record<string, unknown> = {};
+			const rawData = data as Record<string, unknown>;
+
+			for (const rawKey in rawData) {
+				const value = rawData[rawKey];
+
+				if (
+					rawKey.length > 2 &&
+					rawKey.startsWith("<") === true &&
+					rawKey.endsWith(">") === true
+				) {
+					const key = rawKey.slice(1, -1);
+
+					if (Object.prototype.hasOwnProperty.call(result, key) === true) {
+						console.warn(
+							`HtmlString.fromJSON: both "${key}" and "${rawKey}" present — the bracketed version wins`
+						);
+					}
+
+					result[key] =
+						typeof value === "string"
+							? new HtmlString(value)
+							: HtmlString.resolve(value);
+					continue;
+				}
+
+				result[rawKey] = HtmlString.resolve(value);
+			}
+
+			return result as T;
+		}
+
+		return data;
+	}
+}
+
+/**
+ * Marks a value as trusted HTML by returning an `HtmlString` instance.
+ *
+ * @since 6.0.0
+ */
+export default function html(value: unknown): HtmlString {
+	if (value instanceof HtmlString) {
+		return value;
+	}
+
+	return new HtmlString(String(value ?? ""));
+}

--- a/panel/src/panel/legacy.js
+++ b/panel/src/panel/legacy.js
@@ -20,6 +20,7 @@ export default {
 		);
 		app.config.globalProperties.$events = panel.events;
 		app.config.globalProperties.$go = panel.view.open.bind(panel.view);
+		app.config.globalProperties.$html = panel.html;
 		app.config.globalProperties.$reload = panel.reload;
 		app.config.globalProperties.$t = panel.$t = panel.t;
 		app.config.globalProperties.$url = panel.url;

--- a/panel/src/panel/panel.js
+++ b/panel/src/panel/panel.js
@@ -7,6 +7,7 @@ import Drag from "./drag";
 import Drawer from "./drawer";
 import Dropdown from "./dropdown.js";
 import Events from "./events";
+import html from "./html";
 import Language from "./language";
 import Notification from "./notification";
 import Observers from "./observers";
@@ -105,6 +106,7 @@ export default {
 		this.dialog = Dialog(this);
 
 		// methods
+		this.html = html;
 		this.redirect = redirect;
 		this.reload = this.view.reload.bind(this.view);
 

--- a/src/Toolkit/HtmlString.php
+++ b/src/Toolkit/HtmlString.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Kirby\Toolkit;
+
+use JsonSerializable;
+use Stringable;
+
+/**
+ * Marks a string as trusted, pre-escaped HTML so that it can flow through
+ * Panel state to the frontend and be rendered as HTML without further
+ * escaping. Any string not wrapped in this class should be treated as
+ * untrusted on the frontend and escaped at the render site.
+ *
+ * On JSON serialization, parent keys of `HtmlString` values are renamed
+ * from `key` to `<key>` so the frontend can rewrap them. Use
+ * `HtmlString::resolve()` on a data array before encoding.
+ *
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class HtmlString implements JsonSerializable, Stringable
+{
+	public function __construct(
+		protected string $value
+	) {
+	}
+
+	public function __toString(): string
+	{
+		return $this->value;
+	}
+
+	public function jsonSerialize(): string
+	{
+		return $this->value;
+	}
+
+	/**
+	 * Walks an array recursively and renames any key
+	 * whose value is an `HtmlString` from `key` to `<key>`,
+	 * so the JS side can detect and rewrap the value.
+	 */
+	public static function resolve(array $data): array
+	{
+		$result = [];
+
+		foreach ($data as $key => $value) {
+			if ($value instanceof HtmlString) {
+				$result['<' . $key . '>'] = $value;
+				continue;
+			}
+
+			if (is_array($value) === true) {
+				$result[$key] = static::resolve($value);
+				continue;
+			}
+
+			$result[$key] = $value;
+		}
+
+		return $result;
+	}
+
+	public function value(): string
+	{
+		return $this->value;
+	}
+}

--- a/tests/Toolkit/HtmlStringTest.php
+++ b/tests/Toolkit/HtmlStringTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Kirby\Toolkit;
+
+use Kirby\Data\Json;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(HtmlString::class)]
+class HtmlStringTest extends TestCase
+{
+	public function testJsonSerialize(): void
+	{
+		$html = new HtmlString('<b>safe</b>');
+		$this->assertSame('"<b>safe<\/b>"', json_encode($html));
+	}
+
+	public function testJsonEncodeDecode(): void
+	{
+		$data = HtmlString::resolve([
+			'title' => $title = 'untrusted <script>alert(1)</script>',
+			'body'  => new HtmlString($body = '<p>trusted</p>')
+		]);
+
+		$json    = Json::encode($data);
+		$decoded = Json::decode($json);
+
+		$this->assertSame($title, $decoded['title']);
+		$this->assertSame($body, $decoded['<body>']);
+	}
+
+	public function testResolveRenamesTopLevelKey(): void
+	{
+		$data = [
+			'title' => 'plain',
+			'body'  => new HtmlString('<p>html</p>')
+		];
+
+		$resolved = HtmlString::resolve($data);
+
+		$this->assertArrayHasKey('title', $resolved);
+		$this->assertArrayHasKey('<body>', $resolved);
+		$this->assertArrayNotHasKey('body', $resolved);
+		$this->assertInstanceOf(HtmlString::class, $resolved['<body>']);
+	}
+
+	public function testResolveRecursesIntoNestedArrays(): void
+	{
+		$data = [
+			'view' => [
+				'props' => [
+					'help' => new HtmlString('<em>hi</em>'),
+					'name' => 'plain'
+				]
+			]
+		];
+
+		$resolved = HtmlString::resolve($data);
+
+		$this->assertArrayHasKey('<help>', $resolved['view']['props']);
+		$this->assertArrayHasKey('name', $resolved['view']['props']);
+		$this->assertArrayNotHasKey('help', $resolved['view']['props']);
+	}
+
+	public function testResolveWalksArraysOfObjects(): void
+	{
+		$data = [
+			'options' => [
+				['text' => new HtmlString('<b>Bold</b>'), 'value' => 'a'],
+				['text' => 'Plain', 'value' => 'b']
+			]
+		];
+
+		$resolved = HtmlString::resolve($data);
+
+		$this->assertArrayHasKey('<text>', $resolved['options'][0]);
+		$this->assertArrayNotHasKey('text', $resolved['options'][0]);
+		$this->assertArrayHasKey('text', $resolved['options'][1]);
+		$this->assertArrayNotHasKey('<text>', $resolved['options'][1]);
+	}
+
+	public function testResolveLeavesPlainArraysUnchanged(): void
+	{
+		$data = ['a' => 1, 'b' => ['c' => 2]];
+		$this->assertSame($data, HtmlString::resolve($data));
+	}
+
+	public function testResolveDoesNotMutateInput(): void
+	{
+		$data = ['body' => new HtmlString('<p>x</p>')];
+		HtmlString::resolve($data);
+		$this->assertArrayHasKey('body', $data);
+		$this->assertArrayNotHasKey('<body>', $data);
+	}
+
+	public function testToString(): void
+	{
+		$html = new HtmlString('<b>safe</b>');
+		$this->assertSame('<b>safe</b>', (string)$html);
+	}
+
+	public function testValue(): void
+	{
+		$html = new HtmlString('<b>safe</b>');
+		$this->assertSame('<b>safe</b>', $html->value());
+	}
+}


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

First step, setting the building blocks before diving into integration.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- New `Kirby\Toolkit\HtmlString` class and `HtmlString` JS class that wrap and mark strings as safe HTML
- New `this.$html()` Vue helper to mark a string as safe HTML (wraps it in a `HtmlString` object)

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion