### PR TITLE
feat: Class-based KirbyTag

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -2,7 +2,7 @@
 
 use Kirby\Cms\Html;
 use Kirby\Cms\Url;
-use Kirby\Text\KirbyTag;
+use Kirby\Text\LegacyKirbyTag;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Escape;
 use Kirby\Toolkit\Str;
@@ -20,7 +20,7 @@ return [
 		'attr' => [
 			'expiry'
 		],
-		'html' => function (KirbyTag $tag): string {
+		'html' => function (LegacyKirbyTag $tag): string {
 			if (strtolower($tag->date) === 'year') {
 				// make sure cached pages reset the year at New Year,
 				// unless a custom expiry point has been requested
@@ -54,7 +54,7 @@ return [
 			'text',
 			'title'
 		],
-		'html' => function (KirbyTag $tag): string {
+		'html' => function (LegacyKirbyTag $tag): string {
 			return Html::email($tag->value, $tag->text, [
 				'class'  => $tag->class,
 				'rel'    => $tag->rel,
@@ -76,7 +76,7 @@ return [
 			'text',
 			'title'
 		],
-		'html' => function (KirbyTag $tag): string {
+		'html' => function (LegacyKirbyTag $tag): string {
 			if (!$file = $tag->file($tag->value)) {
 				return $tag->text ?? $tag->value;
 			}
@@ -104,7 +104,7 @@ return [
 		'attr' => [
 			'file'
 		],
-		'html' => function (KirbyTag $tag): string {
+		'html' => function (LegacyKirbyTag $tag): string {
 			return Html::gist($tag->value, $tag->file);
 		}
 	],
@@ -127,7 +127,7 @@ return [
 			'title',
 			'width'
 		],
-		'html' => function (KirbyTag $tag): string {
+		'html' => function (LegacyKirbyTag $tag): string {
 			$kirby = $tag->kirby();
 
 			$tag->width  ??= $kirby->option('kirbytext.image.width');
@@ -215,7 +215,7 @@ return [
 			'title',
 			'text',
 		],
-		'html' => function (KirbyTag $tag): string {
+		'html' => function (LegacyKirbyTag $tag): string {
 			// keep $tag->value as the original value (e.g. UUID) for errors
 			$link = $tag->value;
 
@@ -275,7 +275,7 @@ return [
 			'text',
 			'title'
 		],
-		'html' => function (KirbyTag $tag): string {
+		'html' => function (LegacyKirbyTag $tag): string {
 			return Html::tel($tag->value, $tag->text, [
 				'class' => $tag->class,
 				'rel'   => $tag->rel,
@@ -302,7 +302,7 @@ return [
 			'preload',
 			'width',
 		],
-		'html' => function (KirbyTag $tag): string {
+		'html' => function (LegacyKirbyTag $tag): string {
 			// checks and gets if poster is local file
 			if (
 				empty($tag->poster) === false &&

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -874,7 +874,7 @@ class App
 		$data['site']   ??= $data['kirby']->site();
 		$data['parent'] ??= $data['site']->page();
 
-		return (new KirbyTag($type, $value, $attr, $data))->render();
+		return KirbyTag::factory($type, $value, $attr, $data)->render();
 	}
 
 	/**

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -892,7 +892,7 @@ class App
 		$debug   = ($options['debug'] ?? false) === true;
 
 		$text = $this->apply('kirbytags:before', compact('text', 'data', 'options'));
-		$text = KirbyTags::parse($text, $data, debug: $debug);
+		$text = KirbyTags::parse($text, $data, $debug);
 		$text = $this->apply('kirbytags:after', compact('text', 'data', 'options'));
 
 		return $text;

--- a/src/Reflection/Constructor.php
+++ b/src/Reflection/Constructor.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Reflection;
 
+use ReflectionClass;
 use ReflectionMethod;
 use ReflectionParameter;
 
@@ -42,6 +43,21 @@ class Constructor extends ReflectionMethod
 			'accepted' => $accepted,
 			'ignored'  => $ignored
 		];
+	}
+
+	/**
+	 * Returns the constructor for the given class
+	 * or `null` if the class has no constructor
+	 *
+	 * @since 6.0.0
+	 */
+	public static function for(object|string $objectOrClass): static|null
+	{
+		if ((new ReflectionClass($objectOrClass))->getConstructor() === null) {
+			return null;
+		}
+
+		return new static($objectOrClass);
 	}
 
 	/**

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -152,6 +152,14 @@ class KirbyTag
 		return $this->data['kirby'] ?? App::instance();
 	}
 
+	/**
+	 * Returns the parent model
+	 */
+	public function parent(): ModelWithContent|null
+	{
+		return $this->data['parent'] ?? null;
+	}
+
 	public static function parse(
 		string $string,
 		array $data = []
@@ -201,14 +209,6 @@ class KirbyTag
 		$value = array_shift($attributes);
 
 		return new static($type, $value, $attributes, $data);
-	}
-
-	/**
-	 * Returns the parent model
-	 */
-	public function parent(): ModelWithContent|null
-	{
-		return $this->data['parent'] ?? null;
 	}
 
 	public function render(): string

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -6,7 +6,6 @@ use AllowDynamicProperties;
 use Closure;
 use Kirby\Cms\App;
 use Kirby\Cms\File;
-use Kirby\Cms\Helpers;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\Exception\InvalidArgumentException;
@@ -27,11 +26,6 @@ class KirbyTag
 
 	public array $attrs = [];
 	public array $data = [];
-
-	/**
-	 * @deprecated 5.5.0 Use `$tag->kirby()->option()` instead.
-	 */
-	public array $options = [];
 	public string $type;
 	public string|null $value = null;
 
@@ -39,8 +33,7 @@ class KirbyTag
 		string $type,
 		string|null $value = null,
 		array $attrs = [],
-		array $data = [],
-		array $options = []
+		array $data = []
 	) {
 		// type aliases
 		if (isset(static::$types[$type]) === false) {
@@ -69,12 +62,11 @@ class KirbyTag
 			}
 		}
 
-		$this->attrs   = $attrs;
-		$this->data    = $data;
-		$this->options = $options;
-		$this->$type   = $value;
-		$this->type    = $type;
-		$this->value   = $value;
+		$this->attrs = $attrs;
+		$this->data  = $data;
+		$this->$type = $value;
+		$this->type  = $type;
+		$this->value = $value;
 	}
 
 	/**
@@ -160,20 +152,9 @@ class KirbyTag
 		return $this->data['kirby'] ?? App::instance();
 	}
 
-	/**
-	 * @deprecated 5.5.0 Use `$tag->kirby()->option()` instead.
-	 */
-	public function option(string $key, $default = null)
-	{
-		Helpers::deprecated('`$tag->option()` has been deprecated. Use `$tag->kirby()->option()` instead.', 'kirbytag-option');
-
-		return $this->kirby()->option($key, $default);
-	}
-
 	public static function parse(
 		string $string,
-		array $data = [],
-		array $options = []
+		array $data = []
 	): static {
 		// remove the brackets, extract the first attribute (the tag type)
 		$tag  = trim(ltrim($string, '('));
@@ -219,7 +200,7 @@ class KirbyTag
 		// extract and pass its value separately
 		$value = array_shift($attributes);
 
-		return new static($type, $value, $attributes, $data, $options);
+		return new static($type, $value, $attributes, $data);
 	}
 
 	/**

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -6,15 +6,15 @@ use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Reflection\Constructor;
 use Kirby\Uuid\Uri as UuidUri;
 use Kirby\Uuid\Uuid;
-use ReflectionClass;
-use ReflectionProperty;
 
 /**
  * Represents and parses a single KirbyTag.
  *
  * Each tag type is implemented as a subclass.
+ * Its attributes are declared as named constructor arguments.
  * Custom tags registered in the legacy array form
  * are wrapped in a `Kirby\Text\LegacyKirbyTag` instance.
  *
@@ -36,38 +36,9 @@ abstract class KirbyTag
 	public static array $types = [];
 
 	public array $attrs = [];
-
-	public function __construct(
-		public string $type,
-		public string|null $value = null,
-		array $attrs = [],
-		public array $data = []
-	) {
-		$defaults    = $this->kirby()->option('kirbytext.' . $type, []);
-		$this->attrs = array_replace($defaults, $attrs);
-
-		// only keep attributes that the tag type actually defines
-		$availableAttrs = $this->definedAttrs();
-
-		foreach ($this->attrs as $attrName => $attrValue) {
-			$attrName = strtolower($attrName);
-
-			if (in_array($attrName, $availableAttrs, true) === true) {
-				$this->$attrName = $attrValue;
-			}
-		}
-
-		// type aliases
-		if (isset(static::$types[$type]) === false) {
-			if (isset(static::$aliases[$type]) === false) {
-				throw new InvalidArgumentException(
-					message: 'Undefined tag type: ' . $type
-				);
-			}
-
-			$type = static::$aliases[$type];
-		}
-	}
+	public array $data = [];
+	public string $type = '';
+	public string|null $value = null;
 
 	/**
 	 * Magic data and property getter
@@ -80,8 +51,10 @@ abstract class KirbyTag
 	/**
 	 * Magic call `KirbyTag::myType($parameter1, $parameter2)`
 	 */
-	public static function __callStatic(string $type, array $arguments = []): string
-	{
+	public static function __callStatic(
+		string $type,
+		array $arguments = []
+	): string {
 		return static::factory($type, ...$arguments)->render();
 	}
 
@@ -92,33 +65,16 @@ abstract class KirbyTag
 	}
 
 	/**
-	 * Returns the list of attribute names this tag type supports,
-	 * derived from the public, non-static properties declared
-	 * on the concrete tag class
+	 * Returns the list of attribute names this tag type supports.
 	 *
 	 * @since 6.0.0
 	 */
 	public static function attrs(): array
 	{
-		if (isset(static::$attrsCache[static::class]) === true) {
-			return static::$attrsCache[static::class];
-		}
-
-		$class = new ReflectionClass(static::class);
-		$props = $class->getProperties(ReflectionProperty::IS_PUBLIC);
-		$props = array_filter(
-			$props,
-			fn (ReflectionProperty $prop): bool =>
-				$prop->isStatic() === false &&
-				$prop->getDeclaringClass()->getName() !== self::class
-		);
-
-		$attrs = array_map(
-			fn (ReflectionProperty $prop): string => $prop->getName(),
-			$props
-		);
-
-		return static::$attrsCache[static::class] = array_values($attrs);
+		// Deriving the list of attributes from
+		// the named constructor arguments
+		return static::$attrsCache[static::class] ??=
+			Constructor::for(static::class)?->getParameterNames() ?? [];
 	}
 
 	/**
@@ -139,20 +95,28 @@ abstract class KirbyTag
 	}
 
 	/**
-	 * Returns the attribute names the current instance accepts.
-	 * `LegacyKirbyTag` overrides this to read from its definition.
-	 *
+	 * Injects shared, non-attribute state after the tag
+	 * instance has been created from its attribute arguments
 	 * @since 6.0.0
 	 */
-	protected function definedAttrs(): array
-	{
-		return static::attrs();
+	protected function bind(
+		string $type,
+		string|null $value,
+		array $data,
+		array $attrs
+	): static {
+		$this->type  = $type;
+		$this->value = $value;
+		$this->data  = $data;
+		$this->attrs = $attrs;
+		return $this;
 	}
 
 	/**
 	 * Creates a new tag instance for the given type
+	 * @since 6.0.0
 	 */
-	public static function factory(
+	final public static function factory(
 		string $type,
 		string|null $value = null,
 		array $attrs = [],
@@ -171,13 +135,24 @@ abstract class KirbyTag
 
 		$tag = static::$types[$type];
 
-		// legacy array definition
-		if (is_array($tag) === true) {
-			return new LegacyKirbyTag($tag, $type, $value, $attrs, $data);
-		}
+		// merge the per-type option defaults and normalize the
+		// attribute keys, so they can be matched against the
+		// (lowercase) constructor argument names
+		$kirby    = $data['kirby'] ?? App::instance();
+		$defaults = $kirby->option('kirbytext.' . $type, []);
+		$attrs    = array_change_key_case(array_replace($defaults, $attrs));
 
-		// class-based tag definition
-		return new $tag($type, $value, $attrs, $data);
+		// legacy array definitions are wrapped, class-based definitions
+		// receive their attributes as named constructor arguments;
+		// the shared state is injected afterwards via `bind()`
+		$tag = match (true) {
+			is_array($tag) => new LegacyKirbyTag($tag),
+			default        => new $tag(
+				...(Constructor::for($tag)?->getAcceptedArguments($attrs) ?? [])
+			)
+		};
+
+		return $tag->bind($type, $value, $data, $attrs);
 	}
 
 	/**

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -2,39 +2,61 @@
 
 namespace Kirby\Text;
 
-use AllowDynamicProperties;
-use Closure;
 use Kirby\Cms\App;
 use Kirby\Cms\File;
 use Kirby\Cms\ModelWithContent;
-use Kirby\Exception\BadMethodCallException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Uuid\Uri as UuidUri;
 use Kirby\Uuid\Uuid;
+use ReflectionClass;
+use ReflectionProperty;
 
 /**
- * Representation and parse of a single KirbyTag.
+ * Represents and parses a single KirbyTag.
+ *
+ * Each tag type is implemented as a subclass.
+ * Custom tags registered in the legacy array form
+ * are wrapped in a `Kirby\Text\LegacyKirbyTag` instance.
  *
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  */
-#[AllowDynamicProperties]
-class KirbyTag
+abstract class KirbyTag
 {
+	/**
+	 * @var array<string, string>
+	 */
 	public static array $aliases = [];
+	protected static array $attrsCache = [];
+
+	/**
+	 * Registry of all available tag types
+	 * @var array<string, array|class-string<self>>
+	 */
 	public static array $types = [];
 
 	public array $attrs = [];
-	public array $data = [];
-	public string $type;
-	public string|null $value = null;
 
 	public function __construct(
-		string $type,
-		string|null $value = null,
+		public string $type,
+		public string|null $value = null,
 		array $attrs = [],
-		array $data = []
+		public array $data = []
 	) {
+		$defaults    = $this->kirby()->option('kirbytext.' . $type, []);
+		$this->attrs = array_replace($defaults, $attrs);
+
+		// only keep attributes that the tag type actually defines
+		$availableAttrs = $this->definedAttrs();
+
+		foreach ($this->attrs as $attrName => $attrValue) {
+			$attrName = strtolower($attrName);
+
+			if (in_array($attrName, $availableAttrs, true) === true) {
+				$this->$attrName = $attrValue;
+			}
+		}
+
 		// type aliases
 		if (isset(static::$types[$type]) === false) {
 			if (isset(static::$aliases[$type]) === false) {
@@ -45,28 +67,6 @@ class KirbyTag
 
 			$type = static::$aliases[$type];
 		}
-
-		$kirby    = $data['kirby'] ?? App::instance();
-		$defaults = $kirby->option('kirbytext.' . $type, []);
-		$attrs    = array_replace($defaults, $attrs);
-
-		// all available tag attributes
-		$availableAttrs = static::$types[$type]['attr'] ?? [];
-
-		foreach ($attrs as $attrName => $attrValue) {
-			$attrName = strtolower($attrName);
-
-			// applies only defined attributes to safely update
-			if (in_array($attrName, $availableAttrs, true) === true) {
-				$this->{$attrName} = $attrValue;
-			}
-		}
-
-		$this->attrs = $attrs;
-		$this->data  = $data;
-		$this->$type = $value;
-		$this->type  = $type;
-		$this->value = $value;
 	}
 
 	/**
@@ -82,18 +82,7 @@ class KirbyTag
 	 */
 	public static function __callStatic(string $type, array $arguments = []): string
 	{
-		return (new static($type, ...$arguments))->render();
-	}
-
-	public function __get(string $attr)
-	{
-		$attr = strtolower($attr);
-		return $this->$attr ?? null;
-	}
-
-	public function __set(string $name, mixed $value): void
-	{
-		$this->{strtolower($name)} = $value;
+		return static::factory($type, ...$arguments)->render();
 	}
 
 	public function attr(string $name, $default = null)
@@ -102,9 +91,93 @@ class KirbyTag
 		return $this->$name ?? $default;
 	}
 
-	public static function factory(...$arguments): string
+	/**
+	 * Returns the list of attribute names this tag type supports,
+	 * derived from the public, non-static properties declared
+	 * on the concrete tag class
+	 *
+	 * @since 6.0.0
+	 */
+	public static function attrs(): array
 	{
-		return (new static(...$arguments))->render();
+		if (isset(static::$attrsCache[static::class]) === true) {
+			return static::$attrsCache[static::class];
+		}
+
+		$class = new ReflectionClass(static::class);
+		$props = $class->getProperties(ReflectionProperty::IS_PUBLIC);
+		$props = array_filter(
+			$props,
+			fn (ReflectionProperty $prop): bool =>
+				$prop->isStatic() === false &&
+				$prop->getDeclaringClass()->getName() !== self::class
+		);
+
+		$attrs = array_map(
+			fn (ReflectionProperty $prop): string => $prop->getName(),
+			$props
+		);
+
+		return static::$attrsCache[static::class] = array_values($attrs);
+	}
+
+	/**
+	 * Returns the supported attribute names for a registered type
+	 * before an instance exists (used while parsing the raw tag).
+	 *
+	 * @since 6.0.0
+	 */
+	protected static function attrsFor(string $type): array
+	{
+		$definition = static::$types[$type] ?? null;
+
+		return match (true) {
+			is_string($definition) => $definition::attrs(),
+			is_array($definition)  => $definition['attr'] ?? [],
+			default                => []
+		};
+	}
+
+	/**
+	 * Returns the attribute names the current instance accepts.
+	 * `LegacyKirbyTag` overrides this to read from its definition.
+	 *
+	 * @since 6.0.0
+	 */
+	protected function definedAttrs(): array
+	{
+		return static::attrs();
+	}
+
+	/**
+	 * Creates a new tag instance for the given type
+	 */
+	public static function factory(
+		string $type,
+		string|null $value = null,
+		array $attrs = [],
+		array $data = []
+	): static {
+		// resolve type aliases
+		if (isset(static::$types[$type]) === false) {
+			if (isset(static::$aliases[$type]) === false) {
+				throw new InvalidArgumentException(
+					message: 'Undefined tag type: ' . $type
+				);
+			}
+
+			$type = static::$aliases[$type];
+		}
+
+		$tag = static::$types[$type];
+
+		// legacy array definition
+		if (is_array($tag) === true) {
+			return new LegacyKirbyTag($tag, $type, $value, $attrs, $data);
+		}
+
+		// class-based tag definition
+		return new $tag($type, $value, $attrs, $data);
 	}
 
 	/**
@@ -165,7 +238,7 @@ class KirbyTag
 		array $data = []
 	): static {
 		// remove the brackets, extract the first attribute (the tag type)
-		$tag  = trim(ltrim($string, '('));
+		$tag = trim(ltrim($string, '('));
 
 		// use substr instead of rtrim to keep non-tagged brackets
 		// (link: file.pdf text: Download (PDF))
@@ -173,20 +246,20 @@ class KirbyTag
 			$tag = substr($tag, 0, -1);
 		}
 
-		$pos  = strpos($tag, ':');
-		$type = trim(substr($tag, 0, $pos ?: null));
-		$type = strtolower($type);
-		$attr = static::$types[$type]['attr'] ?? [];
+		$pos   = strpos($tag, ':');
+		$type  = trim(substr($tag, 0, $pos ?: null));
+		$type  = strtolower($type);
+		$attrs = static::attrsFor($type);
 
 		// the type should be parsed as an attribute, so we add it here
 		// to the list of possible attributes
-		array_unshift($attr, $type);
+		array_unshift($attrs, $type);
 
 		// ensure that UUIDs protocols aren't matched as attributes
 		$uuids = sprintf('(?!(%s):\/\/)', implode('|', UuidUri::$schemes));
 
 		// extract all attributes
-		$regex = sprintf('/%s(%s):/i', $uuids, implode('|', $attr));
+		$regex  = sprintf('/%s(%s):/i', $uuids, implode('|', $attrs));
 		$search = preg_split($regex, $tag, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
 
 		// $search is now an array with alternating keys and values
@@ -202,27 +275,16 @@ class KirbyTag
 		}
 
 		// combine the two arrays to an associative array
-		$attributes = array_combine($keys, $values);
+		$attrs = array_combine($keys, $values);
 
 		// the first attribute is the type attribute
 		// extract and pass its value separately
-		$value = array_shift($attributes);
+		$value = array_shift($attrs);
 
-		return new static($type, $value, $attributes, $data);
+		return static::factory($type, $value, $attrs, $data);
 	}
 
-	public function render(): string
-	{
-		$callback = static::$types[$this->type]['html'] ?? null;
-
-		if ($callback instanceof Closure) {
-			return (string)$callback($this);
-		}
-
-		throw new BadMethodCallException(
-			message: 'Invalid tag render function in tag: ' . $this->type
-		);
-	}
+	abstract public function render(): string;
 
 	public function type(): string
 	{

--- a/src/Text/KirbyTag.php
+++ b/src/Text/KirbyTag.php
@@ -60,7 +60,7 @@ abstract class KirbyTag
 
 	public function attr(string $name, $default = null)
 	{
-		$name = strtolower($name);
+		$name = static::normalizeAttr($name, $this->declaredAttrs());
 		return $this->$name ?? $default;
 	}
 
@@ -113,6 +113,15 @@ abstract class KirbyTag
 	}
 
 	/**
+	 * Returns the attribute names this tag instance supports
+	 * @since 6.0.0
+	 */
+	protected function declaredAttrs(): array
+	{
+		return static::attrs();
+	}
+
+	/**
 	 * Creates a new tag instance for the given type
 	 * @since 6.0.0
 	 */
@@ -135,12 +144,15 @@ abstract class KirbyTag
 
 		$tag = static::$types[$type];
 
-		// merge the per-type option defaults and normalize the
-		// attribute keys, so they can be matched against the
-		// (lowercase) constructor argument names
+		// merge the per-type option defaults and map the attribute keys
+		// onto the names the type declares, so they can be passed on
+		// as named constructor arguments
 		$kirby    = $data['kirby'] ?? App::instance();
 		$defaults = $kirby->option('kirbytext.' . $type, []);
-		$attrs    = array_change_key_case(array_replace($defaults, $attrs));
+		$attrs    = static::normalizeAttrs(
+			array_replace($defaults, $attrs),
+			static::attrsFor($type)
+		);
 
 		// legacy array definitions are wrapped, class-based definitions
 		// receive their attributes as named constructor arguments;
@@ -198,6 +210,39 @@ abstract class KirbyTag
 	public function kirby(): App
 	{
 		return $this->data['kirby'] ?? App::instance();
+	}
+
+	/**
+	 * Maps an attribute name onto the name the tag type declares
+	 * @since 6.0.0
+	 */
+	protected static function normalizeAttr(string $name, array $names): string
+	{
+		$name = strtolower($name);
+
+		foreach ($names as $declared) {
+			if (strtolower($declared) === $name) {
+				return $declared;
+			}
+		}
+
+		return $name;
+	}
+
+	/**
+	 * Maps all parsed attribute keys onto the names
+	 * the tag type declares
+	 * @since 6.0.0
+	 */
+	protected static function normalizeAttrs(array $attrs, array $names): array
+	{
+		$normalized = [];
+
+		foreach ($attrs as $name => $value) {
+			$normalized[static::normalizeAttr($name, $names)] = $value;
+		}
+
+		return $normalized;
 	}
 
 	/**

--- a/src/Text/KirbyTags.php
+++ b/src/Text/KirbyTags.php
@@ -3,7 +3,6 @@
 namespace Kirby\Text;
 
 use Exception;
-use Kirby\Cms\Helpers;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\Str;
 
@@ -21,18 +20,10 @@ class KirbyTags
 	public static function parse(
 		string|null $text = null,
 		array $data = [],
-		array $options = [],
 		bool $debug = false
 	): string {
 		// make sure $text is a string
 		$text ??= '';
-
-		// @deprecated 5.5.0 the `$options` argument only ever carried the
-		// `debug` flag; derive it from there for backward compatibility
-		if ($options !== []) {
-			Helpers::deprecated('The `$options` argument of `KirbyTags::parse()` has been deprecated. Use the `$debug` argument instead.', 'kirbytags-parse-options');
-			$debug = $options['debug'] ?? $debug;
-		}
 
 		$regex = '!
             (?=[^\]])               # positive lookahead that matches a group after the main expression without including ] in the result

--- a/src/Text/LegacyKirbyTag.php
+++ b/src/Text/LegacyKirbyTag.php
@@ -17,16 +17,8 @@ final class LegacyKirbyTag extends KirbyTag
 	protected array $props = [];
 
 	public function __construct(
-		protected array $definition,
-		string $type,
-		string|null $value = null,
-		array $attrs = [],
-		array $data = []
+		protected array $definition
 	) {
-		parent::__construct($type, $value, $attrs, $data);
-
-		// make the tag value available under its type name (e.g. $tag->test)
-		$this->{strtolower($type)} = $this->value;
 	}
 
 	public function __get(string $name): mixed
@@ -49,9 +41,34 @@ final class LegacyKirbyTag extends KirbyTag
 		unset($this->props[strtolower($name)]);
 	}
 
-	protected function definedAttrs(): array
-	{
-		return $this->definition['attr'] ?? [];
+	/**
+	 * Injects the shared state and, as legacy tags cannot receive
+	 * their attributes as constructor arguments, applies the
+	 * attributes the array definition declares
+	 */
+	protected function bind(
+		string $type,
+		string|null $value,
+		array $data,
+		array $attrs
+	): static {
+		parent::bind($type, $value, $data, $attrs);
+
+		// only keep attributes that the definition actually declares
+		$defined = $this->definition['attr'] ?? [];
+
+		foreach ($attrs as $name => $attrValue) {
+			$name = strtolower($name);
+
+			if (in_array($name, $defined, true) === true) {
+				$this->$name = $attrValue;
+			}
+		}
+
+		// make the tag value available under its type name (e.g. $tag->test)
+		$this->{strtolower($type)} = $this->value;
+
+		return $this;
 	}
 
 	public function render(): string

--- a/src/Text/LegacyKirbyTag.php
+++ b/src/Text/LegacyKirbyTag.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Kirby\Text;
+
+use Closure;
+use Kirby\Exception\BadMethodCallException;
+
+/**
+ * Wraps a KirbyTag that is registered in the legacy array form,
+ * e.g. tags defined by plugins.
+ *
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+final class LegacyKirbyTag extends KirbyTag
+{
+	protected array $props = [];
+
+	public function __construct(
+		protected array $definition,
+		string $type,
+		string|null $value = null,
+		array $attrs = [],
+		array $data = []
+	) {
+		parent::__construct($type, $value, $attrs, $data);
+
+		// make the tag value available under its type name (e.g. $tag->test)
+		$this->{strtolower($type)} = $this->value;
+	}
+
+	public function __get(string $name): mixed
+	{
+		return $this->props[strtolower($name)] ?? null;
+	}
+
+	public function __isset(string $name): bool
+	{
+		return isset($this->props[strtolower($name)]);
+	}
+
+	public function __set(string $name, mixed $value): void
+	{
+		$this->props[strtolower($name)] = $value;
+	}
+
+	public function __unset(string $name): void
+	{
+		unset($this->props[strtolower($name)]);
+	}
+
+	protected function definedAttrs(): array
+	{
+		return $this->definition['attr'] ?? [];
+	}
+
+	public function render(): string
+	{
+		$html = $this->definition['html'] ?? null;
+
+		if ($html instanceof Closure) {
+			return (string)$html($this);
+		}
+
+		throw new BadMethodCallException(
+			message: 'Invalid tag render function in tag: ' . $this->type
+		);
+	}
+}

--- a/src/Text/LegacyKirbyTag.php
+++ b/src/Text/LegacyKirbyTag.php
@@ -11,6 +11,7 @@ use Kirby\Exception\BadMethodCallException;
  *
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
+ * @since     6.0.0
  */
 final class LegacyKirbyTag extends KirbyTag
 {
@@ -55,11 +56,9 @@ final class LegacyKirbyTag extends KirbyTag
 		parent::bind($type, $value, $data, $attrs);
 
 		// only keep attributes that the definition actually declares
-		$defined = $this->definition['attr'] ?? [];
+		$defined = $this->declaredAttrs();
 
 		foreach ($attrs as $name => $attrValue) {
-			$name = strtolower($name);
-
 			if (in_array($name, $defined, true) === true) {
 				$this->$name = $attrValue;
 			}
@@ -69,6 +68,11 @@ final class LegacyKirbyTag extends KirbyTag
 		$this->{strtolower($type)} = $this->value;
 
 		return $this;
+	}
+
+	protected function declaredAttrs(): array
+	{
+		return $this->definition['attr'] ?? [];
 	}
 
 	public function render(): string

--- a/tests/Reflection/ConstructorTest.php
+++ b/tests/Reflection/ConstructorTest.php
@@ -24,6 +24,10 @@ class ReflectableTestChildClass extends ReflectableTestClass
 	}
 }
 
+class ReflectableTestClassWithoutConstructor
+{
+}
+
 #[CoversClass(Constructor::class)]
 class ConstructorTest extends TestCase
 {
@@ -66,6 +70,26 @@ class ConstructorTest extends TestCase
 
 		$this->assertSame($accepted, $result['accepted']);
 		$this->assertSame([], $result['ignored']);
+	}
+
+	public function testFor(): void
+	{
+		// returns a Constructor for a class with a constructor
+		$this->assertInstanceOf(
+			Constructor::class,
+			Constructor::for(ReflectableTestClass::class)
+		);
+
+		// also accepts an object instance
+		$this->assertInstanceOf(
+			Constructor::class,
+			Constructor::for(new ReflectableTestClass('a', 'b'))
+		);
+
+		// returns null for a class without a constructor
+		$this->assertNull(
+			Constructor::for(ReflectableTestClassWithoutConstructor::class)
+		);
 	}
 
 	public function testGetAcceptedArguments(): void

--- a/tests/Text/KirbyTagTest.php
+++ b/tests/Text/KirbyTagTest.php
@@ -4,11 +4,21 @@ namespace Kirby\Text;
 
 use Kirby\Cms\App;
 use Kirby\Cms\Helpers;
-use Kirby\Exception\BadMethodCallException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+
+class TestKirbyTag extends KirbyTag
+{
+	public string|null $a = null;
+	public string|null $b = null;
+
+	public function render(): string
+	{
+		return 'test: ' . $this->value . '-' . $this->a . '-' . $this->b;
+	}
+}
 
 #[CoversClass(KirbyTag::class)]
 class KirbyTagTest extends TestCase
@@ -18,20 +28,10 @@ class KirbyTagTest extends TestCase
 	protected function setUp(): void
 	{
 		KirbyTag::$types = [
-			'test' => [
-				'attr' => ['a', 'b'],
-				'html' => fn ($tag) => 'test: ' . $tag->value . '-' . $tag->a . '-' . $tag->b
-			],
-			'noHtml' => [
-				'attr' => ['a', 'b']
-			],
-			'invalidHtml' => [
-				'attr' => ['a', 'b'],
-				'html' => 'some string'
-			],
-			'file' => [
+			'test'   => TestKirbyTag::class,
+			'legacy' => [
 				'attr' => ['a'],
-				'html' => 'some string'
+				'html' => fn ($tag) => 'legacy'
 			],
 		];
 	}
@@ -40,16 +40,21 @@ class KirbyTagTest extends TestCase
 	{
 		Helpers::$deprecations['kirbytag-option'] = true;
 		KirbyTag::$aliases = [];
-		KirbyTag::$types = [];
+		KirbyTag::$types   = [];
 		App::destroy();
 	}
 
 	public function testConstruct(): void
 	{
-		KirbyTag::$aliases = [];
 		$tag = KirbyTag::parse('test: foo a: attrA b: attrB c: attrC');
+		$this->assertInstanceOf(TestKirbyTag::class, $tag);
 		$this->assertSame('test', $tag->type);
-		$this->assertSame('foo', $tag->test);
+		$this->assertSame('foo', $tag->value);
+
+		// only the attributes the tag type defines are applied
+		$this->assertSame('attrA', $tag->a);
+		$this->assertSame('attrB c: attrC', $tag->b);
+
 		$this->assertSame(['a' => 'attrA', 'b' => 'attrB c: attrC'], $tag->attrs);
 		$this->assertSame([], $tag->data);
 		$this->assertSame('foo', $tag->value);
@@ -59,8 +64,9 @@ class KirbyTagTest extends TestCase
 	{
 		KirbyTag::$aliases = ['foo' => 'test'];
 		$tag = KirbyTag::parse('foo: bar');
+		$this->assertInstanceOf(TestKirbyTag::class, $tag);
 		$this->assertSame('test', $tag->type);
-		$this->assertSame('bar', $tag->test);
+		$this->assertSame('bar', $tag->value);
 	}
 
 	public function testConstructMissingTagType(): void
@@ -82,59 +88,28 @@ class KirbyTagTest extends TestCase
 			'c' => 'dataC'
 		];
 
-		$tag = new KirbyTag('test', 'test value', $attr, $data);
+		$tag = new TestKirbyTag('test', 'test value', $attr, $data);
 
+		// data takes precedence over the property
 		$this->assertSame('dataA', $tag->a());
+		// falls back to the property when no data is set
 		$this->assertSame('attrB', $tag->b());
+		// data-only value
 		$this->assertSame('dataC', $tag->c());
-	}
-
-	public function test__get(): void
-	{
-		$tag = new KirbyTag('test', 'test value', ['a' => 'attrA']);
-
-		// known attribute
-		$this->assertSame('attrA', $tag->a);
-
-		// case-insensitive lookup (attribute name gets lowercased)
-		$this->assertSame('attrA', $tag->A);
-
-		// unknown attribute returns null
-		$this->assertNull($tag->unknown);
-	}
-
-	public function test__set(): void
-	{
-		$tag = new KirbyTag('test', 'test value');
-		$tag->text = 'My Text';
-		$this->assertSame('My Text', $tag->text);
-
-		// overwriting should also work
-		$tag->text = 'Other Text';
-		$this->assertSame('Other Text', $tag->text);
-
-		// case insensitive properties
-		$tag->Caption = 'My Caption';
-		$this->assertSame('My Caption', $tag->caption);
-		$this->assertSame('My Caption', $tag->Caption);
-		$this->assertSame('My Caption', $tag->attr('Caption'));
-		$this->assertSame('My Caption', $tag->attr('caption'));
 	}
 
 	public function test__callStatic(): void
 	{
-		$attr = [
+		$result = KirbyTag::test('test value', [
 			'a' => 'attrA',
 			'b' => 'attrB'
-		];
-
-		$result = KirbyTag::test('test value', $attr);
+		]);
 		$this->assertSame('test: test value-attrA-attrB', $result);
 	}
 
 	public function testAttr(): void
 	{
-		$tag = new KirbyTag('test', 'test value', [
+		$tag = new TestKirbyTag('test', 'test value', [
 			'a' => 'attrA',
 			'b' => 'attrB'
 		]);
@@ -143,14 +118,15 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('attrA', $tag->a);
 		$this->assertSame('attrB', $tag->b);
 
-		// attr helper
+		// attr helper (case-insensitive)
 		$this->assertSame('attrA', $tag->attr('a', 'fallback'));
+		$this->assertSame('attrA', $tag->attr('A', 'fallback'));
 		$this->assertSame('attrB', $tag->attr('b', 'fallback'));
 	}
 
 	public function testAttrFallback(): void
 	{
-		$tag = new KirbyTag('test', 'test value', [
+		$tag = new TestKirbyTag('test', 'test value', [
 			'a' => 'attrA'
 		]);
 
@@ -158,15 +134,24 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('fallback', $tag->attr('b', 'fallback'));
 	}
 
+	public function testAttrs(): void
+	{
+		$this->assertSame(['a', 'b'], TestKirbyTag::attrs());
+	}
+
 	public function testFactory(): void
 	{
-		$attr = [
+		// class-based type
+		$tag = KirbyTag::factory('test', 'test value', [
 			'a' => 'attrA',
 			'b' => 'attrB'
-		];
+		]);
+		$this->assertInstanceOf(TestKirbyTag::class, $tag);
+		$this->assertSame('test: test value-attrA-attrB', $tag->render());
 
-		$result = KirbyTag::factory('test', 'test value', $attr);
-		$this->assertSame('test: test value-attrA-attrB', $result);
+		// legacy array type is wrapped in LegacyKirbyTag
+		$tag = KirbyTag::factory('legacy', 'test value');
+		$this->assertInstanceOf(LegacyKirbyTag::class, $tag);
 	}
 
 	public function testFile(): void
@@ -191,7 +176,7 @@ class KirbyTagTest extends TestCase
 
 		$page = $app->page('a');
 		$file = $page->file('a.jpg');
-		$tag  = new KirbyTag('image', 'foo');
+		$tag  = new TestKirbyTag('test', 'foo');
 		$this->assertSame($file, $tag->file('a/a.jpg'));
 	}
 
@@ -217,7 +202,7 @@ class KirbyTagTest extends TestCase
 
 		$page = $app->page('a');
 		$file = $page->file('a.jpg');
-		$tag  = new KirbyTag('image', 'foo', [], [
+		$tag  = new TestKirbyTag('test', 'foo', [], [
 			'parent' => $page,
 		]);
 		$this->assertSame($file, $tag->file('a.jpg'));
@@ -245,7 +230,7 @@ class KirbyTagTest extends TestCase
 
 		$page = $app->page('a');
 		$file = $page->file('a.jpg');
-		$tag  = new KirbyTag('image', 'foo', [], [
+		$tag  = new TestKirbyTag('test', 'foo', [], [
 			'parent' => $file,
 		]);
 		$this->assertSame($file, $tag->file('a.jpg'));
@@ -274,11 +259,11 @@ class KirbyTagTest extends TestCase
 
 		$page = $app->page('a');
 		$file = $page->file('a.jpg');
-		$tag  = new KirbyTag('image', 'foo');
+		$tag  = new TestKirbyTag('test', 'foo');
 		$this->assertSame($file, $tag->file('file://image-uuid'));
 
 		// with parent
-		$tag = new KirbyTag('image', 'foo', [], [
+		$tag = new TestKirbyTag('test', 'foo', [], [
 			'parent' => $page,
 		]);
 		$this->assertSame($file, $tag->file('file://image-uuid'));
@@ -292,7 +277,7 @@ class KirbyTagTest extends TestCase
 			]
 		]);
 
-		$tag = new KirbyTag('image', 'b.jpg');
+		$tag = new TestKirbyTag('test', 'b.jpg');
 		$this->assertSame($app, $tag->kirby());
 	}
 
@@ -316,8 +301,8 @@ class KirbyTagTest extends TestCase
 			]
 		]);
 
-		$page  = $app->page('a');
-		$tag   = new KirbyTag('image', 'b.jpg', [], [
+		$page = $app->page('a');
+		$tag  = new TestKirbyTag('test', 'b.jpg', [], [
 			'parent' => $page,
 		]);
 
@@ -331,46 +316,46 @@ class KirbyTagTest extends TestCase
 				'(test: test value)',
 				['some' => 'data'],
 				[
-					'type'    => 'test',
-					'value'   => 'test value',
-					'data'    => ['some' => 'data'],
-					'attrs'   => []
+					'type'  => 'test',
+					'value' => 'test value',
+					'data'  => ['some' => 'data'],
+					'attrs' => []
 				]
 			],
 			[
 				'test: test value',
 				[],
 				[
-					'type'    => 'test',
-					'value'   => 'test value',
-					'attrs'   => []
+					'type'  => 'test',
+					'value' => 'test value',
+					'attrs' => []
 				]
 			],
 			[
 				'test:',
 				[],
 				[
-					'type'    => 'test',
-					'value'   => '',
-					'attrs'   => []
+					'type'  => 'test',
+					'value' => '',
+					'attrs' => []
 				]
 			],
 			[
 				'test: ',
 				[],
 				[
-					'type'    => 'test',
-					'value'   => '',
-					'attrs'   => []
+					'type'  => 'test',
+					'value' => '',
+					'attrs' => []
 				]
 			],
 			[
 				'test: test value a: attrA b: attrB',
 				[],
 				[
-					'type'    => 'test',
-					'value'   => 'test value',
-					'attrs'   => [
+					'type'  => 'test',
+					'value' => 'test value',
+					'attrs' => [
 						'a' => 'attrA',
 						'b' => 'attrB'
 					]
@@ -380,9 +365,9 @@ class KirbyTagTest extends TestCase
 				'test:test value a:attrA b:attrB',
 				[],
 				[
-					'type'    => 'test',
-					'value'   => 'test value',
-					'attrs'   => [
+					'type'  => 'test',
+					'value' => 'test value',
+					'attrs' => [
 						'a' => 'attrA',
 						'b' => 'attrB'
 					]
@@ -392,9 +377,9 @@ class KirbyTagTest extends TestCase
 				'test: test value a: attrA b:',
 				[],
 				[
-					'type'    => 'test',
-					'value'   => 'test value',
-					'attrs'   => [
+					'type'  => 'test',
+					'value' => 'test value',
+					'attrs' => [
 						'a' => 'attrA',
 						'b' => ''
 					]
@@ -404,9 +389,9 @@ class KirbyTagTest extends TestCase
 				'test: test value a: attrA b: ',
 				[],
 				[
-					'type'    => 'test',
-					'value'   => 'test value',
-					'attrs'   => [
+					'type'  => 'test',
+					'value' => 'test value',
+					'attrs' => [
 						'a' => 'attrA',
 						'b' => ''
 					]
@@ -416,9 +401,9 @@ class KirbyTagTest extends TestCase
 				'test: test value a: attrA b: attrB ',
 				[],
 				[
-					'type'    => 'test',
-					'value'   => 'test value',
-					'attrs'   => [
+					'type'  => 'test',
+					'value' => 'test value',
+					'attrs' => [
 						'a' => 'attrA',
 						'b' => 'attrB'
 					]
@@ -428,9 +413,9 @@ class KirbyTagTest extends TestCase
 				'test: test value a: attrA c: attrC b: attrB',
 				[],
 				[
-					'type'    => 'test',
-					'value'   => 'test value',
-					'attrs'   => [
+					'type'  => 'test',
+					'value' => 'test value',
+					'attrs' => [
 						'a' => 'attrA c: attrC',
 						'b' => 'attrB'
 					]
@@ -440,21 +425,21 @@ class KirbyTagTest extends TestCase
 				'test: test value a: attrA b: attrB c: attrC',
 				[],
 				[
-					'type'    => 'test',
-					'value'   => 'test value',
-					'attrs'   => [
+					'type'  => 'test',
+					'value' => 'test value',
+					'attrs' => [
 						'a' => 'attrA',
 						'b' => 'attrB c: attrC'
 					]
 				]
 			],
 			[
-				'file: file://abc a: attrA b: attrB c: attrC',
+				'legacy: file://abc a: attrA b: attrB c: attrC',
 				[],
 				[
-					'type'    => 'file',
-					'value'   => 'file://abc',
-					'attrs'   => [
+					'type'  => 'legacy',
+					'value' => 'file://abc',
+					'attrs' => [
 						'a' => 'attrA b: attrB c: attrC'
 					]
 				]
@@ -477,45 +462,21 @@ class KirbyTagTest extends TestCase
 
 	public function testRender(): void
 	{
-		$tag = new KirbyTag('test', 'test value', [
+		$tag = new TestKirbyTag('test', 'test value', [
 			'a' => 'attrA',
 			'b' => 'attrB'
 		]);
 		$this->assertSame('test: test value-attrA-attrB', $tag->render());
 
-		$tag = new KirbyTag('test', '', [
+		$tag = new TestKirbyTag('test', '', [
 			'a' => 'attrA'
 		]);
 		$this->assertSame('test: -attrA-', $tag->render());
 	}
 
-	public function testRenderNoHtml(): void
-	{
-		$this->expectException(BadMethodCallException::class);
-		$this->expectExceptionMessage('Invalid tag render function in tag: noHtml');
-
-		$tag = new KirbyTag('noHtml', 'test value', [
-			'a' => 'attrA',
-			'b' => 'attrB'
-		]);
-		$tag->render();
-	}
-
-	public function testRenderInvalidHtml(): void
-	{
-		$this->expectException(BadMethodCallException::class);
-		$this->expectExceptionMessage('Invalid tag render function in tag: invalidHtml');
-
-		$tag = new KirbyTag('invalidHtml', 'test value', [
-			'a' => 'attrA',
-			'b' => 'attrB'
-		]);
-		$tag->render();
-	}
-
 	public function testType(): void
 	{
-		$tag = new KirbyTag('test', 'test value');
+		$tag = new TestKirbyTag('test', 'test value');
 		$this->assertSame('test', $tag->type());
 	}
 }

--- a/tests/Text/KirbyTagTest.php
+++ b/tests/Text/KirbyTagTest.php
@@ -52,7 +52,6 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('foo', $tag->test);
 		$this->assertSame(['a' => 'attrA', 'b' => 'attrB c: attrC'], $tag->attrs);
 		$this->assertSame([], $tag->data);
-		$this->assertSame([], $tag->options);
 		$this->assertSame('foo', $tag->value);
 	}
 
@@ -297,27 +296,6 @@ class KirbyTagTest extends TestCase
 		$this->assertSame($app, $tag->kirby());
 	}
 
-	public function testOption(): void
-	{
-		// intentionally covers the deprecated `$tag->option()` method,
-		// which still needs to work
-		Helpers::$deprecations['kirbytag-option'] = false;
-
-		new App([
-			'roots'   => ['index' => '/dev/null'],
-			'options' => [
-				'a'      => 'optionA',
-				'nested' => ['b' => 'optionB']
-			]
-		]);
-
-		$tag = new KirbyTag('test', 'test value');
-
-		$this->assertSame('optionA', $tag->option('a'));
-		$this->assertSame('optionB', $tag->option('nested.b'));
-		$this->assertSame('optionC', $tag->option('c', 'optionC'));
-	}
-
 	public function testParent(): void
 	{
 		$app = new App([
@@ -352,18 +330,15 @@ class KirbyTagTest extends TestCase
 			[
 				'(test: test value)',
 				['some' => 'data'],
-				['some' => 'options'],
 				[
 					'type'    => 'test',
 					'value'   => 'test value',
 					'data'    => ['some' => 'data'],
-					'options' => ['some' => 'options'],
 					'attrs'   => []
 				]
 			],
 			[
 				'test: test value',
-				[],
 				[],
 				[
 					'type'    => 'test',
@@ -374,7 +349,6 @@ class KirbyTagTest extends TestCase
 			[
 				'test:',
 				[],
-				[],
 				[
 					'type'    => 'test',
 					'value'   => '',
@@ -384,7 +358,6 @@ class KirbyTagTest extends TestCase
 			[
 				'test: ',
 				[],
-				[],
 				[
 					'type'    => 'test',
 					'value'   => '',
@@ -393,7 +366,6 @@ class KirbyTagTest extends TestCase
 			],
 			[
 				'test: test value a: attrA b: attrB',
-				[],
 				[],
 				[
 					'type'    => 'test',
@@ -407,7 +379,6 @@ class KirbyTagTest extends TestCase
 			[
 				'test:test value a:attrA b:attrB',
 				[],
-				[],
 				[
 					'type'    => 'test',
 					'value'   => 'test value',
@@ -419,7 +390,6 @@ class KirbyTagTest extends TestCase
 			],
 			[
 				'test: test value a: attrA b:',
-				[],
 				[],
 				[
 					'type'    => 'test',
@@ -433,7 +403,6 @@ class KirbyTagTest extends TestCase
 			[
 				'test: test value a: attrA b: ',
 				[],
-				[],
 				[
 					'type'    => 'test',
 					'value'   => 'test value',
@@ -445,7 +414,6 @@ class KirbyTagTest extends TestCase
 			],
 			[
 				'test: test value a: attrA b: attrB ',
-				[],
 				[],
 				[
 					'type'    => 'test',
@@ -459,7 +427,6 @@ class KirbyTagTest extends TestCase
 			[
 				'test: test value a: attrA c: attrC b: attrB',
 				[],
-				[],
 				[
 					'type'    => 'test',
 					'value'   => 'test value',
@@ -472,7 +439,6 @@ class KirbyTagTest extends TestCase
 			[
 				'test: test value a: attrA b: attrB c: attrC',
 				[],
-				[],
 				[
 					'type'    => 'test',
 					'value'   => 'test value',
@@ -484,7 +450,6 @@ class KirbyTagTest extends TestCase
 			],
 			[
 				'file: file://abc a: attrA b: attrB c: attrC',
-				[],
 				[],
 				[
 					'type'    => 'file',
@@ -501,10 +466,10 @@ class KirbyTagTest extends TestCase
 	public function testParse(
 		string $string,
 		array $data,
-		array $options,
 		array $expected
 	): void {
-		$tag = KirbyTag::parse($string, $data, $options);
+		$tag = KirbyTag::parse($string, $data);
+
 		foreach ($expected as $key => $value) {
 			$this->assertSame($value, $tag->$key);
 		}

--- a/tests/Text/KirbyTagTest.php
+++ b/tests/Text/KirbyTagTest.php
@@ -11,8 +11,11 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class TestKirbyTag extends KirbyTag
 {
-	public string|null $a = null;
-	public string|null $b = null;
+	public function __construct(
+		public string|null $a = null,
+		public string|null $b = null
+	) {
+	}
 
 	public function render(): string
 	{
@@ -88,7 +91,7 @@ class KirbyTagTest extends TestCase
 			'c' => 'dataC'
 		];
 
-		$tag = new TestKirbyTag('test', 'test value', $attr, $data);
+		$tag = KirbyTag::factory('test', 'test value', $attr, $data);
 
 		// data takes precedence over the property
 		$this->assertSame('dataA', $tag->a());
@@ -109,7 +112,7 @@ class KirbyTagTest extends TestCase
 
 	public function testAttr(): void
 	{
-		$tag = new TestKirbyTag('test', 'test value', [
+		$tag = KirbyTag::factory('test', 'test value', [
 			'a' => 'attrA',
 			'b' => 'attrB'
 		]);
@@ -126,7 +129,7 @@ class KirbyTagTest extends TestCase
 
 	public function testAttrFallback(): void
 	{
-		$tag = new TestKirbyTag('test', 'test value', [
+		$tag = KirbyTag::factory('test', 'test value', [
 			'a' => 'attrA'
 		]);
 
@@ -176,7 +179,7 @@ class KirbyTagTest extends TestCase
 
 		$page = $app->page('a');
 		$file = $page->file('a.jpg');
-		$tag  = new TestKirbyTag('test', 'foo');
+		$tag  = KirbyTag::factory('test', 'foo');
 		$this->assertSame($file, $tag->file('a/a.jpg'));
 	}
 
@@ -202,7 +205,7 @@ class KirbyTagTest extends TestCase
 
 		$page = $app->page('a');
 		$file = $page->file('a.jpg');
-		$tag  = new TestKirbyTag('test', 'foo', [], [
+		$tag  = KirbyTag::factory('test', 'foo', [], [
 			'parent' => $page,
 		]);
 		$this->assertSame($file, $tag->file('a.jpg'));
@@ -230,7 +233,7 @@ class KirbyTagTest extends TestCase
 
 		$page = $app->page('a');
 		$file = $page->file('a.jpg');
-		$tag  = new TestKirbyTag('test', 'foo', [], [
+		$tag  = KirbyTag::factory('test', 'foo', [], [
 			'parent' => $file,
 		]);
 		$this->assertSame($file, $tag->file('a.jpg'));
@@ -259,11 +262,11 @@ class KirbyTagTest extends TestCase
 
 		$page = $app->page('a');
 		$file = $page->file('a.jpg');
-		$tag  = new TestKirbyTag('test', 'foo');
+		$tag  = KirbyTag::factory('test', 'foo');
 		$this->assertSame($file, $tag->file('file://image-uuid'));
 
 		// with parent
-		$tag = new TestKirbyTag('test', 'foo', [], [
+		$tag = KirbyTag::factory('test', 'foo', [], [
 			'parent' => $page,
 		]);
 		$this->assertSame($file, $tag->file('file://image-uuid'));
@@ -277,7 +280,7 @@ class KirbyTagTest extends TestCase
 			]
 		]);
 
-		$tag = new TestKirbyTag('test', 'b.jpg');
+		$tag = KirbyTag::factory('test', 'b.jpg');
 		$this->assertSame($app, $tag->kirby());
 	}
 
@@ -302,7 +305,7 @@ class KirbyTagTest extends TestCase
 		]);
 
 		$page = $app->page('a');
-		$tag  = new TestKirbyTag('test', 'b.jpg', [], [
+		$tag  = KirbyTag::factory('test', 'b.jpg', [], [
 			'parent' => $page,
 		]);
 
@@ -462,13 +465,13 @@ class KirbyTagTest extends TestCase
 
 	public function testRender(): void
 	{
-		$tag = new TestKirbyTag('test', 'test value', [
+		$tag = KirbyTag::factory('test', 'test value', [
 			'a' => 'attrA',
 			'b' => 'attrB'
 		]);
 		$this->assertSame('test: test value-attrA-attrB', $tag->render());
 
-		$tag = new TestKirbyTag('test', '', [
+		$tag = KirbyTag::factory('test', '', [
 			'a' => 'attrA'
 		]);
 		$this->assertSame('test: -attrA-', $tag->render());
@@ -476,7 +479,7 @@ class KirbyTagTest extends TestCase
 
 	public function testType(): void
 	{
-		$tag = new TestKirbyTag('test', 'test value');
+		$tag = KirbyTag::factory('test', 'test value');
 		$this->assertSame('test', $tag->type());
 	}
 }

--- a/tests/Text/KirbyTagTest.php
+++ b/tests/Text/KirbyTagTest.php
@@ -23,6 +23,19 @@ class TestKirbyTag extends KirbyTag
 	}
 }
 
+class CamelKirbyTag extends KirbyTag
+{
+	public function __construct(
+		public string|null $linkClass = null
+	) {
+	}
+
+	public function render(): string
+	{
+		return 'camel: ' . $this->value . '-' . $this->linkClass;
+	}
+}
+
 #[CoversClass(KirbyTag::class)]
 class KirbyTagTest extends TestCase
 {
@@ -32,6 +45,7 @@ class KirbyTagTest extends TestCase
 	{
 		KirbyTag::$types = [
 			'test'   => TestKirbyTag::class,
+			'camel'  => CamelKirbyTag::class,
 			'legacy' => [
 				'attr' => ['a'],
 				'html' => fn ($tag) => 'legacy'
@@ -127,6 +141,18 @@ class KirbyTagTest extends TestCase
 		$this->assertSame('attrB', $tag->attr('b', 'fallback'));
 	}
 
+	public function testAttrCamelCase(): void
+	{
+		$tag = KirbyTag::factory('camel', 'test value', [
+			'linkclass' => 'red'
+		]);
+
+		// the declared spelling is resolved from any casing
+		$this->assertSame('red', $tag->attr('linkClass', 'fallback'));
+		$this->assertSame('red', $tag->attr('linkclass', 'fallback'));
+		$this->assertSame('red', $tag->attr('LINKCLASS', 'fallback'));
+	}
+
 	public function testAttrFallback(): void
 	{
 		$tag = KirbyTag::factory('test', 'test value', [
@@ -155,6 +181,20 @@ class KirbyTagTest extends TestCase
 		// legacy array type is wrapped in LegacyKirbyTag
 		$tag = KirbyTag::factory('legacy', 'test value');
 		$this->assertInstanceOf(LegacyKirbyTag::class, $tag);
+	}
+
+	public function testFactoryCamelCaseAttr(): void
+	{
+		// a camel-cased constructor argument is filled from any casing
+		foreach (['linkClass', 'linkclass', 'LINKCLASS'] as $name) {
+			$tag = KirbyTag::factory('camel', 'test value', [$name => 'red']);
+
+			$this->assertSame('red', $tag->linkClass);
+			$this->assertSame('camel: test value-red', $tag->render());
+
+			// the attrs array carries the declared spelling
+			$this->assertSame(['linkClass' => 'red'], $tag->attrs);
+		}
 	}
 
 	public function testFile(): void
@@ -460,6 +500,18 @@ class KirbyTagTest extends TestCase
 
 		foreach ($expected as $key => $value) {
 			$this->assertSame($value, $tag->$key);
+		}
+	}
+
+	public function testParseCamelCaseAttr(): void
+	{
+		// the attribute regex is case-insensitive, so a camel-cased
+		// constructor argument must be filled whatever the user types
+		foreach (['linkClass', 'linkclass', 'LinkClass'] as $name) {
+			$tag = KirbyTag::parse('camel: test value ' . $name . ': red');
+
+			$this->assertSame('red', $tag->linkClass);
+			$this->assertSame(['linkClass' => 'red'], $tag->attrs);
 		}
 	}
 

--- a/tests/Text/KirbyTagsTest.php
+++ b/tests/Text/KirbyTagsTest.php
@@ -162,23 +162,6 @@ class KirbyTagsTest extends TestCase
 		$this->assertSame('(undefined: foo)', KirbyTags::parse('(undefined: foo)', [], debug: true));
 	}
 
-	public function testParseWithDeprecatedOptions(): void
-	{
-		// `$options` is a deprecated alias that only ever carried `debug`
-		Helpers::$deprecations['kirbytags-parse-options'] = false;
-
-		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('Just for fun');
-
-		KirbyTag::$types = [
-			'test' => [
-				'html' => fn () => throw new Exception('Just for fun')
-			]
-		];
-
-		KirbyTags::parse('(test: foo)', [], ['debug' => true]);
-	}
-
 	public function testParseWithBrackets(): void
 	{
 		KirbyTag::$types = [

--- a/tests/Text/LegacyKirbyTagTest.php
+++ b/tests/Text/LegacyKirbyTagTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Kirby\Text;
+
+use Kirby\Cms\App;
+use Kirby\Exception\BadMethodCallException;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(LegacyKirbyTag::class)]
+class LegacyKirbyTagTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		KirbyTag::$types = [
+			'test' => [
+				'attr' => ['a', 'b'],
+				'html' => fn ($tag) => 'test: ' . $tag->value . '-' . $tag->a . '-' . $tag->b
+			],
+			'noHtml' => [
+				'attr' => ['a', 'b']
+			],
+			'invalidHtml' => [
+				'attr' => ['a', 'b'],
+				'html' => 'some string'
+			],
+		];
+	}
+
+	protected function tearDown(): void
+	{
+		KirbyTag::$aliases = [];
+		KirbyTag::$types   = [];
+		App::destroy();
+	}
+
+	public function testFactory(): void
+	{
+		$tag = KirbyTag::factory('test', 'test value', [
+			'a' => 'attrA',
+			'b' => 'attrB'
+		]);
+
+		$this->assertInstanceOf(LegacyKirbyTag::class, $tag);
+		$this->assertSame('test', $tag->type);
+		$this->assertSame('test value', $tag->value);
+		$this->assertSame(['a' => 'attrA', 'b' => 'attrB'], $tag->attrs);
+	}
+
+	public function testValueAvailableUnderTypeName(): void
+	{
+		// the tag value is also exposed under the type name (e.g. $tag->test)
+		$tag = KirbyTag::factory('test', 'test value');
+		$this->assertSame('test value', $tag->test);
+	}
+
+	public function testDefinedAttrs(): void
+	{
+		// only attributes declared in the definition are applied as props
+		$tag = KirbyTag::factory('test', 'value', [
+			'a' => 'attrA',
+			'b' => 'attrB',
+			'c' => 'attrC' // not in the definition -> ignored
+		]);
+
+		$this->assertSame('attrA', $tag->a);
+		$this->assertSame('attrB', $tag->b);
+		$this->assertNull($tag->c);
+
+		// but all passed attributes are still available in $attrs
+		$this->assertSame(
+			['a' => 'attrA', 'b' => 'attrB', 'c' => 'attrC'],
+			$tag->attrs
+		);
+	}
+
+	public function test__get(): void
+	{
+		$tag = KirbyTag::factory('test', 'test value', ['a' => 'attrA']);
+
+		// known attribute
+		$this->assertSame('attrA', $tag->a);
+
+		// case-insensitive lookup (attribute name gets lowercased)
+		$this->assertSame('attrA', $tag->A);
+
+		// unknown attribute returns null
+		$this->assertNull($tag->unknown);
+	}
+
+	public function test__set(): void
+	{
+		$tag = KirbyTag::factory('test', 'test value');
+
+		$tag->text = 'My Text';
+		$this->assertSame('My Text', $tag->text);
+
+		// overwriting should also work
+		$tag->text = 'Other Text';
+		$this->assertSame('Other Text', $tag->text);
+
+		// case-insensitive properties
+		$tag->Caption = 'My Caption';
+		$this->assertSame('My Caption', $tag->caption);
+		$this->assertSame('My Caption', $tag->Caption);
+		$this->assertSame('My Caption', $tag->attr('Caption'));
+		$this->assertSame('My Caption', $tag->attr('caption'));
+	}
+
+	public function test__isset(): void
+	{
+		$tag = KirbyTag::factory('test', 'test value', ['a' => 'attrA']);
+
+		$this->assertTrue(isset($tag->a));
+		// case-insensitive
+		$this->assertTrue(isset($tag->A));
+		$this->assertFalse(isset($tag->unknown));
+	}
+
+	public function test__unset(): void
+	{
+		$tag = KirbyTag::factory('test', 'test value', ['a' => 'attrA']);
+
+		$this->assertTrue(isset($tag->a));
+
+		unset($tag->a);
+		$this->assertFalse(isset($tag->a));
+		$this->assertNull($tag->a);
+	}
+
+	public function test__call(): void
+	{
+		$attr = [
+			'a' => 'attrA',
+			'b' => 'attrB'
+		];
+
+		$data = [
+			'a' => 'dataA',
+			'c' => 'dataC'
+		];
+
+		$tag = KirbyTag::factory('test', 'test value', $attr, $data);
+
+		// data takes precedence over the property
+		$this->assertSame('dataA', $tag->a());
+		// falls back to the magic property
+		$this->assertSame('attrB', $tag->b());
+		// data-only value
+		$this->assertSame('dataC', $tag->c());
+	}
+
+	public function testAttr(): void
+	{
+		$tag = KirbyTag::factory('test', 'test value', ['a' => 'attrA']);
+
+		$this->assertSame('attrA', $tag->attr('a'));
+		$this->assertSame('attrA', $tag->attr('A'));
+		$this->assertSame('fallback', $tag->attr('b', 'fallback'));
+	}
+
+	public function testRender(): void
+	{
+		$tag = KirbyTag::factory('test', 'test value', [
+			'a' => 'attrA',
+			'b' => 'attrB'
+		]);
+		$this->assertSame('test: test value-attrA-attrB', $tag->render());
+
+		$tag = KirbyTag::factory('test', '', ['a' => 'attrA']);
+		$this->assertSame('test: -attrA-', $tag->render());
+	}
+
+	public function testRenderMissingHtml(): void
+	{
+		$this->expectException(BadMethodCallException::class);
+		$this->expectExceptionMessage('Invalid tag render function in tag: noHtml');
+
+		$tag = KirbyTag::factory('noHtml', 'test value', [
+			'a' => 'attrA',
+			'b' => 'attrB'
+		]);
+		$tag->render();
+	}
+
+	public function testRenderInvalidHtml(): void
+	{
+		$this->expectException(BadMethodCallException::class);
+		$this->expectExceptionMessage('Invalid tag render function in tag: invalidHtml');
+
+		$tag = KirbyTag::factory('invalidHtml', 'test value', [
+			'a' => 'attrA',
+			'b' => 'attrB'
+		]);
+		$tag->render();
+	}
+}

--- a/tests/Text/LegacyKirbyTagTest.php
+++ b/tests/Text/LegacyKirbyTagTest.php
@@ -24,6 +24,10 @@ class LegacyKirbyTagTest extends TestCase
 				'attr' => ['a', 'b'],
 				'html' => 'some string'
 			],
+			'camel' => [
+				'attr' => ['linkClass'],
+				'html' => fn ($tag) => 'camel: ' . $tag->linkClass
+			],
 		];
 	}
 
@@ -157,6 +161,20 @@ class LegacyKirbyTagTest extends TestCase
 		$this->assertSame('attrA', $tag->attr('a'));
 		$this->assertSame('attrA', $tag->attr('A'));
 		$this->assertSame('fallback', $tag->attr('b', 'fallback'));
+	}
+
+	public function testAttrCamelCase(): void
+	{
+		// a camel-cased `attr` entry is filled from any casing and
+		// stays reachable through the lowercasing magic getter
+		foreach (['linkClass', 'linkclass', 'LINKCLASS'] as $name) {
+			$tag = KirbyTag::factory('camel', 'test value', [$name => 'red']);
+
+			$this->assertSame('red', $tag->linkClass);
+			$this->assertSame('red', $tag->linkclass);
+			$this->assertSame('red', $tag->attr('linkClass'));
+			$this->assertSame('camel: red', $tag->render());
+		}
 	}
 
 	public function testRender(): void


### PR DESCRIPTION
## Review

- [x] Design & concept
- [x] Rough read

**Timing:** no rush

## Description

This is a suggestion to turn KirbyTags from `attr`/`html` arrays into proper classes extending a common base class (`Kirby\Text\KirbyTag`). This PR provides the changes to `Kirby\Text\KirbyTag` for this and adds a `Kirby\Text\LegacyKirbyTag` class that functions as a wrapper for all array-defined tags. These continue to work through the legacy wrapper.

- `KirbyTag` is abstract, `render()` is abstract, and every instance is created through `KirbyTag::factory()`. The registry (`KirbyTag::$types`) now holds either an array definition or a `class-string`.
- A tag declares its attributes as named constructor arguments. `KirbyTag::attrs()` derives the attribute list from the constructor via `Kirby\Reflection\Constructor` and caches it per class, so there is no second place to keep the list in sync.
- Shared, non-attribute state/class properties (`type`, `value`, `data`, `attrs`) are injected after construction via `bind()`. That keeps subclass constructors free of boilerplate. They only ever deal with their own attributes.

The core tags in `config/tags.php` stay array-based in this PR; only the closure type moves to `LegacyKirbyTag`. Migrating them to classes happens in #8198.

## Changelog

### 🎉 Features

- KirbyTags can now be defined as native PHP classes extending `Kirby\Text\KirbyTag`, instead of only as `attr`/`html` array definitions. Attributes are declared as constructor arguments and the render logic lives in a `::render()` method.

### ☠️ Deprecated

- Array definitions for custom KirbyTags. Prefer creating a custom KirbyTag class instead.

### 🚨 Breaking changes

- `Kirby\Text\KirbyTag` is an abstract class now. Use `KirbyTag::factory()` to initialize.
- `Kirby\Text\KirbyTag::factory()` returns the tag instance now instead of the rendered HTM. Call `->render()` on the result to get the HTML.
- Removed `Kirby\Text\KirbyTag::option()` and `Kirby\Text\KirbyTag::$options`. Use `$tag->kirby()->option()` instead.
- Removed the `$options` argument from `Kirby\Text\KirbyTag::parse()` and `Kirby\Text\KirbyTags::parse()`. Use the `$debug` argument of `KirbyTags::parse()` instead.

## Docs

A custom tag is now a class. Attributes become constructor arguments, the tag value stays available as `$this->value`:

```php
<?php

use Kirby\Text\KirbyTag;

class WikipediaTag extends KirbyTag
{
	public function __construct(
		public string|null $text = null,
	) {
	}

	public function render(): string
	{
		return '<a href="https://en.wikipedia.org/wiki/' . $this->value . '">'
			. ($this->text ?? 'Wikipedia') . '</a>';
	}
}

Kirby::plugin('your/plugin', [
	'tags' => [
		'wikipedia' => WikipediaTag::class
	]
]);
```

Used in a text field as `(wikipedia: Kirby text: Read more)`.

## For review team

- [ ] Add changes & docs to release notes draft in Notion
