### PR TITLE
fix: handle broken link tag inline instead of error page

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -2,7 +2,6 @@
 
 use Kirby\Cms\Html;
 use Kirby\Cms\Url;
-use Kirby\Exception\NotFoundException;
 use Kirby\Text\KirbyTag;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Escape;
@@ -203,34 +202,46 @@ return [
 			'text',
 		],
 		'html' => function (KirbyTag $tag): string {
+			// keep $tag->value as the original value (e.g. UUID) for errors
+			$link = $tag->value;
+
 			if (empty($tag->lang) === false) {
-				$tag->value = Url::to($tag->value, $tag->lang);
+				$link = Url::to($link, $tag->lang);
 			}
 
 			// if value is a UUID, resolve to page/file model
 			// and use the URL as value
-			if (Uuid::is($tag->value, ['page', 'file']) === true) {
-				$tag->value = Uuid::for($tag->value)?->toUrl();
+			if (Uuid::is($link, ['page', 'file']) === true) {
+				$link = Uuid::for($link)?->toUrl();
 			}
 
-			// if url is empty, throw exception or link to the error page
-			if ($tag->value === null) {
+			// broken link: handle inline instead of turning the
+			// whole page into the error page
+			if ($link === null) {
+				// debug: visible inline error, no styles to avoid clashes
 				if ($tag->kirby()->option('debug', false) === true) {
-					$error = 'The linked page cannot be found';
+					$error = 'The link "' . $tag->value . '" cannot be found';
 
-					if (empty($tag->text) === false) {
+					if ($tag->text !== null && $tag->text !== '') {
 						$error .= ' for the link text "' . $tag->text . '"';
 					}
 
-					throw new NotFoundException(
-						message: $error
-					);
+					return Html::tag('span', '🚨 ' . $error, [
+						'class' => Str::trim('kirby-broken-link ' . $tag->class)
+					]);
 				}
 
-				$tag->value = Url::to($tag->kirby()->site()->errorPageId());
+				// otherwise drop the link, keep its text (if any)
+				if ($tag->text !== null && $tag->text !== '') {
+					return Html::tag('span', $tag->text, [
+						'class' => $tag->class
+					]);
+				}
+
+				return '';
 			}
 
-			return Html::a($tag->value, $tag->text, [
+			return Html::a($link, $tag->text, [
 				'rel'    => $tag->rel,
 				'class'  => $tag->class,
 				'role'   => $tag->role,

--- a/tests/Text/LinkKirbyTagTest.php
+++ b/tests/Text/LinkKirbyTagTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Text;
 
 use Kirby\Cms\App;
-use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 
@@ -104,14 +103,16 @@ class LinkKirbyTagTest extends TestCase
 		$result = $app->kirbytags('(link: page://page-uuid)');
 		$this->assertSame('<a href="https://getkirby.com/a">getkirby.com/a</a>', $result);
 
+		// broken link without text: dropped entirely
 		$result = $app->kirbytags('(link: page://not-exists)');
-		$this->assertSame('<a href="https://getkirby.com/error">getkirby.com/error</a>', $result);
+		$this->assertSame('', $result);
 
 		$result = $app->kirbytags('(link: file://file-uuid text: file)');
 		$this->assertSame('<a href="' . $app->file('a/foo.jpg')->url() . '">file</a>', $result);
 
+		// broken link with text: link dropped, text kept
 		$result = $app->kirbytags('(link: file://not-exists text: file)');
-		$this->assertSame('<a href="https://getkirby.com/error">file</a>', $result);
+		$this->assertSame('<span>file</span>', $result);
 	}
 
 	public function testWithUuidDebug(): void
@@ -139,10 +140,12 @@ class LinkKirbyTagTest extends TestCase
 			]
 		]);
 
-		$this->expectException(NotFoundException::class);
-		$this->expectExceptionMessage('The linked page cannot be found');
+		$result = $app->kirbytags('(link: page://not-exists)');
+		$this->assertSame('<span class="kirby-broken-link">🚨 The link &quot;page://not-exists&quot; cannot be found</span>', $result);
 
-		$app->kirbytags('(link: page://not-exists)');
+		// a custom class is merged with the broken-link class
+		$result = $app->kirbytags('(link: page://not-exists class: my-link)');
+		$this->assertSame('<span class="kirby-broken-link my-link">🚨 The link &quot;page://not-exists&quot; cannot be found</span>', $result);
 	}
 
 	public function testWithUuidDebugText(): void
@@ -170,10 +173,8 @@ class LinkKirbyTagTest extends TestCase
 			]
 		]);
 
-		$this->expectException(NotFoundException::class);
-		$this->expectExceptionMessage('The linked page cannot be found for the link text "click here"');
-
-		$app->kirbytags('(link: page://not-exists text: click here)');
+		$result = $app->kirbytags('(link: page://not-exists text: click here)');
+		$this->assertSame('<span class="kirby-broken-link">🚨 The link &quot;page://not-exists&quot; cannot be found for the link text &quot;click here&quot;</span>', $result);
 	}
 
 	public function testWithUuidAndLang(): void


### PR DESCRIPTION
## Description

A `(link:)` tag with an unresolvable UUID (e.g. deleted page/file) throws a `NotFoundException`, which turns the whole page into the error page. Instead of that drastic exception (added in #6085), we now handle the broken link inline: in debug mode a visible inline error (prefixed with an emoji and a `kirby-broken-link` class so it can be targeted via CSS, but without any inline styles that could clash with the site), and in production the link is simply dropped (keeping its text). `App::io()` and #6553/#6466 stay untouched.

### Debug on

```
(link: page://deleted-page)
→ <span class="kirby-broken-link">🚨 The link "page://deleted-page" cannot be found</span>

(link: page://deleted-page text: click here)
→ <span class="kirby-broken-link">🚨 The link "page://deleted-page" cannot be found for the link text "click here"</span>
```

### Debug off

```
(link: file://deleted-file text: file)  → <span>file</span>
(link: page://deleted-page)             → (nothing)
```

## Changelog 


### ✨ Enhancements
- A broken `(link:)` tag no longer turns the whole page into the error page #7426


## Docs

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion