### PR TITLE
fix: Restore block navigation in the panel

### DIFF
--- a/panel/src/helpers/history.test.ts
+++ b/panel/src/helpers/history.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { isReactive, reactive, watch } from "vue";
 import History from "./history";
 
 describe("History", () => {
@@ -35,6 +36,27 @@ describe("History", () => {
 			const history = new History();
 
 			expect(() => history.add({ id: "" })).toThrow("The state needs an ID");
+		});
+
+		it("should reactively replace the last item", () => {
+			// when nested in a reactive object, replacing a milestone
+			// must trigger Vue reactivity so watchers/renderers update
+			// (regression: https://github.com/getkirby/kirby/issues/8264)
+			const store = reactive({ history: new History() });
+			expect(isReactive(store.history.milestones)).toBe(true);
+
+			store.history.add({ id: "a" });
+
+			let ids: string[] = [];
+			watch(
+				() => store.history.milestones.map((milestone) => milestone.id),
+				(value) => (ids = value),
+				{ flush: "sync" }
+			);
+
+			store.history.add({ id: "b" }, true);
+
+			expect(ids).toStrictEqual(["b"]);
 		});
 	});
 

--- a/panel/src/helpers/history.ts
+++ b/panel/src/helpers/history.ts
@@ -99,6 +99,8 @@ export default class History<T extends { id: string }> {
 			index = this.milestones.length - 1;
 		}
 
-		this.milestones[index] = state;
+		// use splice instead of index assignment so that Vue 2 can
+		// detect the change and re-render (e.g. the drawer history)
+		this.milestones.splice(index, 1, state);
 	}
 }


### PR DESCRIPTION
## Description

Since #8010 the `History` helper is a plain class and `replace()` uses `this.milestones[index] = state`. Vue 2 doesn't detect array index assignments, so navigating between blocks in a drawer (`replace: true`) hides the current block without rendering the next one. Using `splice()` restores reactivity.

## Changelog

### 🐛 Bug fixes

- Fix block navigation (prev/next) in the panel drawer #8264

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion