### PR TITLE
depr: Deprecate `KirbyTag::$options`/`::option()`

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -855,7 +855,7 @@ class App
 		$data['site']   ??= $data['kirby']->site();
 		$data['parent'] ??= $data['site']->page();
 
-		return (new KirbyTag($type, $value, $attr, $data, $this->options))->render();
+		return (new KirbyTag($type, $value, $attr, $data))->render();
 	}
 
 	/**
@@ -870,9 +870,10 @@ class App
 		$data['parent'] ??= $data['site']->page();
 
 		$options = $this->options;
+		$debug   = ($options['debug'] ?? false) === true;
 
 		$text = $this->apply('kirbytags:before', compact('text', 'data', 'options'));
-		$text = KirbyTags::parse($text, $data, $options);
+		$text = KirbyTags::parse($text, $data, debug: $debug);
 		$text = $this->apply('kirbytags:after', compact('text', 'data', 'options'));
 
 		return $text;

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -6,6 +6,7 @@ use AllowDynamicProperties;
 use Closure;
 use Kirby\Cms\App;
 use Kirby\Cms\File;
+use Kirby\Cms\Helpers;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\Exception\InvalidArgumentException;
@@ -29,6 +30,10 @@ class KirbyTag
 
 	public array $attrs = [];
 	public array $data = [];
+
+	/**
+	 * @deprecated 5.5.0 Use `$tag->kirby()->option()` instead.
+	 */
 	public array $options = [];
 	public string $type;
 	public string|null $value = null;
@@ -156,9 +161,14 @@ class KirbyTag
 		return $this->data['kirby'] ?? App::instance();
 	}
 
+	/**
+	 * @deprecated 5.5.0 Use `$tag->kirby()->option()` instead.
+	 */
 	public function option(string $key, $default = null)
 	{
-		return $this->options[$key] ?? $default;
+		Helpers::deprecated('`$tag->option()` has been deprecated. Use `$tag->kirby()->option()` instead.', 'kirbytag-option');
+
+		return $this->kirby()->option($key, $default);
 	}
 
 	public static function parse(

--- a/src/Text/KirbyTags.php
+++ b/src/Text/KirbyTags.php
@@ -3,6 +3,7 @@
 namespace Kirby\Text;
 
 use Exception;
+use Kirby\Cms\Helpers;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\Str;
 
@@ -23,10 +24,18 @@ class KirbyTags
 	public static function parse(
 		string|null $text = null,
 		array $data = [],
-		array $options = []
+		array $options = [],
+		bool $debug = false
 	): string {
 		// make sure $text is a string
 		$text ??= '';
+
+		// @deprecated 5.5.0 the `$options` argument only ever carried the
+		// `debug` flag; derive it from there for backward compatibility
+		if ($options !== []) {
+			Helpers::deprecated('The `$options` argument of `KirbyTags::parse()` has been deprecated. Use the `$debug` argument instead.', 'kirbytags-parse-options');
+			$debug = $options['debug'] ?? $debug;
+		}
 
 		$regex = '!
             (?=[^\]])               # positive lookahead that matches a group after the main expression without including ] in the result
@@ -36,11 +45,9 @@ class KirbyTags
             \))                     # end of capturing group 1
         !isx';
 
-		return preg_replace_callback($regex, function ($match) use ($data, $options) {
-			$debug = $options['debug'] ?? false;
-
+		return preg_replace_callback($regex, function ($match) use ($data, $debug) {
 			try {
-				return KirbyTag::parse($match[0], $data, $options)->render();
+				return KirbyTag::parse($match[0], $data)->render();
 			} catch (InvalidArgumentException $e) {
 				// stay silent in production and ignore non-existing tags
 				if (

--- a/tests/Text/KirbyTagTest.php
+++ b/tests/Text/KirbyTagTest.php
@@ -265,25 +265,18 @@ class KirbyTagTest extends TestCase
 
 	public function testOption(): void
 	{
-		$attr = [
-			'a' => 'attrA',
-			'b' => 'attrB'
-		];
+		new App([
+			'roots'   => ['index' => '/dev/null'],
+			'options' => [
+				'a'      => 'optionA',
+				'nested' => ['b' => 'optionB']
+			]
+		]);
 
-		$data = [
-			'a' => 'dataA',
-			'b' => 'dataB'
-		];
-
-		$options = [
-			'a' => 'optionA',
-			'b' => 'optionB'
-		];
-
-		$tag = new KirbyTag('test', 'test value', $attr, $data, $options);
+		$tag = new KirbyTag('test', 'test value');
 
 		$this->assertSame('optionA', $tag->option('a'));
-		$this->assertSame('optionB', $tag->option('b'));
+		$this->assertSame('optionB', $tag->option('nested.b'));
 		$this->assertSame('optionC', $tag->option('c', 'optionC'));
 	}
 

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Text;
 
 use Exception;
 use Kirby\Cms\App;
+use Kirby\Cms\Helpers;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
@@ -30,6 +31,7 @@ class KirbyTagsTest extends TestCase
 
 	protected function tearDown(): void
 	{
+		Helpers::$deprecations['kirbytags-parse-options'] = true;
 		Dir::remove(static::TMP);
 	}
 
@@ -122,7 +124,7 @@ class KirbyTagsTest extends TestCase
 			]
 		];
 
-		KirbyTags::parse('(test: foo)', [], ['debug' => true]);
+		KirbyTags::parse('(test: foo)', [], debug: true);
 	}
 
 	public function testParseWithExceptionDebug2(): void
@@ -136,7 +138,7 @@ class KirbyTagsTest extends TestCase
 			]
 		];
 
-		KirbyTags::parse('(invalidargument: foo)', [], ['debug' => true]);
+		KirbyTags::parse('(invalidargument: foo)', [], debug: true);
 	}
 
 	public function testParseWithExceptionDebug3(): void
@@ -149,7 +151,24 @@ class KirbyTagsTest extends TestCase
 			]
 		];
 
-		$this->assertSame('(undefined: foo)', KirbyTags::parse('(undefined: foo)', [], ['debug' => true]));
+		$this->assertSame('(undefined: foo)', KirbyTags::parse('(undefined: foo)', [], debug: true));
+	}
+
+	public function testParseWithDeprecatedOptions(): void
+	{
+		// `$options` is a deprecated alias that only ever carried `debug`
+		Helpers::$deprecations['kirbytags-parse-options'] = false;
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('Just for fun');
+
+		KirbyTag::$types = [
+			'test' => [
+				'html' => fn () => throw new Exception('Just for fun')
+			]
+		];
+
+		KirbyTags::parse('(test: foo)', [], ['debug' => true]);
 	}
 
 	public function testParseWithBrackets(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

It has been weird that currently we pass all app options, not just the one for the specific KirbyTag as $options. Then `::option()` wasn't supporting dot notation. And all our own KirbbyTags never use it but go through `$tag->kirby()->option()`.

To simplify this (and to allow easier migration to class-based KirbyTags), I would love to remove this in v6. 

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- New `$debug` parameter in `Kirby\Text\KirbyTags::parse()`

### ☠️ Deprecated
<!-- 
e.g. Deprecate method X. Use method Y instead.
-->
- `Kirby\Text\KirbyTag::option()` and `Kirby\Text\KirbyTag::$options`: Use `$tag->kirby()->option()` instead.
- `Kirby\Text\KirbyTags::parse()`: `$options` parameter. Use new `$debug` parameter instead.

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion