### PR TITLE
fix: Localize invalid form save toast

### DIFF
--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -428,8 +428,9 @@ class Fields extends Collection
 
 		if ($errors !==	[]) {
 			throw new InvalidArgumentException(
-				fallback: 'Invalid form with errors',
-				details: $errors
+				key: 'form.incomplete',
+				details: $errors,
+				fallback: 'Invalid form with errors'
 			);
 		}
 	}

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -980,7 +980,7 @@ class FieldsTest extends TestCase
 		);
 
 		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Invalid form with errors');
+		$this->expectExceptionMessage('Please fix all form errors');
 
 		$fields->validate();
 	}


### PR DESCRIPTION
## Description

The form-error save toast was hardcoded to English because `Fields::validate()` threw the exception with only a `fallback` and no `key`. Passing `key: 'form.incomplete'` reconnects the already-existing (but orphaned) `error.form.incomplete` translation, so the toast is now localized. The English `fallback` is kept as a safety net.

## Changelog

### 🐛 Bug fixes

- Localize the "Invalid form with errors" save toast to the Panel language #8278

## Docs
<!--
Add any notes that help to document the feature/changes. Doesn't need
to be your best writing, just a few words and/or code snippets.
If applicable, add links to existing docs pages where the docs can be placed.
-->


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion