### PR TITLE
feat: `v-safe-html`

### DIFF
--- a/panel/src/config/safeHtml.test.ts
+++ b/panel/src/config/safeHtml.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { HtmlString } from "@/panel/html";
+import safeHtml from "./safeHtml";
+
+const TestComponent = {
+	props: ["value"],
+	template: `<div v-safe-html="value" />`
+};
+
+function mountWithDirective(value: unknown) {
+	return mount(TestComponent, {
+		props: { value },
+		global: { plugins: [safeHtml] }
+	});
+}
+
+describe("config.safeHtml", () => {
+	describe("v-safe-html directive", () => {
+		it("escapes a plain string", () => {
+			const wrapper = mountWithDirective("<script>alert(1)</script>");
+			expect(wrapper.find("script").exists()).toBe(false);
+			expect(wrapper.element.innerHTML).toBe(
+				"&lt;script&gt;alert(1)&lt;/script&gt;"
+			);
+		});
+
+		it("renders an HtmlString as raw HTML", () => {
+			const wrapper = mountWithDirective(
+				new HtmlString("<strong>safe</strong>")
+			);
+			expect(wrapper.find("strong").exists()).toBe(true);
+			expect(wrapper.find("strong").text()).toBe("safe");
+		});
+
+		it("renders null as empty string", () => {
+			const wrapper = mountWithDirective(null);
+			expect(wrapper.element.innerHTML).toBe("");
+		});
+
+		it("updates innerHTML when bound value changes", async () => {
+			const wrapper = mountWithDirective("<b>1</b>");
+			expect(wrapper.element.innerHTML).toBe("&lt;b&gt;1&lt;/b&gt;");
+
+			await wrapper.setProps({ value: new HtmlString("<b>2</b>") });
+			expect(wrapper.find("b").exists()).toBe(true);
+			expect(wrapper.find("b").text()).toBe("2");
+		});
+
+		it("escapes when an HtmlString is replaced with a plain string", async () => {
+			const wrapper = mountWithDirective(new HtmlString("<b>trusted</b>"));
+			expect(wrapper.find("b").exists()).toBe(true);
+
+			await wrapper.setProps({ value: "<b>untrusted</b>" });
+			expect(wrapper.find("b").exists()).toBe(false);
+			expect(wrapper.element.innerHTML).toBe("&lt;b&gt;untrusted&lt;/b&gt;");
+		});
+	});
+});

--- a/panel/src/config/safeHtml.ts
+++ b/panel/src/config/safeHtml.ts
@@ -1,0 +1,41 @@
+import type { App, DirectiveBinding } from "vue";
+import { escapeHTML } from "@/helpers/string";
+import { HtmlString } from "@/panel/html";
+
+export default {
+	install(app: App) {
+		const render = (el: HTMLElement, binding: DirectiveBinding) => {
+			if (binding.value instanceof HtmlString) {
+				el.innerHTML = binding.value.toString();
+				return;
+			}
+
+			if (binding.value === null || binding.value === undefined) {
+				el.innerHTML = "";
+				return;
+			}
+
+			el.innerHTML = escapeHTML(binding.value);
+		};
+
+		/**
+		 * v-safe-html directive
+		 *
+		 * Safe-by-default replacement for `v-html`: plain strings are
+		 * HTML-escaped at the render site, `HtmlString` instances
+		 * (flagged as trusted by the backend) are written through
+		 * unchanged. The bound value can be a `String`, an
+		 * `HtmlString`, `null` or `undefined`.
+		 */
+		app.directive("safe-html", {
+			mounted: render,
+			updated: (el, binding) => {
+				if (binding.value === binding.oldValue) {
+					return;
+				}
+
+				render(el, binding);
+			}
+		});
+	}
+};

--- a/panel/src/index.ts
+++ b/panel/src/index.ts
@@ -8,6 +8,7 @@ import I18n from "./config/i18n";
 import Legacy from "./panel/legacy";
 import Libraries from "./libraries/index";
 import Panel from "./panel/panel";
+import SafeHtml from "./config/safeHtml";
 
 import preserveDataAttrs from "./mixins/preserveDataAttrs";
 import preserveListeners from "./mixins/preserveListeners";
@@ -54,6 +55,7 @@ import "./styles/utilities.css";
  */
 app.use(I18n);
 app.use(ErrorHandling);
+app.use(SafeHtml);
 app.use(Legacy);
 
 /**

--- a/panel/src/panel/state.test.ts
+++ b/panel/src/panel/state.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { HtmlString } from "./html";
 import State from "./state";
 
 describe("panel.state", () => {
@@ -59,6 +60,24 @@ describe("panel.state", () => {
 			state.set({ message: null });
 
 			expect(state.message).toStrictEqual("default");
+		});
+
+		it("rewraps <key> payloads into HtmlString instances", () => {
+			const state = State("test", {
+				title: null as string | null,
+				body: null as string | HtmlString | null
+			});
+
+			state.set({
+				title: "untrusted <script>",
+				"<body>": "<p>trusted</p>"
+			} as never);
+
+			expect(state.title).toStrictEqual("untrusted <script>");
+			expect(state.body).toBeInstanceOf(HtmlString);
+			expect((state.body as HtmlString).toString()).toStrictEqual(
+				"<p>trusted</p>"
+			);
 		});
 
 		it("throws when state is not a plain object", () => {

--- a/panel/src/panel/state.ts
+++ b/panel/src/panel/state.ts
@@ -1,4 +1,5 @@
 import { reactive } from "vue";
+import { HtmlString } from "./html";
 import { isObject } from "@/helpers/object";
 
 /**
@@ -57,6 +58,11 @@ export default function State<T extends Record<string, unknown>>(
 			if (isObject(state) === false) {
 				throw new Error(`Invalid ${this.key()} state`);
 			}
+
+			// rewrap any `<key>` payloads into HtmlString instances
+			// (including nested objects and arrays), so that the
+			// backend can flag trusted HTML through the same JSON shape
+			state = HtmlString.resolve(state);
 
 			const defaults = this.defaults();
 

--- a/src/Panel/State.php
+++ b/src/Panel/State.php
@@ -8,6 +8,7 @@ use Kirby\Cms\Language;
 use Kirby\Cms\User;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Date;
+use Kirby\Toolkit\HtmlString;
 use Kirby\Toolkit\Str;
 
 /**
@@ -273,17 +274,20 @@ class State
 		if ($globals === false) {
 			// filter data, if only globals headers or
 			// query parameters are requested
-			return $this->filter($data);
+			$data = $this->filter($data);
+			return HtmlString::resolve($data);
 		}
 
 		// load globals for the full document response
 		$globals = $this->globals();
 
 		// resolve and merge globals and shared data
-		return array_merge_recursive(
+		$data = array_merge_recursive(
 			A::apply($globals),
 			A::apply($data)
 		);
+
+		return HtmlString::resolve($data);
 	}
 
 	public function translation(): array


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

### Merge first

- [x] https://github.com/getkirby/kirby/pull/8175

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- New `v-safe-html` Vue directive that only renders passed `HtmlString` objects as HTML, escapes any other passed string

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion