### PR TITLE
feat: IP rate limiting for identity-unknown auth

### DIFF
--- a/src/Auth/Limits.php
+++ b/src/Auth/Limits.php
@@ -51,7 +51,7 @@ class Limits
 		);
 	}
 
-	public function ensure(string $email): void
+	public function ensure(string|null $email = null): void
 	{
 		if ($this->isBlocked($email) === true) {
 			$this->kirby->trigger('user.login:failed', ['email' => $email]);
@@ -64,7 +64,13 @@ class Limits
 		return $this->kirby->root('accounts') . '/.logins';
 	}
 
-	public function isBlocked(string $email): bool
+	/**
+	 * Checks whether the current visitor's IP or the given email
+	 * has exceeded the allowed number of trials. The email is
+	 * optional so that identity-unknown flows (e.g. passwordless
+	 * passkey login) can still enforce the IP-based limit.
+	 */
+	public function isBlocked(string|null $email = null): bool
 	{
 		$log    = $this->log();
 		$ip     = $this->kirby->visitor()->ip(hash: true);
@@ -77,7 +83,10 @@ class Limits
 		// check the email-based rate limit without a prior
 		// user lookup so that the timing difference of the lookup
 		// does not leak whether an email address actually exists
-		if (($log['by-email'][$email]['trials'] ?? 0) >= $trials) {
+		if (
+			$email !== null &&
+			($log['by-email'][$email]['trials'] ?? 0) >= $trials
+		) {
 			return true;
 		}
 

--- a/src/Auth/Methods.php
+++ b/src/Auth/Methods.php
@@ -49,6 +49,11 @@ class Methods
 			);
 		}
 
+		// Reject blocked IPs before running any method.
+		// This covers the pre-identification phase of passwordless
+		// methods (e.g. passkeys, where no email is known upfront).
+		$this->auth->limits()->ensure();
+
 		return $this->get($type)->authenticate($email, $password, $long);
 	}
 

--- a/tests/Auth/LimitsTest.php
+++ b/tests/Auth/LimitsTest.php
@@ -64,12 +64,56 @@ class LimitsTest extends TestCase
 			static::TMP . '/site/accounts/.logins'
 		);
 
-		// IP 10.1 (87084f, 9 trials) and marge are both below
+		// IP 10.1 (9 trials) and marge are both below
 		// the limit, so ensure() must not throw or fire the hook
 		$this->app->visitor()->ip('10.1.123.234');
 		$this->limits->ensure('marge@simpsons.com');
 
 		$this->assertNull($this->failedEmail);
+	}
+
+	public function testEnsureWithoutEmail(): void
+	{
+		copy(
+			static::FIXTURES . '/logins.json',
+			static::TMP . '/site/accounts/.logins'
+		);
+
+		// IP 10.2 (10 trials) is blocked at the IP level,
+		// so ensure() throttles even without a known identity
+		$this->app->visitor()->ip('10.2.123.234');
+
+		// prime to prove the hook actually fires
+		$this->failedEmail = 'foo';
+
+		try {
+			$this->limits->ensure();
+			$this->fail('Expected a RateLimitException');
+		} catch (RateLimitException) {
+			// expected
+		}
+
+		// the user.login:failed hook fires with a null email
+		// because no identity is known in a passwordless flow
+		$this->assertNull($this->failedEmail);
+	}
+
+	public function testEnsureWithoutEmailPasses(): void
+	{
+		copy(
+			static::FIXTURES . '/logins.json',
+			static::TMP . '/site/accounts/.logins'
+		);
+
+		// IP 10.1 (9 trials) is below the limit and no email
+		// is given, so there is nothing that could trip the limiter
+		$this->app->visitor()->ip('10.1.123.234');
+
+		$this->failedEmail = 'foz';
+		$this->limits->ensure();
+
+		// the hook must not fire, so the sentinel survives
+		$this->assertSame('foz', $this->failedEmail);
 	}
 
 	public function testFile(): void
@@ -125,7 +169,7 @@ class LimitsTest extends TestCase
 
 	public function testIsBlockedByEmailForUnknownUser(): void
 	{
-		// IP 10.1 (87084f) is not present, so the only possible
+		// IP 10.1 is not present, so the only possible
 		// block comes from the email-based limit
 		file_put_contents($this->limits->file(), json_encode([
 			'by-ip' => [],
@@ -142,6 +186,23 @@ class LimitsTest extends TestCase
 		// ghost is not a registered user, but the email-based limit
 		// still applies because isBlocked() does no user lookup
 		$this->assertTrue($this->limits->isBlocked('ghost@simpsons.com'));
+	}
+
+	public function testIsBlockedWithoutEmail(): void
+	{
+		copy(
+			static::FIXTURES . '/logins.json',
+			static::TMP . '/site/accounts/.logins'
+		);
+
+		// IP 10.1 (9 trials) is below the limit; with no
+		// email the email branch is skipped without a lookup
+		$this->app->visitor()->ip('10.1.123.234');
+		$this->assertFalse($this->limits->isBlocked());
+
+		// IP 10.2 (10 trials) is blocked at the IP level
+		$this->app->visitor()->ip('10.2.123.234');
+		$this->assertTrue($this->limits->isBlocked());
 	}
 
 	public function testLog(): void

--- a/tests/Auth/MethodsTest.php
+++ b/tests/Auth/MethodsTest.php
@@ -2,11 +2,13 @@
 
 namespace Kirby\Auth;
 
+use Kirby\Auth\Exception\RateLimitException;
 use Kirby\Auth\Method\CodeMethod;
 use Kirby\Auth\Method\PasswordMethod;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
+use Kirby\Filesystem\Dir;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(Methods::class)]
@@ -62,6 +64,39 @@ class MethodsTest extends TestCase
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Auth method "foo" is not enabled');
 		$methods->authenticate('foo', 'marge@simpsons.com', 'secret123');
+	}
+
+	public function testAuthenticateBlockedIp(): void
+	{
+		$accounts = static::TMP . '/site/accounts';
+		Dir::make($accounts);
+		copy(static::FIXTURES . '/logins.json', $accounts . '/.logins');
+
+		// IP 10.2 (38f0a0, 10 trials) is blocked at the IP level, so the
+		// backstop rejects even a valid password before the method runs
+		$this->app->visitor()->ip('10.2.123.234');
+
+		$methods = $this->app->auth()->methods();
+
+		$this->expectException(RateLimitException::class);
+		$methods->authenticate('password', 'marge@simpsons.com', 'secret123');
+	}
+
+	public function testAuthenticateNotBlockedBelowLimit(): void
+	{
+		$accounts = static::TMP . '/site/accounts';
+		Dir::make($accounts);
+		copy(static::FIXTURES . '/logins.json', $accounts . '/.logins');
+
+		// IP 10.1 (87084f, 9 trials) is below the limit, so the backstop
+		// lets the attempt through and authentication still succeeds
+		$this->app->visitor()->ip('10.1.123.234');
+
+		$methods = $this->app->auth()->methods();
+		$result  = $methods->authenticate('password', 'marge@simpsons.com', 'secret123');
+
+		$this->assertInstanceOf(User::class, $result);
+		$this->assertSame('marge', $result->id());
 	}
 
 	public function testConfigDefaults(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Especially for indentity/email-less auth methods (e.g. passkeys), we still want to rate limit requests at least by IP if we cannot do it at that early stage by email yet. This PR allows to run `$auth->limits()->ensure()` without an email address and runs it like that for any `Methods::authenticate()` as pre-check (so even earlier than `::validatePassword()` - which also will not necessarily will be called by all auth methods, e.g. passkeys).