### PR TITLE
fix: Ensure columns in DB `->where()` calls

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -848,11 +848,25 @@ class Query
 				// ->where(['username' => 'myuser']);
 				} elseif (is_array($args[0]) === true) {
 					// simple array mode (AND operator)
-					$sql = $this->database->sql()->values($this->table, $args[0], ' AND ', true, true);
+					$sql = $this->database->sql();
 
-					$result = $sql['query'];
+					// every column in the array must be a valid column;
+					// otherwise the condition would be silently dropped
+					// (in Sql::valueSet()) and the clause could collapse to
+					// nothing, turning a scoped update/delete into a
+					// full-table operation
+					foreach (array_keys($args[0]) as $column) {
+						if ($sql->columnName($this->table, $column) === null) {
+							throw new InvalidArgumentException(
+								message: 'Invalid column "' . $column . '" in clause'
+							);
+						}
+					}
 
-					$this->bindings($sql['bindings']);
+					$values = $sql->values($this->table, $args[0], ' AND ', true, true);
+					$result = $values['query'];
+
+					$this->bindings($values['bindings']);
 				} elseif (is_callable($args[0]) === true) {
 					$query = clone $this;
 
@@ -905,6 +919,12 @@ class Query
 					// validate column
 					$sql = $this->database->sql();
 					$key = $sql->columnName($this->table, $args[0]);
+
+					if ($key === null) {
+						throw new InvalidArgumentException(
+							message: 'Invalid column "' . $args[0] . '" in clause'
+						);
+					}
 
 					// ->where('username', 'in', ['myuser', 'myotheruser']);
 					// ->where('quantity', 'between', [10, 50]);

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -275,6 +275,24 @@ class QueryTest extends TestCase
 		$this->assertCount(4, $users);
 	}
 
+	public function testDeleteRejectsInvalidWhereColumn(): void
+	{
+		$this->assertCount(5, $this->database->table('users')->all());
+
+		try {
+			$this->database
+				->table('users')
+				->delete(['foo' => 'whatever']);
+
+			$this->fail('Expected an exception for an invalid where column');
+		} catch (InvalidArgumentException) {
+			// expected to throw instead of deleting every row
+		}
+
+		// the table must be untouched
+		$this->assertCount(5, $this->database->table('users')->all());
+	}
+
 	public function testMagicCall(): void
 	{
 		$user = $this->database
@@ -458,6 +476,17 @@ class QueryTest extends TestCase
 		$this->assertCount(2, $users);
 	}
 
+	public function testHavingInvalidColumn(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid column "foo" in clause');
+
+		$this->database
+			->table('users')
+			->having('foo', '>', 1)
+			->count();
+	}
+
 	public function testWhere(): void
 	{
 		// numeric comparison
@@ -576,6 +605,28 @@ class QueryTest extends TestCase
 		$this->database
 			->table('users')
 			->where('username', '<!>', 'john')
+			->count();
+	}
+
+	public function testWhereInvalidColumnArray(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid column "foo" in clause');
+
+		$this->database
+			->table('users')
+			->where(['foo' => 'whatever'])
+			->count();
+	}
+
+	public function testWhereInvalidColumn(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid column "foo" in clause');
+
+		$this->database
+			->table('users')
+			->where('foo', '=', 'whatever')
 			->count();
 	}
 


### PR DESCRIPTION

`Sql::valueSet()` simply drops column keys that don't exist on the table. This can be fatal for `->where()` queries though, e.g. if run on `->delete()->where()`. A deletion that is supposed run on a very defined selection of rows can end up deleting all rows if the column names do not match (e.g. name got updated but forgotten to adapt this in the code). PR now throws on any non-existing column name in `->where()` or `->having()` (in the associative array notation).

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Database queries: ensure columns exist in `->where()` and `->having()` clauses instead of simply dropping non-existing columns from those clauses


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion