### PR TITLE
feat: Optional 2FA

### DIFF
--- a/config/api/routes/users.php
+++ b/config/api/routes/users.php
@@ -186,7 +186,10 @@ return [
 			// validate password of acting user unless they have logged in to reset it;
 			// always validate password of acting user when changing password of other users
 			if ($this->session()->get('kirby.resetPassword') !== true || $user->is($currentUser) !== true) {
-				$currentUser->validatePassword($this->requestBody('currentPassword'));
+				$this->kirby()->auth()->ensurePassword(
+					$currentUser,
+					$this->requestBody('currentPassword')
+				);
 			}
 
 			$result = $user->changePassword($this->requestBody('password'));

--- a/config/areas/account/drawers.php
+++ b/config/areas/account/drawers.php
@@ -11,6 +11,10 @@ return [
 		...$drawers['user.security.method.code'],
 		'pattern' => '(account)/security/method/code',
 	],
+	'account.security.challenge.email' => [
+		...$drawers['user.security.challenge.email'],
+		'pattern' => '(account)/security/challenge/email',
+	],
 	'account.security.challenge.totp' => [
 		...$drawers['user.security.challenge.totp'],
 		'pattern' => '(account)/security/challenge/totp',

--- a/config/areas/users/drawers.php
+++ b/config/areas/users/drawers.php
@@ -2,6 +2,7 @@
 
 use Kirby\Panel\Controller\Drawer\FieldDrawerController;
 use Kirby\Panel\Controller\Drawer\SectionDrawerController;
+use Kirby\Panel\Controller\Drawer\UserEmailChallengeDrawerController;
 use Kirby\Panel\Controller\Drawer\UserSecurityCodeMethodDrawerController;
 use Kirby\Panel\Controller\Drawer\UserSecurityDrawerController;
 use Kirby\Panel\Controller\Drawer\UserTotpDrawerController;
@@ -15,6 +16,10 @@ return [
 	'user.security.method.code' => [
 		'pattern' => 'users/(:any)/security/method/code',
 		'action'  => UserSecurityCodeMethodDrawerController::class
+	],
+	'user.security.challenge.email' => [
+		'pattern' => 'users/(:any)/security/challenge/email',
+		'action'  => UserEmailChallengeDrawerController::class
 	],
 	'user.security.challenge.totp' => [
 		'pattern' => 'users/(:any)/security/challenge/totp',

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -585,6 +585,7 @@
 	"login.challenge.email.enable.label": "Enable codes via email",
 	"login.challenge.email.help": "Enter the code just sent to your email inbox.",
 	"login.challenge.email.label": "Code via email",
+	"login.challenge.email.reset": "Codes via email are active as a second factor. Changing the address disables them until the new one has been confirmed.",
 	"login.challenge.totp.label": "Authenticator app",
 	"login.challenges.help": "Two-factor methods can add an additional layer of security by requiring more than just a password to sign in.",
 	"login.challenges.label": "Two-factor methods",

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -578,6 +578,12 @@
 	"lock.isUnlocked": "Was unlocked by another user",
 
 	"login": "Log in",
+	"login.challenge.email.description": "Send a one‑time code to your email address that is used as a second factor when signing into your account.",
+	"login.challenge.email.disable.confirm": "Do you really want to disable codes via email for {user}?",
+	"login.challenge.email.disable.label": "Disable codes via email",
+	"login.challenge.email.empty": "Codes via email not set up yet",
+	"login.challenge.email.enable.label": "Enable codes via email",
+	"login.challenge.email.help": "Enter the code just sent to your email inbox.",
 	"login.challenge.email.label": "Code via email",
 	"login.challenge.totp.label": "Authenticator app",
 	"login.challenges.help": "Two-factor methods can add an additional layer of security by requiring more than just a password to sign in.",

--- a/panel/src/components/Drawers/UserEmailChallengeDrawer.vue
+++ b/panel/src/components/Drawers/UserEmailChallengeDrawer.vue
@@ -1,0 +1,158 @@
+<template>
+	<k-drawer
+		ref="drawer"
+		v-bind="$props"
+		class="k-user-email-challenge-drawer"
+		@cancel="$emit('cancel')"
+		@submit="$emit('cancel')"
+	>
+		<form ref="form" class="k-stack" style="gap: var(--spacing-6)">
+			<k-user-info :label="$t('account')" :user="user" />
+
+			<k-drawer-text :text="$t('login.challenge.email.description')" />
+
+			<template v-if="isAccount">
+				<!-- 1. start the process, which sends the code -->
+				<k-button
+					v-if="hasCode === false"
+					:disabled="isLoading"
+					:icon="isLoading ? 'loader' : actionIcon"
+					:text="actionText"
+					:theme="actionTheme"
+					variant="filled"
+					@click="start"
+				/>
+
+				<!-- 2. confirm with the code that was sent -->
+				<template v-else>
+					<k-text-field
+						:counter="false"
+						:help="$t('login.challenge.email.help')"
+						:label="codeLabel"
+						:placeholder="$t('login.code.placeholder.email')"
+						:required="true"
+						:value="code"
+						autocomplete="one-time-code"
+						font="monospace"
+						@input="code = $event"
+					/>
+
+					<k-button
+						:disabled="isLoading"
+						:icon="isLoading ? 'loader' : 'check'"
+						:text="actionText"
+						:theme="actionTheme"
+						variant="filled"
+						@click="confirm"
+					/>
+				</template>
+			</template>
+
+			<!-- an admin managing another user re-enters their own password -->
+			<k-button
+				v-else-if="isEnabled"
+				:disabled="isLoading"
+				:icon="isLoading ? 'loader' : 'unlock'"
+				:text="$t('disable')"
+				theme="negative"
+				variant="filled"
+				@click="disableAsAdmin"
+			/>
+
+			<k-empty v-else icon="email-unread">
+				{{ $t("login.challenge.email.empty") }}
+			</k-empty>
+		</form>
+	</k-drawer>
+</template>
+
+<script>
+import UserCredentialDrawer from "./UserCredentialDrawer.vue";
+
+/**
+ * Drawer to enable/disable codes via email as a second factor
+ *
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+export default {
+	extends: UserCredentialDrawer,
+	props: {
+		isEnabled: Boolean
+	},
+	emits: ["cancel", "submit"],
+	data() {
+		return {
+			code: "",
+			hasCode: false
+		};
+	},
+	computed: {
+		actionIcon() {
+			return this.isEnabled ? "unlock" : "lock";
+		},
+		actionText() {
+			return this.isEnabled ? this.$t("disable") : this.$t("activate");
+		},
+		actionTheme() {
+			return this.isEnabled ? "negative" : "positive";
+		},
+		codeLabel() {
+			if (this.isEnabled === true) {
+				return this.$t("login.challenge.email.disable.label");
+			}
+
+			return this.$t("login.challenge.email.enable.label");
+		}
+	},
+	watch: {
+		isEnabled() {
+			// the challenge was just enabled or disabled, so the
+			// completed step must not stay on screen
+			this.reset();
+		}
+	},
+	methods: {
+		async confirm() {
+			if (this.$refs.form.reportValidity()) {
+				await this.request(this.isEnabled ? "remove" : "create", {
+					authorization: this.code
+				});
+			}
+		},
+		disableAsAdmin() {
+			// an admin managing another user re-enters their own password
+			this.confirmPassword({
+				text: this.$t("login.challenge.email.disable.confirm", {
+					user: this.$helper.string.escapeHTML(this.user.email)
+				}),
+				button: {
+					text: this.$t("disable"),
+					icon: "unlock"
+				},
+				onSubmit: (password) => this.request("remove", { password })
+			});
+		},
+		reset() {
+			this.code = "";
+			this.hasCode = false;
+		},
+		async start() {
+			this.isLoading = true;
+
+			try {
+				const response = await this.$panel.drawer.post({ action: "code" });
+
+				if (response === false) {
+					return;
+				}
+
+				this.hasCode = true;
+			} finally {
+				this.isLoading = false;
+			}
+		}
+	}
+};
+</script>

--- a/panel/src/components/Drawers/UserEmailChallengeDrawer.vue
+++ b/panel/src/components/Drawers/UserEmailChallengeDrawer.vue
@@ -6,7 +6,12 @@
 		@cancel="$emit('cancel')"
 		@submit="$emit('cancel')"
 	>
-		<form ref="form" class="k-stack" style="gap: var(--spacing-6)">
+		<form
+			ref="form"
+			class="k-stack"
+			style="gap: var(--spacing-6)"
+			@submit.prevent="onSubmit"
+		>
 			<k-user-info :label="$t('account')" :user="user" />
 
 			<k-drawer-text :text="$t('login.challenge.email.description')" />
@@ -133,6 +138,11 @@ export default {
 				},
 				onSubmit: (password) => this.request("remove", { password })
 			});
+		},
+		onSubmit() {
+			if (this.isAccount === true && this.hasCode === true) {
+				this.confirm();
+			}
 		},
 		reset() {
 			this.code = "";

--- a/panel/src/components/Drawers/UserTotpDrawer.vue
+++ b/panel/src/components/Drawers/UserTotpDrawer.vue
@@ -7,7 +7,12 @@
 		@cancel="$emit('cancel')"
 		@submit="$emit('cancel')"
 	>
-		<form ref="form" class="k-stack" style="gap: var(--spacing-6)">
+		<form
+			ref="form"
+			class="k-stack"
+			style="gap: var(--spacing-6)"
+			@submit.prevent="onSubmit"
+		>
 			<k-user-info :label="$t('account')" :user="user" />
 
 			<k-drawer-text :text="$t('login.totp.description')" />
@@ -149,6 +154,13 @@ export default {
 				},
 				onSubmit: (password) => this.request("remove", { password })
 			});
+		},
+		onSubmit() {
+			if (this.isAccount === false) {
+				return;
+			}
+
+			this.isEnabled ? this.disable() : this.create();
 		}
 	}
 };

--- a/panel/src/components/Drawers/UserWebauthnDrawer.vue
+++ b/panel/src/components/Drawers/UserWebauthnDrawer.vue
@@ -7,7 +7,12 @@
 		@cancel="$emit('cancel')"
 		@submit="$emit('cancel')"
 	>
-		<form ref="form" class="k-stack" style="gap: var(--spacing-6)">
+		<form
+			ref="form"
+			class="k-stack"
+			style="gap: var(--spacing-6)"
+			@submit.prevent="onSubmit"
+		>
 			<k-user-info :label="$t('account')" :user="user" />
 
 			<k-box
@@ -149,6 +154,11 @@ export default {
 				(authorization) => this.request("remove", { id, authorization }),
 				(error) => this.$panel.notification.error(error)
 			);
+		},
+		onSubmit() {
+			if (this.isAccount === true) {
+				this.create();
+			}
 		}
 	}
 };

--- a/panel/src/components/Drawers/index.js
+++ b/panel/src/components/Drawers/index.js
@@ -7,6 +7,7 @@ import StateDrawer from "./StateDrawer.vue";
 import FormDrawer from "./FormDrawer.vue";
 import StructureDrawer from "./StructureDrawer.vue";
 import TextDrawer from "./TextDrawer.vue";
+import UserEmailChallengeDrawer from "./UserEmailChallengeDrawer.vue";
 import UserSecurityDrawer from "./UserSecurityDrawer.vue";
 import UserTotpDrawer from "./UserTotpDrawer.vue";
 import UserWebauthnDrawer from "./UserWebauthnDrawer.vue";
@@ -22,6 +23,7 @@ export default {
 		app.component("k-form-drawer", FormDrawer);
 		app.component("k-structure-drawer", StructureDrawer);
 		app.component("k-text-drawer", TextDrawer);
+		app.component("k-user-email-challenge-drawer", UserEmailChallengeDrawer);
 		app.component("k-user-security-drawer", UserSecurityDrawer);
 		app.component("k-user-totp-drawer", UserTotpDrawer);
 		app.component("k-user-webauthn-drawer", UserWebauthnDrawer);

--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -121,12 +121,16 @@ class Auth
 			$this->challenges->create($session, $email, $mode);
 
 		} catch (Throwable $e) {
+			// drop the previous challenge; its type and data must not
+			// survive, or its code could be verified against the email below
+			$this->challenges->clear($session);
+
 			// only re-throw the exception in auth debug mode
 			$this->fail($e);
 
-			// always make sure to still set the email, mode and timeout,
-			// even if the challenge wasn't created;
-			// this avoids leaking whether the user exists
+			// restore only email, mode and timeout (deliberately no type or
+			// data), so the failure still looks like a pending challenge
+			// and does not leak whether the user exists
 			$timeout = $this->challenges()->timeout();
 			$session->set('kirby.challenge.email', $email);
 			$session->set('kirby.challenge.mode', $mode);

--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -208,6 +208,36 @@ class Auth
 	}
 
 	/**
+	 * Re-confirms the password of an already authenticated user before
+	 * a sensitive action, inside the shared rate-limit envelope so that
+	 * a hijacked session cannot brute-force it.
+	 *
+	 * @internal
+	 * @since 6.0.0
+	 *
+	 * @throws RateLimitException If the rate limit was exceeded
+	 * @throws InvalidArgumentException If the password is not valid
+	 */
+	public function ensurePassword(
+		User $user,
+		#[SensitiveParameter]
+		string|null $password
+	): void {
+		$email = $user->email();
+
+		$this->limits->ensure($email);
+
+		try {
+			$user->validatePassword($password);
+		} catch (Throwable $e) {
+			// confirming a password is not a login attempt,
+			// so do not fire user.login:failed
+			$this->limits->track($email, triggerHook: false);
+			throw $e;
+		}
+	}
+
+	/**
 	 * Throws an exception only in debug mode, otherwise falls back
 	 * to a public error without sensitive information
 	 *

--- a/src/Auth/Challenge.php
+++ b/src/Auth/Challenge.php
@@ -2,8 +2,10 @@
 
 namespace Kirby\Auth;
 
+use Closure;
 use Kirby\Cms\App;
 use Kirby\Cms\User;
+use Kirby\Exception\PermissionException;
 use Kirby\Panel\Ui\Component;
 use Kirby\Toolkit\HasI18n;
 use Kirby\Toolkit\Str;
@@ -29,6 +31,35 @@ abstract class Challenge
 		protected int $timeout
 	) {
 		$this->kirby = $user->kirby();
+	}
+
+	/**
+	 * Verifies the input and invalidates a single-use nonce on failure
+	 *
+	 * @throws PermissionException If the input could not be verified
+	 */
+	public function attempt(
+		#[SensitiveParameter]
+		mixed $input,
+		Pending $pending,
+		Closure $invalidate
+	): void {
+		$success = false;
+
+		try {
+			$success = $this->verify($input, $pending) === true;
+
+			if ($success === false) {
+				throw new PermissionException(key: 'access.code');
+			}
+		} finally {
+			// a single-use challenge signs a one-time nonce that must be
+			// invalidated even after a failed attempt (e.g. WebAuthn); a
+			// reusable code is kept so it can be retried within its lifetime
+			if ($success === false && $this->isSingleUse() === true) {
+				$invalidate();
+			}
+		}
 	}
 
 	/**

--- a/src/Auth/Challenge/EmailChallenge.php
+++ b/src/Auth/Challenge/EmailChallenge.php
@@ -54,6 +54,26 @@ class EmailChallenge extends Challenge
 	}
 
 	/**
+	 * As a second factor, the email challenge is opt-in per user,
+	 * so that users are not forced into it just by having an email
+	 * address. For every other purpose it stays always available.
+	 */
+	public static function isAvailable(User $user, string $mode): bool
+	{
+		if ($mode !== '2fa') {
+			return true;
+		}
+
+		if ($user->secret('email') === true) {
+			return true;
+		}
+
+		// enforced 2FA needs a factor for every user, so email stays
+		// the baseline for those who have not set up anything else
+		return $user->kirby()->auth()->methods()->hasAnyRequiring2FA();
+	}
+
+	/**
 	 * Sends the email with the code to the user
 	 */
 	protected function send(string $code): void
@@ -105,10 +125,9 @@ class EmailChallenge extends Challenge
 	{
 		return [
 			new Button(
-				icon:     static::icon(),
-				text:     static::i18n('login.challenge.email.label'),
-				dialog:   $user->panel()->url(true) . '/changeEmail',
-				disabled: !$user->permissions()->can('changeEmail')
+				icon:   static::icon(),
+				text:   static::i18n('login.challenge.email.label'),
+				drawer: $user->panel()->url(true) . '/security/challenge/email'
 			)
 		];
 	}

--- a/src/Auth/Challenge/EmailChallenge.php
+++ b/src/Auth/Challenge/EmailChallenge.php
@@ -68,8 +68,8 @@ class EmailChallenge extends Challenge
 			return true;
 		}
 
-		// enforced 2FA needs a factor for every user, so email stays
-		// the baseline for those who have not set up anything else
+		// enforced 2FA must not lock out users, so email stays
+		// available for everybody as long as it is required
 		return $user->kirby()->auth()->methods()->hasAnyRequiring2FA();
 	}
 

--- a/src/Auth/Challenges.php
+++ b/src/Auth/Challenges.php
@@ -193,6 +193,15 @@ class Challenges
 	}
 
 	/**
+	 * Checks whether at least one challenge is available
+	 * for the user and purpose/mode
+	 */
+	public function hasAvailable(User $user, string $mode): bool
+	{
+		return $this->available($user, $mode) !== [];
+	}
+
+	/**
 	 * Writes challenge state into the session
 	 */
 	protected function store(

--- a/src/Auth/Challenges.php
+++ b/src/Auth/Challenges.php
@@ -152,7 +152,7 @@ class Challenges
 		return $email;
 	}
 
-	protected function ensureNotTimeout(Session $session): int|null
+	protected function ensureNotTimeout(Session $session): void
 	{
 		// time-limiting; check this early so that we can
 		// destroy the session no matter if the user exists
@@ -167,8 +167,6 @@ class Challenges
 			$this->clear($session);
 			throw new ChallengeTimeoutException();
 		}
-
-		return $timeout;
 	}
 
 	/**
@@ -186,6 +184,8 @@ class Challenges
 	 * Returns an instance of the requested auth challenge.
 	 * (This is based on the config. You might need to check
 	 * yourself if the method should be available in your context)
+	 *
+	 * @param int|null $timeout Lifetime in seconds, not an expiry timestamp
 	 */
 	public function get(
 		string $type,
@@ -300,9 +300,9 @@ class Challenges
 		mixed $input
 	): Challenge {
 		// ensure we have an active challenge for a valid user
-		$timeout = $this->ensureNotTimeout($session);
-		$email   = $this->ensureActiveChallenge($session);
-		$user    = $this->kirby->user($email);
+		$this->ensureNotTimeout($session);
+		$email = $this->ensureActiveChallenge($session);
+		$user  = $this->kirby->user($email);
 
 		if ($user === null) {
 			throw new UserNotFoundException(name: $email);
@@ -314,7 +314,7 @@ class Challenges
 		$mode      = $session->get('kirby.challenge.mode');
 		$data      = $session->get('kirby.challenge.data');
 		$data      = Pending::from($data ?? []);
-		$challenge = $this->get($type, $user, $mode, $timeout);
+		$challenge = $this->get($type, $user, $mode);
 
 		$challenge->attempt(
 			input:      $input,

--- a/src/Auth/Challenges.php
+++ b/src/Auth/Challenges.php
@@ -8,12 +8,10 @@ use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
-use Kirby\Exception\PermissionException;
 use Kirby\Exception\UserNotFoundException;
 use Kirby\Session\Session;
 use Kirby\Toolkit\A;
 use SensitiveParameter;
-use Throwable;
 
 /**
  * Handler for all auth challenges
@@ -318,19 +316,11 @@ class Challenges
 		$data      = Pending::from($data ?? []);
 		$challenge = $this->get($type, $user, $mode, $timeout);
 
-		try {
-			if ($challenge->verify($input, $data) !== true) {
-				throw new PermissionException(key: 'access.code');
-			}
-		} catch (Throwable $e) {
-			// a single-use challenge signs a one-time
-			// nonce that must not survive a failed attempt
-			if ($challenge->isSingleUse() === true) {
-				$this->clear($session);
-			}
-
-			throw $e;
-		}
+		$challenge->attempt(
+			input:      $input,
+			pending:    $data,
+			invalidate: fn () => $this->clear($session)
+		);
 
 		return $challenge;
 	}

--- a/src/Auth/Challenges.php
+++ b/src/Auth/Challenges.php
@@ -308,8 +308,6 @@ class Challenges
 			throw new UserNotFoundException(name: $email);
 		}
 
-		$this->auth->limits()->ensure($email);
-
 		$type      = $session->get('kirby.challenge.type');
 		$mode      = $session->get('kirby.challenge.mode');
 		$data      = $session->get('kirby.challenge.data');

--- a/src/Auth/Challenges.php
+++ b/src/Auth/Challenges.php
@@ -38,10 +38,23 @@ class Challenges
 
 	public function available(User $user, string $mode): array
 	{
-		return array_values(A::filter(
+		$available = array_values(A::filter(
 			$this->enabled(),
 			fn ($type) => $this->class($type)::isAvailable($user, $mode)
 		));
+
+		// a single-factor flow (e.g. the `code` login method or a
+		// password reset) must not be weaker than the second factor
+		// the user has set up, so it is limited to those challenges
+		if ($mode !== '2fa') {
+			$factors = $this->available($user, '2fa');
+
+			if ($factors !== []) {
+				return array_values(array_intersect($available, $factors));
+			}
+		}
+
+		return $available;
 	}
 
 	/**

--- a/src/Auth/Challenges.php
+++ b/src/Auth/Challenges.php
@@ -221,13 +221,12 @@ class Challenges
 		string $email,
 		string $mode
 	): void {
-		$data    = $challenge->create();
-		$timeout = $this->timeout();
+		$data = $challenge->create();
 
 		$session->set('kirby.challenge.email', $email);
 		$session->set('kirby.challenge.type', $challenge->type());
 		$session->set('kirby.challenge.mode', $mode);
-		$session->set('kirby.challenge.timeout', time() + $timeout);
+		$session->set('kirby.challenge.timeout', time() + $challenge->timeout());
 
 		if ($data !== null) {
 			$session->set('kirby.challenge.data', $data->toArray());

--- a/src/Auth/Method.php
+++ b/src/Auth/Method.php
@@ -70,16 +70,6 @@ abstract class Method
 	}
 
 	/**
-	 * Checks if this method uses challenges
-	 */
-	public static function isUsingChallenges(
-		Auth $auth,
-		array $options = []
-	): bool {
-		return false;
-	}
-
-	/**
 	 * Returns the config options for this method
 	 */
 	public function options(): array

--- a/src/Auth/Method/BasicAuthMethod.php
+++ b/src/Auth/Method/BasicAuthMethod.php
@@ -47,7 +47,7 @@ class BasicAuthMethod extends Method
 			?? throw new PermissionException(message: 'Invalid password'); // @codeCoverageIgnore
 
 		/**
-		 * @var \Kirby\Auth\Method\PasswordMethod $method
+		 * @var PasswordMethod $method
 		 */
 		$method = $this->auth->methods()->get('password');
 

--- a/src/Auth/Method/BasicAuthMethod.php
+++ b/src/Auth/Method/BasicAuthMethod.php
@@ -13,6 +13,11 @@ use SensitiveParameter;
 /**
  * HTTP basic authentication
  *
+ * Validates the same email + password credentials as `PasswordMethod`.
+ * As it cannot run a challenge, it defers the 2FA policy
+ * to `PasswordMethod::has2FA()` and rejects users that would be
+ * challenged there instead of skipping their second factor.
+ *
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  * @since     6.0.0
@@ -24,6 +29,7 @@ class BasicAuthMethod extends Method
 	 * so `$long` isn't relevant here
 	 *
 	 * @throws InvalidArgumentException If the password is missing
+	 * @throws PermissionException If the user has a second factor set up
 	 */
 	public function authenticate(
 		string|null $email,
@@ -37,8 +43,23 @@ class BasicAuthMethod extends Method
 			);
 		}
 
-		return $this->auth->validatePassword($email, $password)
+		$user = $this->auth->validatePassword($email, $password)
 			?? throw new PermissionException(message: 'Invalid password'); // @codeCoverageIgnore
+
+		/**
+		 * @var \Kirby\Auth\Method\PasswordMethod $method
+		 */
+		$method = $this->auth->methods()->get('password');
+
+		// users without a second factor (e.g. dedicated
+		// API accounts) can keep using basic auth
+		if ($method->has2FA($user) === true) {
+			throw new PermissionException(
+				message: 'Basic authentication cannot be used with 2FA'
+			);
+		}
+
+		return $user;
 	}
 
 	/**
@@ -114,7 +135,11 @@ class BasicAuthMethod extends Method
 
 		// if any login method requires 2FA,
 		// basic auth without 2FA would be a weakness
-		if (in_array(true, array_column($methods, '2fa'), true) === true) {
+		//
+		// without enforced 2FA this general gate stays open, as it
+		// cannot know which user is authenticating; users who set
+		// up a second factor are rejected in `::authenticate()`
+		if ($auth->methods()->hasAnyRequiring2FA() === true) {
 			if ($fail === true) {
 				throw new PermissionException(
 					message: 'Basic authentication cannot be used with 2FA'

--- a/src/Auth/Method/BasicAuthMethod.php
+++ b/src/Auth/Method/BasicAuthMethod.php
@@ -142,7 +142,7 @@ class BasicAuthMethod extends Method
 		if ($auth->methods()->hasAnyRequiring2FA() === true) {
 			if ($fail === true) {
 				throw new PermissionException(
-					message: 'Basic authentication cannot be used with 2FA'
+					message: 'Basic authentication cannot be used with required 2FA'
 				);
 			}
 

--- a/src/Auth/Method/CodeMethod.php
+++ b/src/Auth/Method/CodeMethod.php
@@ -62,19 +62,12 @@ class CodeMethod extends Method
 		return true;
 	}
 
-	public static function isUsingChallenges(
-		Auth $auth,
-		array $options = []
-	): bool {
-		return true;
-	}
-
 	/**
 	 * Don't allow to circumvent 2FA by 1FA code method
 	 */
 	protected static function isWithoutAny2FA(Auth $auth): bool
 	{
-		if (in_array(true, array_column($auth->methods()->config(), '2fa'), true) === true) {
+		if ($auth->methods()->hasAnyRequiring2FA() === true) {
 			throw new InvalidArgumentException(
 				message: 'The "' . static::type() . '" login method cannot be enabled when 2FA is required'
 			);

--- a/src/Auth/Method/PasswordMethod.php
+++ b/src/Auth/Method/PasswordMethod.php
@@ -3,7 +3,6 @@
 namespace Kirby\Auth\Method;
 
 use InvalidArgumentException;
-use Kirby\Auth\Auth;
 use Kirby\Auth\Method;
 use Kirby\Auth\Status;
 use Kirby\Cms\User;
@@ -68,27 +67,19 @@ class PasswordMethod extends Method
 	}
 
 	/**
-	 * Checks whether a second-factor is required
+	 * Checks whether a second factor is required for this user
 	 */
-	protected function has2FA(User $user): bool
+	public function has2FA(User $user): bool
 	{
-		return static::isUsingChallenges(
-			$this->auth,
-			$this->options
-		);
-	}
-
-	public static function isUsingChallenges(
-		Auth $auth,
-		array $options = []
-	): bool {
-		$option = $options['2fa'] ?? null;
-
-		if ($option === true) {
+		// enforced: every user needs a second factor,
+		// even if they have not set one up yet
+		if (($this->options['2fa'] ?? null) === true) {
 			return true;
 		}
 
-		return false;
+		// otherwise only challenge users who have any
+		// second factor set up (= available) for them
+		return $this->auth->challenges()->hasAvailable($user, '2fa');
 	}
 
 	public static function settings(User $user): array

--- a/src/Auth/Method/WebauthnMethod.php
+++ b/src/Auth/Method/WebauthnMethod.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Auth\Method;
 
-use Kirby\Auth\Auth;
 use Kirby\Auth\Exception\LoginNotPermittedException;
 use Kirby\Auth\Method;
 use Kirby\Auth\Service\Webauthn;
@@ -118,13 +117,6 @@ class WebauthnMethod extends Method
 	public static function icon(): string
 	{
 		return 'fingerprint';
-	}
-
-	public static function isUsingChallenges(
-		Auth $auth,
-		array $options = []
-	): bool {
-		return false;
 	}
 
 	public static function settings(User $user): array

--- a/src/Auth/Methods.php
+++ b/src/Auth/Methods.php
@@ -188,18 +188,11 @@ class Methods
 	}
 
 	/**
-	 * Checks if any method is using challenges
+	 * Checks if any method requires 2FA
 	 */
-	public function hasAnyUsingChallenges(): bool
+	public function hasAnyRequiring2FA(): bool
 	{
-		foreach ($this->enabled() as $method => $options) {
-			$class = $this->class($method);
-
-			if ($class::isUsingChallenges($this->auth, $options) === true) {
-				return true;
-			}
-		}
-
-		return false;
+		return in_array(true, array_column($this->config(), '2fa'), true);
 	}
+
 }

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -235,14 +235,19 @@ class System
 
 	/**
 	 * Check if the Panel has 2FA activated
+	 *
+	 * @deprecated 6.0.0 Use `$kirby->auth()->methods()->hasAnyRequiring2FA()` instead
 	 */
 	public function is2FA(): bool
 	{
-		return ($this->loginMethods()['password']['2fa'] ?? null) === true;
+		return $this->app->auth()->methods()->hasAnyRequiring2FA();
 	}
 
 	/**
 	 * Check if the Panel has 2FA with TOTP activated
+	 *
+	 * @deprecated 6.0.0 Use `$kirby->auth()->methods()->hasAnyRequiring2FA()` and
+	 *                   `$kirby->auth()->enabledChallenges()` instead
 	 */
 	public function is2FAWithTOTP(): bool
 	{

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -46,6 +46,12 @@ trait UserActions
 				$user = $user->clone(['email' => $email]);
 				$user->updateCredentials(['email' => $email]);
 
+				// the email challenge was confirmed for the old address,
+				// so the opt-in must not carry over to the new one
+				if ($user->secret('email') === true) {
+					$user->writeSecret('email', null);
+				}
+
 				return $user;
 			}
 		);

--- a/src/Panel/Controller/Dialog/UserChangeEmailDialogController.php
+++ b/src/Panel/Controller/Dialog/UserChangeEmailDialogController.php
@@ -16,6 +16,19 @@ use Kirby\Panel\Ui\Dialog\FormDialog;
  */
 class UserChangeEmailDialogController extends UserDialogController
 {
+	/**
+	 * The email challenge opt-in is reset by `$user->changeEmail()`,
+	 * because it only ever proved the old address was reachable
+	 */
+	protected function help(): string|null
+	{
+		if ($this->user->secret('email') !== true) {
+			return null;
+		}
+
+		return $this->i18n('login.challenge.email.reset');
+	}
+
 	public function load(): Dialog
 	{
 		return new FormDialog(
@@ -24,7 +37,8 @@ class UserChangeEmailDialogController extends UserDialogController
 					'label'     => $this->i18n('email'),
 					'required'  => true,
 					'type'      => 'email',
-					'preselect' => true
+					'preselect' => true,
+					'help'      => $this->help()
 				]
 			],
 			submitButton: $this->i18n('change'),

--- a/src/Panel/Controller/Dialog/UserChangePasswordDialogController.php
+++ b/src/Panel/Controller/Dialog/UserChangePasswordDialogController.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Panel\Controller\Dialog;
 
+use Kirby\Auth\Exception\RateLimitException;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Panel\Field;
@@ -87,8 +88,15 @@ class UserChangePasswordDialogController extends UserDialogController
 		// validate the current password of the acting user
 		try {
 			if ($this->canSkipConfirmation() === false) {
-				$this->kirby->user()->validatePassword($currentPassword);
+				$this->kirby->auth()->ensurePassword(
+					$this->kirby->user(),
+					$currentPassword
+				);
 			}
+		} catch (RateLimitException $e) {
+			// surface the limit honestly instead of as a wrong password,
+			// otherwise the user keeps retrying against a closed door
+			throw $e;
 		} catch (Exception) {
 			// catching and re-throwing exception to avoid automatic
 			// sign-out of current user from the Panel

--- a/src/Panel/Controller/Drawer/UserCredentialDrawerController.php
+++ b/src/Panel/Controller/Drawer/UserCredentialDrawerController.php
@@ -7,6 +7,7 @@ use Kirby\Auth\Pending;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\PermissionException;
+use Throwable;
 
 /**
  * Shared base for drawers that manage a removable login credential
@@ -42,7 +43,12 @@ abstract class UserCredentialDrawerController extends UserDrawerController
 
 		$this->kirby->session()->set(
 			'kirby.security.authorize.' . $this->user->id(),
-			$pending->toArray()
+			[
+				...$pending->toArray(),
+				// the stored code is only valid for the challenge's
+				// lifetime, so a leaked session cannot reuse it forever
+				'expires' => time() + $challenge->timeout()
+			]
 		);
 
 		return $pending->public();
@@ -91,15 +97,50 @@ abstract class UserCredentialDrawerController extends UserDrawerController
 	 */
 	protected function authorizeCurrentUser(): void
 	{
+		$key       = 'kirby.security.authorize.' . $this->user->id();
+		$session   = $this->kirby->session();
+		$limits    = $this->kirby->auth()->limits();
+		$email     = $this->user->email();
+
+		// block once the shared auth rate limit is exhausted, so that the
+		// secret/code cannot be brute-forced from a hijacked session
+		$limits->ensure($email);
+
 		$challenge = $this->challenge();
-		$pending   = $this->kirby->session()->pull('kirby.security.authorize.' . $this->user->id()) ?? [];
-		$pending   = Pending::from($pending);
+		$stored    = $session->get($key) ?? [];
+		$input     = $this->request->get('authorization');
 
-		$input = $this->request->get('authorization');
+		// a stored code is only valid for the challenge's lifetime
+		$expires = $stored['expires'] ?? null;
 
-		if ($challenge->verify($input, $pending) !== true) {
+		if (is_int($expires) === true && $expires < time()) {
+			$session->remove($key);
 			throw new InvalidArgumentException(key: 'access.code');
 		}
+
+		try {
+			if ($challenge->verify($input, Pending::from($stored)) !== true) {
+				throw new InvalidArgumentException(key: 'access.code');
+			}
+		} catch (Throwable $e) {
+			// count the failed attempt against the rate limit
+			$limits->track($email, triggerHook: false);
+
+			// a single-use challenge signs a one-time nonce that must be
+			// invalidated even after a failed attempt (e.g. WebAuthn); a
+			// reusable code is kept so the account owner can retry
+			// with the correct code within its lifetime
+			// instead of being locked out by a single typo
+			if ($challenge->isSingleUse() === true) {
+				$session->remove($key);
+			}
+
+			throw $e;
+		}
+
+		// the action is authorized: consume the pending so the same
+		// code or nonce cannot be replayed for another change
+		$session->remove($key);
 	}
 
 	/**

--- a/src/Panel/Controller/Drawer/UserCredentialDrawerController.php
+++ b/src/Panel/Controller/Drawer/UserCredentialDrawerController.php
@@ -74,11 +74,21 @@ abstract class UserCredentialDrawerController extends UserDrawerController
 	 */
 	protected function authorizeAdmin(): void
 	{
+		$admin    = $this->kirby->user();
+		$limits   = $this->kirby->auth()->limits();
+		$email    = $admin->email();
 		$password = $this->request->get('password');
 
+		// throttle like any other credential check, so that a hijacked
+		// session cannot brute-force the admin's own password
+		$limits->ensure($email);
+
 		try {
-			$this->kirby->user()->validatePassword($password);
+			$admin->validatePassword($password);
 		} catch (InvalidArgumentException $e) {
+			// count the failed attempt against the rate limit
+			$limits->track($email, triggerHook: false);
+
 			// re-throw without the 401 http code: a wrong password here
 			// is a validation error to show inline, not an authentication
 			// failure that would log the current admin out

--- a/src/Panel/Controller/Drawer/UserCredentialDrawerController.php
+++ b/src/Panel/Controller/Drawer/UserCredentialDrawerController.php
@@ -115,26 +115,18 @@ abstract class UserCredentialDrawerController extends UserDrawerController
 
 		if (is_int($expires) === true && $expires < time()) {
 			$session->remove($key);
-			throw new InvalidArgumentException(key: 'access.code');
+			throw new PermissionException(key: 'access.code');
 		}
 
 		try {
-			if ($challenge->verify($input, Pending::from($stored)) !== true) {
-				throw new InvalidArgumentException(key: 'access.code');
-			}
+			$challenge->attempt(
+				input:      $input,
+				pending:    Pending::from($stored),
+				invalidate: fn () => $session->remove($key)
+			);
 		} catch (Throwable $e) {
 			// count the failed attempt against the rate limit
 			$limits->track($email, triggerHook: false);
-
-			// a single-use challenge signs a one-time nonce that must be
-			// invalidated even after a failed attempt (e.g. WebAuthn); a
-			// reusable code is kept so the account owner can retry
-			// with the correct code within its lifetime
-			// instead of being locked out by a single typo
-			if ($challenge->isSingleUse() === true) {
-				$session->remove($key);
-			}
-
 			throw $e;
 		}
 

--- a/src/Panel/Controller/Drawer/UserCredentialDrawerController.php
+++ b/src/Panel/Controller/Drawer/UserCredentialDrawerController.php
@@ -75,20 +75,11 @@ abstract class UserCredentialDrawerController extends UserDrawerController
 	protected function authorizeAdmin(): void
 	{
 		$admin    = $this->kirby->user();
-		$limits   = $this->kirby->auth()->limits();
-		$email    = $admin->email();
 		$password = $this->request->get('password');
 
-		// throttle like any other credential check, so that a hijacked
-		// session cannot brute-force the admin's own password
-		$limits->ensure($email);
-
 		try {
-			$admin->validatePassword($password);
+			$this->kirby->auth()->ensurePassword($admin, $password);
 		} catch (InvalidArgumentException $e) {
-			// count the failed attempt against the rate limit
-			$limits->track($email, triggerHook: false);
-
 			// re-throw without the 401 http code: a wrong password here
 			// is a validation error to show inline, not an authentication
 			// failure that would log the current admin out

--- a/src/Panel/Controller/Drawer/UserEmailChallengeDrawerController.php
+++ b/src/Panel/Controller/Drawer/UserEmailChallengeDrawerController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Kirby\Panel\Controller\Drawer;
+
+use Kirby\Auth\Challenge\EmailChallenge;
+use Kirby\Cms\User;
+use Kirby\Cms\UserRules;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Panel\Ui\Drawer;
+
+/**
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ * @unstable
+ */
+class UserEmailChallengeDrawerController extends UserCredentialDrawerController
+{
+	public function __construct(User $user)
+	{
+		parent::__construct($user, 'email');
+
+		// ensure user has the necessary permissions
+		UserRules::changeSecret($user, 'email', null);
+	}
+
+	protected function create(): User
+	{
+		parent::create();
+
+		// completing the challenge proves that the address is
+		// actually reachable, so that nobody can lock themselves
+		// out of their account with undeliverable emails
+		$this->authorizeCurrentUser();
+
+		return $this->user->changeSecret('email', true);
+	}
+
+	protected function isEnabled(): bool
+	{
+		return $this->user->secret('email') === true;
+	}
+
+	public function load(): Drawer
+	{
+		return new Drawer(
+			component: 'k-user-email-challenge-drawer',
+			icon:      EmailChallenge::icon(),
+			title:     $this->i18n('login.challenge.email.label'),
+			isAccount: $this->isCurrentUser(),
+			isEnabled: $this->isEnabled(),
+			size:      'tiny',
+			user:      $this->user->panel()->info()
+		);
+	}
+
+	protected function remove(): User
+	{
+		$this->authorize();
+		return $this->user->changeSecret('email', null);
+	}
+
+	/**
+	 * Sends a one-time code to the user's email address and
+	 * remembers it for the following create/remove action.
+	 */
+	protected function send(): User
+	{
+		$this->authorization();
+		return $this->user;
+	}
+
+	public function submit(): bool
+	{
+		$this->user = match ($action = $this->request->get('action')) {
+			'code'   => $this->send(),
+			'create' => $this->create(),
+			'remove' => $this->remove(),
+			default  => throw new InvalidArgumentException(
+				message: 'Invalid action: ' . $action
+			)
+		};
+
+		return true;
+	}
+
+}

--- a/src/Panel/Controller/Drawer/UserEmailChallengeDrawerController.php
+++ b/src/Panel/Controller/Drawer/UserEmailChallengeDrawerController.php
@@ -66,7 +66,18 @@ class UserEmailChallengeDrawerController extends UserCredentialDrawerController
 	 */
 	protected function send(): User
 	{
+		if ($this->isCurrentUser() === false) {
+			return $this->user;
+		}
+
+		$limits = $this->kirby->auth()->limits();
+		$email  = $this->user->email();
+
+		$limits->ensure($email);
+		$limits->track($email, triggerHook: false);
+
 		$this->authorization();
+
 		return $this->user;
 	}
 

--- a/src/Panel/Controller/Drawer/UserEmailChallengeDrawerController.php
+++ b/src/Panel/Controller/Drawer/UserEmailChallengeDrawerController.php
@@ -6,6 +6,7 @@ use Kirby\Auth\Challenge\EmailChallenge;
 use Kirby\Cms\User;
 use Kirby\Cms\UserRules;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\PermissionException;
 use Kirby\Panel\Ui\Drawer;
 
 /**
@@ -63,11 +64,17 @@ class UserEmailChallengeDrawerController extends UserCredentialDrawerController
 	/**
 	 * Sends a one-time code to the user's email address and
 	 * remembers it for the following create/remove action.
+	 *
+	 * @throws PermissionException If the code is not for the current user
 	 */
 	protected function send(): User
 	{
+		// only the account owner can prove that their own inbox is
+		// reachable; an admin manages the challenge with their password
 		if ($this->isCurrentUser() === false) {
-			return $this->user;
+			throw new PermissionException(
+				message: 'You cannot send a login code for ' . $this->user->email()
+			);
 		}
 
 		$limits = $this->kirby->auth()->limits();

--- a/src/Panel/Controller/Drawer/UserSecurityDrawerController.php
+++ b/src/Panel/Controller/Drawer/UserSecurityDrawerController.php
@@ -25,12 +25,6 @@ class UserSecurityDrawerController extends UserDrawerController
 
 	public function challenges(): array
 	{
-		$methods = $this->auth()->methods();
-
-		if ($methods->hasAnyUsingChallenges() === false) {
-			return [];
-		}
-
 		$buttons    = [];
 		$challenges = $this->auth()->challenges();
 
@@ -73,7 +67,7 @@ class UserSecurityDrawerController extends UserDrawerController
 
 		$methods = $this->auth()->methods()->enabled();
 
-		foreach ($methods as $type => $options) {
+		foreach (array_keys($methods) as $type) {
 			$method  = $this->auth()->methods()->class($type);
 			$buttons = [
 				...$buttons,

--- a/tests/Api/Routes/AccountRoutesTest.php
+++ b/tests/Api/Routes/AccountRoutesTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Api;
 
+use Kirby\Auth\Exception\RateLimitException;
 use Kirby\Blueprint\Blueprint;
 use Kirby\Blueprint\Section;
 use Kirby\Cms\App;
@@ -219,6 +220,48 @@ class AccountRoutesTest extends TestCase
 		$this->app->api()->call('account/password', 'PATCH', [
 			'body' => [
 				'currentPassword' => 'definitely-not-correct',
+				'password'        => 'super-secure-new-password'
+			]
+		]);
+	}
+
+	public function testChangePasswordWrongCurrentPasswordConsumesRateLimit(): void
+	{
+		try {
+			$this->app->api()->call('account/password', 'PATCH', [
+				'body' => [
+					'currentPassword' => 'definitely-not-correct',
+					'password'        => 'super-secure-new-password'
+				]
+			]);
+
+			$this->fail('Expected InvalidArgumentException');
+		} catch (InvalidArgumentException) {
+			// expected
+		}
+
+		// the guess must count against the shared auth budget, so that a
+		// hijacked session cannot brute-force the current password here
+		$log = $this->app->auth()->limits()->log();
+		$this->assertSame(1, $log['by-email'][$this->app->user()->email()]['trials']);
+	}
+
+	public function testChangePasswordRateLimited(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => ['auth' => ['trials' => 1]]
+		]);
+		$this->app->impersonate('test@getkirby.com');
+
+		// exhaust the limit for this visitor
+		$this->app->auth()->limits()->track('test@getkirby.com', triggerHook: false);
+
+		// even the correct password must not be checked any more
+		$this->expectException(RateLimitException::class);
+
+		$this->app->api()->call('account/password', 'PATCH', [
+			'body' => [
+				'currentPassword' => '12345678',
 				'password'        => 'super-secure-new-password'
 			]
 		]);

--- a/tests/Auth/AuthChallengeTest.php
+++ b/tests/Auth/AuthChallengeTest.php
@@ -52,7 +52,12 @@ class AuthChallengeTest extends TestCase
 			]
 		]);
 
-		F::write(static::TMP . '/site/accounts/marge/.htpasswd', self::$password);
+		// the email challenge is opt-in as a second factor,
+		// so enable it for the user that tests the 2FA flow
+		F::write(
+			static::TMP . '/site/accounts/marge/.htpasswd',
+			self::$password . "\n" . '{"email":true}'
+		);
 
 		$this->auth = $this->app->auth();
 	}

--- a/tests/Auth/AuthChallengeTest.php
+++ b/tests/Auth/AuthChallengeTest.php
@@ -74,6 +74,27 @@ class AuthChallengeTest extends TestCase
 		$this->assertSame('email', $session->get('kirby.challenge.type'));
 	}
 
+	public function testCreateChallengeClearsStaleState(): void
+	{
+		$session = $this->app->session();
+
+		// a first challenge stores its type and data
+		$this->auth->createChallenge('marge@simpsons.com');
+		$this->assertSame('email', $session->get('kirby.challenge.type'));
+		$this->assertNotNull($session->get('kirby.challenge.data'));
+
+		try {
+			$this->auth->createChallenge('lisa@simpsons.com');
+		} catch (Throwable) {
+			// expected in debug mode
+		}
+
+		// nothing of the first challenge may survive, otherwise its code
+		// could be verified against the new email
+		$this->assertNull($session->get('kirby.challenge.type'));
+		$this->assertNull($session->get('kirby.challenge.data'));
+	}
+
 	public function testCreateChallengeInvalidUser(): void
 	{
 		$this->app  = $this->app->clone(['options' => ['auth' => ['debug' => false]]]);

--- a/tests/Auth/AuthTest.php
+++ b/tests/Auth/AuthTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Auth;
 
 use Exception;
+use Kirby\Auth\Exception\RateLimitException;
 use Kirby\Cms\App;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
@@ -181,6 +182,57 @@ class AuthTest extends TestCase
 		$auth = new BasicAuth($data);
 		$user = $this->auth->currentUserFromBasicAuth($auth);
 		$this->assertSame('marge@simpsons.com', $user->email());
+	}
+
+	public function testEnsurePassword(): void
+	{
+		$this->auth->ensurePassword(
+			$this->app->user('marge'),
+			'springfield123'
+		);
+
+		// a correct password records no failure at all
+		$this->assertNull($this->failedEmail);
+		$this->assertFileDoesNotExist(static::TMP . '/site/accounts/.logins');
+	}
+
+	public function testEnsurePasswordInvalid(): void
+	{
+		try {
+			$this->auth->ensurePassword(
+				$this->app->user('marge'),
+				'wrong-password'
+			);
+
+			$this->fail('Expected InvalidArgumentException');
+		} catch (InvalidArgumentException) {
+			// expected
+		}
+
+		// the guess counts against the shared budget, but confirming a
+		// password is not a login attempt, so no hook is fired
+		$log = $this->auth->limits()->log();
+		$this->assertSame(1, $log['by-email']['marge@simpsons.com']['trials']);
+		$this->assertNull($this->failedEmail);
+	}
+
+	public function testEnsurePasswordRateLimited(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => ['auth' => ['trials' => 1]]
+		]);
+		$this->auth = $this->app->auth();
+
+		// exhaust the limit for this visitor
+		$this->auth->limits()->track('marge@simpsons.com', triggerHook: false);
+
+		// even the correct password must not be checked any more
+		$this->expectException(RateLimitException::class);
+
+		$this->auth->ensurePassword(
+			$this->app->user('marge'),
+			'springfield123'
+		);
 	}
 
 	public function testGuard(): void

--- a/tests/Auth/Challenge/EmailChallengeTest.php
+++ b/tests/Auth/Challenge/EmailChallengeTest.php
@@ -203,7 +203,43 @@ class EmailChallengeTest extends TestCase
 	public function testIsAvailable(): void
 	{
 		$this->assertTrue(EmailChallenge::isAvailable($this->user, 'login'));
-		$this->assertTrue(EmailChallenge::isAvailable($this->user, '2fa'));
+		$this->assertTrue(EmailChallenge::isAvailable($this->user, 'password-reset'));
+	}
+
+	public function testIsAvailable2FA(): void
+	{
+		// as a second factor, the challenge is opt-in per user
+		$this->assertFalse(EmailChallenge::isAvailable($this->user, '2fa'));
+
+		$this->app->impersonate('kirby');
+		$user = $this->user->changeSecret('email', true);
+
+		$this->assertTrue(EmailChallenge::isAvailable($user, '2fa'));
+	}
+
+	public function testIsAvailable2FAEnforced(): void
+	{
+		// enforced 2FA needs a factor for every user, so email stays
+		// available for those who have not opted in
+		$this->app = $this->app->clone([
+			'options' => [
+				'auth' => [
+					'methods' => ['password' => ['2fa' => true]]
+				]
+			]
+		]);
+
+		$user = $this->app->user('marge');
+		$this->assertTrue(EmailChallenge::isAvailable($user, '2fa'));
+	}
+
+	public function testIsAvailable2FAWithoutOptIn(): void
+	{
+		// the opt-in must not be satisfied by any other truthy value
+		$this->app->impersonate('kirby');
+		$user = $this->user->changeSecret('email', 'yes');
+
+		$this->assertFalse(EmailChallenge::isAvailable($user, '2fa'));
 	}
 
 	public function testIsEnabled(): void
@@ -227,6 +263,13 @@ class EmailChallengeTest extends TestCase
 	{
 		$settings = EmailChallenge::settings($this->user);
 		$this->assertCount(1, $settings);
+
+		$props = $settings[0]->render()['props'];
+		$this->assertSame('email-unread', $props['icon']);
+		$this->assertSame(
+			$this->user->panel()->url(true) . '/security/challenge/email',
+			$props['drawer']
+		);
 	}
 
 	public function testTimeout(): void

--- a/tests/Auth/ChallengeTest.php
+++ b/tests/Auth/ChallengeTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Kirby\Auth;
+
+use Kirby\Cms\User;
+use Kirby\Exception\LogicException;
+use Kirby\Exception\PermissionException;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+class AttemptChallenge extends Challenge
+{
+	public static bool $singleUse = false;
+	public static bool $throws = false;
+
+	public function create(): Pending|null
+	{
+		return null;
+	}
+
+	public function isSingleUse(): bool
+	{
+		return static::$singleUse;
+	}
+
+	public function verify(mixed $input, Pending $data): bool
+	{
+		if (static::$throws === true) {
+			throw new LogicException(message: 'Broken challenge');
+		}
+
+		return $input === 'ok';
+	}
+}
+
+#[CoversClass(Challenge::class)]
+class ChallengeTest extends TestCase
+{
+	public const string TMP = KIRBY_TMP_DIR . '/Auth.Challenge';
+
+	protected User $user;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->app = $this->app->clone([
+			'users' => [
+				[
+					'email' => 'marge@simpsons.com',
+					'id'    => 'marge',
+				]
+			]
+		]);
+
+		$this->user = $this->app->user('marge');
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+
+		AttemptChallenge::$singleUse = false;
+		AttemptChallenge::$throws    = false;
+	}
+
+	protected function challenge(): AttemptChallenge
+	{
+		return new AttemptChallenge(
+			user:    $this->user,
+			mode:    '2fa',
+			timeout: 600
+		);
+	}
+
+	public function testAttempt(): void
+	{
+		$invalidated = false;
+
+		$this->challenge()->attempt(
+			input:      'ok',
+			pending:    new Pending(),
+			invalidate: function () use (&$invalidated) {
+				$invalidated = true;
+			}
+		);
+
+		$this->assertFalse($invalidated);
+	}
+
+	public function testAttemptInvalid(): void
+	{
+		$invalidated = false;
+
+		try {
+			$this->challenge()->attempt(
+				input:      'nope',
+				pending:    new Pending(),
+				invalidate: function () use (&$invalidated) {
+					$invalidated = true;
+				}
+			);
+
+			$this->fail('Expected PermissionException');
+		} catch (PermissionException $e) {
+			$this->assertSame('error.access.code', $e->getCode());
+		}
+
+		// a reusable code survives a failed attempt so that the
+		// user can retry within its lifetime
+		$this->assertFalse($invalidated);
+	}
+
+	public function testAttemptInvalidSingleUse(): void
+	{
+		AttemptChallenge::$singleUse = true;
+
+		$invalidated = false;
+
+		try {
+			$this->challenge()->attempt(
+				input:      'nope',
+				pending:    new Pending(),
+				invalidate: function () use (&$invalidated) {
+					$invalidated = true;
+				}
+			);
+
+			$this->fail('Expected PermissionException');
+		} catch (PermissionException) {
+			// expected
+		}
+
+		$this->assertTrue($invalidated);
+	}
+
+	public function testAttemptThrows(): void
+	{
+		AttemptChallenge::$throws = true;
+
+		$invalidated = false;
+
+		try {
+			$this->challenge()->attempt(
+				input:      'ok',
+				pending:    new Pending(),
+				invalidate: function () use (&$invalidated) {
+					$invalidated = true;
+				}
+			);
+
+			$this->fail('Expected LogicException');
+		} catch (LogicException) {
+			// expected
+		}
+
+		// a reusable code is kept even when the challenge itself blows up
+		$this->assertFalse($invalidated);
+	}
+
+	public function testAttemptThrowsSingleUse(): void
+	{
+		AttemptChallenge::$singleUse = true;
+		AttemptChallenge::$throws    = true;
+
+		$invalidated = false;
+
+		try {
+			$this->challenge()->attempt(
+				input:      'ok',
+				pending:    new Pending(),
+				invalidate: function () use (&$invalidated) {
+					$invalidated = true;
+				}
+			);
+
+			$this->fail('Expected LogicException');
+		} catch (LogicException) {
+			// expected
+		}
+
+		// the nonce must be burnt even if the exception
+		// comes from the challenge instead of a wrong input
+		$this->assertTrue($invalidated);
+	}
+}

--- a/tests/Auth/ChallengesTest.php
+++ b/tests/Auth/ChallengesTest.php
@@ -249,6 +249,16 @@ class ChallengesTest extends TestCase
 		$this->assertSame(123, $challenge->timeout());
 	}
 
+	public function testHasAvailable(): void
+	{
+		$user = $this->app->user('marge');
+
+		$this->assertTrue($this->challenges->hasAvailable($user, 'login'));
+
+		DummyChallenge::$available = false;
+		$this->assertFalse($this->challenges->hasAvailable($user, 'login'));
+	}
+
 	public function testSwitch(): void
 	{
 		$this->app = $this->app->clone([

--- a/tests/Auth/ChallengesTest.php
+++ b/tests/Auth/ChallengesTest.php
@@ -76,6 +76,25 @@ class DummyChallenge2 extends Challenge
 	}
 }
 
+class DummyChallenge3 extends Challenge
+{
+	public function create(): Pending|null
+	{
+		return null;
+	}
+
+	// a plugin challenge may define its own lifetime
+	public function timeout(): int
+	{
+		return 42;
+	}
+
+	public function verify(mixed $input, Pending $data): bool
+	{
+		return true;
+	}
+}
+
 #[CoversClass(Challenges::class)]
 class ChallengesTest extends TestCase
 {
@@ -96,8 +115,9 @@ class ChallengesTest extends TestCase
 		DummyChallenge::$pending    = null;
 		DummyChallenge2::$available = true;
 
-		Challenges::$challenges['dummy'] = DummyChallenge::class;
+		Challenges::$challenges['dummy']  = DummyChallenge::class;
 		Challenges::$challenges['dummy2'] = DummyChallenge2::class;
+		Challenges::$challenges['dummy3'] = DummyChallenge3::class;
 
 		$this->app = $this->app->clone([
 			'options' => [
@@ -120,7 +140,11 @@ class ChallengesTest extends TestCase
 	protected function tearDown(): void
 	{
 		parent::tearDown();
-		unset(Challenges::$challenges['dummy'], Challenges::$challenges['dummy2']);
+		unset(
+			Challenges::$challenges['dummy'],
+			Challenges::$challenges['dummy2'],
+			Challenges::$challenges['dummy3']
+		);
 
 	}
 
@@ -233,6 +257,30 @@ class ChallengesTest extends TestCase
 		$this->assertSame('marge@simpsons.com', $session->get('kirby.challenge.email'));
 		$this->assertSame('login', $session->get('kirby.challenge.mode'));
 		$this->assertSame(MockTime::$time + $this->challenges->timeout(), $session->get('kirby.challenge.timeout'));
+	}
+
+	public function testCreateChallengeTimeout(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'auth' => [
+					'challenges' => ['dummy3']
+				]
+			]
+		]);
+
+		$this->challenges = new Challenges($this->app->auth(), $this->app);
+
+		$session = $this->app->session();
+		$this->challenges->create($session, 'marge@simpsons.com', 'login');
+
+		// the session expiry follows the challenge's own lifetime,
+		// not the `auth.challenge.timeout` option
+		$this->assertNotSame(42, $this->challenges->timeout());
+		$this->assertSame(
+			MockTime::$time + 42,
+			$session->get('kirby.challenge.timeout')
+		);
 	}
 
 	public function testCreateUnavailable(): void

--- a/tests/Auth/ChallengesTest.php
+++ b/tests/Auth/ChallengesTest.php
@@ -433,6 +433,22 @@ class ChallengesTest extends TestCase
 		$this->assertSame([['input' => 'ok', 'data' => ['public' => 'x', 'secret' => 'secret']]], DummyChallenge::$verified);
 	}
 
+	public function testVerifyLifetime(): void
+	{
+		$session = $this->session();
+		$session->set('kirby.challenge.type', 'dummy');
+		$session->set('kirby.challenge.email', 'marge@simpsons.com');
+		$session->set('kirby.challenge.mode', 'login');
+		$session->set('kirby.challenge.timeout', time() + 1000);
+		$session->set('kirby.challenge.data', ['public' => 'x', 'secret' => 'secret']);
+
+		$result = $this->challenges->verify($session, 'ok');
+
+		// the challenge gets its lifetime in seconds, not the
+		// absolute expiry timestamp stored in the session
+		$this->assertSame($this->challenges->timeout(), $result->timeout());
+	}
+
 	public function testVerifyInvalid(): void
 	{
 		$session = $this->session();

--- a/tests/Auth/ChallengesTest.php
+++ b/tests/Auth/ChallengesTest.php
@@ -10,6 +10,7 @@ use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Exception\PermissionException;
 use Kirby\Exception\UserNotFoundException;
+use Kirby\Filesystem\F;
 use Kirby\Session\Session;
 use Kirby\Tests\MockTime;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -138,6 +139,53 @@ class ChallengesTest extends TestCase
 		DummyChallenge::$available = false;
 		$available = $this->challenges->available($user, 'login');
 		$this->assertSame([], $available);
+	}
+
+	public function testAvailableLimitedToSecondFactor(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'auth' => [
+					'challenges' => ['totp', 'email']
+				]
+			]
+		]);
+
+		// the user has set up TOTP as their second factor
+		F::write(
+			static::TMP . '/site/accounts/marge/.htpasswd',
+			User::hashPassword('12345678') . "\n" . '{"totp":"JBSWY3DPEHPK3PXP"}'
+		);
+
+		$challenges = new Challenges($this->app->auth(), $this->app);
+		$user       = $this->app->user('marge');
+
+		$this->assertSame(['totp'], $challenges->available($user, '2fa'));
+
+		// the single-factor flows must not offer the weaker email
+		// code to a user who has set up a second factor
+		$this->assertSame(['totp'], $challenges->available($user, 'login'));
+		$this->assertSame(['totp'], $challenges->available($user, 'password-reset'));
+	}
+
+	public function testAvailableWithoutSecondFactor(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'auth' => [
+					'challenges' => ['totp', 'email']
+				]
+			]
+		]);
+
+		$challenges = new Challenges($this->app->auth(), $this->app);
+		$user       = $this->app->user('marge');
+
+		$this->assertSame([], $challenges->available($user, '2fa'));
+
+		// without a second factor the single-factor flows are unrestricted
+		$this->assertSame(['email'], $challenges->available($user, 'login'));
+		$this->assertSame(['email'], $challenges->available($user, 'password-reset'));
 	}
 
 	public function testClass(): void

--- a/tests/Auth/Method/BasicAuthMethodTest.php
+++ b/tests/Auth/Method/BasicAuthMethodTest.php
@@ -26,12 +26,6 @@ class BasicAuthMethodTest extends TestCase
 				protected bool $ssl,
 				protected object|null $header
 			) {
-				parent::__construct(options: [
-					'url' => [
-						'scheme' => $ssl ? 'https' : 'http',
-						'host'   => 'example.com'
-					]
-				]);
 			}
 
 			public function ssl(): bool
@@ -52,46 +46,50 @@ class BasicAuthMethodTest extends TestCase
 		bool $allowInsecure = false,
 		bool $hasPassword = true,
 		bool $hasAnyWith2FA = false,
+		bool $userHas2FA = false,
 		object|null $header = null
 	): Auth&Stub {
-		$kirby   = $this->createStub(App::class);
-		$request = $this->request($isSsl, $header);
-		$kirby->method('request')->willReturn($request);
+		$kirby = $this->createConfiguredStub(App::class, [
+			'request' => $this->request($isSsl, $header),
+		]);
 		$kirby->method('option')->willReturnCallback(
-			function (string $key) use ($auth, $allowInsecure) {
-				return match ($key) {
-					'api.basicAuth'     => $auth,
-					'api.allowInsecure' => $allowInsecure,
-					default              => null
-				};
+			fn (string $key) => match ($key) {
+				'api.basicAuth'     => $auth,
+				'api.allowInsecure' => $allowInsecure,
+				default             => null
 			}
 		);
 
-		$methods = $this->createStub(Methods::class);
-		$config = $hasPassword === true ? ['password' => []] : [];
+		$config = $hasPassword ? ['password' => []] : [];
 
-		if ($hasAnyWith2FA === true && $hasPassword === true) {
+		if ($hasAnyWith2FA && $hasPassword) {
 			$config['password']['2fa'] = true;
 		}
 
-		$methods->method('config')->willReturn($config);
+		$password = $this->createConfiguredStub(PasswordMethod::class, [
+			'has2FA' => $userHas2FA,
+		]);
 
-		$auth = $this->createStub(Auth::class);
-		$auth->method('kirby')->willReturn($kirby);
-		$auth->method('methods')->willReturn($methods);
+		$methods = $this->createConfiguredStub(Methods::class, [
+			'config'             => $config,
+			'get'                => $password,
+			'hasAnyRequiring2FA' => $hasAnyWith2FA,
+		]);
 
-		return $auth;
+		return $this->createConfiguredStub(Auth::class, [
+			'kirby'   => $kirby,
+			'methods' => $methods,
+		]);
 	}
 
 	protected function header(
 		string $user = 'kirby',
 		string $password = 'secret'
 	): BasicAuth {
-		$header = $this->createStub(BasicAuth::class);
-		$header->method('username')->willReturn($user);
-		$header->method('password')->willReturn($password);
-
-		return $header;
+		return $this->createConfiguredStub(BasicAuth::class, [
+			'username' => $user,
+			'password' => $password,
+		]);
 	}
 
 	public function testAuthenticate(): void
@@ -107,6 +105,36 @@ class BasicAuthMethodTest extends TestCase
 		$method = new BasicAuthMethod(auth: $auth);
 		$result = $method->authenticate('kirby@getkirby.com', 'topsecret');
 		$this->assertSame($user, $result);
+	}
+
+	public function testAuthenticateWithUser2FA(): void
+	{
+		// the user would be challenged on regular password login,
+		// so basic auth must not let them skip the second factor
+		$auth = $this->auth(userHas2FA: true, header: $this->header());
+		$auth->method('validatePassword')
+			->willReturn($this->createStub(User::class));
+
+		$this->expectException(PermissionException::class);
+		$this->expectExceptionMessage('Basic authentication cannot be used with 2FA');
+
+		$method = new BasicAuthMethod(auth: $auth);
+		$method->authenticate('kirby@getkirby.com', 'topsecret');
+	}
+
+	public function testAuthenticateWithoutUser2FA(): void
+	{
+		// dedicated API accounts without a second factor
+		// can still use basic auth when 2FA is not enforced
+		$user = $this->createStub(User::class);
+		$auth = $this->auth(userHas2FA: false, header: $this->header());
+		$auth->method('validatePassword')->willReturn($user);
+
+		$method = new BasicAuthMethod(auth: $auth);
+		$this->assertSame(
+			$user,
+			$method->authenticate('kirby@getkirby.com', 'topsecret')
+		);
 	}
 
 	public function testAuthenticateWithoutPassword(): void

--- a/tests/Auth/Method/BasicAuthMethodTest.php
+++ b/tests/Auth/Method/BasicAuthMethodTest.php
@@ -223,7 +223,7 @@ class BasicAuthMethodTest extends TestCase
 		$this->assertFalse(BasicAuthMethod::isEnabled($auth));
 
 		$this->expectException(PermissionException::class);
-		$this->expectExceptionMessage('Basic authentication cannot be used with 2FA');
+		$this->expectExceptionMessage('Basic authentication cannot be used with required 2FA');
 		BasicAuthMethod::isEnabled($auth, fail: true);
 	}
 

--- a/tests/Auth/Method/CodeMethodTest.php
+++ b/tests/Auth/Method/CodeMethodTest.php
@@ -32,6 +32,7 @@ class CodeMethodTest extends TestCase
 		}
 
 		$methods->method('config')->willReturn($config);
+		$methods->method('hasAnyRequiring2FA')->willReturn($has2fa === true);
 
 		$auth = $this->createStub(Auth::class);
 		$auth->method('methods')->willReturn($methods);
@@ -106,12 +107,6 @@ class CodeMethodTest extends TestCase
 		$this->expectExceptionMessage('The "code" and "password-reset" login methods cannot be enabled together');
 
 		CodeMethod::isEnabled($auth);
-	}
-
-	public function testIsUsingChallenges(): void
-	{
-		$auth = $this->auth();
-		$this->assertTrue(CodeMethod::isUsingChallenges($auth));
 	}
 
 	public function testSettings(): void

--- a/tests/Auth/Method/MethodTest.php
+++ b/tests/Auth/Method/MethodTest.php
@@ -15,10 +15,4 @@ class MethodTest extends TestCase
 		$auth = $this->createStub(Auth::class);
 		$this->assertTrue(Method::isEnabled($auth));
 	}
-
-	public function testIsUsingChallenges(): void
-	{
-		$auth = $this->createStub(Auth::class);
-		$this->assertFalse(Method::isUsingChallenges($auth));
-	}
 }

--- a/tests/Auth/Method/PasswordMethodTest.php
+++ b/tests/Auth/Method/PasswordMethodTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Auth\Method;
 
 use InvalidArgumentException;
 use Kirby\Auth\Auth;
+use Kirby\Auth\Challenges;
 use Kirby\Auth\Method;
 use Kirby\Auth\Status;
 use Kirby\Cms\User;
@@ -89,6 +90,75 @@ class PasswordMethodTest extends TestCase
 		$this->assertSame(['marge@simpsons.com', false, '2fa'], $challenge);
 	}
 
+	public function testAuthenticateWithoutSecondFactor(): void
+	{
+		$login = [];
+		$user  = $this->createStub(User::class);
+		$user->method('loginPasswordless')
+			->willReturnCallback(function ($options) use (&$login) {
+				$login[] = $options;
+			});
+
+		$validate   = null;
+		$challenges = $this->createStub(Challenges::class);
+		$challenges->method('hasAvailable')->willReturn(false);
+
+		$auth = $this->createStub(Auth::class);
+		$auth->method('validatePassword')
+			->willReturnCallback(function (...$args) use (&$validate, $user) {
+				$validate = $args;
+				return $user;
+			});
+		$auth->method('challenges')->willReturn($challenges);
+		$auth->method('createChallenge')
+			->willReturnCallback(function () {
+				throw new RuntimeException('createChallenge should not be called');
+			});
+
+		// 2FA is not enforced and the user has no second factor
+		$method = new PasswordMethod(auth: $auth);
+		$result = $method->authenticate('marge@simpsons.com', 'springfield123', true);
+
+		$this->assertInstanceOf(User::class, $result);
+		$this->assertSame($user, $result);
+		$this->assertSame(['marge@simpsons.com', 'springfield123'], $validate);
+		$this->assertSame([[
+			'createMode' => 'cookie',
+			'long'       => true
+		]], $login);
+	}
+
+	public function testAuthenticateWithSecondFactor(): void
+	{
+		$status       = $this->createStub(Status::class);
+		$user         = $this->createStub(User::class);
+		$validate     = null;
+		$challenge    = null;
+		$challenges   = $this->createStub(Challenges::class);
+		$challenges->method('hasAvailable')->willReturn(true);
+
+		$auth = $this->createStub(Auth::class);
+		$auth->method('validatePassword')
+			->willReturnCallback(function (...$args) use (&$validate, $user) {
+				$validate = $args;
+				return $user;
+			});
+		$auth->method('challenges')->willReturn($challenges);
+		$auth->method('createChallenge')
+			->willReturnCallback(function (...$args) use (&$challenge, $status) {
+				$challenge = $args;
+				return $status;
+			});
+
+		// 2FA is not enforced, but the user opted into a second factor
+		$method = new PasswordMethod(auth: $auth);
+		$result = $method->authenticate('marge@simpsons.com', 'springfield123');
+
+		$this->assertSame($status, $result);
+		$this->assertSame(['marge@simpsons.com', 'springfield123'], $validate);
+		$this->assertSame(['marge@simpsons.com', false, '2fa'], $challenge);
+	}
+
 	public function testAuthenticateWithoutPassword(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
@@ -109,14 +179,6 @@ class PasswordMethodTest extends TestCase
 	{
 		$auth = $this->createStub(Auth::class);
 		$this->assertTrue(PasswordMethod::isEnabled($auth));
-	}
-
-	public function testIsUsingChallenges(): void
-	{
-		$auth = $this->createStub(Auth::class);
-
-		$this->assertFalse(PasswordMethod::isUsingChallenges($auth));
-		$this->assertTrue(PasswordMethod::isUsingChallenges($auth, ['2fa' => true]));
 	}
 
 	public function testOptions(): void

--- a/tests/Auth/Method/PasswordResetMethodTest.php
+++ b/tests/Auth/Method/PasswordResetMethodTest.php
@@ -26,6 +26,7 @@ class PasswordResetMethodTest extends TestCase
 		}
 
 		$methods->method('config')->willReturn($config);
+		$methods->method('hasAnyRequiring2FA')->willReturn($has2fa === true);
 
 		$auth = $this->createStub(Auth::class);
 		$auth->method('methods')->willReturn($methods);
@@ -90,12 +91,6 @@ class PasswordResetMethodTest extends TestCase
 		$this->expectExceptionMessage('The "password-reset" login method cannot be enabled when 2FA is required');
 
 		PasswordResetMethod::isEnabled($auth);
-	}
-
-	public function testIsUsingChallenges(): void
-	{
-		$auth = $this->auth();
-		$this->assertTrue(PasswordResetMethod::isUsingChallenges($auth));
 	}
 
 	public function testSettings(): void

--- a/tests/Auth/Method/WebauthnMethodTest.php
+++ b/tests/Auth/Method/WebauthnMethodTest.php
@@ -106,11 +106,6 @@ class WebauthnMethodTest extends TestCase
 		$this->assertSame('fingerprint', WebauthnMethod::icon());
 	}
 
-	public function testIsUsingChallenges(): void
-	{
-		$this->assertFalse(WebauthnMethod::isUsingChallenges($this->app->auth()));
-	}
-
 	public function testSettings(): void
 	{
 		$settings = WebauthnMethod::settings($this->app->user('marge'));

--- a/tests/Auth/MethodsTest.php
+++ b/tests/Auth/MethodsTest.php
@@ -278,44 +278,6 @@ class MethodsTest extends TestCase
 		$this->assertFalse($methods->has('password-reset'));
 	}
 
-	public function testHasAnyUsingChallenges(): void
-	{
-		$app = $this->app->clone([
-			'options' => [
-				'auth' => [
-					'methods' => [
-						'password' => ['2fa' => true],
-					]
-				]
-			]
-		]);
-
-		$methods = $app->auth()->methods();
-		$this->assertTrue($methods->hasAnyUsingChallenges());
-
-		$app = $this->app->clone([
-			'options' => [
-				'auth' => [
-					'methods' => ['password', 'code']
-				]
-			]
-		]);
-
-		$methods = $app->auth()->methods();
-		$this->assertTrue($methods->hasAnyUsingChallenges());
-
-		$app = $this->app->clone([
-			'options' => [
-				'auth' => [
-					'methods' => ['password']
-				]
-			]
-		]);
-
-		$methods = $app->auth()->methods();
-		$this->assertFalse($methods->hasAnyUsingChallenges());
-	}
-
 	public function testHasWithDisabled(): void
 	{
 		$app = $this->app->clone([

--- a/tests/Cms/User/UserChangeEmailTest.php
+++ b/tests/Cms/User/UserChangeEmailTest.php
@@ -57,6 +57,35 @@ class UserChangeEmailTest extends ModelTestCase
 		$this->assertSame('another@domain.com', $user->email());
 	}
 
+	public function testChangeEmailResetsEmailChallenge(): void
+	{
+		$user = new User(['email' => 'editor@domain.com']);
+		$user = $user->changeSecret('email', true);
+
+		$this->assertTrue($user->secret('email'));
+
+		// the opt-in only proved the *old* address was reachable
+		$user = $user->changeEmail('another@domain.com');
+		$this->assertNull($user->secret('email'));
+
+		// verify the value stored on disk
+		$user = $this->app->clone()->user($user->id());
+		$this->assertNull($user->secret('email'));
+	}
+
+	public function testChangeEmailKeepsOtherSecrets(): void
+	{
+		$user = new User(['email' => 'editor@domain.com']);
+		$user = $user->changeSecret('totp', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567');
+		$user = $user->changeEmail('another@domain.com');
+
+		// only the email challenge is tied to the address
+		$this->assertSame(
+			'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
+			$this->app->clone()->user($user->id())->secret('totp')
+		);
+	}
+
 	public function testChangeEmailHooks(): void
 	{
 		$calls = 0;

--- a/tests/Panel/Areas/AccountDrawersTest.php
+++ b/tests/Panel/Areas/AccountDrawersTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kirby\Panel\Areas;
+
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+
+#[CoversNothing]
+class AccountDrawersTest extends TestCase
+{
+	public function testMirrorsUserDrawers(): void
+	{
+		// the account area should re-expose every user drawer
+		// under its own pattern
+		$root    = dirname(__DIR__, 3);
+		$users   = require $root . '/config/areas/users/drawers.php';
+		$account = require $root . '/config/areas/account/drawers.php';
+
+		foreach ($users as $key => $drawer) {
+			$mirror = 'account.' . substr($key, strlen('user.'));
+
+			$this->assertArrayHasKey(
+				$mirror,
+				$account,
+				'Missing account drawer for ' . $key
+			);
+			$this->assertSame($drawer['action'], $account[$mirror]['action']);
+		}
+	}
+}

--- a/tests/Panel/Controller/Dialog/UserChangeEmailDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/UserChangeEmailDialogControllerTest.php
@@ -45,8 +45,23 @@ class UserChangeEmailDialogControllerTest extends TestCase
 
 		$props = $dialog->props();
 		$this->assertSame('Email', $props['fields']['email']['label']);
+		$this->assertNull($props['fields']['email']['help']);
 		$this->assertSame('Change', $props['submitButton']);
 		$this->assertSame('test@getkirby.com', $props['value']['email']);
+	}
+
+	public function testLoadWithEmailChallenge(): void
+	{
+		$user = $this->app->user('test')->changeSecret('email', true);
+
+		$dialog = (new UserChangeEmailDialogController($user))->load();
+		$props  = $dialog->props();
+
+		// changing the address resets the opt-in, so the dialog says so
+		$this->assertSame(
+			'Codes via email are active as a second factor. Changing the address disables them until the new one has been confirmed.',
+			$props['fields']['email']['help']
+		);
 	}
 
 	public function testSubmit(): void

--- a/tests/Panel/Controller/Dialog/UserChangePasswordDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/UserChangePasswordDialogControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Panel\Controller\Dialog;
 
+use Kirby\Auth\Exception\RateLimitException;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Panel\TestCase;
@@ -193,6 +194,60 @@ class UserChangePasswordDialogControllerTest extends TestCase
 
 		$user       = $this->app->user('test');
 		$controller = new UserChangePasswordDialogController($user);
+		$controller->submit();
+	}
+
+	public function testSubmitWithInvalidCurrentPasswordConsumesRateLimit(): void
+	{
+		$this->app = $this->app->clone([
+			'request' => [
+				'query' => [
+					'currentPassword'      => '123456',
+					'password'             => 'abcdefgh',
+					'passwordConfirmation' => 'abcdefgh'
+				]
+			]
+		]);
+
+		$this->app->impersonate('test@getkirby.com');
+
+		$controller = new UserChangePasswordDialogController($this->app->user('test'));
+
+		try {
+			$controller->submit();
+			$this->fail('Expected InvalidArgumentException');
+		} catch (InvalidArgumentException) {
+			// expected
+		}
+
+		// the guess must count against the shared auth budget, so that a
+		// hijacked session cannot brute-force the current password here
+		$log = $this->app->auth()->limits()->log();
+		$this->assertSame(1, $log['by-email']['test@getkirby.com']['trials']);
+	}
+
+	public function testSubmitRateLimited(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => ['auth' => ['trials' => 1]],
+			'request' => [
+				'query' => [
+					'currentPassword'      => '12345678',
+					'password'             => 'abcdefgh',
+					'passwordConfirmation' => 'abcdefgh'
+				]
+			]
+		]);
+
+		$this->app->impersonate('test@getkirby.com');
+
+		// exhaust the limit for this visitor
+		$this->app->auth()->limits()->track('test@getkirby.com', triggerHook: false);
+
+		$controller = new UserChangePasswordDialogController($this->app->user('test'));
+
+		// the limit surfaces as itself, not masked as a wrong password
+		$this->expectException(RateLimitException::class);
 		$controller->submit();
 	}
 

--- a/tests/Panel/Controller/Drawer/UserCredentialDrawerControllerTest.php
+++ b/tests/Panel/Controller/Drawer/UserCredentialDrawerControllerTest.php
@@ -4,9 +4,11 @@ namespace Kirby\Panel\Controller\Drawer;
 
 use Kirby\Auth\Challenge;
 use Kirby\Auth\Challenge\TotpChallenge;
+use Kirby\Auth\Exception\RateLimitException;
 use Kirby\Auth\Pending;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\PermissionException;
 use Kirby\Panel\TestCase;
 use Kirby\Toolkit\Totp;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -31,6 +33,14 @@ class DummyCredentialChallenge extends Challenge
 	}
 }
 
+class DummySingleUseCredentialChallenge extends DummyCredentialChallenge
+{
+	public function isSingleUse(): bool
+	{
+		return true;
+	}
+}
+
 class DummyUserCredentialDrawerController extends UserCredentialDrawerController
 {
 	public function __construct(User $user, string $type = 'totp')
@@ -46,6 +56,11 @@ class DummyUserCredentialDrawerController extends UserCredentialDrawerController
 	public function authorize(): void
 	{
 		parent::authorize();
+	}
+
+	public function create(): User
+	{
+		return parent::create();
 	}
 
 	public function challenge(): Challenge
@@ -75,7 +90,8 @@ class UserCredentialDrawerControllerTest extends TestCase
 
 		$this->app = $this->app->clone([
 			'authChallenges' => [
-				'dummy' => DummyCredentialChallenge::class
+				'dummy'            => DummyCredentialChallenge::class,
+				'dummy-single-use' => DummySingleUseCredentialChallenge::class
 			],
 			'users' => [
 				[
@@ -117,10 +133,13 @@ class UserCredentialDrawerControllerTest extends TestCase
 		$result     = $controller->authorization();
 
 		$this->assertNull($result);
-		$this->assertSame(
-			['public' => null, 'secret' => null],
-			$this->app->session()->get('kirby.security.authorize.test')
-		);
+
+		// the pending is stored with an expiry so a leaked session
+		// cannot reuse the code indefinitely
+		$stored = $this->app->session()->get('kirby.security.authorize.test');
+		$this->assertNull($stored['public']);
+		$this->assertNull($stored['secret']);
+		$this->assertGreaterThan(time(), $stored['expires']);
 	}
 
 	public function testAuthorizationForOtherUser(): void
@@ -144,13 +163,11 @@ class UserCredentialDrawerControllerTest extends TestCase
 		$result     = $controller->authorization();
 
 		$this->assertSame(['id' => 'pending-public'], $result);
-		$this->assertSame(
-			[
-				'public' => ['id' => 'pending-public'],
-				'secret' => 'pending-secret'
-			],
-			$this->app->session()->get('kirby.security.authorize.test')
-		);
+
+		$stored = $this->app->session()->get('kirby.security.authorize.test');
+		$this->assertSame(['id' => 'pending-public'], $stored['public']);
+		$this->assertSame('pending-secret', $stored['secret']);
+		$this->assertGreaterThan(time(), $stored['expires']);
 	}
 
 	public function testAuthorizeAsAdmin(): void
@@ -214,6 +231,112 @@ class UserCredentialDrawerControllerTest extends TestCase
 		$controller->authorize();
 	}
 
+	public function testAuthorizeAsCurrentUserKeepsReusableCodeOnFailure(): void
+	{
+		// a reusable code (challenge is not single-use) must survive a
+		// failed attempt, so the account owner can retry with the correct
+		// one instead of being locked out after a single typo
+		$this->setRequest(['authorization' => 'wrong-secret']);
+		$this->app->impersonate('test');
+
+		$this->app->session()->set('kirby.security.authorize.test', [
+			'public' => null,
+			'secret' => 'pending-secret'
+		]);
+
+		$controller = new DummyUserCredentialDrawerController($this->app->user('test'), 'dummy');
+
+		try {
+			$controller->authorize();
+			$this->fail('Expected InvalidArgumentException was not thrown');
+		} catch (InvalidArgumentException $e) {
+			$this->assertSame('error.access.code', $e->getCode());
+		}
+
+		// the stored pending is untouched and ready for the next attempt
+		$this->assertSame(
+			['public' => null, 'secret' => 'pending-secret'],
+			$this->app->session()->get('kirby.security.authorize.test')
+		);
+	}
+
+	public function testAuthorizeAsCurrentUserClearsSingleUseCodeOnFailure(): void
+	{
+		// a single-use nonce must be invalidated even after a failed
+		// attempt so that it cannot be replayed within its lifetime
+		$this->setRequest(['authorization' => 'wrong-secret']);
+		$this->app->impersonate('test');
+
+		$this->app->session()->set('kirby.security.authorize.test', [
+			'public' => null,
+			'secret' => 'pending-secret'
+		]);
+
+		$controller = new DummyUserCredentialDrawerController($this->app->user('test'), 'dummy-single-use');
+
+		try {
+			$controller->authorize();
+			$this->fail('Expected InvalidArgumentException was not thrown');
+		} catch (InvalidArgumentException) {
+			// expected
+		}
+
+		$this->assertNull(
+			$this->app->session()->get('kirby.security.authorize.test')
+		);
+	}
+
+	public function testAuthorizeAsCurrentUserWithExpiredCode(): void
+	{
+		// a stored code past its lifetime is rejected and cleared,
+		// even if the input itself would have matched
+		$this->setRequest(['authorization' => 'pending-secret']);
+		$this->app->impersonate('test');
+
+		$this->app->session()->set('kirby.security.authorize.test', [
+			'public'  => null,
+			'secret'  => 'pending-secret',
+			'expires' => 1
+		]);
+
+		$controller = new DummyUserCredentialDrawerController($this->app->user('test'), 'dummy');
+
+		try {
+			$controller->authorize();
+			$this->fail('Expected InvalidArgumentException was not thrown');
+		} catch (InvalidArgumentException $e) {
+			$this->assertSame('error.access.code', $e->getCode());
+		}
+
+		$this->assertNull(
+			$this->app->session()->get('kirby.security.authorize.test')
+		);
+	}
+
+	public function testAuthorizeAsCurrentUserRateLimited(): void
+	{
+		// once the shared auth rate limit is hit, no further code
+		// can be tried until the limit resets
+		$this->app = $this->app->clone([
+			'options' => ['auth' => ['trials' => 1]]
+		]);
+		$this->setRequest(['authorization' => 'pending-secret']);
+		$this->app->impersonate('test');
+
+		// exhaust the limit for this visitor
+		$this->app->auth()->limits()->track('test@getkirby.com');
+
+		$this->app->session()->set('kirby.security.authorize.test', [
+			'public' => null,
+			'secret' => 'pending-secret'
+		]);
+
+		$controller = new DummyUserCredentialDrawerController($this->app->user('test'), 'dummy');
+
+		$this->expectException(RateLimitException::class);
+		$controller->authorize();
+	}
+
 	public function testChallenge(): void
 	{
 		$controller = new DummyUserCredentialDrawerController($this->app->user('test'), 'totp');
@@ -222,6 +345,19 @@ class UserCredentialDrawerControllerTest extends TestCase
 		$this->assertInstanceOf(TotpChallenge::class, $challenge);
 		$this->assertSame('2fa', $challenge->mode());
 		$this->assertTrue($challenge->user()->is($this->app->user('test')));
+	}
+
+	public function testCreateForOtherUser(): void
+	{
+		// adding a login credential is only ever allowed for one's own
+		// account: an admin managing another user is rejected here, before
+		// any challenge verification (`authorizeCurrentUser()`) can run
+		$this->app->impersonate('admin');
+
+		$controller = new DummyUserCredentialDrawerController($this->app->user('test'));
+
+		$this->expectException(PermissionException::class);
+		$controller->create();
 	}
 
 	public function testIsCurrentUser(): void

--- a/tests/Panel/Controller/Drawer/UserCredentialDrawerControllerTest.php
+++ b/tests/Panel/Controller/Drawer/UserCredentialDrawerControllerTest.php
@@ -183,6 +183,45 @@ class UserCredentialDrawerControllerTest extends TestCase
 		$this->assertTrue($this->app->user()->is($this->app->user('admin')));
 	}
 
+	public function testAuthorizeAsAdminConsumesRateLimit(): void
+	{
+		$this->setRequest(['password' => 'wrongpass']);
+		$this->app->impersonate('admin');
+
+		$controller = new DummyUserCredentialDrawerController($this->app->user('test'));
+
+		try {
+			$controller->authorize();
+			$this->fail('Expected InvalidArgumentException');
+		} catch (InvalidArgumentException) {
+			// expected
+		}
+
+		// the guess counts against the admin's own budget, never
+		// against the user they are managing
+		$log = $this->app->auth()->limits()->log();
+		$this->assertSame(1, $log['by-email']['admin@getkirby.com']['trials']);
+		$this->assertArrayNotHasKey('test@getkirby.com', $log['by-email']);
+	}
+
+	public function testAuthorizeAsAdminRateLimited(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => ['auth' => ['trials' => 1]]
+		]);
+		$this->setRequest(['password' => 'adminpass123']);
+		$this->app->impersonate('admin');
+
+		// exhaust the limit for this visitor
+		$this->app->auth()->limits()->track('admin@getkirby.com');
+
+		$controller = new DummyUserCredentialDrawerController($this->app->user('test'));
+
+		// even the correct password must not be checked any more
+		$this->expectException(RateLimitException::class);
+		$controller->authorize();
+	}
+
 	public function testAuthorizeAsAdminWithWrongPassword(): void
 	{
 		$this->setRequest(['password' => 'wrongpass']);

--- a/tests/Panel/Controller/Drawer/UserCredentialDrawerControllerTest.php
+++ b/tests/Panel/Controller/Drawer/UserCredentialDrawerControllerTest.php
@@ -225,7 +225,7 @@ class UserCredentialDrawerControllerTest extends TestCase
 
 		$controller = new DummyUserCredentialDrawerController($this->app->user('test'), 'totp');
 
-		$this->expectException(InvalidArgumentException::class);
+		$this->expectException(PermissionException::class);
 		$this->expectExceptionCode('error.access.code');
 
 		$controller->authorize();
@@ -248,8 +248,8 @@ class UserCredentialDrawerControllerTest extends TestCase
 
 		try {
 			$controller->authorize();
-			$this->fail('Expected InvalidArgumentException was not thrown');
-		} catch (InvalidArgumentException $e) {
+			$this->fail('Expected PermissionException was not thrown');
+		} catch (PermissionException $e) {
 			$this->assertSame('error.access.code', $e->getCode());
 		}
 
@@ -276,8 +276,8 @@ class UserCredentialDrawerControllerTest extends TestCase
 
 		try {
 			$controller->authorize();
-			$this->fail('Expected InvalidArgumentException was not thrown');
-		} catch (InvalidArgumentException) {
+			$this->fail('Expected PermissionException was not thrown');
+		} catch (PermissionException) {
 			// expected
 		}
 
@@ -303,8 +303,8 @@ class UserCredentialDrawerControllerTest extends TestCase
 
 		try {
 			$controller->authorize();
-			$this->fail('Expected InvalidArgumentException was not thrown');
-		} catch (InvalidArgumentException $e) {
+			$this->fail('Expected PermissionException was not thrown');
+		} catch (PermissionException $e) {
 			$this->assertSame('error.access.code', $e->getCode());
 		}
 

--- a/tests/Panel/Controller/Drawer/UserEmailChallengeDrawerControllerTest.php
+++ b/tests/Panel/Controller/Drawer/UserEmailChallengeDrawerControllerTest.php
@@ -1,0 +1,307 @@
+<?php
+
+namespace Kirby\Panel\Controller\Drawer;
+
+use Kirby\Cms\User;
+use Kirby\Email\Email;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\PermissionException;
+use Kirby\Panel\TestCase;
+use Kirby\Panel\Ui\Drawer;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(UserEmailChallengeDrawerController::class)]
+#[CoversClass(UserCredentialDrawerController::class)]
+class UserEmailChallengeDrawerControllerTest extends TestCase
+{
+	public const string TMP = KIRBY_TMP_DIR . '/Panel.Controller.Drawer.UserEmailChallengeDrawerController';
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		Email::$debug  = true;
+		Email::$emails = [];
+
+		$this->app = $this->app->clone([
+			// the challenge derives its sender address from the host
+			'server' => [
+				'SERVER_NAME' => 'getkirby.com'
+			],
+			'users' => [
+				[
+					'id'       => 'test',
+					'name'     => 'Test User',
+					'email'    => 'test@getkirby.com',
+					'role'     => 'admin',
+					'password' => User::hashPassword('password123')
+				],
+				[
+					'id'       => 'admin',
+					'email'    => 'admin@getkirby.com',
+					'role'     => 'admin',
+					'password' => User::hashPassword('adminpass123')
+				]
+			],
+			'site' => [
+				'title' => 'Test Site'
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+	}
+
+	protected function tearDown(): void
+	{
+		Email::$debug  = false;
+		Email::$emails = [];
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Opts the test user into the email challenge
+	 */
+	protected function enableEmailChallenge(): void
+	{
+		$this->app->user('test')->changeSecret('email', true);
+	}
+
+	/**
+	 * Stores a pending challenge for the test user, just like
+	 * the `code` action would have done before the user submits
+	 */
+	protected function storeCode(string $code = '123456'): void
+	{
+		$this->app->session()->set('kirby.security.authorize.test', [
+			'public' => null,
+			'secret' => User::hashPassword($code)
+		]);
+	}
+
+	public function testFactory(): void
+	{
+		$controller = UserEmailChallengeDrawerController::factory('test');
+		$this->assertInstanceOf(UserEmailChallengeDrawerController::class, $controller);
+	}
+
+	public function testLoad(): void
+	{
+		$this->app->impersonate('test');
+
+		$user       = $this->app->user('test');
+		$controller = new UserEmailChallengeDrawerController($user);
+		$drawer     = $controller->load();
+
+		$this->assertInstanceOf(Drawer::class, $drawer);
+		$this->assertSame('k-user-email-challenge-drawer', $drawer->component);
+		$this->assertSame('email-unread', $drawer->icon);
+		$this->assertNotNull($drawer->title);
+
+		$props = $drawer->props();
+		$this->assertTrue($props['isAccount']);
+		$this->assertFalse($props['isEnabled']);
+		$this->assertSame(
+			['avatar' => null, 'email' => 'test@getkirby.com', 'name' => 'Test User'],
+			$props['user']
+		);
+
+		// opening the drawer must not send an email on its own
+		$this->assertSame([], Email::$emails);
+	}
+
+	public function testLoadForOtherUser(): void
+	{
+		$this->enableEmailChallenge();
+		$this->app->impersonate('admin');
+
+		$controller = new UserEmailChallengeDrawerController($this->app->user('test'));
+		$props      = $controller->load()->props();
+
+		$this->assertFalse($props['isAccount']);
+		$this->assertTrue($props['isEnabled']);
+	}
+
+	public function testSubmitCode(): void
+	{
+		$this->setRequest(['action' => 'code']);
+		$this->app->impersonate('test');
+
+		$result = (new UserEmailChallengeDrawerController($this->app->user('test')))->submit();
+
+		$this->assertTrue($result);
+		$this->assertCount(1, Email::$emails);
+		$this->assertSame(
+			['test@getkirby.com' => 'Test User'],
+			Email::$emails[0]->to()
+		);
+
+		// the emailed code is kept for the following create/remove action
+		$body = Email::$emails[0]->body()->text();
+		preg_match('/[0-9]{3} [0-9]{3}/', $body, $code);
+		$this->assertNotEmpty($code[0]);
+
+		$pending = $this->app->session()->get('kirby.security.authorize.test');
+		$this->assertTrue(
+			password_verify(str_replace(' ', '', $code[0]), $pending['secret'])
+		);
+	}
+
+	public function testSubmitCodeForOtherUser(): void
+	{
+		// an admin authorizes with their own password instead,
+		// so no code must be sent to the other user
+		$this->setRequest(['action' => 'code']);
+		$this->app->impersonate('admin');
+
+		$controller = new UserEmailChallengeDrawerController($this->app->user('test'));
+
+		$this->assertTrue($controller->submit());
+		$this->assertSame([], Email::$emails);
+	}
+
+	public function testSubmitCreate(): void
+	{
+		// the code is entered as it was formatted in the email
+		$this->setRequest([
+			'action'        => 'create',
+			'authorization' => '123 456'
+		]);
+		$this->app->impersonate('test');
+		$this->storeCode();
+
+		$result = (new UserEmailChallengeDrawerController($this->app->user('test')))->submit();
+
+		$this->assertTrue($result);
+		$this->assertTrue($this->app->user('test')->secret('email'));
+	}
+
+	public function testSubmitCreateForOtherUser(): void
+	{
+		// an admin must not opt another user into the challenge:
+		// only the account owner can prove their address is reachable
+		$this->setRequest(['action' => 'create']);
+		$this->app->impersonate('admin');
+
+		$controller = new UserEmailChallengeDrawerController($this->app->user('test'));
+
+		try {
+			$controller->submit();
+			$this->fail('Expected PermissionException was not thrown');
+		} catch (PermissionException) {
+			$this->assertNull($this->app->user('test')->secret('email'));
+		}
+	}
+
+	public function testSubmitCreateWithWrongCode(): void
+	{
+		$this->setRequest([
+			'action'        => 'create',
+			'authorization' => '000 000'
+		]);
+		$this->app->impersonate('test');
+		$this->storeCode();
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionCode('error.access.code');
+
+		(new UserEmailChallengeDrawerController($this->app->user('test')))->submit();
+	}
+
+	public function testSubmitCreateWithoutCode(): void
+	{
+		// the code action must run first, otherwise there is
+		// nothing to verify the user's input against
+		$this->setRequest([
+			'action'        => 'create',
+			'authorization' => '000 000'
+		]);
+		$this->app->impersonate('test');
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionCode('error.access.code');
+
+		(new UserEmailChallengeDrawerController($this->app->user('test')))->submit();
+	}
+
+	public function testSubmitRemoveAsAccount(): void
+	{
+		// the account owner opts out by entering a fresh code,
+		// proving they still control the address
+		$this->enableEmailChallenge();
+
+		$this->setRequest([
+			'action'        => 'remove',
+			'authorization' => '123 456'
+		]);
+		$this->app->impersonate('test');
+		$this->storeCode();
+
+		$result = (new UserEmailChallengeDrawerController($this->app->user('test')))->submit();
+
+		$this->assertTrue($result);
+		$this->assertNull($this->app->user('test')->secret('email'));
+	}
+
+	public function testSubmitRemoveAsAccountWithWrongCode(): void
+	{
+		$this->enableEmailChallenge();
+
+		$this->setRequest([
+			'action'        => 'remove',
+			'authorization' => '000 000'
+		]);
+		$this->app->impersonate('test');
+		$this->storeCode();
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionCode('error.access.code');
+
+		(new UserEmailChallengeDrawerController($this->app->user('test')))->submit();
+	}
+
+	public function testSubmitRemoveAsAdmin(): void
+	{
+		// an admin opts another user out with their own password,
+		// e.g. when that user lost access to their mailbox
+		$this->enableEmailChallenge();
+
+		$this->setRequest([
+			'action'   => 'remove',
+			'password' => 'adminpass123'
+		]);
+		$this->app->impersonate('admin');
+
+		$result = (new UserEmailChallengeDrawerController($this->app->user('test')))->submit();
+
+		$this->assertTrue($result);
+		$this->assertNull($this->app->user('test')->secret('email'));
+	}
+
+	public function testSubmitRemoveAsAdminWithWrongPassword(): void
+	{
+		$this->enableEmailChallenge();
+
+		$this->setRequest([
+			'action'   => 'remove',
+			'password' => 'wrongpass'
+		]);
+		$this->app->impersonate('admin');
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionCode('error.user.password.wrong');
+
+		(new UserEmailChallengeDrawerController($this->app->user('test')))->submit();
+	}
+
+	public function testSubmitWithInvalidAction(): void
+	{
+		$this->setRequest(['action' => 'nope']);
+		$this->app->impersonate('kirby');
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid action: nope');
+
+		(new UserEmailChallengeDrawerController($this->app->user('test')))->submit();
+	}
+}

--- a/tests/Panel/Controller/Drawer/UserEmailChallengeDrawerControllerTest.php
+++ b/tests/Panel/Controller/Drawer/UserEmailChallengeDrawerControllerTest.php
@@ -202,7 +202,7 @@ class UserEmailChallengeDrawerControllerTest extends TestCase
 		$this->app->impersonate('test');
 		$this->storeCode();
 
-		$this->expectException(InvalidArgumentException::class);
+		$this->expectException(PermissionException::class);
 		$this->expectExceptionCode('error.access.code');
 
 		(new UserEmailChallengeDrawerController($this->app->user('test')))->submit();
@@ -218,7 +218,7 @@ class UserEmailChallengeDrawerControllerTest extends TestCase
 		]);
 		$this->app->impersonate('test');
 
-		$this->expectException(InvalidArgumentException::class);
+		$this->expectException(PermissionException::class);
 		$this->expectExceptionCode('error.access.code');
 
 		(new UserEmailChallengeDrawerController($this->app->user('test')))->submit();
@@ -254,7 +254,7 @@ class UserEmailChallengeDrawerControllerTest extends TestCase
 		$this->app->impersonate('test');
 		$this->storeCode();
 
-		$this->expectException(InvalidArgumentException::class);
+		$this->expectException(PermissionException::class);
 		$this->expectExceptionCode('error.access.code');
 
 		(new UserEmailChallengeDrawerController($this->app->user('test')))->submit();

--- a/tests/Panel/Controller/Drawer/UserEmailChallengeDrawerControllerTest.php
+++ b/tests/Panel/Controller/Drawer/UserEmailChallengeDrawerControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Panel\Controller\Drawer;
 
+use Kirby\Auth\Exception\RateLimitException;
 use Kirby\Cms\User;
 use Kirby\Email\Email;
 use Kirby\Exception\InvalidArgumentException;
@@ -147,6 +148,19 @@ class UserEmailChallengeDrawerControllerTest extends TestCase
 		);
 	}
 
+	public function testSubmitCodeConsumesRateLimit(): void
+	{
+		$this->setRequest(['action' => 'code']);
+		$this->app->impersonate('test');
+
+		(new UserEmailChallengeDrawerController($this->app->user('test')))->submit();
+
+		// sending the code is a metered side effect, so it has to
+		// consume budget like any other challenge creation
+		$log = $this->app->auth()->limits()->log();
+		$this->assertSame(1, $log['by-email']['test@getkirby.com']['trials']);
+	}
+
 	public function testSubmitCodeForOtherUser(): void
 	{
 		// an admin authorizes with their own password instead,
@@ -158,6 +172,32 @@ class UserEmailChallengeDrawerControllerTest extends TestCase
 
 		$this->assertTrue($controller->submit());
 		$this->assertSame([], Email::$emails);
+
+		// nothing was sent, so the other user's budget must stay untouched
+		$this->assertSame([], $this->app->auth()->limits()->log()['by-email']);
+	}
+
+	public function testSubmitCodeRateLimited(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => ['auth' => ['trials' => 1]]
+		]);
+
+		$this->setRequest(['action' => 'code']);
+		$this->app->impersonate('test');
+
+		$user = $this->app->user('test');
+		(new UserEmailChallengeDrawerController($user))->submit();
+
+		try {
+			(new UserEmailChallengeDrawerController($user))->submit();
+			$this->fail('Expected RateLimitException');
+		} catch (RateLimitException) {
+			// expected
+		}
+
+		// the limit has to fire before the mail goes out
+		$this->assertCount(1, Email::$emails);
 	}
 
 	public function testSubmitCreate(): void

--- a/tests/Panel/Controller/Drawer/UserEmailChallengeDrawerControllerTest.php
+++ b/tests/Panel/Controller/Drawer/UserEmailChallengeDrawerControllerTest.php
@@ -170,7 +170,16 @@ class UserEmailChallengeDrawerControllerTest extends TestCase
 
 		$controller = new UserEmailChallengeDrawerController($this->app->user('test'));
 
-		$this->assertTrue($controller->submit());
+		try {
+			$controller->submit();
+			$this->fail('Expected PermissionException was not thrown');
+		} catch (PermissionException $e) {
+			$this->assertSame(
+				'You cannot send a login code for test@getkirby.com',
+				$e->getMessage()
+			);
+		}
+
 		$this->assertSame([], Email::$emails);
 
 		// nothing was sent, so the other user's budget must stay untouched

--- a/tests/Panel/Controller/Drawer/UserSecurityDrawerControllerTest.php
+++ b/tests/Panel/Controller/Drawer/UserSecurityDrawerControllerTest.php
@@ -32,10 +32,12 @@ class UserSecurityDrawerControllerTest extends TestCase
 
 	public function testChallenges(): void
 	{
+		// no challenge is enabled on this site
 		$this->app = $this->app->clone([
 			'options' => [
 				'auth' => [
-					'methods' => ['password']
+					'methods'    => ['password'],
+					'challenges' => []
 				]
 			]
 		]);
@@ -43,6 +45,25 @@ class UserSecurityDrawerControllerTest extends TestCase
 		$user       = $this->app->user('test');
 		$controller = new UserSecurityDrawerController($user);
 		$this->assertSame([], $controller->challenges());
+
+		// without enforced 2FA users can still opt into a second factor
+		$this->app = $this->app->clone([
+			'options' => [
+				'auth' => [
+					'methods'    => ['password'],
+					'challenges' => ['totp']
+				]
+			]
+		]);
+
+		$this->app->impersonate('test');
+
+		$user       = $this->app->user('test');
+		$controller = new UserSecurityDrawerController($user);
+		$challenges = $controller->challenges();
+
+		$this->assertCount(1, $challenges);
+		$this->assertSame('qr-code', $challenges[0]['icon']);
 
 
 		$this->app = $this->app->clone([
@@ -63,7 +84,7 @@ class UserSecurityDrawerControllerTest extends TestCase
 
 		$this->assertCount(2, $challenges);
 		$this->assertSame('email-unread', $challenges[0]['icon']);
-		$this->assertSame($user->panel()->url(true) . '/changeEmail', $challenges[0]['dialog']);
+		$this->assertSame($user->panel()->url(true) . '/security/challenge/email', $challenges[0]['drawer']);
 		$this->assertSame('qr-code', $challenges[1]['icon']);
 		$this->assertSame($user->panel()->url(true) . '/security/challenge/totp', $challenges[1]['drawer']);
 	}

--- a/tests/Panel/Controller/Drawer/UserTotpDrawerControllerTest.php
+++ b/tests/Panel/Controller/Drawer/UserTotpDrawerControllerTest.php
@@ -197,7 +197,7 @@ class UserTotpDrawerControllerTest extends TestCase
 		]);
 		$this->app->impersonate('test');
 
-		$this->expectException(InvalidArgumentException::class);
+		$this->expectException(PermissionException::class);
 		$this->expectExceptionCode('error.access.code');
 
 		(new UserTotpDrawerController($this->app->user('test')))->submit();


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review

- [x] Design & concept
- [x] Deep read
- [x] Security check

**Timing:** No rush, but ideally before the v6-beta.4

## Description

Adds optional, per-user two-factor authentication and makes it the default behaviour. 

Previously, 2FA was all-or-nothing per install (`2fa => true`). This branch lets individual users opt into a second factor (passkey, TOTP or email code) without an admin enforcing it for everyone. 

It also adds a new sub drawer in the security drawer for the "Code via email" second factor that users can activate themselves.

`PasswordMethod::has2FA()` is now public and resolves per user:

- `2fa => true`: enforced for every user (unchanged)
- otherwise a user is only challenged if they have set up a factor themselves, (checked via `Challenges::hasAvailable($user, '2fa')`)

`EmailChallenge` becomes opt-in as a second factor, so simply having an email address no longer forces it. It stays available for every other mode (password reset, `code` login method), and when 2FA is enforced it stays the baseline factor for users who haven't set up anything else, so nobody is locked out. Users activate it from their security settings (having to enter the emailed code once when activating it doubles as a deliverability check).

HTTP Basic auth can't run a challenge, so `BasicAuthMethod::authenticate()` now defers to `PasswordMethod::has2FA()` and rejects any user who would be challenged, while letting factor-less accounts (e.g. dedicated API users) keep working.

Also in this branch:

- `UserCredentialDrawerController::authorizeCurrentUser()`: the pending challenge stored in the session now expires with the challenge timeout, failed attempts count against the shared auth rate limit, single-use challenges (WebAuthn) are invalidated after a failed attempt, and the pending is consumed on success so a code or nonce can't be replayed for a second change. Reusable codes deliberately survive a typo, so the account owner isn't locked out by one wrong digit.

Deliberately out of scope: 
- enforcing 2FA per role
- a UI to  set up 2FA for a user when it is enforced globally, but the user yet has none (onboarding extension)

## Changelog

### 🎉 Features

- Two-factor authentication can now be enabled per user: everyone can enable a second factor for their own account (passkey, authenticator app or "Code via email") from their account security settings, without an admin having to enforce it install-wide.
- `auth.methods.password.2fa` is now opt-in by default: leave it unset and only users who set up a second factor are challenged. Set it to `true` to keep requiring a second factor from every user.

### ☠️ Deprecated

- `Kirby\Cms\System::is2FA()`: use `$kirby->auth()->methods()->hasAnyRequiring2FA()` instead.
- `Kirby\Cms\System::is2FAWithTOTP()`: use `$kirby->auth()->methods()->hasAnyRequiring2FA()` together with `$kirby->auth()->enabledChallenges()` instead.

## Docs

On most sites, forcing 2FA on every editor isn't realistic, but the admins still want it for themselves (and/or anyone that is willing to use it). Until now that wasn't possible: `2fa => true` hit everyone or nobody. Now every user decides for their own account, and admins can still enforce it site-wide when they need to.

Update the 2FA / login methods page:

```php
// site/config/config.php
return [
	'auth' => [
		'methods' => [
			// default: every user can opt into a second factor themselves
			'password',

			// or: require a second factor from every user
			'password' => ['2fa' => true]
		]
	]
];
```

How a user enables a second factor: Account → Security → pick "Passkey", "Authenticator app" or "Code via email".

For "Code via email": press Activate, Kirby sends a one-time code to the account's email address, entering it activates the challenge. That step is intentional: it proves the address is actually reachable before it becomes a login requirement. Disabling works the same way. An admin disabling it for someone else confirms with their own admin password instead.

Worth documenting as a gotcha: HTTP Basic auth (`api.basicAuth`) can't run a challenge, so a user with a second factor can no longer authenticate with it. API accounts should stay without a second factor (and `2fa => true` disables basic auth entirely, as before).

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion