### PR TITLE
feat: `Auth::guard()` rate-limit helper

### DIFF
--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Auth;
 
+use Closure;
 use Kirby\Auth\Exception\ChallengeTimeoutException;
 use Kirby\Auth\Exception\LoginNotPermittedException;
 use Kirby\Auth\Exception\RateLimitException;
@@ -232,6 +233,51 @@ class Auth
 	{
 		$this->user->flush();
 		$this->status = null;
+	}
+
+	/**
+	 * Runs some auth attempt inside the shared rate-limit envelope:
+	 * enforces the limit up front and, on any failure, tracks the
+	 * attempt, adds timing jitter and hides the real reason behind a
+	 * generic fallback error.
+	 *
+	 * @since 6.0.0
+	 * @internal
+	 *
+	 * @throws \Throwable Fallback or the original error in debug mode
+	 */
+	public function guard(
+		string|null $email,
+		Closure $attempt,
+		Throwable|null $fallback = null
+	): mixed {
+		try {
+			$this->limits->ensure($email);
+			return $attempt();
+
+		} catch (Throwable $e) {
+			// a hit that already is the rate limit was tracked
+			// when the limit fired, so don't count it twice here
+			if ($e instanceof RateLimitException === false) {
+				try {
+					$this->limits->track($email);
+				} catch (Throwable $tracked) {
+					// keep the tracking error (e.g. limit exceeded)
+					$e = $tracked;
+				}
+			}
+
+			// sleep for a random amount of milliseconds to make
+			// automated attacks harder and to avoid leaking whether
+			// the email/user exists
+			usleep(random_int(10000, 2000000));
+
+			// keep throwing the original error in debug mode,
+			// otherwise hide it to avoid leaking security-relevant info
+			$this->fail($e, $fallback);
+
+			return null;
+		}
 	}
 
 	/**
@@ -513,51 +559,31 @@ class Auth
 	): User|null {
 		$email = Idn::decodeEmail($email);
 
-		try {
-			$this->limits->ensure($email);
-			$user = $this->kirby->users()->find($email);
+		return $this->guard(
+			email:    $email,
+			attempt: function () use ($email, $password) {
+				$user = $this->kirby->users()->find($email);
 
-			// validate the user and its password
-			if (
-				$user instanceof User &&
-				$user->validatePassword($password) === true
-			) {
-				return $user;
-			}
-
-			// run a dummy password_verify() when the user is not found so
-			// that the timing is indistinguishable from a regular failure;
-			// without this, the absence of a bcrypt computation
-			// could leak whether the email address is registered
-			if ($user instanceof User === false) {
-				password_verify($password, '$2y$10$EixZaYVK1fsbw1ZfbX3OXePaWxn96p36WQoeG6Lruj3vjPGga31lW');
-			}
-
-			throw new UserNotFoundException($email);
-
-		} catch (Throwable $e) {
-			$error = $e;
-
-			// log invalid login trial unless the rate limit is already active
-			if ($error instanceof RateLimitException === false) {
-				try {
-					$this->limits->track($email);
-				} catch (Throwable $e) {
-					// $error is overwritten with the exception
-					// from the track method if there's one
-					$error = $e;
+				// validate the user and its password
+				if (
+					$user instanceof User &&
+					$user->validatePassword($password) === true
+				) {
+					return $user;
 				}
-			}
 
-			// sleep for a random amount of milliseconds
-			// to make automated attacks harder
-			usleep(random_int(10000, 2000000));
+				// run a dummy password_verify() when the user is not found
+				// so that the timing is indistinguishable from a regular
+				// failure; without this, the absence of a bcrypt computation
+				// could leak whether the email address is registered
+				if ($user instanceof User === false) {
+					password_verify($password, '$2y$10$EixZaYVK1fsbw1ZfbX3OXePaWxn96p36WQoeG6Lruj3vjPGga31lW');
+				}
 
-			// keep throwing the original error in debug mode,
-			// otherwise hide it to avoid leaking security-relevant information
-			$this->fail($error, new LoginNotPermittedException());
-			return null;
-		}
+				throw new UserNotFoundException($email);
+			},
+			fallback: new LoginNotPermittedException()
+		);
 	}
 
 	/**
@@ -582,46 +608,36 @@ class Auth
 		$session = $this->kirby->session();
 		$email   = $session->get('kirby.challenge.email');
 
-		try {
-			$challenge = $this->challenges->verify($session, $input);
-			$user      = $challenge->user();
+		return $this->guard(
+			email:   $email,
+			attempt: function () use ($session, $input) {
+				try {
+					$challenge = $this->challenges->verify($session, $input);
 
-			$this->logout();
-			$user->loginPasswordless();
+				} catch (ChallengeTimeoutException $e) {
+					// a timed-out challenge already cleared its own session
+					// state; additionally drop any active login so the
+					// pending session cannot be reused
+					$this->logout();
+					throw $e;
+				}
 
-			// allow the user to set a new password
-			// without knowing the previous one
-			if ($challenge->mode() === 'password-reset') {
-				$session->set('kirby.resetPassword', true);
-			}
+				$user = $challenge->user();
 
-			$this->setUser($user);
-			return $user;
-
-		} catch (Throwable $e) {
-			if ($e instanceof ChallengeTimeoutException) {
 				$this->logout();
-			}
+				$user->loginPasswordless();
 
-			// hook was already fired for RateLimitException
-			if (
-				empty($email) === false &&
-				$e instanceof RateLimitException === false
-			) {
-				$this->limits->track($email);
-			}
+				// allow the user to set a new password
+				// without knowing the previous one
+				if ($challenge->mode() === 'password-reset') {
+					$session->set('kirby.resetPassword', true);
+				}
 
-			// sleep for a random amount of milliseconds
-			// to make automated attacks harder and to
-			// avoid leaking whether the user exists
-			usleep(random_int(10000, 2000000));
+				$this->setUser($user);
 
-			$fallback = new PermissionException(key: 'access.code');
-
-			// keep throwing the original error in debug mode,
-			// otherwise hide it to avoid leaking security-relevant information
-			$this->fail($e, $fallback);
-			return null;
-		}
+				return $user;
+			},
+			fallback: new PermissionException(key: 'access.code')
+		);
 	}
 }

--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -10,6 +10,7 @@ use Kirby\Auth\Method\BasicAuthMethod;
 use Kirby\Auth\User as AuthUser;
 use Kirby\Cms\App;
 use Kirby\Cms\User;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\PermissionException;
 use Kirby\Exception\UserNotFoundException;
 use Kirby\Http\Idn;
@@ -607,6 +608,23 @@ class Auth
 	): User|null {
 		$session = $this->kirby->session();
 		$email   = $session->get('kirby.challenge.email');
+
+		// `::guard()` tracks every non-rate-limit failure as an attempt.
+		// This method can be reached with a missing/expired challenge
+		// in the session. In that case, unlike `::login()`, there is
+		// nothing to really attempt at all here. Reject it, so that
+		// this will not consume the rate-limit budget
+		if (
+			is_string($email) !== true ||
+			is_string($session->get('kirby.challenge.type')) !== true
+		) {
+			$this->fail(
+				new InvalidArgumentException(
+					message: 'No authentication challenge is active'
+				),
+				 new PermissionException(key: 'access.code')
+			);
+		}
 
 		return $this->guard(
 			email:   $email,

--- a/tests/Auth/AuthChallengeTest.php
+++ b/tests/Auth/AuthChallengeTest.php
@@ -166,6 +166,27 @@ class AuthChallengeTest extends TestCase
 		$this->assertSame('marge', $data['kirby.userId'] ?? null);
 	}
 
+	public function testVerifyChallengePasswordReset(): void
+	{
+		$session = $this->app->session();
+
+		$session->set('kirby.challenge.email', 'marge@simpsons.com');
+		$session->set('kirby.challenge.data', ['secret' => self::$password]);
+		$session->set('kirby.challenge.mode', 'password-reset');
+		$session->set('kirby.challenge.type', 'email');
+		$session->set('kirby.challenge.timeout', time() + 60);
+
+		$this->assertSame(
+			$this->app->user('marge@simpsons.com'),
+			$this->auth->verifyChallenge('12345678')
+		);
+
+		// a password-reset challenge flags the session so the user
+		// may set a new password without knowing the previous one
+		$data = $session->data()->get();
+		$this->assertTrue($data['kirby.resetPassword'] ?? false);
+	}
+
 	public function testVerifyChallengeNoChallenge(): void
 	{
 		$this->expectException(InvalidArgumentException::class);

--- a/tests/Auth/AuthChallengeTest.php
+++ b/tests/Auth/AuthChallengeTest.php
@@ -193,6 +193,34 @@ class AuthChallengeTest extends TestCase
 		$this->auth->verifyChallenge('123456');
 	}
 
+	public function testVerifyChallengeNoChallengeDoesNotTrack(): void
+	{
+		// a code submission without an active challenge is not an
+		// authentication attempt: it must neither consume the IP
+		// rate-limit budget nor fire the user.login:failed hook
+		F::remove(static::TMP . '/site/accounts/.logins');
+
+		$count = 0;
+
+		$this->app = $this->app->clone([
+			'hooks' => [
+				'user.login:failed' => function () use (&$count) {
+					$count++;
+				}
+			]
+		]);
+		$this->auth = $this->app->auth();
+
+		try {
+			$this->auth->verifyChallenge('123456');
+			$this->fail('The challenge verification should have failed');
+		} catch (InvalidArgumentException) {
+			$this->assertSame(0, $count);
+			$this->assertSame([], $this->auth->limits()->log()['by-ip']);
+			$this->assertFileDoesNotExist(static::TMP . '/site/accounts/.logins');
+		}
+	}
+
 	public function testVerifyChallengeRateLimited(): void
 	{
 		$session = $this->app->session();

--- a/tests/Auth/AuthTest.php
+++ b/tests/Auth/AuthTest.php
@@ -2,7 +2,7 @@
 
 namespace Kirby\Auth;
 
-use Kirby\Auth\Exception\RateLimitException;
+use Exception;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\PermissionException;
@@ -162,6 +162,214 @@ class AuthTest extends TestCase
 		$auth = new BasicAuth($data);
 		$user = $this->auth->currentUserFromBasicAuth($auth);
 		$this->assertSame('marge@simpsons.com', $user->email());
+	}
+
+	public function testGuard(): void
+	{
+		// a successful attempt returns its result untouched
+		// and records no failure
+		$result = $this->auth->guard(
+			'marge@simpsons.com',
+			fn () => 'success'
+		);
+
+		$this->assertSame('success', $result);
+		$this->assertNull($this->failedEmail);
+		$this->assertFileDoesNotExist(static::TMP . '/site/accounts/.logins');
+	}
+
+	public function testGuardEnforcesRateLimit(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'auth' => ['debug' => false]
+			]
+		]);
+		$this->auth = $this->app->auth();
+
+		copy(
+			static::FIXTURES . '/logins.json',
+			static::TMP . '/site/accounts/.logins'
+		);
+
+		// IP 10.2 (10 trials) is already blocked
+		$this->app->visitor()->ip('10.2.123.234');
+
+		$ran    = false;
+		$thrown = false;
+
+		try {
+			$this->auth->guard(
+				'marge@simpsons.com',
+				function () use (&$ran) {
+					$ran = true;
+					return 'should never run';
+				},
+				new PermissionException(message: 'hidden fallback')
+			);
+
+		} catch (PermissionException $e) {
+			$this->assertSame('hidden fallback', $e->getMessage());
+			$thrown = true;
+		}
+
+		$this->assertTrue($thrown);
+
+		// the attempt is short-circuited before it can run
+		$this->assertFalse($ran);
+
+		// the pre-existing rate-limit hit is not tracked twice
+		$log = $this->auth->limits()->log();
+		$this->assertSame(10, $log['by-ip']['38f0a08519792a17e18a251008f3a116977907f921b0b287c8']['trials']);
+	}
+
+	public function testGuardKeepsTrackingError(): void
+	{
+		// if tracking the failed attempt fails itself (here via a
+		// throwing user.login:failed hook) `::guard()` surfaces that
+		// tracking error instead of the original failure
+		$this->app = $this->app->clone([
+			'hooks' => [
+				'user.login:failed' => function () {
+					throw new Exception('tracking failed');
+				}
+			]
+		]);
+		$this->auth = $this->app->auth();
+
+		$this->app->visitor()->ip('10.3.123.234');
+
+		// debug mode (default) rethrows whatever error guard keeps
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage('tracking failed');
+
+		$this->auth->guard(
+			'marge@simpsons.com',
+			fn () => throw new InvalidArgumentException(message: 'real reason')
+		);
+	}
+
+	public function testGuardRethrowsInDebugMode(): void
+	{
+		// auth.debug defaults to true in the test setup, so the
+		// real error is surfaced instead of the generic fallback
+		$this->app->visitor()->ip('10.3.123.234');
+
+		$thrown = false;
+
+		try {
+			$this->auth->guard(
+				'marge@simpsons.com',
+				fn () => throw new InvalidArgumentException(message: 'real reason'),
+				new PermissionException(message: 'hidden fallback')
+			);
+		} catch (InvalidArgumentException $e) {
+			$this->assertSame('real reason', $e->getMessage());
+			$thrown = true;
+		}
+
+		$this->assertTrue($thrown);
+	}
+
+	public function testGuardReturnsNullWithoutFallback(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'auth' => ['debug' => false]
+			]
+		]);
+		$this->auth = $this->app->auth();
+
+		$this->app->visitor()->ip('10.3.123.234');
+
+		// without a fallback the hidden failure is swallowed
+		// and guard() resolves to null
+		$result = $this->auth->guard(
+			'marge@simpsons.com',
+			fn () => throw new InvalidArgumentException(message: 'real reason')
+		);
+
+		$this->assertNull($result);
+
+		// the failed attempt is still tracked
+		$this->assertSame('marge@simpsons.com', $this->failedEmail);
+	}
+
+	public function testGuardTracksAndHidesFailure(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'auth' => ['debug' => false]
+			]
+		]);
+		$this->auth = $this->app->auth();
+
+		$this->app->visitor()->ip('10.3.123.234');
+
+		$thrown = false;
+
+		try {
+			$this->auth->guard(
+				'marge@simpsons.com',
+				fn () => throw new InvalidArgumentException(message: 'real reason'),
+				new PermissionException(message: 'hidden fallback')
+			);
+		} catch (PermissionException $e) {
+			// the real reason is hidden behind the generic fallback
+			$this->assertSame('hidden fallback', $e->getMessage());
+			$thrown = true;
+		}
+
+		$this->assertTrue($thrown);
+
+		// the failed attempt is tracked by IP and email
+		// and the user.login:failed hook has fired
+		$log = $this->auth->limits()->log();
+		$this->assertSame(1, $log['by-ip']['85a06e36d926cb901f05d1167913ebd7ec3d8f5bce4551f5da']['trials']);
+		$this->assertSame(1, $log['by-email']['marge@simpsons.com']['trials']);
+		$this->assertSame('marge@simpsons.com', $this->failedEmail);
+	}
+
+	public function testGuardWithoutEmail(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'auth' => ['debug' => false]
+			]
+		]);
+		$this->auth = $this->app->auth();
+
+		copy(
+			static::FIXTURES . '/logins.json',
+			static::TMP . '/site/accounts/.logins'
+		);
+
+		// IP 10.2 (10 trials) is blocked, so an
+		// identity-unknown attempt is throttled by IP alone
+		$this->app->visitor()->ip('10.2.123.234');
+
+		// prime to prove the hook fires with a null email
+		$this->failedEmail = 'foo';
+
+		$ran    = false;
+		$thrown = false;
+
+		try {
+			$this->auth->guard(
+				null,
+				function () use (&$ran) {
+					$ran = true;
+					return 'should never run';
+				},
+				new PermissionException(message: 'hidden fallback')
+			);
+		} catch (PermissionException) {
+			$thrown = true;
+		}
+
+		$this->assertTrue($thrown);
+		$this->assertFalse($ran);
+		$this->assertNull($this->failedEmail);
 	}
 
 	public function testImpersonate(): void
@@ -451,49 +659,37 @@ class AuthTest extends TestCase
 		$this->assertNull($this->failedEmail);
 	}
 
-	public function testValidatePasswordInvalidUser(): void
-	{
-		$this->app = $this->app->clone([
-			'options' => [
-				'auth' => ['debug' => false]
-			]
-		]);
-		$this->auth = $this->app->auth();
-
-		copy(
-			static::FIXTURES . '/logins.json',
-			static::TMP . '/site/accounts/.logins'
-		);
-
-		$this->app->visitor()->ip('10.3.123.234');
-
-		$thrown = false;
-
-		try {
-			$this->auth->validatePassword('invalid@example.com', 'springfield123');
-		} catch (PermissionException $e) {
-			$this->assertSame('Invalid login', $e->getMessage());
-			$thrown = true;
-		}
-
-		$this->assertTrue($thrown);
-		$this->assertSame(1, $this->auth->limits()->log()['by-ip']['85a06e36d926cb901f05d1167913ebd7ec3d8f5bce4551f5da']['trials']);
-		$this->assertSame('invalid@example.com', $this->failedEmail);
-	}
-
 	public function testValidatePasswordInvalidPassword(): void
 	{
+		$this->app->visitor()->ip('10.3.123.234');
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Wrong password');
+
+		$this->auth->validatePassword('marge@simpsons.com', 'invalid-password');
+	}
+
+	public function testValidatePasswordInvalidUser(): void
+	{
+		$this->app->visitor()->ip('10.3.123.234');
+
+		$this->expectException(UserNotFoundException::class);
+		$this->expectExceptionMessage('The user "lisa@simpsons.com" cannot be found');
+
+		$this->auth->validatePassword('lisa@simpsons.com', 'springfield123');
+	}
+
+	public function testValidatePasswordIsGuarded(): void
+	{
+		// validatePassword() routes failures through Auth::guard(),
+		// so in production the real error is hidden and the attempt
+		// is tracked
 		$this->app = $this->app->clone([
 			'options' => [
 				'auth' => ['debug' => false]
 			]
 		]);
 		$this->auth = $this->app->auth();
-
-		copy(
-			static::FIXTURES . '/logins.json',
-			static::TMP . '/site/accounts/.logins'
-		);
 
 		$this->app->visitor()->ip('10.3.123.234');
 
@@ -507,106 +703,8 @@ class AuthTest extends TestCase
 		}
 
 		$this->assertTrue($thrown);
-		$this->assertSame(1, $this->auth->limits()->log()['by-ip']['85a06e36d926cb901f05d1167913ebd7ec3d8f5bce4551f5da']['trials']);
 		$this->assertSame(1, $this->auth->limits()->log()['by-email']['marge@simpsons.com']['trials']);
 		$this->assertSame('marge@simpsons.com', $this->failedEmail);
-	}
-
-	public function testValidatePasswordBlocked(): void
-	{
-		$this->app = $this->app->clone([
-			'options' => [
-				'auth' => ['debug' => false]
-			]
-		]);
-		$this->auth = $this->app->auth();
-
-		copy(
-			static::FIXTURES . '/logins.json',
-			static::TMP . '/site/accounts/.logins'
-		);
-
-		$this->app->visitor()->ip('10.2.123.234');
-
-		$thrown = false;
-
-		try {
-			$this->auth->validatePassword('marge@simpsons.com', 'springfield123');
-		} catch (PermissionException $e) {
-			$this->assertSame('Invalid login', $e->getMessage());
-			$thrown = true;
-		}
-
-		$this->assertTrue($thrown);
-		$this->assertSame('marge@simpsons.com', $this->failedEmail);
-	}
-
-	public function testValidatePasswordDebugInvalidUser(): void
-	{
-		copy(
-			static::FIXTURES . '/logins.json',
-			static::TMP . '/site/accounts/.logins'
-		);
-
-		$this->app->visitor()->ip('10.3.123.234');
-
-		$thrown = false;
-
-		try {
-			$this->auth->validatePassword('lisa@simpsons.com', 'springfield123');
-		} catch (UserNotFoundException $e) {
-			$this->assertSame('The user "lisa@simpsons.com" cannot be found', $e->getMessage());
-			$thrown = true;
-		}
-
-		$this->assertTrue($thrown);
-		$this->assertSame(1, $this->auth->limits()->log()['by-ip']['85a06e36d926cb901f05d1167913ebd7ec3d8f5bce4551f5da']['trials']);
-		$this->assertSame('lisa@simpsons.com', $this->failedEmail);
-	}
-
-	public function testValidatePasswordDebugInvalidPassword(): void
-	{
-		copy(
-			static::FIXTURES . '/logins.json',
-			static::TMP . '/site/accounts/.logins'
-		);
-
-		$this->app->visitor()->ip('10.3.123.234');
-
-		$thrown = false;
-
-		try {
-			$this->auth->validatePassword('marge@simpsons.com', 'invalid-password');
-		} catch (InvalidArgumentException $e) {
-			$this->assertSame('Wrong password', $e->getMessage());
-			$thrown = true;
-		}
-
-		$this->assertTrue($thrown);
-		$this->assertSame(1, $this->auth->limits()->log()['by-ip']['85a06e36d926cb901f05d1167913ebd7ec3d8f5bce4551f5da']['trials']);
-		$this->assertSame(1, $this->auth->limits()->log()['by-email']['marge@simpsons.com']['trials']);
-		$this->assertSame('marge@simpsons.com', $this->failedEmail);
-	}
-
-	public function testValidatePasswordDebugBlocked(): void
-	{
-		copy(
-			static::FIXTURES . '/logins.json',
-			static::TMP . '/site/accounts/.logins'
-		);
-
-		$this->app->visitor()->ip('10.2.123.234');
-
-		$thrown = false;
-
-		try {
-			$this->auth->validatePassword('homer@simpsons.com', 'springfield123');
-		} catch (RateLimitException $e) {
-			$thrown = true;
-		}
-
-		$this->assertTrue($thrown);
-		$this->assertSame('homer@simpsons.com', $this->failedEmail);
 	}
 
 	public function testValidatePasswordWithUnicodeEmail(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

### Merge first

- [x] https://github.com/getkirby/kirby/pull/8259

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- New `Kirby\Auth\Auth::guard()` helper to wrap an auth attempt with rate-limiting and error handling


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion