### PR TITLE
fix: Rank order of writer marks

### DIFF
--- a/panel/src/helpers/writer.js
+++ b/panel/src/helpers/writer.js
@@ -50,14 +50,23 @@ export const allowedExtensions = (available, allowed) => {
 	return Object.keys(available);
 };
 
+/**
+ * Returns all available marks.
+ *
+ * The order  determines the ProseMirror schema mark rank, which
+ * decides the nesting priority: marks listed first wrap the ones listed
+ * later. Interactive marks (link, email) come first so that they are not
+ * split up by decorative marks like bold or italic.
+ * @see https://github.com/getkirby/kirby/issues/5481
+ */
 export const availableMarks = (options = {}) => {
 	return {
+		link: new Link(options.link ?? {}),
+		email: new Email(options.email ?? {}),
 		bold: new Bold(options.bold ?? {}),
 		clear: new Clear(options.clear ?? {}),
 		code: new Code(options.code ?? {}),
-		email: new Email(options.email ?? {}),
 		italic: new Italic(options.italic ?? {}),
-		link: new Link(options.link ?? {}),
 		strike: new Strike(options.strike ?? {}),
 		sup: new Sup(options.sup ?? {}),
 		sub: new Sub(options.sub ?? {}),
@@ -167,8 +176,11 @@ export const filterExtensions = (available, allowed) => {
 
 	let installed = {};
 
-	for (const extension in available) {
-		if (allowed.includes(extension)) {
+	// iterate over `allowed` (not `available`) so that the order defined
+	// in the blueprint is preserved; this order becomes the ProseMirror
+	// schema mark rank and thus determines the nesting priority of marks
+	for (const extension of allowed) {
+		if (available[extension]) {
 			installed[extension] = available[extension];
 		}
 	}

--- a/panel/src/helpers/writer.test.js
+++ b/panel/src/helpers/writer.test.js
@@ -134,6 +134,14 @@ describe("availableMarks", () => {
 		}
 	});
 
+	it("should rank interactive marks first for nesting priority", () => {
+		// link and email must come before decorative marks so that they
+		// are not split up by them (see #5481)
+		const keys = Object.keys(availableMarks());
+		expect(keys[0]).toBe("link");
+		expect(keys[1]).toBe("email");
+	});
+
 	it("should pass options to constructors", () => {
 		const marks = availableMarks({ bold: { custom: "value" } });
 		expect(marks.bold.options.custom).toBe("value");
@@ -281,6 +289,11 @@ describe("filterExtensions", () => {
 		expect(Object.keys(result)).toEqual(["a", "c"]);
 	});
 
+	it("should preserve the allowed order for arrays", () => {
+		const result = filterExtensions(available, ["c", "a"]);
+		expect(Object.keys(result)).toEqual(["c", "a"]);
+	});
+
 	it("should filter by object", () => {
 		const result = filterExtensions(available, {
 			a: true,
@@ -288,6 +301,14 @@ describe("filterExtensions", () => {
 			c: { option: 1 }
 		});
 		expect(Object.keys(result)).toEqual(["a", "c"]);
+	});
+
+	it("should preserve the allowed order for objects", () => {
+		const result = filterExtensions(available, {
+			c: true,
+			a: true
+		});
+		expect(Object.keys(result)).toEqual(["c", "a"]);
 	});
 
 	it("should ignore unknown extensions in array", () => {


### PR DESCRIPTION

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

Moved the feature part of the issue over to: https://feedback.getkirby.com/755

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Writer field: respect the order marks are listed in the blueprint as their relative rank, e.g. italics inside a link don't split link into multiple `<a>` tags anymore
#5481



## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion