### PR TITLE
feat: Clear single-use challenge nonce on failure

### DIFF
--- a/src/Auth/Challenge.php
+++ b/src/Auth/Challenge.php
@@ -80,6 +80,15 @@ abstract class Challenge
 	}
 
 	/**
+	 * Whether the challenge relies on a single-use nonce
+	 * that must be invalidated after every verification attempt
+	 */
+	public function isSingleUse(): bool
+	{
+		return false;
+	}
+
+	/**
 	 * Returns the purpose of the challenge
 	 * @return 'login'|'password-reset'|'2fa'
 	 */

--- a/src/Auth/Challenges.php
+++ b/src/Auth/Challenges.php
@@ -13,6 +13,7 @@ use Kirby\Exception\UserNotFoundException;
 use Kirby\Session\Session;
 use Kirby\Toolkit\A;
 use SensitiveParameter;
+use Throwable;
 
 /**
  * Handler for all auth challenges
@@ -287,7 +288,6 @@ class Challenges
 			throw new UserNotFoundException(name: $email);
 		}
 
-		// rate-limiting
 		$this->auth->limits()->ensure($email);
 
 		$type      = $session->get('kirby.challenge.type');
@@ -296,8 +296,18 @@ class Challenges
 		$data      = Pending::from($data ?? []);
 		$challenge = $this->get($type, $user, $mode, $timeout);
 
-		if ($challenge->verify($input, $data) !== true) {
-			throw new PermissionException(key: 'access.code');
+		try {
+			if ($challenge->verify($input, $data) !== true) {
+				throw new PermissionException(key: 'access.code');
+			}
+		} catch (Throwable $e) {
+			// a single-use challenge signs a one-time
+			// nonce that must not survive a failed attempt
+			if ($challenge->isSingleUse() === true) {
+				$this->clear($session);
+			}
+
+			throw $e;
 		}
 
 		return $challenge;

--- a/tests/Auth/Challenge/EmailChallengeTest.php
+++ b/tests/Auth/Challenge/EmailChallengeTest.php
@@ -211,6 +211,12 @@ class EmailChallengeTest extends TestCase
 		$this->assertTrue(EmailChallenge::isEnabled($this->app->auth()));
 	}
 
+	public function testIsSingleUse(): void
+	{
+		$challenge = new EmailChallenge($this->user, 'login', 600);
+		$this->assertFalse($challenge->isSingleUse());
+	}
+
 	public function testMode(): void
 	{
 		$challenge = new EmailChallenge($this->user, 'password-reset', 900);

--- a/tests/Auth/Challenge/TotpChallengeTest.php
+++ b/tests/Auth/Challenge/TotpChallengeTest.php
@@ -72,6 +72,12 @@ class TotpChallengeTest extends TestCase
 		$this->assertFalse(TotpChallenge::isAvailable($this->user, 'login'));
 	}
 
+	public function testIsSingleUse(): void
+	{
+		$challenge = new TotpChallenge($this->user, 'login', 600);
+		$this->assertFalse($challenge->isSingleUse());
+	}
+
 	public function testMode(): void
 	{
 		$challenge = new TotpChallenge($this->user, '2fa', 300);

--- a/tests/Auth/ChallengesTest.php
+++ b/tests/Auth/ChallengesTest.php
@@ -18,6 +18,7 @@ class DummyChallenge extends Challenge
 {
 	public static bool $available = true;
 	public static bool $enabled = true;
+	public static bool $singleUse = false;
 	public static array $created  = [];
 	public static array $verified = [];
 	public static Pending|null $pending = null;
@@ -25,6 +26,11 @@ class DummyChallenge extends Challenge
 	public static function isEnabled(Auth $auth): bool
 	{
 		return static::$enabled;
+	}
+
+	public function isSingleUse(): bool
+	{
+		return static::$singleUse;
 	}
 
 	public function create(): Pending|null
@@ -83,6 +89,7 @@ class ChallengesTest extends TestCase
 
 		DummyChallenge::$available  = true;
 		DummyChallenge::$enabled    = true;
+		DummyChallenge::$singleUse  = false;
 		DummyChallenge::$created    = [];
 		DummyChallenge::$verified   = [];
 		DummyChallenge::$pending    = null;
@@ -380,6 +387,53 @@ class ChallengesTest extends TestCase
 		$this->expectException(PermissionException::class);
 
 		$this->challenges->verify($session, 'nope');
+	}
+
+	public function testVerifyInvalidClearsSingleUseChallenge(): void
+	{
+		DummyChallenge::$singleUse = true;
+
+		$session = $this->session();
+		$session->set('kirby.challenge.type', 'dummy');
+		$session->set('kirby.challenge.email', 'marge@simpsons.com');
+		$session->set('kirby.challenge.mode', 'login');
+		$session->set('kirby.challenge.timeout', time() + 1000);
+		$session->set('kirby.challenge.data', ['public' => 'x', 'secret' => 'secret']);
+
+		try {
+			$this->challenges->verify($session, 'nope');
+			$this->fail('Expected PermissionException');
+		} catch (PermissionException) {
+			// expected
+		}
+
+		// the data for a single-use challenge must
+		// not survive a failed attempt
+		$this->assertNull($session->get('kirby.challenge.type'));
+		$this->assertNull($session->get('kirby.challenge.email'));
+		$this->assertNull($session->get('kirby.challenge.data'));
+	}
+
+	public function testVerifyInvalidKeepsReusableChallenge(): void
+	{
+		$session = $this->session();
+		$session->set('kirby.challenge.type', 'dummy');
+		$session->set('kirby.challenge.email', 'marge@simpsons.com');
+		$session->set('kirby.challenge.mode', 'login');
+		$session->set('kirby.challenge.timeout', time() + 1000);
+		$session->set('kirby.challenge.data', ['public' => 'x', 'secret' => 'secret']);
+
+		try {
+			$this->challenges->verify($session, 'nope');
+			$this->fail('Expected PermissionException');
+		} catch (PermissionException) {
+			// expected
+		}
+
+		// code-based challenges (not single-use) stay valid
+		// so the user can retry a mistyped code
+		$this->assertSame('dummy', $session->get('kirby.challenge.type'));
+		$this->assertSame(['public' => 'x', 'secret' => 'secret'], $session->get('kirby.challenge.data'));
 	}
 
 	public function testVerifyTimeout(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

New `Challenge::isSingleUse()` that regulates whether a challenge can be retried after a failed verification (Yes for code based challenges, but e.g. passkeys should be single use). If single use, we wipe the auth session data for the challenge after a failed attempt.