### PR TITLE
feat: Add cache expiry handling to the date KirbyTag

### DIFF
--- a/config/tags.php
+++ b/config/tags.php
@@ -17,10 +17,24 @@ return [
 	 * Date
 	 */
 	'date' => [
-		'attr' => [],
+		'attr' => [
+			'expiry'
+		],
 		'html' => function (KirbyTag $tag): string {
 			if (strtolower($tag->date) === 'year') {
+				// make sure cached pages reset the year at New Year,
+				// unless a custom expiry point has been requested
+				$tag->kirby()->response()->expires(
+					$tag->expiry ?? 'first day of January next year'
+				);
+
 				return date('Y');
+			}
+
+			// let authors control the cache expiry for custom formats,
+			// e.g. `(date: Y-m-d expiry: tomorrow)`
+			if ($tag->expiry !== null) {
+				$tag->kirby()->response()->expires($tag->expiry);
 			}
 
 			// escape the formatted date to prevent injecting HTML

--- a/tests/Text/DateKirbyTagTest.php
+++ b/tests/Text/DateKirbyTagTest.php
@@ -3,22 +3,65 @@
 namespace Kirby\Text;
 
 use Kirby\Cms\App;
+use Kirby\Filesystem\Dir;
 use Kirby\TestCase;
 
 class DateKirbyTagTest extends TestCase
 {
+	public const TMP = KIRBY_TMP_DIR . '/Text.DateKirbyTag';
+
+	protected function setUp(): void
+	{
+		$this->app = new App([
+			'roots' => [
+				'index' => static::TMP
+			]
+		]);
+
+		Dir::make(static::TMP);
+	}
+
+	protected function tearDown(): void
+	{
+		Dir::remove(static::TMP);
+	}
+
 	public function testDate(): void
 	{
-		$app = App::instance();
-		$this->assertSame(date('d.m.Y'), $app->kirbytags('(date: d.m.Y)'));
-		$this->assertSame(date('Y'), $app->kirbytags('(date: year)'));
+		$this->assertSame(date('d.m.Y'), $this->app->kirbytags('(date: d.m.Y)'));
+		$this->assertSame(date('Y'), $this->app->kirbytags('(date: year)'));
 	}
 
 	public function testDateWithHtml(): void
 	{
-		$app = App::instance();
-
 		// HTML special characters in the format must be escaped
-		$this->assertSame('&lt;b&gt;', $app->kirbytags('(date: <b>)'));
+		$this->assertSame('&lt;b&gt;', $this->app->kirbytags('(date: <b>)'));
+	}
+
+	public function testDateYearSetsCacheExpiry(): void
+	{
+		$this->assertSame(date('Y'), $this->app->kirbytags('(date: year)'));
+		$this->assertSame(
+			strtotime('first day of January next year'),
+			$this->app->response()->expires()
+		);
+	}
+
+	public function testDateYearWithCustomExpiry(): void
+	{
+		$this->assertSame(date('Y'), $this->app->kirbytags('(date: year expiry: tomorrow)'));
+		$this->assertSame(strtotime('tomorrow'), $this->app->response()->expires());
+	}
+
+	public function testDateWithoutExpiry(): void
+	{
+		$this->assertSame(date('d.m.Y'), $this->app->kirbytags('(date: d.m.Y)'));
+		$this->assertNull($this->app->response()->expires());
+	}
+
+	public function testDateWithCustomExpiry(): void
+	{
+		$this->assertSame(date('d.m.Y'), $this->app->kirbytags('(date: d.m.Y expiry: tomorrow)'));
+		$this->assertSame(strtotime('tomorrow'), $this->app->response()->expires());
 	}
 }


### PR DESCRIPTION
## Description

`(date: year)` showed a stale year on cached pages. The `date` tag now sets a cache expiry via `$kirby->response()->expires()`, with a new optional `expiry` attribute for a custom reset point:

```
(date: year)                      // cache resets at the start of next year
(date: Y-m-d)                     // no expiry unless set
(date: Y-m-d expiry: tomorrow)    // cache resets at midnight
```

## Changelog

### ✨ Enhancements

- The `(date:)` KirbyTag keeps cached pages up to date and supports a new optional `expiry` attribute #7746

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion