### PR TITLE
feat: Content Negotiation

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception as GlobalException;
 use Generator;
 use Kirby\Api\Api;
+use Kirby\Cms\App\Resolver;
 use Kirby\Content\Storage;
 use Kirby\Content\VersionCache;
 use Kirby\Data\Data;
@@ -1255,7 +1256,7 @@ class App
 	 * Path resolver for the router
 	 *
 	 * @unstable
-	 * @throws \Kirby\Exception\NotFoundException if the home page cannot be found
+	 * @throws \Kirby\Exception\LogicException if the home page cannot be found
 	 */
 	public function resolve(
 		string|null $path = null,
@@ -1267,97 +1268,14 @@ class App
 		// set the current locale
 		$this->setCurrentLanguage($language);
 
-		// directly prevent path with incomplete content representation
-		if (Str::endsWith($path, '.') === true) {
+		try {
+			return (new Resolver($this))->resolve($path);
+		} catch (NotFoundException) {
+			// an unresolvable path resolves to null, so the router falls
+			// through to the error page (the old resolver behavior);
+			// a missing home page throws a LogicException and bubbles up
 			return null;
 		}
-
-		// the site is needed a couple times here
-		$site = $this->site();
-
-		// use the home page
-		if ($path === null) {
-			if ($homePage = $site->homePage()) {
-				return $homePage;
-			}
-
-			throw new NotFoundException(
-				message: 'The home page does not exist'
-			);
-		}
-
-		// search for the page by path
-		$page = $site->find($path);
-
-		// search for a draft if the page cannot be found
-		if (!$page && $draft = $site->draft($path)) {
-			if (
-				($this->user() && $draft->isAccessible()) ||
-				$draft->renderVersionFromRequest() !== null
-			) {
-				$page = $draft;
-			}
-		}
-
-		// try to resolve content representations if the path has an extension
-		$extension = F::extension($path);
-
-		// no content representation? then return the page
-		if (empty($extension) === true) {
-			return $page;
-		}
-
-		// only try to return a representation
-		// when the page has been found
-		if ($page) {
-			// if extension is the default content type,
-			// redirect to page URL without extension
-			if ($extension === 'html') {
-				return Response::redirect($page->url(), 301);
-			}
-
-			try {
-				$response = $this->response();
-				$output   = $page->render([], $extension);
-
-				// attach a MIME type based on the representation
-				// only if no custom MIME type was set
-				if ($response->type() === null) {
-					$response->type($extension);
-				}
-
-				return $response->body($output);
-			} catch (NotFoundException) {
-				return null;
-			}
-		}
-
-		// try to resolve clean URLs to site files
-		if (str_contains($path, '/') === false) {
-			return $this->resolveFile($site->file($path));
-		}
-
-		$id       = dirname($path);
-		$filename = basename($path);
-
-		// try to resolve clean URLs to files for pages and drafts
-		if ($page = $site->findPageOrDraft($id)) {
-			// don't leak files on draft pages through clean URLs:
-			// only serve them to an authenticated user with access
-			// permission or a request with a valid preview token
-			if (
-				$page->isDraft() === true &&
-				($this->user() && $page->isAccessible()) === false &&
-				$page->renderVersionFromRequest() === null
-			) {
-				return null;
-			}
-
-			return $this->resolveFile($page->file($filename));
-		}
-
-		// none of our resolvers were successful
-		return null;
 	}
 
 	/**
@@ -1371,17 +1289,11 @@ class App
 			return null;
 		}
 
-		$option = $this->option('content.fileRedirects', false);
-
-		if ($option === true) {
+		// the file redirect logic is owned by the resolver
+		if ((new Resolver($this))->isResolvableFile($file) === true) {
 			return $file;
 		}
 
-		if ($option instanceof Closure) {
-			return $option($file) === true ? $file : null;
-		}
-
-		// option was set to `false` or an invalid value
 		return null;
 	}
 

--- a/src/Cms/App/Resolver.php
+++ b/src/Cms/App/Resolver.php
@@ -46,7 +46,7 @@ class Resolver
 	}
 
 	/**
-	 * Checks whether a draft can be accessed by the current user 
+	 * Checks whether a draft can be accessed by the current user
 	 * or through a token-authenticated request.
 	 */
 	protected function isAccessibleDraft(Page $page): bool
@@ -117,7 +117,7 @@ class Resolver
 
 		// resolve filenames without path to site files
 		if (str_contains($path, '/') === false) {
-			return $this->resolveFile($this->site->file($path));
+			return $this->resolveSiteFile($path);
 		}
 
 		return $this->resolvePageFile($path);
@@ -268,5 +268,13 @@ class Resolver
 
 		// nothing matched -> render the page as HTML
 		return null;
+	}
+
+	/**
+	 * @throws \Kirby\Exception\NotFoundException if the file cannot be found or accessed
+	 */
+	protected function resolveSiteFile(string $path): File
+	{
+		return $this->resolveFile($this->site->file($path));
 	}
 }

--- a/src/Cms/App/Resolver.php
+++ b/src/Cms/App/Resolver.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace Kirby\Cms\App;
+
+use Closure;
+use Kirby\Cms\App;
+use Kirby\Cms\File;
+use Kirby\Cms\Page;
+use Kirby\Cms\Responder;
+use Kirby\Cms\Response;
+use Kirby\Cms\Site;
+use Kirby\Exception\LogicException;
+use Kirby\Exception\NotFoundException;
+use Kirby\Filesystem\F;
+use Kirby\Filesystem\Mime;
+
+/**
+ * Request Path Resolver
+ *
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ */
+class Resolver
+{
+	protected Site $site;
+
+	public function __construct(
+		protected App $kirby,
+	) {
+		$this->site = $kirby->site();
+	}
+
+	/**
+	 * Returns a potential content representation or file extension
+	 */
+	protected function detectExtension(string $path): string|null
+	{
+		$extension = F::extension($path);
+
+		if ($extension === '') {
+			return null;
+		}
+
+		return $extension;
+	}
+
+	/**
+	 * Checks whether a draft can be access by the current user or through a
+	 * token-authenticated request.
+	 */
+	protected function isAccessibleDraft(Page $page): bool
+	{
+		return
+			($this->kirby->user() !== null && $page->isAccessible() === true) ||
+			$page->renderVersionFromRequest() !== null;
+	}
+
+	/**
+	 * Checks whether a file may be served through a clean URL,
+	 * based on the `content.fileRedirects` option
+	 */
+	public function isResolvableFile(File $file): bool
+	{
+		$option = $this->kirby->option('content.fileRedirects', false);
+
+		if ($option === true) {
+			return true;
+		}
+
+		if ($option instanceof Closure) {
+			return $option($file) === true;
+		}
+
+		// option was set to `false` or an invalid value
+		return false;
+	}
+
+	/**
+	 * Used in routes to resolve request paths
+	 *
+	 * @throws \Kirby\Exception\NotFoundException if the page does not exist
+	 */
+	public function resolve(string|null $path = null): File|Page|Responder|Response
+	{
+		// directly prevent path with incomplete content representation
+		if (str_ends_with($path ?? '', '.') === true) {
+			throw new NotFoundException(
+				message: 'Incomplete content representation'
+			);
+		}
+
+		// home page
+		if ($path === null) {
+			return $this->resolveHomePage();
+		}
+
+		// get a potential content representation or file extension
+		$extension = $this->detectExtension($path);
+
+		// the path leads directly to a public page
+		if ($page = $this->site->children()->find($path)) {
+			return $this->resolvePage($page, $extension);
+		}
+
+		// the path leads to a draft
+		if ($draft = $this->site->draft($path)) {
+			return $this->resolveDraft($draft, $extension);
+		}
+
+		// no file
+		if ($extension === null) {
+			throw new NotFoundException(
+				key: 'page.undefined'
+			);
+		}
+
+		// resolve filenames without path to site files
+		if (str_contains($path, '/') === false) {
+			return $this->resolveFile($this->site->file($path));
+		}
+
+		return $this->resolvePageFile($path);
+	}
+
+	/**
+	 * @throws \Kirby\Exception\NotFoundException if the draft cannot be accessed
+	 */
+	protected function resolveDraft(Page $draft, string|null $extension = null): Page|Responder|Response
+	{
+		if ($this->isAccessibleDraft($draft) === true) {
+			return $this->resolvePage($draft, $extension);
+		}
+
+		throw new NotFoundException(
+			key: 'page.undefined'
+		);
+	}
+
+	/**
+	 * @throws \Kirby\Exception\NotFoundException if the file cannot be found or accessed
+	 */
+	protected function resolveFile(File|null $file): File
+	{
+		if ($file === null || $this->isResolvableFile($file) === false) {
+			throw new NotFoundException(
+				key: 'file.undefined'
+			);
+		}
+
+		return $file;
+	}
+
+	/**
+	 * @throws \Kirby\Exception\LogicException if the home page does not exist
+	 */
+	protected function resolveHomePage(): Page|Responder|Response
+	{
+		if ($page = $this->site->homePage()) {
+			return $this->resolvePage($page);
+		}
+
+		// a missing home page is a hard configuration error, not a 404;
+		// throwing a LogicException lets it bubble up past App::call()
+		// instead of being turned into the error page
+		throw new LogicException(
+			message: 'The home page does not exist'
+		);
+	}
+
+	/**
+	 * @throws \Kirby\Exception\NotFoundException if the page cannot be found
+	 */
+	protected function resolvePage(Page $page, string|null $extension = null): Page|Responder|Response
+	{
+		if ($extension === null) {
+			// no explicit representation in the URL: use content negotiation
+			// to pick a representation based on the accepted MIME types,
+			// otherwise return the page for regular HTML rendering
+			return $this->resolvePreferredRepresentation($page) ?? $page;
+		}
+
+		// a content representation was requested through the URL
+		// if extension is the default content type,
+		// redirect to the page URL without extension
+		if ($extension === 'html') {
+			return Response::redirect($page->url(), 301);
+		}
+
+		return $this->resolvePageResponse($page, $extension);
+	}
+
+	/**
+	 * @throws \Kirby\Exception\NotFoundException if the file cannot be found or accessed
+	 */
+	protected function resolvePageFile(string $path): File
+	{
+		$id        = dirname($path);
+		$filename  = basename($path);
+
+		if ($page = $this->site->findPageOrDraft($id)) {
+			// make sure to not leak files on draft pages through clean URLs:
+			// only serve them to an authenticated user with access
+			// permission or a request with a valid preview token
+			if ($page->isDraft() === false || $this->isAccessibleDraft($page) === true) {
+				return $this->resolveFile($page->file($filename));
+			}
+		}
+
+		throw new NotFoundException(
+			key: 'file.undefined'
+		);
+	}
+
+	protected function resolvePageResponse(Page $page, string $extension): Responder
+	{
+		$response = $this->kirby->response();
+		$output   = $page->render([], $extension);
+
+		// attach a MIME type based on the representation
+		// only if no custom MIME type was set
+		if ($response->type() === null) {
+			$response->type($extension);
+		}
+
+		$response->body($output);
+
+		return $response;
+	}
+
+	/**
+	 * Resolves a page to a content representation based on the
+	 * MIME types accepted by the visitor (content negotiation).
+	 * Returns a prepared response for the preferred representation
+	 * or `null` if the page should be rendered as regular HTML.
+	 */
+	protected function resolvePreferredRepresentation(Page $page): Responder|null
+	{
+		// content negotiation can be disabled via config
+		if ($this->kirby->option('content.negotiation', true) === false) {
+			return null;
+		}
+
+		// the response depends on the Accept header from now on;
+		// let caches/proxies know so they don't mix up variants
+		$response = $this->kirby->response();
+		$response->header('Vary', 'Accept');
+
+		// walk the accepted MIME types in quality order (highest first)
+		foreach ($this->kirby->visitor()->acceptedMimeTypes() as $accepted) {
+			$mime = $accepted->type();
+
+			// HTML (the default output) already satisfies this Accept
+			// entry, including wildcards like `text/*` or `*/*`
+			// (browsers, curl) -> stop and render the page as usual
+			if (Mime::matches('text/html', $mime) === true) {
+				return null;
+			}
+
+			// probe each extension the MIME type maps to
+			// for an existing content representation
+			foreach (Mime::toExtensions($mime) as $extension) {
+				try {
+					$page->representation($extension);
+				} catch (NotFoundException) {
+					// no representation for this type, try the next
+					continue;
+				}
+
+				return $this->resolvePageResponse($page, $extension);
+			}
+		}
+
+		// nothing matched -> render the page as HTML
+		return null;
+	}
+}

--- a/src/Cms/App/Resolver.php
+++ b/src/Cms/App/Resolver.php
@@ -236,11 +236,6 @@ class Resolver
 	 */
 	protected function resolvePreferredRepresentation(Page $page): Responder|null
 	{
-		// content negotiation can be disabled via config
-		if ($this->kirby->option('content.negotiation', true) === false) {
-			return null;
-		}
-
 		// the response depends on the Accept header from now on;
 		// let caches/proxies know so they don't mix up variants
 		$response = $this->kirby->response();

--- a/src/Cms/App/Resolver.php
+++ b/src/Cms/App/Resolver.php
@@ -236,11 +236,6 @@ class Resolver
 	 */
 	protected function resolvePreferredRepresentation(Page $page): Responder|null
 	{
-		// the response depends on the Accept header from now on;
-		// let caches/proxies know so they don't mix up variants
-		$response = $this->kirby->response();
-		$response->header('Vary', 'Accept');
-
 		// walk the accepted MIME types in quality order (highest first)
 		foreach ($this->kirby->visitor()->acceptedMimeTypes() as $accepted) {
 			$mime = $accepted->type();
@@ -261,6 +256,11 @@ class Resolver
 					// no representation for this type, try the next
 					continue;
 				}
+
+				// the response depends on the Accept header from now on;
+				// let caches/proxies know so they don't mix up variants
+				$response = $this->kirby->response();
+				$response->header('Vary', 'Accept');
 
 				return $this->resolvePageResponse($page, $extension);
 			}

--- a/src/Cms/App/Resolver.php
+++ b/src/Cms/App/Resolver.php
@@ -19,6 +19,7 @@ use Kirby\Filesystem\Mime;
  *
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ * @since     6.0.0
  */
 class Resolver
 {
@@ -31,7 +32,7 @@ class Resolver
 	}
 
 	/**
-	 * Returns a potential content representation or file extension
+	 * Returns the content representation/file extension from a path
 	 */
 	protected function detectExtension(string $path): string|null
 	{
@@ -45,8 +46,8 @@ class Resolver
 	}
 
 	/**
-	 * Checks whether a draft can be access by the current user or through a
-	 * token-authenticated request.
+	 * Checks whether a draft can be accessed by the current user 
+	 * or through a token-authenticated request.
 	 */
 	protected function isAccessibleDraft(Page $page): bool
 	{
@@ -179,7 +180,7 @@ class Resolver
 			return $this->resolvePreferredRepresentation($page) ?? $page;
 		}
 
-		// a content representation was requested through the URL
+		// a content representation was requested through the URL;
 		// if extension is the default content type,
 		// redirect to the page URL without extension
 		if ($extension === 'html') {

--- a/tests/Cms/App/AppResolveTest.php
+++ b/tests/Cms/App/AppResolveTest.php
@@ -2,16 +2,16 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Exception\LogicException;
 use Kirby\Filesystem\F;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(App::class)]
 class AppResolveTest extends TestCase
 {
-	public const string FIXTURES = __DIR__ . '/fixtures';
-	public const string TMP      = KIRBY_TMP_DIR . '/Cms.AppResolve';
+	public const string TMP = KIRBY_TMP_DIR . '/Cms.AppResolve';
 
-	public function testResolveHomePage(): void
+	public function testResolve(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -19,41 +19,37 @@ class AppResolveTest extends TestCase
 			],
 			'site' => [
 				'children' => [
-					[
-						'slug' => 'home'
-					]
+					['slug' => 'test']
 				]
 			]
 		]);
 
-		$result = $app->resolve(null);
-
-		$this->assertIsPage($result);
-		$this->assertTrue($result->isHomePage());
-	}
-
-	public function testResolveMainPage(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null'
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug' => 'test'
-					]
-				]
-			]
-		]);
-
+		// the resolver result is passed through
 		$result = $app->resolve('test');
 
 		$this->assertIsPage($result);
 		$this->assertSame('test', $result->id());
 	}
 
-	public function testResolveSubPage(): void
+	public function testResolveMissingPageReturnsNull(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'site' => [
+				'children' => [
+					['slug' => 'test']
+				]
+			]
+		]);
+
+		// a NotFoundException from the resolver is turned into null
+		// so the router can fall through to the error page
+		$this->assertNull($app->resolve('does-not-exist'));
+	}
+
+	public function testResolveInaccessibleFileReturnsNull(): void
 	{
 		$app = new App([
 			'roots' => [
@@ -62,692 +58,42 @@ class AppResolveTest extends TestCase
 			'site' => [
 				'children' => [
 					[
-						'slug' => 'test',
-						'children' => [
-							['slug' => 'subpage']
+						'slug'  => 'test',
+						'files' => [
+							['filename' => 'test.jpg']
 						]
 					]
 				]
 			]
 		]);
 
-		$result = $app->resolve('test/subpage');
-
-		$this->assertIsPage($result);
-		$this->assertSame('test/subpage', $result->id());
+		// file redirects are disabled by default, so the file
+		// is not resolvable and null is returned
+		$this->assertNull($app->resolve('test/test.jpg'));
 	}
 
-	public function testResolveDraft(): void
+	public function testResolveMissingHomePageThrows(): void
 	{
 		$app = new App([
 			'roots' => [
 				'index' => '/dev/null'
 			],
 			'site' => [
-				'children' => [
-					[
-						'slug' => 'test',
-						'drafts' => [
-							[
-								'slug'  => 'a-draft',
-							]
-						]
-					]
-				]
+				'children' => []
 			]
 		]);
 
-		$result = $app->resolve('test/a-draft');
-		$this->assertNull($result);
+		// a missing home page is a hard error that is not caught
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('The home page does not exist');
+
+		$app->resolve(null);
 	}
 
-	public function testResolveDraftWithUser(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null'
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug'   => 'test',
-						'drafts' => [
-							['slug' => 'a-draft']
-						]
-					]
-				]
-			],
-			'users' => [
-				['email' => 'admin@getkirby.com', 'role' => 'admin']
-			]
-		]);
-
-		$app->impersonate('admin@getkirby.com');
-
-		$result = $app->resolve('test/a-draft');
-
-		$this->assertIsPage($result);
-		$this->assertSame('test/a-draft', $result->id());
-	}
-
-	public function testResolveDraftWithUserDeniedByPermission(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null'
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug'   => 'test',
-						'drafts' => [
-							['slug' => 'a-draft']
-						]
-					]
-				]
-			],
-			'roles' => [
-				[
-					'name'        => 'editor',
-					'permissions' => [
-						'pages' => ['access' => false]
-					]
-				]
-			],
-			'users' => [
-				['email' => 'editor@getkirby.com', 'role' => 'editor']
-			]
-		]);
-
-		$app->impersonate('editor@getkirby.com');
-
-		$result = $app->resolve('test/a-draft');
-
-		$this->assertNull($result);
-	}
-
-	public function testResolveDraftWithToken(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null'
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug' => 'test',
-						'drafts' => [
-							[
-								'slug'  => 'a-draft',
-							]
-						]
-					]
-				]
-			]
-		]);
-
-		$token = $app->page('test/a-draft')->version()->previewToken();
-		$app   = $app->clone([
-			'request' => [
-				'query' => ['_token' => $token]
-			]
-		]);
-
-		$result = $app->resolve('test/a-draft');
-
-		$this->assertIsPage($result);
-		$this->assertSame('test/a-draft', $result->id());
-	}
-
-	public function testResolveDraftWithTokenBypassesPermission(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null'
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug'   => 'test',
-						'drafts' => [
-							['slug' => 'a-draft']
-						]
-					]
-				]
-			],
-			'roles' => [
-				[
-					'name'        => 'editor',
-					'permissions' => [
-						'pages' => ['access' => false]
-					]
-				]
-			],
-			'users' => [
-				['email' => 'editor@getkirby.com', 'role' => 'editor']
-			]
-		]);
-
-		$token = $app->page('test/a-draft')->version()->previewToken();
-		$app   = $app->clone([
-			'request' => [
-				'query' => ['_token' => $token]
-			]
-		]);
-
-		$app->impersonate('editor@getkirby.com');
-
-		$result = $app->resolve('test/a-draft');
-
-		$this->assertIsPage($result);
-		$this->assertSame('test/a-draft', $result->id());
-	}
-
-	public function testResolvePageRepresentation(): void
-	{
-		F::write($template = static::TMP . '/test.php', 'html');
-		F::write($template = static::TMP . '/test.xml.php', 'xml');
-		F::write(
-			$template = static::TMP . '/test.png.php',
-			'<?php $kirby->response()->type("image/jpeg"); ?>png'
-		);
-
-		$app = new App([
-			'roots' => [
-				'index'     => '/dev/null',
-				'templates' => static::TMP
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug'     => 'test',
-						'template' => 'test'
-					]
-				],
-			]
-		]);
-
-		// missing representation
-		$result = $app->resolve('test.json');
-		$this->assertNull($result);
-		$result = $app->resolve('test.');
-		$this->assertNull($result);
-
-		// xml representation
-		$result = $app->clone()->resolve('test.xml');
-		$this->assertInstanceOf(Responder::class, $result);
-		$this->assertSame('application/xml', $result->type());
-		$this->assertSame('xml', $result->body());
-
-		// representation with custom MIME type
-		$result = $app->clone()->resolve('test.png');
-		$this->assertInstanceOf(Responder::class, $result);
-		$this->assertSame('image/jpeg', $result->type());
-		$this->assertSame('png', $result->body());
-	}
-
-	public function testResolvePageHtmlRepresentation(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null',
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug'     => 'test',
-						'template' => 'test'
-					]
-				],
-			]
-		]);
-
-		$response = $app->resolve('test.html');
-		$this->assertSame(301, $response->code());
-		$this->assertSame('/test', $response->header('Location'));
-
-	}
-
-	protected function negotiationApp(string|null $accept, array $props = []): App
-	{
-		$app = new App([
-			...$props,
-			'roots' => [
-				'index'     => '/dev/null',
-				'templates' => static::TMP
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug'     => 'test',
-						'template' => 'test'
-					]
-				]
-			]
-		]);
-
-		if ($accept !== null) {
-			$app->visitor()->acceptedMimeType($accept);
-		}
-
-		return $app;
-	}
-
-	public function testResolvePageContentNegotiation(): void
+	public function testResolveWithLanguage(): void
 	{
 		F::write(static::TMP . '/test.php', 'html');
-		F::write(static::TMP . '/test.md.php', '# Markdown');
-
-		// the visitor prefers markdown and a representation exists
-		$app    = $this->negotiationApp('text/markdown');
-		$result = $app->resolve('test');
-		$this->assertInstanceOf(Responder::class, $result);
-		$this->assertSame('text/markdown', $result->type());
-		$this->assertSame('# Markdown', $result->body());
-		$this->assertSame('Accept', $app->response()->header('Vary'));
-
-		// the visitor prefers HTML: render the page as usual,
-		// but the response still varies by the Accept header
-		$app    = $this->negotiationApp('text/html');
-		$result = $app->resolve('test');
-		$this->assertIsPage($result);
-		$this->assertSame('Accept', $app->response()->header('Vary'));
-
-		// a wildcard Accept header resolves to HTML
-		$app    = $this->negotiationApp('*/*');
-		$this->assertIsPage($app->resolve('test'));
-
-		// a preferred type without a representation falls back
-		// to the next accepted type (HTML)
-		$app    = $this->negotiationApp('application/xml, text/html');
-		$this->assertIsPage($app->resolve('test'));
-
-		// a preferred type without a representation and without
-		// HTML acceptance still renders the page as HTML
-		$app    = $this->negotiationApp('application/json');
-		$this->assertIsPage($app->resolve('test'));
-	}
-
-	public function testResolvePageContentNegotiationDisabled(): void
-	{
-		F::write(static::TMP . '/test.php', 'html');
-		F::write(static::TMP . '/test.md.php', '# Markdown');
-
-		$app = $this->negotiationApp('text/markdown', [
-			'options' => [
-				'content' => [
-					'negotiation' => false
-				]
-			]
-		]);
-
-		$result = $app->resolve('test');
-		$this->assertIsPage($result);
-		$this->assertNull($app->response()->header('Vary'));
-	}
-
-	public function testResolveFileDefault(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null',
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug' => 'test',
-						'files' => [
-							['filename' => 'test.jpg']
-						],
-					]
-				]
-			]
-		]);
-
-		// missing file
-		$result = $app->resolve('test/test.png');
-		$this->assertNull($result);
-
-		// existing file
-		$result = $app->resolve('test/test.jpg');
-		$this->assertNull($result);
-	}
-
-	public function testResolveSiteFile(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null',
-			],
-			'site' => [
-				'files' => [
-					['filename' => 'test.jpg']
-				],
-			],
-			'options' => [
-				'content' => [
-					'fileRedirects' => true
-				]
-			]
-		]);
-
-		// missing file
-		$result = $app->resolve('test.png');
-		$this->assertNull($result);
-
-		// existing file
-		$result = $app->resolve('test.jpg');
-
-		$this->assertIsFile($result);
-		$this->assertSame('test.jpg', $result->id());
-	}
-
-	public function testResolvePageFile(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null',
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug' => 'test',
-						'files' => [
-							['filename' => 'test.jpg']
-						],
-					]
-				],
-				'files' => [
-					['filename' => 'test-site.jpg']
-				]
-			],
-			'options' => [
-				'content' => [
-					'fileRedirects' => true
-				]
-			]
-		]);
-
-		// missing file
-		$result = $app->resolve('test/test.png');
-		$this->assertNull($result);
-
-		// file that only exists on the site
-		$result = $app->resolve('another-page/test-site.jpg');
-		$this->assertNull($result);
-
-		// existing file
-		$result = $app->resolve('test/test.jpg');
-
-		$this->assertIsFile($result);
-		$this->assertSame('test/test.jpg', $result->id());
-	}
-
-	public function testResolveDraftFileWithoutAccess(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null',
-			],
-			'site' => [
-				'drafts' => [
-					[
-						'slug'  => 'a-draft',
-						'files' => [
-							['filename' => 'test.jpg']
-						],
-					]
-				]
-			],
-			'options' => [
-				'content' => [
-					'fileRedirects' => true
-				]
-			]
-		]);
-
-		// a file on a draft page must not be exposed to
-		// anonymous visitors through clean file URLs
-		$result = $app->resolve('a-draft/test.jpg');
-		$this->assertNull($result);
-	}
-
-	public function testResolveDraftFileWithUser(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null',
-			],
-			'site' => [
-				'drafts' => [
-					[
-						'slug'  => 'a-draft',
-						'files' => [
-							['filename' => 'test.jpg']
-						],
-					]
-				]
-			],
-			'users' => [
-				['email' => 'admin@getkirby.com', 'role' => 'admin']
-			],
-			'options' => [
-				'content' => [
-					'fileRedirects' => true
-				]
-			]
-		]);
-
-		$app->impersonate('admin@getkirby.com');
-
-		$result = $app->resolve('a-draft/test.jpg');
-
-		$this->assertIsFile($result);
-		$this->assertSame('a-draft/test.jpg', $result->id());
-	}
-
-	public function testResolveDraftFileWithUserDeniedByPermission(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null',
-			],
-			'site' => [
-				'drafts' => [
-					[
-						'slug'  => 'a-draft',
-						'files' => [
-							['filename' => 'test.jpg']
-						],
-					]
-				]
-			],
-			'roles' => [
-				[
-					'name'        => 'editor',
-					'permissions' => [
-						'pages' => ['access' => false]
-					]
-				]
-			],
-			'users' => [
-				['email' => 'editor@getkirby.com', 'role' => 'editor']
-			],
-			'options' => [
-				'content' => [
-					'fileRedirects' => true
-				]
-			]
-		]);
-
-		$app->impersonate('editor@getkirby.com');
-
-		$result = $app->resolve('a-draft/test.jpg');
-		$this->assertNull($result);
-	}
-
-	public function testResolveDraftFileWithToken(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null',
-			],
-			'site' => [
-				'drafts' => [
-					[
-						'slug'  => 'a-draft',
-						'files' => [
-							['filename' => 'test.jpg']
-						],
-					]
-				]
-			],
-			'options' => [
-				'content' => [
-					'fileRedirects' => true
-				]
-			]
-		]);
-
-		$token = $app->page('a-draft')->version()->previewToken();
-		$app   = $app->clone([
-			'request' => [
-				'query' => ['_token' => $token]
-			]
-		]);
-
-		$result = $app->resolve('a-draft/test.jpg');
-
-		$this->assertIsFile($result);
-		$this->assertSame('a-draft/test.jpg', $result->id());
-	}
-
-	public function testResolveFileEnabled(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null',
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug' => 'test',
-						'files' => [
-							['filename' => 'test.jpg']
-						],
-					]
-				]
-			],
-			'options' => [
-				'content' => [
-					'fileRedirects' => true
-				]
-			]
-		]);
-
-		// missing file
-		$result1 = $app->resolve('test/test.png');
-		$result2 = $app->resolveFile($app->page('test')->file('test.png'));
-		$this->assertNull($result1);
-		$this->assertNull($result2);
-
-		// existing file
-		$result1 = $app->resolve('test/test.jpg');
-		$result2 = $app->resolveFile($app->page('test')->file('test.jpg'));
-		$this->assertSame($result1, $result2);
-		$this->assertIsFile($result1);
-		$this->assertSame('test/test.jpg', $result1->id());
-	}
-
-	public function testResolveFileDisabled(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null',
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug' => 'test',
-						'files' => [
-							['filename' => 'test.jpg']
-						],
-					]
-				]
-			],
-		]);
-
-		// missing file
-		$result1 = $app->resolve('test/test.png');
-		$result2 = $app->resolveFile($app->page('test')->file('test.png'));
-		$this->assertNull($result1);
-		$this->assertNull($result2);
-
-		// existing file
-		$result1 = $app->resolve('test/test.jpg');
-		$result2 = $app->resolveFile($app->page('test')->file('test.jpg'));
-		$this->assertNull($result1);
-		$this->assertNull($result2);
-	}
-
-	public function testResolveFileClosure(): void
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null',
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug' => 'test',
-						'files' => [
-							[
-								'content'  => [
-									'public' => 'true'
-								],
-								'filename' => 'test-public.jpg'
-							],
-							[
-								'content'  => [
-									'public' => 'false'
-								],
-								'filename' => 'test-private.jpg'
-							]
-						],
-					]
-				]
-			],
-			'options' => [
-				'content' => [
-					'fileRedirects' => fn (File $file): bool => $file->public()->toBool()
-				]
-			]
-		]);
-
-		// missing file
-		$result1 = $app->resolve('test/test.png');
-		$result2 = $app->resolveFile($app->page('test')->file('test.png'));
-		$this->assertNull($result1);
-		$this->assertNull($result2);
-
-		// existing file (allowed)
-		$result1 = $app->resolve('test/test-public.jpg');
-		$result2 = $app->resolveFile($app->page('test')->file('test-public.jpg'));
-		$this->assertSame($result1, $result2);
-		$this->assertIsFile($result1);
-		$this->assertSame('test/test-public.jpg', $result1->id());
-
-		// existing file (not allowed)
-		$result1 = $app->resolve('test/test-private.jpg');
-		$result2 = $app->resolveFile($app->page('test')->file('test-private.jpg'));
-		$this->assertNull($result1);
-		$this->assertNull($result2);
-	}
-
-	public function testResolveMultilangPageRepresentation(): void
-	{
-		F::write($template = static::TMP . '/test.php', 'html');
-		F::write($template = static::TMP . '/test.xml.php', 'xml');
+		F::write(static::TMP . '/test.xml.php', 'xml');
 
 		$app = new App([
 			'roots' => [
@@ -777,75 +123,54 @@ class AppResolveTest extends TestCase
 			]
 		]);
 
-		/**
-		 * Default language (DE)
-		 */
-
-		// finding the page
-		$result = $app->resolve('test');
-
-		$this->assertIsPage($result);
-		$this->assertSame('test', $result->id());
-		$this->assertSame('de', $app->language()->code());
-
-		// missing representation
-		$result = $app->resolve('test.json');
-
-		$this->assertNull($result);
-		$this->assertSame('de', $app->language()->code());
-
-		// xml presentation
+		// resolving sets the current language (default)
 		$result = $app->resolve('test.xml');
-
 		$this->assertInstanceOf(Responder::class, $result);
 		$this->assertSame('xml', $result->body());
 		$this->assertSame('de', $app->language()->code());
 
-		/**
-		 * Secondary language (EN)
-		 */
-
-		// finding the page
-		$result = $app->resolve('test', 'en');
-
-		$this->assertIsPage($result);
-		$this->assertSame('test', $result->id());
-		$this->assertSame('en', $app->language()->code());
-
-		// missing representation
-		$result = $app->resolve('test.json', 'en');
-
-		$this->assertNull($result);
-		$this->assertSame('en', $app->language()->code());
-
-		// xml presentation
+		// the language argument switches the current language
 		$result = $app->resolve('test.xml', 'en');
-
 		$this->assertInstanceOf(Responder::class, $result);
 		$this->assertSame('xml', $result->body());
+		$this->assertSame('en', $app->language()->code());
+
+		// a missing representation still returns null in the given language
+		$this->assertNull($app->resolve('test.json', 'en'));
 		$this->assertSame('en', $app->language()->code());
 	}
 
-	public function testRepresentationErrorType(): void
+	public function testResolveFile(): void
 	{
-		$this->app = new App([
-			'templates' => [
-				'blog' => static::FIXTURES . '/templates/test.php',
+		$props = [
+			'roots' => [
+				'index' => '/dev/null'
 			],
 			'site' => [
 				'children' => [
 					[
-						'slug' => 'blog',
-						'template' => 'blog'
+						'slug'  => 'test',
+						'files' => [
+							['filename' => 'test.jpg']
+						]
 					]
 				]
 			]
+		];
+
+		// disabled by default
+		$app = new App($props);
+		$this->assertNull($app->resolveFile($app->page('test')->file('test.jpg')));
+
+		// enabled
+		$app = new App([
+			...$props,
+			'options' => ['content' => ['fileRedirects' => true]]
 		]);
+		$file = $app->page('test')->file('test.jpg');
+		$this->assertSame($file, $app->resolveFile($file));
 
-		$this->assertNull($this->app->resolve('blog.php'));
-
-		// there must be no forced php response type if the
-		// representation cannot be found
-		$this->assertNull($this->app->response()->type());
+		// non-existing file
+		$this->assertNull($app->resolveFile(null));
 	}
 }

--- a/tests/Cms/App/AppResolveTest.php
+++ b/tests/Cms/App/AppResolveTest.php
@@ -308,6 +308,84 @@ class AppResolveTest extends TestCase
 
 	}
 
+	protected function negotiationApp(string|null $accept, array $props = []): App
+	{
+		$app = new App([
+			...$props,
+			'roots' => [
+				'index'     => '/dev/null',
+				'templates' => static::TMP
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'test',
+						'template' => 'test'
+					]
+				]
+			]
+		]);
+
+		if ($accept !== null) {
+			$app->visitor()->acceptedMimeType($accept);
+		}
+
+		return $app;
+	}
+
+	public function testResolvePageContentNegotiation(): void
+	{
+		F::write(static::TMP . '/test.php', 'html');
+		F::write(static::TMP . '/test.md.php', '# Markdown');
+
+		// the visitor prefers markdown and a representation exists
+		$app    = $this->negotiationApp('text/markdown');
+		$result = $app->resolve('test');
+		$this->assertInstanceOf(Responder::class, $result);
+		$this->assertSame('text/markdown', $result->type());
+		$this->assertSame('# Markdown', $result->body());
+		$this->assertSame('Accept', $app->response()->header('Vary'));
+
+		// the visitor prefers HTML: render the page as usual,
+		// but the response still varies by the Accept header
+		$app    = $this->negotiationApp('text/html');
+		$result = $app->resolve('test');
+		$this->assertIsPage($result);
+		$this->assertSame('Accept', $app->response()->header('Vary'));
+
+		// a wildcard Accept header resolves to HTML
+		$app    = $this->negotiationApp('*/*');
+		$this->assertIsPage($app->resolve('test'));
+
+		// a preferred type without a representation falls back
+		// to the next accepted type (HTML)
+		$app    = $this->negotiationApp('application/xml, text/html');
+		$this->assertIsPage($app->resolve('test'));
+
+		// a preferred type without a representation and without
+		// HTML acceptance still renders the page as HTML
+		$app    = $this->negotiationApp('application/json');
+		$this->assertIsPage($app->resolve('test'));
+	}
+
+	public function testResolvePageContentNegotiationDisabled(): void
+	{
+		F::write(static::TMP . '/test.php', 'html');
+		F::write(static::TMP . '/test.md.php', '# Markdown');
+
+		$app = $this->negotiationApp('text/markdown', [
+			'options' => [
+				'content' => [
+					'negotiation' => false
+				]
+			]
+		]);
+
+		$result = $app->resolve('test');
+		$this->assertIsPage($result);
+		$this->assertNull($app->response()->header('Vary'));
+	}
+
 	public function testResolveFileDefault(): void
 	{
 		$app = new App([

--- a/tests/Cms/App/ResolverTest.php
+++ b/tests/Cms/App/ResolverTest.php
@@ -278,7 +278,7 @@ class ResolverTest extends TestCase
 		// xml representation
 		$result = $this->resolve($app->clone(), 'test.xml');
 		$this->assertInstanceOf(Responder::class, $result);
-		$this->assertSame('text/xml', $result->type());
+		$this->assertSame('application/xml', $result->type());
 		$this->assertSame('xml', $result->body());
 
 		// representation with custom MIME type

--- a/tests/Cms/App/ResolverTest.php
+++ b/tests/Cms/App/ResolverTest.php
@@ -355,6 +355,32 @@ class ResolverTest extends TestCase
 		$this->assertIsPage($this->resolve($app, 'test'));
 	}
 
+	public function testResolvePageWithoutRepresentations(): void
+	{
+		F::write(static::TMP . '/test.php', 'html');
+
+		$app = $this->app->clone([
+			'roots' => [
+				'templates' => static::TMP
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'test',
+						'template' => 'test'
+					]
+				]
+			]
+		]);
+
+		// the page has no content representations, so the response
+		// never depends on the Accept header and must not vary by it
+		$app->visitor()->acceptedMimeType('application/json');
+		$result = $this->resolve($app, 'test');
+		$this->assertIsPage($result);
+		$this->assertNull($app->response()->header('Vary'));
+	}
+
 	public function testResolveFileDefault(): void
 	{
 		$app = $this->app->clone([

--- a/tests/Cms/App/ResolverTest.php
+++ b/tests/Cms/App/ResolverTest.php
@@ -1,0 +1,745 @@
+<?php
+
+namespace Kirby\Cms\App;
+
+use Kirby\Cms\App;
+use Kirby\Cms\File;
+use Kirby\Cms\Responder;
+use Kirby\Cms\TestCase;
+use Kirby\Exception\LogicException;
+use Kirby\Exception\NotFoundException;
+use Kirby\Filesystem\F;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Resolver::class)]
+class ResolverTest extends TestCase
+{
+	public const string FIXTURES = __DIR__ . '/fixtures';
+	public const string TMP      = KIRBY_TMP_DIR . '/Cms.App.Resolver';
+
+	/**
+	 * Asserts that resolving the given path throws a NotFoundException
+	 */
+	protected function assertResolveNotFound(App $app, string|null $path): void
+	{
+		try {
+			(new Resolver($app))->resolve($path);
+			$this->fail('Expected a NotFoundException for path: ' . ($path ?? 'null'));
+		} catch (NotFoundException) {
+			$this->assertTrue(true);
+		}
+	}
+
+	protected function resolve(App $app, string|null $path = null): mixed
+	{
+		return (new Resolver($app))->resolve($path);
+	}
+
+	public function testResolveHomePage(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					['slug' => 'home']
+				]
+			]
+		]);
+
+		$result = $this->resolve($app, null);
+
+		$this->assertIsPage($result);
+		$this->assertTrue($result->isHomePage());
+	}
+
+	public function testResolveHomePageMissing(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => []
+			]
+		]);
+
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage('The home page does not exist');
+
+		$this->resolve($app, null);
+	}
+
+	public function testResolveMainPage(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					['slug' => 'test']
+				]
+			]
+		]);
+
+		$result = $this->resolve($app, 'test');
+
+		$this->assertIsPage($result);
+		$this->assertSame('test', $result->id());
+	}
+
+	public function testResolveSubPage(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug' => 'test',
+						'children' => [
+							['slug' => 'subpage']
+						]
+					]
+				]
+			]
+		]);
+
+		$result = $this->resolve($app, 'test/subpage');
+
+		$this->assertIsPage($result);
+		$this->assertSame('test/subpage', $result->id());
+	}
+
+	public function testResolveDraft(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'   => 'test',
+						'drafts' => [
+							['slug' => 'a-draft']
+						]
+					]
+				]
+			]
+		]);
+
+		$this->assertResolveNotFound($app, 'test/a-draft');
+	}
+
+	public function testResolveDraftWithUser(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'   => 'test',
+						'drafts' => [
+							['slug' => 'a-draft']
+						]
+					]
+				]
+			],
+			'users' => [
+				['email' => 'admin@getkirby.com', 'role' => 'admin']
+			]
+		]);
+
+		$app->impersonate('admin@getkirby.com');
+
+		$result = $this->resolve($app, 'test/a-draft');
+
+		$this->assertIsPage($result);
+		$this->assertSame('test/a-draft', $result->id());
+	}
+
+	public function testResolveDraftWithUserDeniedByPermission(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'   => 'test',
+						'drafts' => [
+							['slug' => 'a-draft']
+						]
+					]
+				]
+			],
+			'roles' => [
+				[
+					'name'        => 'editor',
+					'permissions' => [
+						'pages' => ['access' => false]
+					]
+				]
+			],
+			'users' => [
+				['email' => 'editor@getkirby.com', 'role' => 'editor']
+			]
+		]);
+
+		$app->impersonate('editor@getkirby.com');
+
+		$this->assertResolveNotFound($app, 'test/a-draft');
+	}
+
+	public function testResolveDraftWithToken(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'   => 'test',
+						'drafts' => [
+							['slug' => 'a-draft']
+						]
+					]
+				]
+			]
+		]);
+
+		$token = $app->page('test/a-draft')->version()->previewToken();
+		$app   = $app->clone([
+			'request' => [
+				'query' => ['_token' => $token]
+			]
+		]);
+
+		$result = $this->resolve($app, 'test/a-draft');
+
+		$this->assertIsPage($result);
+		$this->assertSame('test/a-draft', $result->id());
+	}
+
+	public function testResolveDraftWithTokenBypassesPermission(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'   => 'test',
+						'drafts' => [
+							['slug' => 'a-draft']
+						]
+					]
+				]
+			],
+			'roles' => [
+				[
+					'name'        => 'editor',
+					'permissions' => [
+						'pages' => ['access' => false]
+					]
+				]
+			],
+			'users' => [
+				['email' => 'editor@getkirby.com', 'role' => 'editor']
+			]
+		]);
+
+		$token = $app->page('test/a-draft')->version()->previewToken();
+		$app   = $app->clone([
+			'request' => [
+				'query' => ['_token' => $token]
+			]
+		]);
+
+		$app->impersonate('editor@getkirby.com');
+
+		$result = $this->resolve($app, 'test/a-draft');
+
+		$this->assertIsPage($result);
+		$this->assertSame('test/a-draft', $result->id());
+	}
+
+	public function testResolvePageRepresentation(): void
+	{
+		F::write(static::TMP . '/test.php', 'html');
+		F::write(static::TMP . '/test.xml.php', 'xml');
+		F::write(
+			static::TMP . '/test.png.php',
+			'<?php $kirby->response()->type("image/jpeg"); ?>png'
+		);
+
+		$app = $this->app->clone([
+			'roots' => [
+				'templates' => static::TMP
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'test',
+						'template' => 'test'
+					]
+				],
+			]
+		]);
+
+		// missing representation
+		$this->assertResolveNotFound($app, 'test.json');
+
+		// incomplete content representation
+		$this->assertResolveNotFound($app, 'test.');
+
+		// xml representation
+		$result = $this->resolve($app->clone(), 'test.xml');
+		$this->assertInstanceOf(Responder::class, $result);
+		$this->assertSame('text/xml', $result->type());
+		$this->assertSame('xml', $result->body());
+
+		// representation with custom MIME type
+		$result = $this->resolve($app->clone(), 'test.png');
+		$this->assertInstanceOf(Responder::class, $result);
+		$this->assertSame('image/jpeg', $result->type());
+		$this->assertSame('png', $result->body());
+	}
+
+	public function testResolvePageHtmlRepresentation(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'test',
+						'template' => 'test'
+					]
+				],
+			]
+		]);
+
+		$response = $this->resolve($app, 'test.html');
+		$this->assertSame(301, $response->code());
+		$this->assertSame('/test', $response->header('Location'));
+	}
+
+	public function testResolvePageContentNegotiation(): void
+	{
+		F::write(static::TMP . '/test.php', 'html');
+		F::write(static::TMP . '/test.md.php', '# Markdown');
+
+		$app = $this->app->clone([
+			'roots' => [
+				'templates' => static::TMP
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'test',
+						'template' => 'test'
+					]
+				]
+			]
+		]);
+
+		// the visitor prefers markdown and a representation exists
+		$app->visitor()->acceptedMimeType('text/markdown');
+		$result = $this->resolve($app, 'test');
+		$this->assertInstanceOf(Responder::class, $result);
+		$this->assertSame('text/markdown', $result->type());
+		$this->assertSame('# Markdown', $result->body());
+		$this->assertSame('Accept', $app->response()->header('Vary'));
+
+		// the visitor prefers HTML: render the page as usual,
+		// but the response still varies by the Accept header
+		$app->visitor()->acceptedMimeType('text/html');
+		$result = $this->resolve($app, 'test');
+		$this->assertIsPage($result);
+		$this->assertSame('Accept', $app->response()->header('Vary'));
+
+		// a wildcard Accept header resolves to HTML
+		$app->visitor()->acceptedMimeType('*/*');
+		$this->assertIsPage($this->resolve($app, 'test'));
+
+		// a preferred type without a representation falls back
+		// to the next accepted type (HTML)
+		$app->visitor()->acceptedMimeType('application/xml, text/html');
+		$this->assertIsPage($this->resolve($app, 'test'));
+
+		// a preferred type without a representation and without
+		// HTML acceptance still renders the page as HTML
+		$app->visitor()->acceptedMimeType('application/json');
+		$this->assertIsPage($this->resolve($app, 'test'));
+	}
+
+	public function testResolvePageContentNegotiationDisabled(): void
+	{
+		F::write(static::TMP . '/test.php', 'html');
+		F::write(static::TMP . '/test.md.php', '# Markdown');
+
+		$app = $this->app->clone([
+			'roots' => [
+				'templates' => static::TMP
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'test',
+						'template' => 'test'
+					]
+				]
+			],
+			'options' => [
+				'content' => [
+					'negotiation' => false
+				]
+			],
+		]);
+
+		$result = $this->resolve($app, 'test');
+		$this->assertIsPage($result);
+		$this->assertNull($app->response()->header('Vary'));
+	}
+
+	public function testResolveFileDefault(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'  => 'test',
+						'files' => [
+							['filename' => 'test.jpg']
+						],
+					]
+				]
+			]
+		]);
+
+		// missing file
+		$this->assertResolveNotFound($app, 'test/test.png');
+
+		// existing file, but file redirects are disabled by default
+		$this->assertResolveNotFound($app, 'test/test.jpg');
+	}
+
+	public function testResolveSiteFile(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'files' => [
+					['filename' => 'test.jpg']
+				],
+			],
+			'options' => [
+				'content' => [
+					'fileRedirects' => true
+				]
+			]
+		]);
+
+		// missing file
+		$this->assertResolveNotFound($app, 'test.png');
+
+		// existing file
+		$result = $this->resolve($app, 'test.jpg');
+		$this->assertIsFile($result);
+		$this->assertSame('test.jpg', $result->id());
+	}
+
+	public function testResolvePageFile(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'  => 'test',
+						'files' => [
+							['filename' => 'test.jpg']
+						],
+					]
+				],
+				'files' => [
+					['filename' => 'test-site.jpg']
+				]
+			],
+			'options' => [
+				'content' => [
+					'fileRedirects' => true
+				]
+			]
+		]);
+
+		// missing file
+		$this->assertResolveNotFound($app, 'test/test.png');
+
+		// file that only exists on the site
+		$this->assertResolveNotFound($app, 'another-page/test-site.jpg');
+
+		// existing file
+		$result = $this->resolve($app, 'test/test.jpg');
+		$this->assertIsFile($result);
+		$this->assertSame('test/test.jpg', $result->id());
+	}
+
+	public function testResolveDraftFileWithoutAccess(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'drafts' => [
+					[
+						'slug'  => 'a-draft',
+						'files' => [
+							['filename' => 'test.jpg']
+						],
+					]
+				]
+			],
+			'options' => [
+				'content' => [
+					'fileRedirects' => true
+				]
+			]
+		]);
+
+		// a file on a draft page must not be exposed to
+		// anonymous visitors through clean file URLs
+		$this->assertResolveNotFound($app, 'a-draft/test.jpg');
+	}
+
+	public function testResolveDraftFileWithUser(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'drafts' => [
+					[
+						'slug'  => 'a-draft',
+						'files' => [
+							['filename' => 'test.jpg']
+						],
+					]
+				]
+			],
+			'users' => [
+				['email' => 'admin@getkirby.com', 'role' => 'admin']
+			],
+			'options' => [
+				'content' => [
+					'fileRedirects' => true
+				]
+			]
+		]);
+
+		$app->impersonate('admin@getkirby.com');
+
+		$result = $this->resolve($app, 'a-draft/test.jpg');
+		$this->assertIsFile($result);
+		$this->assertSame('a-draft/test.jpg', $result->id());
+	}
+
+	public function testResolveDraftFileWithUserDeniedByPermission(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'drafts' => [
+					[
+						'slug'  => 'a-draft',
+						'files' => [
+							['filename' => 'test.jpg']
+						],
+					]
+				]
+			],
+			'roles' => [
+				[
+					'name'        => 'editor',
+					'permissions' => [
+						'pages' => ['access' => false]
+					]
+				]
+			],
+			'users' => [
+				['email' => 'editor@getkirby.com', 'role' => 'editor']
+			],
+			'options' => [
+				'content' => [
+					'fileRedirects' => true
+				]
+			]
+		]);
+
+		$app->impersonate('editor@getkirby.com');
+
+		$this->assertResolveNotFound($app, 'a-draft/test.jpg');
+	}
+
+	public function testResolveDraftFileWithToken(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'drafts' => [
+					[
+						'slug'  => 'a-draft',
+						'files' => [
+							['filename' => 'test.jpg']
+						],
+					]
+				]
+			],
+			'options' => [
+				'content' => [
+					'fileRedirects' => true
+				]
+			]
+		]);
+
+		$token = $app->page('a-draft')->version()->previewToken();
+		$app   = $app->clone([
+			'request' => [
+				'query' => ['_token' => $token]
+			]
+		]);
+
+		$result = $this->resolve($app, 'a-draft/test.jpg');
+		$this->assertIsFile($result);
+		$this->assertSame('a-draft/test.jpg', $result->id());
+	}
+
+	public function testResolveFileEnabled(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'  => 'test',
+						'files' => [
+							['filename' => 'test.jpg']
+						],
+					]
+				]
+			],
+			'options' => [
+				'content' => [
+					'fileRedirects' => true
+				]
+			]
+		]);
+
+		// missing file
+		$this->assertResolveNotFound($app, 'test/test.png');
+
+		// existing file
+		$result = $this->resolve($app, 'test/test.jpg');
+		$this->assertIsFile($result);
+		$this->assertSame('test/test.jpg', $result->id());
+	}
+
+	public function testResolveFileDisabled(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'  => 'test',
+						'files' => [
+							['filename' => 'test.jpg']
+						],
+					]
+				]
+			],
+		]);
+
+		// missing file
+		$this->assertResolveNotFound($app, 'test/test.png');
+
+		// existing file, but file redirects are disabled
+		$this->assertResolveNotFound($app, 'test/test.jpg');
+	}
+
+	public function testResolveFileClosure(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'  => 'test',
+						'files' => [
+							[
+								'content'  => ['public' => 'true'],
+								'filename' => 'test-public.jpg'
+							],
+							[
+								'content'  => ['public' => 'false'],
+								'filename' => 'test-private.jpg'
+							]
+						],
+					]
+				]
+			],
+			'options' => [
+				'content' => [
+					'fileRedirects' => fn (File $file): bool => $file->public()->toBool()
+				]
+			]
+		]);
+
+		// missing file
+		$this->assertResolveNotFound($app, 'test/test.png');
+
+		// existing file (allowed)
+		$result = $this->resolve($app, 'test/test-public.jpg');
+		$this->assertIsFile($result);
+		$this->assertSame('test/test-public.jpg', $result->id());
+
+		// existing file (not allowed)
+		$this->assertResolveNotFound($app, 'test/test-private.jpg');
+	}
+
+	public function testIsResolvableFile(): void
+	{
+		$props = [
+			'site' => [
+				'files' => [
+					[
+						'content'  => ['public' => 'true'],
+						'filename' => 'public.jpg'
+					],
+					[
+						'content'  => ['public' => 'false'],
+						'filename' => 'private.jpg'
+					]
+				]
+			]
+		];
+
+		// disabled by default
+		$app = $this->app->clone($props);
+		$this->assertFalse((new Resolver($app))->isResolvableFile($app->site()->file('public.jpg')));
+
+		// enabled for all files
+		$app = $this->app->clone([
+			...$props,
+			'options' => ['content' => ['fileRedirects' => true]]
+		]);
+		$this->assertTrue((new Resolver($app))->isResolvableFile($app->site()->file('public.jpg')));
+
+		// enabled per file through a closure
+		$app = $this->app->clone([
+			...$props,
+			'options' => [
+				'content' => [
+					'fileRedirects' => fn (File $file): bool => $file->public()->toBool()
+				]
+			]
+		]);
+		$resolver = new Resolver($app);
+		$this->assertTrue($resolver->isResolvableFile($app->site()->file('public.jpg')));
+		$this->assertFalse($resolver->isResolvableFile($app->site()->file('private.jpg')));
+	}
+
+	public function testResolveRepresentationErrorType(): void
+	{
+		$app = $this->app->clone([
+			'templates' => [
+				'blog' => static::FIXTURES . '/templates/test.php',
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'blog',
+						'template' => 'blog'
+					]
+				]
+			]
+		]);
+
+		$this->assertResolveNotFound($app, 'blog.php');
+
+		// there must be no forced php response type if the
+		// representation cannot be found
+		$this->assertNull($app->response()->type());
+	}
+}

--- a/tests/Cms/App/ResolverTest.php
+++ b/tests/Cms/App/ResolverTest.php
@@ -355,35 +355,6 @@ class ResolverTest extends TestCase
 		$this->assertIsPage($this->resolve($app, 'test'));
 	}
 
-	public function testResolvePageContentNegotiationDisabled(): void
-	{
-		F::write(static::TMP . '/test.php', 'html');
-		F::write(static::TMP . '/test.md.php', '# Markdown');
-
-		$app = $this->app->clone([
-			'roots' => [
-				'templates' => static::TMP
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug'     => 'test',
-						'template' => 'test'
-					]
-				]
-			],
-			'options' => [
-				'content' => [
-					'negotiation' => false
-				]
-			],
-		]);
-
-		$result = $this->resolve($app, 'test');
-		$this->assertIsPage($result);
-		$this->assertNull($app->response()->header('Vary'));
-	}
-
 	public function testResolveFileDefault(): void
 	{
 		$app = $this->app->clone([

--- a/tests/Cms/Routes/RouterTest.php
+++ b/tests/Cms/Routes/RouterTest.php
@@ -3,7 +3,7 @@
 namespace Kirby\Cms;
 
 use InvalidArgumentException;
-use Kirby\Exception\NotFoundException;
+use Kirby\Exception\LogicException;
 use Kirby\Filesystem\F;
 use Kirby\Http\Response;
 use Kirby\Toolkit\I18n;
@@ -71,7 +71,7 @@ class RouterTest extends TestCase
 			]
 		]);
 
-		$this->expectException(NotFoundException::class);
+		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('The home page does not exist');
 
 		$app->call('/');
@@ -628,7 +628,7 @@ class RouterTest extends TestCase
 			]
 		]);
 
-		$this->expectException(NotFoundException::class);
+		$this->expectException(LogicException::class);
 		$this->expectExceptionMessage('The home page does not exist');
 
 		$app->call('/');


### PR DESCRIPTION
## Changelog 

### 🎉 Features

#### Automatic content negotiation for content representations 

Content representations are available by appending their matching extension to the URL. With content negotiation, they can now also be accessed through the `Accept` header in requests without appending the extension. 

As an example, if your page type has a markdown content representation (`site/templates/mypage.md.php`), you can use the accept header `Accept: text/markdown, text/html` to prefer the markdown representation over the html representation.  

### ♻️ Refactored

- New `Kirby\Cms\App\Resolver` class, which handles all the logic from the `Kirby\Cms\App::resolve()` method

### 🚨 Breaking changes

- Running `Kirby\Cms\App::resolve()` for the home page, when the home page is missing will now throw a `Kirby\Exception\LogicException` instead of a `Kirby\Exception\NotFoundException`. The home page should not be missing at all and is an indicator of a broken installation. A logic exception makes more sense here and it can bubble up more naturally. 

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion