### PR TITLE
fix: Zero-denominator EXIF GPS

### DIFF
--- a/src/Image/Location.php
+++ b/src/Image/Location.php
@@ -85,6 +85,11 @@ class Location implements Stringable
 			return (float)$parts[0];
 		}
 
+		// guard against forged EXIF with a zero denominator
+		if ((float)$parts[1] === 0.0) {
+			return 0.0;
+		}
+
 		return (float)($parts[0]) / (float)($parts[1]);
 	}
 

--- a/tests/Image/LocationTest.php
+++ b/tests/Image/LocationTest.php
@@ -25,6 +25,19 @@ class LocationTest extends TestCase
 		$this->assertSame(-0.016666666666666666, $camera->lng());
 	}
 
+	public function testNumZeroDenominator(): void
+	{
+		$location = new Location([
+			'GPSLatitudeRef'  => 'N',
+			'GPSLatitude'     => ['1/0', '0/1', '0/1'],
+			'GPSLongitudeRef' => 'E',
+			'GPSLongitude'    => ['1/1', '0/1', '0/1']
+		]);
+
+		$this->assertSame(0.0, $location->lat());
+		$this->assertSame(1.0, $location->lng());
+	}
+
 	public function testToArray(): void
 	{
 		$camera = new Location($this->_exif());


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Prevent division-by-zero crashed in `Kirby\Image\Location::num()` through malformed EXIF data

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion