### PR TITLE
fix: TypeError in PageTree.preselect when refs are cleared

### DIFF
--- a/panel/src/components/Navigation/PageTree.vue
+++ b/panel/src/components/Navigation/PageTree.vue
@@ -105,6 +105,11 @@ export default {
 				}
 
 				await this.open(item);
+
+				if (!tree.$refs[value]?.[0]) {
+					return;
+				}
+
 				tree = tree.$refs[value][0];
 			}
 


### PR DESCRIPTION
## Changelog 

### 🐛 Bug fixes

- Fix TypeError in PageTree.preselect when refs are cleared #7747

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion