### PR TITLE
[v6] fix: Use proper generic for `Item::$siblings`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -88,11 +88,6 @@
       <code><![CDATA[[...$this->data, ...$object->data]]]></code>
     </InvalidPropertyAssignmentValue>
   </file>
-  <file src="src/Cms/HasSiblings.php">
-    <InvalidMethodCall>
-      <code><![CDATA[not]]></code>
-    </InvalidMethodCall>
-  </file>
   <file src="src/Cms/LicenseStatus.php">
     <InvalidReturnStatement>
       <code><![CDATA[I18n::translate('license.status.' . $this->value . '.label')]]></code>

--- a/src/Cms/Item.php
+++ b/src/Cms/Item.php
@@ -32,6 +32,10 @@ class Item
 	protected string $id;
 	protected array $params;
 	protected ModelWithContent $parent;
+
+	/**
+	 * @var TCollection
+	 */
 	protected Items $siblings;
 
 	/**
@@ -99,7 +103,7 @@ class Item
 	 * Returns the sibling collection
 	 * This is required by the HasSiblings trait
 	 *
-	 * @psalm-return self::ITEMS_CLASS
+	 * @return TCollection
 	 */
 	protected function siblingsCollection(): Items
 	{


### PR DESCRIPTION
Can be merged right after https://github.com/getkirby/kirby/pull/8195 lands, only clears the Psalm baseline in addition.