### PR TITLE
`QrCode`: Escape attrs & guard max size

### DIFF
--- a/src/Image/QrCode.php
+++ b/src/Image/QrCode.php
@@ -7,6 +7,7 @@ use GdImage;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\Filesystem\F;
+use Kirby\Toolkit\Escape;
 use Stringable;
 
 /**
@@ -152,7 +153,10 @@ class QrCode implements Stringable
 			fn ($x, $y, $width, $height) => 'M' . $x . ',' . $y . 'h' . $width . 'v' . $height . 'h-' . $width . 'z'
 		);
 
-		$size = $size ? ' style="width: ' . $size . '"' : '';
+		// escape the values that end up in SVG (XML) attributes
+		$color = Escape::xml($color);
+		$back  = Escape::xml($back);
+		$size  = $size ? ' style="width: ' . Escape::xml((string)$size) . '"' : '';
 
 		return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' . $vbw . ' ' . $vbh . '" stroke="none"' . $size . '>' .
 			'<rect width="100%" height="100%" fill="' . $back . '"/>' .

--- a/src/Image/QrCode.php
+++ b/src/Image/QrCode.php
@@ -1037,6 +1037,14 @@ class QrCode implements Stringable
 			}
 		}
 
+		// reject data that does not fit into the largest QR version
+		// instead of overflowing into undefined version/capacity
+		if ($version > 40) {
+			throw new InvalidArgumentException(
+				message: 'The provided data exceeds the maximum capacity of a QR code'
+			);
+		}
+
 		// with the version in place, try to raise
 		// the error correction level as long as
 		// the data still fits

--- a/tests/Image/QrCodeTest.php
+++ b/tests/Image/QrCodeTest.php
@@ -146,6 +146,15 @@ class QrCodeTest extends TestCase
 		$this->assertSame($qr->toSvg(), (string)$qr);
 	}
 
+	public function testVersionDataExceedsCapacity(): void
+	{
+		// binary mode caps at 2953 bytes
+		$qr = new QrCode(str_repeat('a', 3000));
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('The provided data exceeds the maximum capacity of a QR code');
+		$qr->toSvg();
+	}
+
 	public function testWrite(): void
 	{
 		Dir::make(static::TMP);

--- a/tests/Image/QrCodeTest.php
+++ b/tests/Image/QrCodeTest.php
@@ -115,6 +115,31 @@ class QrCodeTest extends TestCase
 		$this->assertStringContainsString('<rect width="100%" height="100%" fill="#00ff00"/>', $svg);
 	}
 
+	public function testToSvgEscapesAttrs(): void
+	{
+		$qr = new QrCode('https://getkirby.com');
+
+		// none of the attribute values may break out of their attribute
+		$svg = $qr->toSvg(
+			color: '#000" onload="alert(1)',
+			back:  '#fff"><script>alert(2)</script>',
+			size:  '1px" onload="alert(3)'
+		);
+		$this->assertStringNotContainsString('<script', $svg);
+		$this->assertStringNotContainsString('onload="', $svg);
+		$this->assertStringStartsWith('<svg', $svg);
+		$this->assertStringEndsWith('</svg>', $svg);
+
+		// valid hex colors and CSS sizes pass through unchanged
+		$svg = $qr->toSvg(size: '100%', color: '#ff0000', back: '#00ff00');
+		$this->assertStringContainsString('style="width: 100%"', $svg);
+		$this->assertStringContainsString('fill="#ff0000"', $svg);
+		$this->assertStringContainsString('fill="#00ff00"', $svg);
+		$svg = $qr->toSvg(color: 'rgb(255, 0, 0)', back: 'hsl(120, 100%, 50%)');
+		$this->assertStringContainsString('fill="rgb(255, 0, 0)"', $svg);
+		$this->assertStringContainsString('fill="hsl(120, 100%, 50%)"', $svg);
+	}
+
 	public function testToString(): void
 	{
 		$qr = new QrCode('https://getkirby.com');


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Escape attributes of `Kirby\Image\QrCode::toSvg()`
- Throw error when QR code data exceeds the capacity of the max version

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion