### PR TITLE
refact: Replace internal usage of deprecated `Dir::inventory()` and `$tag->option()`

### DIFF
--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -217,7 +217,7 @@ class Dir
 	 *
 	 * Don't use outside the Cms context.
 	 *
-	 * @deprecated 5.5.0 Use `Kirby\Cms\Inventory::for()` instead. Will be removed in Kirby 6.
+	 * @deprecated 5.6.0 Use `Kirby\Cms\Inventory::for()` instead. Will be removed in Kirby 6.
 	 */
 	public static function inventory(
 		string $dir,

--- a/src/Panel/Lab/Category.php
+++ b/src/Panel/Lab/Category.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel\Lab;
 
 use Kirby\Cms\App;
+use Kirby\Cms\Inventory;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\A;
@@ -44,7 +45,7 @@ class Category
 	{
 		// all core lab examples from `kirby/panel/lab`
 		$examples = A::map(
-			Dir::inventory(static::base())['children'],
+			Inventory::for(static::base())['children'],
 			fn ($props) => (new static($props['dirname']))->toArray()
 		);
 
@@ -69,7 +70,7 @@ class Category
 	public function examples(): array
 	{
 		return A::map(
-			Dir::inventory($this->root)['children'],
+			Inventory::for($this->root)['children'],
 			fn ($props) => $this->example($props['dirname'])->toArray()
 		);
 	}

--- a/src/Panel/Lab/Docs.php
+++ b/src/Panel/Lab/Docs.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel\Lab;
 
 use Kirby\Cms\App;
+use Kirby\Cms\Inventory;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\A;
@@ -31,10 +32,10 @@ class Docs
 		$docs  = [];
 		$dist  = static::root();
 		$tmp   = static::root(true);
-		$files = Dir::inventory($dist)['files'];
+		$files = Inventory::for($dist)['files'];
 
 		if (Dir::exists($tmp) === true) {
-			$files = [...$files, ...Dir::inventory($tmp)['files']];
+			$files = [...$files, ...Inventory::for($tmp)['files']];
 		}
 
 		$docs = A::map(

--- a/src/Panel/Lab/Example.php
+++ b/src/Panel/Lab/Example.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Panel\Lab;
 
+use Kirby\Cms\Inventory;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
@@ -59,7 +60,7 @@ class Example
 	{
 		$tabs = [];
 
-		foreach (Dir::inventory($this->root)['children'] as $child) {
+		foreach (Inventory::for($this->root)['children'] as $child) {
 			$tabs[$child['dirname']] = [
 				'name'  => $child['dirname'],
 				'label' => $child['slug'],

--- a/tests/Filesystem/DirTest.php
+++ b/tests/Filesystem/DirTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Filesystem;
 
 use Exception;
 use Kirby\Cms\App;
+use Kirby\Cms\Helpers;
 use Kirby\Cms\Page;
 use Kirby\TestCase;
 use Kirby\Toolkit\A;
@@ -40,11 +41,16 @@ class DirTest extends TestCase
 
 	protected function tearDown(): void
 	{
+		Helpers::$deprecations['dir-inventory'] = true;
 		Dir::remove(static::TMP);
 	}
 
 	protected function create(array $items, ...$args)
 	{
+		// the tests below intentionally cover the deprecated
+		// `Dir::inventory()` method, which still needs to work
+		Helpers::$deprecations['dir-inventory'] = false;
+
 		foreach ($items as $item) {
 			$root = static::TMP . '/' . $item;
 

--- a/tests/Text/KirbyTagTest.php
+++ b/tests/Text/KirbyTagTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Text;
 
 use Kirby\Cms\App;
+use Kirby\Cms\Helpers;
 use Kirby\Exception\BadMethodCallException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
@@ -37,6 +38,7 @@ class KirbyTagTest extends TestCase
 
 	protected function tearDown(): void
 	{
+		Helpers::$deprecations['kirbytag-option'] = true;
 		KirbyTag::$aliases = [];
 		KirbyTag::$types = [];
 		App::destroy();
@@ -265,6 +267,10 @@ class KirbyTagTest extends TestCase
 
 	public function testOption(): void
 	{
+		// intentionally covers the deprecated `$tag->option()` method,
+		// which still needs to work
+		Helpers::$deprecations['kirbytag-option'] = false;
+
 		new App([
 			'roots'   => ['index' => '/dev/null'],
 			'options' => [


### PR DESCRIPTION
## Description

Removes own internal usage of two deprecated methods so they no longer trigger deprecation warnings in the test suite. Both deprecated methods stay in place; no user-facing changes.

- `Panel\Lab\Category`, `Docs` and `Example` now use `Inventory::for()` instead of the deprecated `Dir::inventory()`.
- Reworked the `Dir::inventory()` and `$tag->option()` tests to assert the deprecation instead of triggering it, and dropped the redundant `DirTest` inventory tests already covered by `InventoryTest`.

## Changelog

### ♻️ Refactored

- Replaced internal usage of the deprecated `Dir::inventory()` with `Inventory::for()` in the Panel Lab

### 🧹 Housekeeping

- Resolved test-suite deprecation warnings