### PR TITLE
feat: `F::update()`

### DIFF
--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -507,72 +507,6 @@ class F
 	}
 
 	/**
-	 * Serializes concurrent read-modify-writes of a file by
-	 * holding an exclusive `flock` for the whole operation, so
-	 * that other writers (that lock the same way) cannot lose
-	 * each other's updates. The `$modifier` callback receives
-	 * the current file contents.
-	 *
-	 * @since 5.5.0
-	 */
-	public static function modify(
-		string $file,
-		callable $modifier
-	): bool {
-		// ensure the parent directory exists so `fopen('c+')`
-		// can create the file if it does not yet exist
-		if (is_dir(dirname($file)) === false) {
-			if (Dir::make(dirname($file)) === false) {
-				return false; // @codeCoverageIgnore
-			}
-		}
-
-		// `c+` opens read/write, creates the file if missing,
-		// and does NOT truncate. So we can read existing
-		// contents under the lock before rewriting.
-		$handle = @fopen($file, 'c+');
-
-		if ($handle === false) {
-			return false;
-		}
-
-		try {
-			if (flock($handle, LOCK_EX) === false) {
-				return false; // @codeCoverageIgnore
-			}
-
-			$contents = stream_get_contents($handle);
-
-			// treat an unreadable stream as empty so the
-			// modifier is always handed a string
-			if ($contents === false) {
-				$contents = ''; // @codeCoverageIgnore
-			}
-
-			$new = $modifier($contents);
-
-			// the modifier must return the new contents as a
-			// string; `null` or any other type aborts the write
-			if (is_string($new) === false) {
-				return false;
-			}
-
-			rewind($handle);
-			ftruncate($handle, 0);
-
-			if (fwrite($handle, $new) === false) {
-				return false; // @codeCoverageIgnore
-			}
-
-			fflush($handle);
-			return true;
-		} finally {
-			// `fclose()` releases the `flock()` automatically
-			fclose($handle);
-		}
-	}
-
-	/**
 	 * Get the file's last modification time.
 	 *
 	 * @param 'date'|'intl'|'strftime'|null $handler Custom date handler or `null`
@@ -1060,6 +994,72 @@ class F
 		}
 
 		return false;
+	}
+
+	/**
+	 * Serializes concurrent read-update-writes of a file by
+	 * holding an exclusive `flock` for the whole operation, so
+	 * that other writers (that lock the same way) cannot lose
+	 * each other's updates. The `$modifier` callback receives
+	 * the current file contents.
+	 *
+	 * @since 5.5.0
+	 */
+	public static function update(
+		string $file,
+		callable $modifier
+	): bool {
+		// ensure the parent directory exists so `fopen('c+')`
+		// can create the file if it does not yet exist
+		if (is_dir(dirname($file)) === false) {
+			if (Dir::make(dirname($file)) === false) {
+				return false; // @codeCoverageIgnore
+			}
+		}
+
+		// `c+` opens read/write, creates the file if missing,
+		// and does NOT truncate. So we can read existing
+		// contents under the lock before rewriting.
+		$handle = @fopen($file, 'c+');
+
+		if ($handle === false) {
+			return false;
+		}
+
+		try {
+			if (flock($handle, LOCK_EX) === false) {
+				return false; // @codeCoverageIgnore
+			}
+
+			$contents = stream_get_contents($handle);
+
+			// treat an unreadable stream as empty so the
+			// modifier is always handed a string
+			if ($contents === false) {
+				$contents = ''; // @codeCoverageIgnore
+			}
+
+			$new = $modifier($contents);
+
+			// the modifier must return the new contents as a
+			// string; `null` or any other type aborts the write
+			if (is_string($new) === false) {
+				return false;
+			}
+
+			rewind($handle);
+			ftruncate($handle, 0);
+
+			if (fwrite($handle, $new) === false) {
+				return false; // @codeCoverageIgnore
+			}
+
+			fflush($handle);
+			return true;
+		} finally {
+			// `fclose()` releases the `flock()` automatically
+			fclose($handle);
+		}
 	}
 
 	/**

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -507,6 +507,72 @@ class F
 	}
 
 	/**
+	 * Serializes concurrent read-modify-writes of a file by
+	 * holding an exclusive `flock` for the whole operation, so
+	 * that other writers (that lock the same way) cannot lose
+	 * each other's updates. The `$modifier` callback receives
+	 * the current file contents.
+	 *
+	 * @since 5.5.0
+	 */
+	public static function modify(
+		string $file,
+		callable $modifier
+	): bool {
+		// ensure the parent directory exists so `fopen('c+')`
+		// can create the file if it does not yet exist
+		if (is_dir(dirname($file)) === false) {
+			if (Dir::make(dirname($file)) === false) {
+				return false; // @codeCoverageIgnore
+			}
+		}
+
+		// `c+` opens read/write, creates the file if missing,
+		// and does NOT truncate. So we can read existing
+		// contents under the lock before rewriting.
+		$handle = @fopen($file, 'c+');
+
+		if ($handle === false) {
+			return false;
+		}
+
+		try {
+			if (flock($handle, LOCK_EX) === false) {
+				return false; // @codeCoverageIgnore
+			}
+
+			$contents = stream_get_contents($handle);
+
+			// treat an unreadable stream as empty so the
+			// modifier is always handed a string
+			if ($contents === false) {
+				$contents = ''; // @codeCoverageIgnore
+			}
+
+			$new = $modifier($contents);
+
+			// the modifier must return the new contents as a
+			// string; `null` or any other type aborts the write
+			if (is_string($new) === false) {
+				return false;
+			}
+
+			rewind($handle);
+			ftruncate($handle, 0);
+
+			if (fwrite($handle, $new) === false) {
+				return false; // @codeCoverageIgnore
+			}
+
+			fflush($handle);
+			return true;
+		} finally {
+			// `fclose()` releases the `flock()` automatically
+			fclose($handle);
+		}
+	}
+
+	/**
 	 * Get the file's last modification time.
 	 *
 	 * @param 'date'|'intl'|'strftime'|null $handler Custom date handler or `null`

--- a/src/Filesystem/F.php
+++ b/src/Filesystem/F.php
@@ -1011,8 +1011,9 @@ class F
 	): bool {
 		// ensure the parent directory exists so `fopen('c+')`
 		// can create the file if it does not yet exist
-		if (is_dir(dirname($file)) === false) {
-			if (Dir::make(dirname($file)) === false) {
+		$dir = dirname($file);
+		if (is_dir($dir) === false) {
+			if (Dir::make($dir) === false) {
 				return false; // @codeCoverageIgnore
 			}
 		}
@@ -1054,8 +1055,7 @@ class F
 				return false; // @codeCoverageIgnore
 			}
 
-			fflush($handle);
-			return true;
+			return fflush($handle);
 		} finally {
 			// `fclose()` releases the `flock()` automatically
 			fclose($handle);

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -501,6 +501,119 @@ class FTest extends TestCase
 		$this->assertSame(filemtime($this->test), F::modified($this->test));
 	}
 
+	public function testModifyCreatesFileAndParentDir(): void
+	{
+		$target = static::TMP . '/nested/dir/new.txt';
+		$this->assertFileDoesNotExist($target);
+
+		$received = null;
+		$result = F::modify($target, function (string $contents) use (&$received): string {
+			$received = $contents;
+			return 'fresh';
+		});
+
+		$this->assertTrue($result);
+		$this->assertSame('', $received);
+		$this->assertSame('fresh', file_get_contents($target));
+	}
+
+	public function testModifyExistingFileTruncatesToNewContents(): void
+	{
+		F::write($this->test, 'a long original content');
+
+		$result = F::modify(
+			$this->test,
+			fn (string $contents) => strtoupper($contents) . '!'
+		);
+
+		$this->assertTrue($result);
+		$this->assertSame('A LONG ORIGINAL CONTENT!', file_get_contents($this->test));
+	}
+
+	public function testModifyShorterReplacementIsNotPaddedFromOldContents(): void
+	{
+		F::write($this->test, 'the original is much longer than the replacement');
+
+		F::modify($this->test, fn () => 'short');
+
+		// must not contain trailing bytes from the original
+		$this->assertSame('short', file_get_contents($this->test));
+	}
+
+	public function testModifyAbortsWhenModifierReturnsNull(): void
+	{
+		F::write($this->test, 'untouched');
+
+		$result = F::modify($this->test, fn () => null);
+
+		$this->assertFalse($result);
+		$this->assertSame('untouched', file_get_contents($this->test));
+	}
+
+	public function testModifyAbortsWhenModifierReturnsNonString(): void
+	{
+		F::write($this->test, 'untouched');
+
+		// only a string is written; any other return value
+		// (here an int) aborts the write like `null` does
+		$result = F::modify($this->test, fn () => 123);
+
+		$this->assertFalse($result);
+		$this->assertSame('untouched', file_get_contents($this->test));
+	}
+
+	public function testModifyReturnsFalseWhenFileCannotBeOpened(): void
+	{
+		// a directory cannot be opened with `fopen()` in `c+` mode,
+		// so `modify()` returns false without invoking the modifier
+		Dir::make($dir = static::TMP . '/a-directory');
+
+		$called = false;
+		$result = F::modify($dir, function () use (&$called) {
+			$called = true;
+			return 'nope';
+		});
+
+		$this->assertFalse($result);
+		$this->assertFalse($called);
+	}
+
+	public function testModifyPropagatesModifierException(): void
+	{
+		F::write($this->test, 'before');
+
+		try {
+			F::modify($this->test, function (): string {
+				throw new Exception('boom');
+			});
+			$this->fail('Expected exception was not thrown');
+
+		} catch (Exception $e) {
+			$this->assertSame('boom', $e->getMessage());
+		}
+
+		// file should remain unchanged
+		$this->assertSame('before', file_get_contents($this->test));
+
+		// lock must have been released, a new modify succeeds
+		$this->assertTrue(F::modify($this->test, fn () => 'after'));
+		$this->assertSame('after', file_get_contents($this->test));
+	}
+
+	public function testModifySerializesSequentialReadModifyWrites(): void
+	{
+		F::write($this->test, '0');
+
+		for ($i = 0; $i < 50; $i++) {
+			F::modify(
+				$this->test,
+				fn ($content): string => (string)((int)$content + 1)
+			);
+		}
+
+		$this->assertSame('50', file_get_contents($this->test));
+	}
+
 	public function testName(): void
 	{
 		$this->assertSame('test', F::name($this->sample));

--- a/tests/Filesystem/FTest.php
+++ b/tests/Filesystem/FTest.php
@@ -501,119 +501,6 @@ class FTest extends TestCase
 		$this->assertSame(filemtime($this->test), F::modified($this->test));
 	}
 
-	public function testModifyCreatesFileAndParentDir(): void
-	{
-		$target = static::TMP . '/nested/dir/new.txt';
-		$this->assertFileDoesNotExist($target);
-
-		$received = null;
-		$result = F::modify($target, function (string $contents) use (&$received): string {
-			$received = $contents;
-			return 'fresh';
-		});
-
-		$this->assertTrue($result);
-		$this->assertSame('', $received);
-		$this->assertSame('fresh', file_get_contents($target));
-	}
-
-	public function testModifyExistingFileTruncatesToNewContents(): void
-	{
-		F::write($this->test, 'a long original content');
-
-		$result = F::modify(
-			$this->test,
-			fn (string $contents) => strtoupper($contents) . '!'
-		);
-
-		$this->assertTrue($result);
-		$this->assertSame('A LONG ORIGINAL CONTENT!', file_get_contents($this->test));
-	}
-
-	public function testModifyShorterReplacementIsNotPaddedFromOldContents(): void
-	{
-		F::write($this->test, 'the original is much longer than the replacement');
-
-		F::modify($this->test, fn () => 'short');
-
-		// must not contain trailing bytes from the original
-		$this->assertSame('short', file_get_contents($this->test));
-	}
-
-	public function testModifyAbortsWhenModifierReturnsNull(): void
-	{
-		F::write($this->test, 'untouched');
-
-		$result = F::modify($this->test, fn () => null);
-
-		$this->assertFalse($result);
-		$this->assertSame('untouched', file_get_contents($this->test));
-	}
-
-	public function testModifyAbortsWhenModifierReturnsNonString(): void
-	{
-		F::write($this->test, 'untouched');
-
-		// only a string is written; any other return value
-		// (here an int) aborts the write like `null` does
-		$result = F::modify($this->test, fn () => 123);
-
-		$this->assertFalse($result);
-		$this->assertSame('untouched', file_get_contents($this->test));
-	}
-
-	public function testModifyReturnsFalseWhenFileCannotBeOpened(): void
-	{
-		// a directory cannot be opened with `fopen()` in `c+` mode,
-		// so `modify()` returns false without invoking the modifier
-		Dir::make($dir = static::TMP . '/a-directory');
-
-		$called = false;
-		$result = F::modify($dir, function () use (&$called) {
-			$called = true;
-			return 'nope';
-		});
-
-		$this->assertFalse($result);
-		$this->assertFalse($called);
-	}
-
-	public function testModifyPropagatesModifierException(): void
-	{
-		F::write($this->test, 'before');
-
-		try {
-			F::modify($this->test, function (): string {
-				throw new Exception('boom');
-			});
-			$this->fail('Expected exception was not thrown');
-
-		} catch (Exception $e) {
-			$this->assertSame('boom', $e->getMessage());
-		}
-
-		// file should remain unchanged
-		$this->assertSame('before', file_get_contents($this->test));
-
-		// lock must have been released, a new modify succeeds
-		$this->assertTrue(F::modify($this->test, fn () => 'after'));
-		$this->assertSame('after', file_get_contents($this->test));
-	}
-
-	public function testModifySerializesSequentialReadModifyWrites(): void
-	{
-		F::write($this->test, '0');
-
-		for ($i = 0; $i < 50; $i++) {
-			F::modify(
-				$this->test,
-				fn ($content): string => (string)((int)$content + 1)
-			);
-		}
-
-		$this->assertSame('50', file_get_contents($this->test));
-	}
-
 	public function testName(): void
 	{
 		$this->assertSame('test', F::name($this->sample));
@@ -951,6 +838,119 @@ class FTest extends TestCase
 		$this->assertFalse(F::unlink(static::TMP . '/folder'));
 
 		$this->assertTrue($called);
+	}
+
+	public function testUpdateCreatesFileAndParentDir(): void
+	{
+		$target = static::TMP . '/nested/dir/new.txt';
+		$this->assertFileDoesNotExist($target);
+
+		$received = null;
+		$result = F::update($target, function (string $contents) use (&$received): string {
+			$received = $contents;
+			return 'fresh';
+		});
+
+		$this->assertTrue($result);
+		$this->assertSame('', $received);
+		$this->assertSame('fresh', file_get_contents($target));
+	}
+
+	public function testUpdateExistingFileTruncatesToNewContents(): void
+	{
+		F::write($this->test, 'a long original content');
+
+		$result = F::update(
+			$this->test,
+			fn (string $contents) => strtoupper($contents) . '!'
+		);
+
+		$this->assertTrue($result);
+		$this->assertSame('A LONG ORIGINAL CONTENT!', file_get_contents($this->test));
+	}
+
+	public function testUpdateShorterReplacementIsNotPaddedFromOldContents(): void
+	{
+		F::write($this->test, 'the original is much longer than the replacement');
+
+		F::update($this->test, fn () => 'short');
+
+		// must not contain trailing bytes from the original
+		$this->assertSame('short', file_get_contents($this->test));
+	}
+
+	public function testUpdateAbortsWhenModifierReturnsNull(): void
+	{
+		F::write($this->test, 'untouched');
+
+		$result = F::update($this->test, fn () => null);
+
+		$this->assertFalse($result);
+		$this->assertSame('untouched', file_get_contents($this->test));
+	}
+
+	public function testUpdateAbortsWhenModifierReturnsNonString(): void
+	{
+		F::write($this->test, 'untouched');
+
+		// only a string is written; any other return value
+		// (here an int) aborts the write like `null` does
+		$result = F::update($this->test, fn () => 123);
+
+		$this->assertFalse($result);
+		$this->assertSame('untouched', file_get_contents($this->test));
+	}
+
+	public function testUpdateReturnsFalseWhenFileCannotBeOpened(): void
+	{
+		// a directory cannot be opened with `fopen()` in `c+` mode,
+		// so `modify()` returns false without invoking the modifier
+		Dir::make($dir = static::TMP . '/a-directory');
+
+		$called = false;
+		$result = F::update($dir, function () use (&$called) {
+			$called = true;
+			return 'nope';
+		});
+
+		$this->assertFalse($result);
+		$this->assertFalse($called);
+	}
+
+	public function testUpdatePropagatesModifierException(): void
+	{
+		F::write($this->test, 'before');
+
+		try {
+			F::update($this->test, function (): string {
+				throw new Exception('boom');
+			});
+			$this->fail('Expected exception was not thrown');
+
+		} catch (Exception $e) {
+			$this->assertSame('boom', $e->getMessage());
+		}
+
+		// file should remain unchanged
+		$this->assertSame('before', file_get_contents($this->test));
+
+		// lock must have been released, a new modify succeeds
+		$this->assertTrue(F::update($this->test, fn () => 'after'));
+		$this->assertSame('after', file_get_contents($this->test));
+	}
+
+	public function testUpdateSerializesSequentialReadModifyWrites(): void
+	{
+		F::write($this->test, '0');
+
+		for ($i = 0; $i < 50; $i++) {
+			F::update(
+				$this->test,
+				fn ($content): string => (string)((int)$content + 1)
+			);
+		}
+
+		$this->assertSame('50', file_get_contents($this->test));
 	}
 
 	public function testURI(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

I am not 100% sure about the name but I think for certain aspects, it would be good to have a toolkit method that allows us to read a file, update its content and write it while under lock, so no simultaneous request could alter the file in between the read and the write, leading to content loss. Probably not a quick fix for this happening to content files, but other aspects like rate limit files etc.

```php
F::update(
    $path,
    fn (string $currentContent) => $newContent
)
```

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- New `Kirby\Filesystem\F::update($file, $callback)` method that reads and updates a file under lock


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion