### PR TITLE
fix: Improve dialog and picker scrolling

### DIFF
--- a/panel/lab/components/scrollable/index.php
+++ b/panel/lab/components/scrollable/index.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'docs' => 'k-scrollable',
+];

--- a/panel/lab/components/scrollable/index.vue
+++ b/panel/lab/components/scrollable/index.vue
@@ -1,0 +1,172 @@
+<template>
+	<k-lab-examples class="k-scrollable-examples">
+		<k-lab-example label="Default">
+			<k-text>
+				<p>
+					When the content is taller than the container, both edges fade to hint
+					at hidden content. Scroll to see the fade disappear at the top or
+					bottom edge. When the content fits, no fade is shown.
+				</p>
+			</k-text>
+			<!-- @code -->
+			<div class="k-scrollable-frame">
+				<k-scrollable class="k-scrollable-demo">
+					<k-box v-for="n in 24" :key="n" theme="purple" :text="`Item ${n}`" />
+				</k-scrollable>
+			</div>
+			<!-- @code-end -->
+		</k-lab-example>
+
+		<k-lab-example label="fade: end">
+			<k-text>
+				<p>
+					Fades only the bottom edge. Use this when the top holds sticky content
+					(toolbars, table headers) that must not be faded.
+				</p>
+			</k-text>
+			<!-- @code -->
+			<div class="k-scrollable-frame">
+				<k-scrollable class="k-scrollable-demo" fade="end">
+					<k-box v-for="n in 24" :key="n" theme="purple" :text="`Item ${n}`" />
+				</k-scrollable>
+			</div>
+			<!-- @code-end -->
+		</k-lab-example>
+
+		<k-lab-example label="fade: start">
+			<!-- @code -->
+			<div class="k-scrollable-frame">
+				<k-scrollable class="k-scrollable-demo" fade="start">
+					<k-box v-for="n in 24" :key="n" theme="purple" :text="`Item ${n}`" />
+				</k-scrollable>
+			</div>
+			<!-- @code-end -->
+		</k-lab-example>
+
+		<k-lab-example label="fade: false">
+			<!-- @code -->
+			<div class="k-scrollable-frame">
+				<k-scrollable class="k-scrollable-demo" :fade="false">
+					<k-box v-for="n in 24" :key="n" theme="purple" :text="`Item ${n}`" />
+				</k-scrollable>
+			</div>
+			<!-- @code-end -->
+		</k-lab-example>
+
+		<k-lab-example label="axis: inline">
+			<k-text>
+				<p>Fades the horizontal scroll edges.</p>
+			</k-text>
+			<!-- @code -->
+			<div class="k-scrollable-frame k-scrollable-frame-inline">
+				<k-scrollable
+					class="k-scrollable-demo k-scrollable-demo-inline"
+					axis="inline"
+				>
+					<k-box v-for="n in 20" :key="n" theme="purple" :text="`Col ${n}`" />
+				</k-scrollable>
+			</div>
+			<!-- @code-end -->
+		</k-lab-example>
+
+		<k-lab-example label="In a dialog">
+			<k-text>
+				<p>
+					The dialog body is a <code>k-scrollable</code>. When the content is
+					taller than the viewport, the body stays within the frame, scrolls,
+					and fades both edges.
+				</p>
+			</k-text>
+			<!-- @code -->
+			<k-button
+				icon="open"
+				variant="filled"
+				@click="
+					$panel.dialog.open({
+						component: 'k-text-dialog',
+						props: {
+							size: 'tiny',
+							text: text
+						}
+					})
+				"
+			>
+				Open long dialog
+			</k-button>
+			<!-- @code-end -->
+		</k-lab-example>
+
+		<k-lab-example label="In a drawer">
+			<k-text>
+				<p>
+					The drawer body uses <code>fade="end"</code>, so only the bottom edge
+					fades, keeping sticky toolbars and table headers at the top sharp.
+				</p>
+			</k-text>
+			<!-- @code -->
+			<k-button
+				icon="open"
+				variant="filled"
+				@click="
+					$panel.drawer.open({
+						component: 'k-text-drawer',
+						props: {
+							size: 'tiny',
+							title: 'Long drawer',
+							text: text
+						}
+					})
+				"
+			>
+				Open long drawer
+			</k-button>
+			<!-- @code-end -->
+		</k-lab-example>
+	</k-lab-examples>
+</template>
+
+<script>
+export default {
+	computed: {
+		text() {
+			return Array.from(
+				{ length: 20 },
+				(_, index) =>
+					`<p>Paragraph ${index + 1} — Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>`
+			).join("");
+		}
+	}
+};
+</script>
+
+<style>
+.k-scrollable-examples .k-text {
+	margin-bottom: var(--spacing-3);
+	max-width: 40rem;
+}
+.k-scrollable-frame {
+	height: 12rem;
+	border: 1px solid var(--color-border);
+	border-radius: var(--rounded);
+	background: var(--color-white);
+	overflow: clip;
+}
+.k-scrollable-frame-inline {
+	height: auto;
+}
+.k-scrollable-demo {
+	display: grid;
+	gap: var(--spacing-2);
+	padding: var(--spacing-3);
+	height: 100%;
+}
+.k-scrollable-demo-inline {
+	display: flex;
+	height: auto;
+}
+.k-scrollable-demo-inline .k-box {
+	width: 8rem;
+	flex-shrink: 0;
+	justify-content: center;
+}
+</style>

--- a/panel/src/components/Collection/Collection.vue
+++ b/panel/src/components/Collection/Collection.vue
@@ -1,36 +1,41 @@
 <template>
-	<div class="k-collection">
-		<k-empty
-			v-if="items.length === 0"
-			v-bind="empty"
-			:layout="layout"
-			v-on="listeners"
-		/>
-
-		<k-items
-			v-else
-			v-bind="{
-				columns,
-				fields,
-				index: resolvedIndex,
-				items,
-				layout,
-				link,
-				selecting,
-				size,
-				sortable,
-				theme
-			}"
-			@change="$emit('change', $event)"
-			@item="$emit('item', $event)"
-			@option="onOption"
-			@select="onSelect"
-			@sort="$emit('sort', $event)"
+	<div :data-scrollable="scrollable" class="k-collection">
+		<component
+			:is="scrollable ? 'k-scrollable' : 'div'"
+			class="k-collection-body"
 		>
-			<template #options="{ item, index }">
-				<slot name="options" v-bind="{ item, index }" />
-			</template>
-		</k-items>
+			<k-empty
+				v-if="items.length === 0"
+				v-bind="empty"
+				:layout="layout"
+				v-on="listeners"
+			/>
+
+			<k-items
+				v-else
+				v-bind="{
+					columns,
+					fields,
+					index: resolvedIndex,
+					items,
+					layout,
+					link,
+					selecting,
+					size,
+					sortable,
+					theme
+				}"
+				@change="$emit('change', $event)"
+				@item="$emit('item', $event)"
+				@option="onOption"
+				@select="onSelect"
+				@sort="$emit('sort', $event)"
+			>
+				<template #options="{ item, index }">
+					<slot name="options" v-bind="{ item, index }" />
+				</template>
+			</k-items>
+		</component>
 
 		<footer v-if="help || hasPagination" class="k-collection-footer">
 			<k-text class="k-help k-collection-help" :html="help" />
@@ -76,7 +81,12 @@ export default {
 		pagination: {
 			type: [Boolean, Object],
 			default: false
-		}
+		},
+		/**
+		 * Whether the items should scroll within the available space
+		 * @since 5.6.0
+		 */
+		scrollable: Boolean
 	},
 	emits: ["action", "change", "empty", "item", "option", "paginate", "sort"],
 	computed: {
@@ -141,6 +151,20 @@ export default {
 </script>
 
 <style>
+.k-collection[data-scrollable="true"] {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+}
+.k-collection[data-scrollable="true"] .k-collection-body {
+	flex: 1;
+	min-height: 0;
+}
+/* if body isn't scrollable, render-less wrapper  */
+.k-collection-body:not(.k-scrollable) {
+	display: contents;
+}
+
 .k-collection-footer {
 	display: flex;
 	justify-content: space-between;

--- a/panel/src/components/Dialogs/Dialog.vue
+++ b/panel/src/components/Dialogs/Dialog.vue
@@ -67,6 +67,7 @@ export default {
 	background: var(--dialog-color-back);
 	color: var(--dialog-color-text);
 	width: clamp(10rem, 100%, var(--dialog-width));
+	max-height: calc(100dvh - var(--dialog-margin) - var(--dialog-margin));
 	box-shadow: var(--dialog-shadow);
 	border-radius: var(--dialog-rounded);
 	line-height: 1;

--- a/panel/src/components/Dialogs/Elements/Body.vue
+++ b/panel/src/components/Dialogs/Elements/Body.vue
@@ -14,7 +14,10 @@ export default {};
 
 <style>
 .k-dialog-body {
+	min-height: 0;
 	padding: var(--dialog-padding);
+	overflow-y: auto;
+	overscroll-behavior: contain;
 }
 .k-dialog:has(.k-dialog-footer) .k-dialog-body {
 	padding-bottom: 0;

--- a/panel/src/components/Dialogs/Elements/Body.vue
+++ b/panel/src/components/Dialogs/Elements/Body.vue
@@ -1,7 +1,7 @@
 <template>
-	<div class="k-dialog-body">
+	<k-scrollable class="k-dialog-body">
 		<slot />
-	</div>
+	</k-scrollable>
 </template>
 
 <script>
@@ -14,10 +14,7 @@ export default {};
 
 <style>
 .k-dialog-body {
-	min-height: 0;
 	padding: var(--dialog-padding);
-	overflow-y: auto;
-	overscroll-behavior: contain;
 }
 .k-dialog:has(.k-dialog-footer) .k-dialog-body {
 	padding-bottom: 0;

--- a/panel/src/components/Dialogs/ModelsDialog.vue
+++ b/panel/src/components/Dialogs/ModelsDialog.vue
@@ -16,6 +16,7 @@
 			}"
 			:items="items"
 			:link="false"
+			:scrollable="true"
 			:pagination="{
 				details: true,
 				dropdown: false,
@@ -169,18 +170,12 @@ export default {
 </script>
 
 <style>
-.k-models-dialog :where(.k-dialog-body, .k-collection) {
+.k-models-dialog .k-dialog-body {
 	display: flex;
 	flex-direction: column;
-	min-height: 0;
 }
-.k-models-dialog .k-dialog-body {
-	overflow: hidden;
-}
-.k-models-dialog .k-items {
-	min-height: 0;
-	overflow-y: auto;
-	overscroll-behavior: contain;
+.k-models-dialog .k-collection {
+	flex: 1;
 }
 .k-models-dialog .k-list-item {
 	cursor: pointer;

--- a/panel/src/components/Dialogs/ModelsDialog.vue
+++ b/panel/src/components/Dialogs/ModelsDialog.vue
@@ -169,6 +169,19 @@ export default {
 </script>
 
 <style>
+.k-models-dialog :where(.k-dialog-body, .k-collection) {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+}
+.k-models-dialog .k-dialog-body {
+	overflow: hidden;
+}
+.k-models-dialog .k-items {
+	min-height: 0;
+	overflow-y: auto;
+	overscroll-behavior: contain;
+}
 .k-models-dialog .k-list-item {
 	cursor: pointer;
 }

--- a/panel/src/components/Dialogs/PageMoveDialog.vue
+++ b/panel/src/components/Dialogs/PageMoveDialog.vue
@@ -49,13 +49,23 @@ export default {
 </script>
 
 <style>
+.k-page-move-dialog .k-dialog-body {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
 .k-page-move-dialog .k-headline {
+	flex-shrink: 0;
 	margin-bottom: var(--spacing-2);
 }
 .k-page-move-parent {
 	--tree-color-back: var(--input-color-back);
 	--tree-branch-color-back: var(--input-color-back);
 	--tree-branch-hover-color-back: var(--panel-color-back);
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+	overscroll-behavior: contain;
 	padding: var(--spacing-3);
 	background: var(--tree-color-back);
 	border-radius: var(--rounded);

--- a/panel/src/components/Drawers/Elements/Body.vue
+++ b/panel/src/components/Drawers/Elements/Body.vue
@@ -1,7 +1,7 @@
 <template>
-	<div class="k-drawer-body scroll-y-auto">
+	<k-scrollable class="k-drawer-body" fade="end">
 		<slot />
-	</div>
+	</k-scrollable>
 </template>
 
 <script>

--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -64,24 +64,28 @@
 					data-type="page"
 					class="k-link-input-body"
 				>
-					<div class="k-page-browser">
+					<k-scrollable class="k-page-browser">
 						<k-page-tree
 							:current="$helper.link.getPageUUID(value)"
 							:root="false"
 							@select="selectModel($event)"
 						/>
-					</div>
+					</k-scrollable>
 				</div>
 				<div
 					v-else-if="currentType.id === 'file'"
 					data-type="file"
 					class="k-link-input-body"
 				>
-					<k-file-browser
-						:opened="$panel.view.props.model.uuid ?? $panel.view.props.model.id"
-						:selected="$helper.link.getFileUUID(value)"
-						@select="selectModel($event)"
-					/>
+					<k-scrollable>
+						<k-file-browser
+							:opened="
+								$panel.view.props.model.uuid ?? $panel.view.props.model.id
+							"
+							:selected="$helper.link.getFileUUID(value)"
+							@select="selectModel($event)"
+						/>
+					</k-scrollable>
 				</div>
 			</template>
 		</k-input>
@@ -326,11 +330,8 @@ export default {
 	--tree-branch-hover-color-back: var(--panel-color-back);
 }
 
-.k-link-input-body .k-page-browser,
-.k-link-input-body .k-file-browser {
+.k-link-input-body > .k-scrollable {
 	max-height: 50dvh;
-	overflow-y: auto;
-	overscroll-behavior: contain;
 }
 
 .k-link-input-body[data-type="page"] .k-page-browser {

--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -67,8 +67,8 @@
 					<k-page-tree
 						:current="$helper.link.getPageUUID(value)"
 						:root="false"
+						:scrollable="true"
 						class="k-page-browser"
-						scrollable
 						@select="selectModel($event)"
 					/>
 				</div>

--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -64,28 +64,24 @@
 					data-type="page"
 					class="k-link-input-body"
 				>
-					<k-scrollable class="k-page-browser">
-						<k-page-tree
-							:current="$helper.link.getPageUUID(value)"
-							:root="false"
-							@select="selectModel($event)"
-						/>
-					</k-scrollable>
+					<k-page-tree
+						:current="$helper.link.getPageUUID(value)"
+						:root="false"
+						class="k-page-browser"
+						scrollable
+						@select="selectModel($event)"
+					/>
 				</div>
 				<div
 					v-else-if="currentType.id === 'file'"
 					data-type="file"
 					class="k-link-input-body"
 				>
-					<k-scrollable>
-						<k-file-browser
-							:opened="
-								$panel.view.props.model.uuid ?? $panel.view.props.model.id
-							"
-							:selected="$helper.link.getFileUUID(value)"
-							@select="selectModel($event)"
-						/>
-					</k-scrollable>
+					<k-file-browser
+						:opened="$panel.view.props.model.uuid ?? $panel.view.props.model.id"
+						:selected="$helper.link.getFileUUID(value)"
+						@select="selectModel($event)"
+					/>
 				</div>
 			</template>
 		</k-input>
@@ -330,7 +326,7 @@ export default {
 	--tree-branch-hover-color-back: var(--panel-color-back);
 }
 
-.k-link-input-body > .k-scrollable {
+.k-link-input-body > :where(.k-page-browser, .k-file-browser) {
 	max-height: 50dvh;
 }
 

--- a/panel/src/components/Forms/Field/LinkField.vue
+++ b/panel/src/components/Forms/Field/LinkField.vue
@@ -319,7 +319,6 @@ export default {
 
 .k-link-input-body {
 	display: grid;
-	overflow: hidden;
 	border-top: 1px solid var(--color-border);
 	background: var(--input-color-back);
 	--tree-color-back: var(--input-color-back);
@@ -327,12 +326,18 @@ export default {
 	--tree-branch-hover-color-back: var(--panel-color-back);
 }
 
+.k-link-input-body .k-page-browser,
+.k-link-input-body .k-file-browser {
+	max-height: 50dvh;
+	overflow-y: auto;
+	overscroll-behavior: contain;
+}
+
 .k-link-input-body[data-type="page"] .k-page-browser {
 	padding: var(--spacing-2);
 	padding-bottom: calc(var(--spacing-2) - 1px);
 	width: 100%;
 	container-type: inline-size;
-	overflow: auto;
 }
 .k-link-field .k-tags-field-preview {
 	--tag-rounded: var(--rounded-sm);

--- a/panel/src/components/Layout/Scrollable.vue
+++ b/panel/src/components/Layout/Scrollable.vue
@@ -1,7 +1,12 @@
 <template>
-	<div :data-axis="axis" :data-fade="fade" class="k-scrollable">
+	<component
+		:is="element"
+		:data-axis="axis"
+		:data-fade="fade"
+		class="k-scrollable"
+	>
 		<slot />
-	</div>
+	</component>
 </template>
 
 <script>
@@ -26,6 +31,13 @@ export default {
 		axis: {
 			type: String,
 			default: "block"
+		},
+		/**
+		 * The rendered HTML element
+		 */
+		element: {
+			type: String,
+			default: "div"
 		},
 		/**
 		 * Which scrollable edges to fade to hint at hidden content.

--- a/panel/src/components/Layout/Scrollable.vue
+++ b/panel/src/components/Layout/Scrollable.vue
@@ -1,0 +1,120 @@
+<template>
+	<div :data-axis="axis" :data-fade="fade" class="k-scrollable">
+		<slot />
+	</div>
+</template>
+
+<script>
+/**
+ * The `k-scrollable` component is a scroll container
+ * that keeps its content within the available space
+ * and hints at hidden content with a fade on the scrollable
+ * edges. Use it wherever content can grow taller (or wider)
+ * than its container, e.g. inside dialogs, drawers or collections.
+ *
+ * @example
+ * <k-scrollable><!-- long content --></k-scrollable>
+ *
+ * @since 5.6.0
+ */
+export default {
+	props: {
+		/**
+		 * Scroll axis
+		 * @values "block", "inline"
+		 */
+		axis: {
+			type: String,
+			default: "block"
+		},
+		/**
+		 * Which scrollable edges to fade to hint at hidden content.
+		 * @values true, false, "start", "end"
+		 */
+		fade: {
+			type: [Boolean, String],
+			default: true,
+			validator: (value) =>
+				typeof value === "boolean" || ["start", "end"].includes(value)
+		}
+	}
+};
+</script>
+
+<style>
+.k-scrollable {
+	--k-scrollable-fade: var(--spacing-6);
+
+	min-block-size: 0;
+	min-inline-size: 0;
+	overscroll-behavior: contain;
+}
+.k-scrollable[data-axis="block"] {
+	overflow-y: auto;
+}
+.k-scrollable[data-axis="inline"] {
+	overflow-x: auto;
+}
+
+@supports (animation-timeline: scroll()) {
+	@property --k-scrollable-fade-start {
+		syntax: "<length>";
+		inherits: false;
+		initial-value: 0px;
+	}
+	@property --k-scrollable-fade-end {
+		syntax: "<length>";
+		inherits: false;
+		initial-value: 0px;
+	}
+
+	.k-scrollable[data-fade]:not([data-fade="false"]) {
+		--k-scrollable-fade-start-size: var(--k-scrollable-fade);
+		--k-scrollable-fade-end-size: var(--k-scrollable-fade);
+
+		animation: k-scrollable-fade-start, k-scrollable-fade-end;
+		animation-fill-mode: both;
+		animation-range:
+			0 var(--k-scrollable-fade),
+			calc(100% - var(--k-scrollable-fade)) 100%;
+	}
+	/* Only fade a single edge; keep sticky content on the other edge sharp */
+	.k-scrollable[data-fade="start"] {
+		--k-scrollable-fade-end-size: 0px;
+	}
+	.k-scrollable[data-fade="end"] {
+		--k-scrollable-fade-start-size: 0px;
+	}
+	.k-scrollable[data-fade]:not([data-fade="false"])[data-axis="block"] {
+		animation-timeline: scroll(self block);
+		mask-image: linear-gradient(
+			to bottom,
+			transparent,
+			#000 var(--k-scrollable-fade-start),
+			#000 calc(100% - var(--k-scrollable-fade-end)),
+			transparent
+		);
+	}
+	.k-scrollable[data-fade]:not([data-fade="false"])[data-axis="inline"] {
+		animation-timeline: scroll(self inline);
+		mask-image: linear-gradient(
+			to right,
+			transparent,
+			#000 var(--k-scrollable-fade-start),
+			#000 calc(100% - var(--k-scrollable-fade-end)),
+			transparent
+		);
+	}
+
+	@keyframes k-scrollable-fade-start {
+		to {
+			--k-scrollable-fade-start: var(--k-scrollable-fade-start-size);
+		}
+	}
+	@keyframes k-scrollable-fade-end {
+		from {
+			--k-scrollable-fade-end: var(--k-scrollable-fade-end-size);
+		}
+	}
+}
+</style>

--- a/panel/src/components/Layout/index.js
+++ b/panel/src/components/Layout/index.js
@@ -13,6 +13,7 @@ import Header from "./Header.vue";
 import IconFrame from "./Frame/IconFrame.vue";
 import ImageFrame from "./Frame/ImageFrame.vue";
 import Overlay from "./Overlay.vue";
+import Scrollable from "./Scrollable.vue";
 import Stack from "./Stack.vue";
 import Stat from "./Stat.vue";
 import Stats from "./Stats.vue";
@@ -38,6 +39,7 @@ export default {
 		app.component("k-image-frame", ImageFrame);
 		app.component("k-image", ImageFrame);
 		app.component("k-overlay", Overlay);
+		app.component("k-scrollable", Scrollable);
 		app.component("k-stack", Stack);
 		app.component("k-stat", Stat);
 		app.component("k-stats", Stats);

--- a/panel/src/components/Navigation/Browser.vue
+++ b/panel/src/components/Navigation/Browser.vue
@@ -1,5 +1,5 @@
 <template>
-	<nav class="k-browser">
+	<k-scrollable element="nav" class="k-browser">
 		<div class="k-browser-items">
 			<label
 				v-for="item in items"
@@ -23,7 +23,7 @@
 				</span>
 			</label>
 		</div>
-	</nav>
+	</k-scrollable>
 </template>
 
 <script>

--- a/panel/src/components/Navigation/FileBrowser.vue
+++ b/panel/src/components/Navigation/FileBrowser.vue
@@ -4,6 +4,7 @@
 			<aside ref="tree" class="k-file-browser-tree">
 				<k-page-tree
 					:current="page?.value ?? opened"
+					scrollable
 					@select="selectPage"
 					@toggleBranch="togglePage"
 				/>
@@ -22,9 +23,8 @@
 					@select="selectFile"
 				/>
 			</div>
-			<div class="k-file-browser-pagination" @click.stop>
+			<div v-if="hasPagination" class="k-file-browser-pagination" @click.stop>
 				<k-pagination
-					v-if="pagination"
 					v-bind="pagination"
 					:details="true"
 					@paginate="paginate"
@@ -62,6 +62,11 @@ export default {
 			pagination: null,
 			view: this.opened ? "files" : "tree"
 		};
+	},
+	computed: {
+		hasPagination() {
+			return this.pagination?.total > this.pagination?.limit;
+		}
 	},
 	methods: {
 		paginate(pagination) {
@@ -131,17 +136,30 @@ export default {
 	grid-template-areas:
 		"tree items"
 		"tree pagination";
+	max-height: inherit;
+	min-height: 0;
 }
 
 .k-file-browser-tree {
 	grid-area: tree;
+	display: flex;
+	min-height: 0;
 	padding: var(--spacing-2);
 	border-right: 1px solid var(--color-border);
 }
+.k-file-browser-tree > .k-tree {
+	flex: 1;
+}
 .k-file-browser-items {
 	grid-area: items;
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
 	padding: var(--spacing-2);
 	background: var(--file-browser-items-color-back);
+}
+.k-file-browser-items > .k-browser {
+	flex: 1;
 }
 .k-file-browser-back-button {
 	display: none;

--- a/panel/src/components/Navigation/FileBrowser.vue
+++ b/panel/src/components/Navigation/FileBrowser.vue
@@ -4,7 +4,7 @@
 			<aside ref="tree" class="k-file-browser-tree">
 				<k-page-tree
 					:current="page?.value ?? opened"
-					scrollable
+					:scrollable="true"
 					@select="selectPage"
 					@toggleBranch="togglePage"
 				/>

--- a/panel/src/components/Navigation/FileBrowser.vue
+++ b/panel/src/components/Navigation/FileBrowser.vue
@@ -144,22 +144,27 @@ export default {
 	grid-area: tree;
 	display: flex;
 	min-height: 0;
-	padding: var(--spacing-2);
 	border-right: 1px solid var(--color-border);
 }
 .k-file-browser-tree > .k-tree {
 	flex: 1;
 }
+.k-file-browser-tree .k-scrollable {
+	padding: var(--spacing-2);
+}
+
 .k-file-browser-items {
 	grid-area: items;
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
-	padding: var(--spacing-2);
 	background: var(--file-browser-items-color-back);
 }
 .k-file-browser-items > .k-browser {
 	flex: 1;
+}
+.k-file-browser-items > .k-browser {
+	padding: var(--spacing-2);
 }
 .k-file-browser-back-button {
 	display: none;

--- a/panel/src/components/Navigation/Tree.vue
+++ b/panel/src/components/Navigation/Tree.vue
@@ -1,5 +1,7 @@
 <template>
-	<ul
+	<component
+		:is="scrollable ? 'k-scrollable' : 'ul'"
+		v-bind="scrollable ? { element: 'ul' } : {}"
 		:class="['k-tree', $options.name, $attrs.class]"
 		:style="{ '--tree-level': level, ...$attrs.style }"
 	>
@@ -36,6 +38,7 @@
 					v-bind="$props"
 					:items="item.children"
 					:level="level + 1"
+					:scrollable="false"
 					@close="$emit('close', $event)"
 					@open="$emit('open', $event)"
 					@select="$emit('select', $event)"
@@ -43,7 +46,7 @@
 				/>
 			</template>
 		</li>
-	</ul>
+	</component>
 </template>
 
 <script>
@@ -68,6 +71,9 @@ export default {
 		level: {
 			default: 0,
 			type: Number
+		},
+		scrollable: {
+			type: Boolean
 		}
 	},
 	emits: ["close", "open", "select", "toggle"],


### PR DESCRIPTION
## Description

Constrains dialogs to the available viewport height and moves scrolling to their content areas, keeping action buttons visible.

Model picker dialogs now keep the search and actions fixed while only the item list scrolls. Expanded page and file browsers in link fields also scroll independently.

## Changelog

### ✨ Enhancements

- Constrain dialogs and expanded link browsers to the viewport #6012
- Keep model picker actions visible while scrolling the item list #8160


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion