### PR TITLE
fix: Update `Toolkit\Html` tags lists

### DIFF
--- a/src/Content/FieldMethods.php
+++ b/src/Content/FieldMethods.php
@@ -122,8 +122,8 @@ trait FieldMethods
 	 */
 	public function inline(): static
 	{
-		// List of valid inline elements taken from:
-		// https://developer.mozilla.org/de/docs/Web/HTML/Inline_elemente
+		// List of valid inline elements based on the WHATWG text-level
+		// semantics: https://html.spec.whatwg.org/multipage/text-level-semantics.html
 		// Obsolete elements, script tags, image maps and form elements have
 		// been excluded for safety reasons and as they are most likely not
 		// needed in most cases.

--- a/src/Toolkit/Html.php
+++ b/src/Toolkit/Html.php
@@ -33,28 +33,40 @@ class Html extends Xml
 
 	/**
 	 * List of HTML tags that can be used inline
+	 * (text-level semantics as defined by the WHATWG HTML standard,
+	 * plus `img`: https://html.spec.whatwg.org/multipage/text-level-semantics.html)
 	 */
 	public static array $inlineList = [
-		'b',
-		'i',
-		'small',
-		'abbr',
-		'cite',
-		'code',
-		'dfn',
-		'em',
-		'kbd',
-		'strong',
-		'samp',
-		'var',
 		'a',
+		'abbr',
+		'b',
+		'bdi',
 		'bdo',
 		'br',
+		'cite',
+		'code',
+		'data',
+		'dfn',
+		'em',
+		'i',
 		'img',
+		'kbd',
+		'mark',
 		'q',
+		'rp',
+		'rt',
+		'ruby',
+		's',
+		'samp',
+		'small',
 		'span',
+		'strong',
 		'sub',
-		'sup'
+		'sup',
+		'time',
+		'u',
+		'var',
+		'wbr'
 	];
 
 	/**
@@ -69,21 +81,20 @@ class Html extends Xml
 
 	/**
 	 * List of HTML tags that are considered to be self-closing
+	 * (void elements as defined by the WHATWG HTML standard:
+	 * https://html.spec.whatwg.org/multipage/syntax.html#void-elements)
 	 */
 	public static array $voidList = [
 		'area',
 		'base',
 		'br',
 		'col',
-		'command',
 		'embed',
 		'hr',
 		'img',
 		'input',
-		'keygen',
 		'link',
 		'meta',
-		'param',
 		'source',
 		'track',
 		'wbr'


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Dropped from void list:
`command`, `keygen`, `param`

Added to inline list:
`bdi`, `data`, `mark`, `rp`, `rt`, `ruby`, `s`, `time`, `u`, `wbr`

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- Updated `Kirby\Toolkit\Html::$inlineList` and `Kirby\Toolkit\Html::$voidList`

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- Removed command, keygen and param from `Html::$voidList` as they are obsolete and no longer part of the [WHATWG void elements list](https://html.spec.whatwg.org/multipage/syntax.html#void-elements). `Html::isVoid()` now returns false for these tags, and `Html::tag()` no longer forces them to be self-closing.

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion