### PR TITLE
fix: Reflect latest change in live preview

### DIFF
--- a/panel/src/panel/content.test.ts
+++ b/panel/src/panel/content.test.ts
@@ -416,6 +416,37 @@ describe("panel.content", () => {
 				expect.objectContaining({ values: { title: "Draft" } })
 			);
 		});
+
+		it("waits for the API request before emitting the save event", async () => {
+			const panel = createPanel();
+			const content = Content(panel);
+
+			// keep the request pending so we can observe the state in between
+			let resolveRequest: () => void;
+			(panel.api.post as ReturnType<typeof vi.fn>).mockReturnValue(
+				new Promise<void>((resolve) => (resolveRequest = resolve))
+			);
+
+			const promise = content.save({ title: "Draft" });
+
+			// flush pending microtasks
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			// the event must not be emitted while the request is still pending
+			expect(panel.events.emit).not.toHaveBeenCalledWith(
+				"content.save",
+				expect.anything()
+			);
+
+			resolveRequest!();
+			await promise;
+
+			// once the request is done, the event is emitted
+			expect(panel.events.emit).toHaveBeenCalledWith(
+				"content.save",
+				expect.objectContaining({ values: { title: "Draft" } })
+			);
+		});
 	});
 
 	describe("saveLazy()", () => {

--- a/panel/src/panel/content.ts
+++ b/panel/src/panel/content.ts
@@ -308,8 +308,8 @@ export default function Content(panel: Panel) {
 				options.silent = true;
 			}
 
-			// await the response so the save event isn't emitted
-			// before the content is actually persisted
+			// await the response so the request method call isn't
+			// resolved before the content is actually persisted
 			await panel.api.post(
 				api + "/changes/" + method,
 				values,

--- a/panel/src/panel/content.ts
+++ b/panel/src/panel/content.ts
@@ -308,7 +308,9 @@ export default function Content(panel: Panel) {
 				options.silent = true;
 			}
 
-			panel.api.post(
+			// await the response so the save event isn't emitted
+			// before the content is actually persisted
+			await panel.api.post(
 				api + "/changes/" + method,
 				values,
 				options as Record<string, unknown>


### PR DESCRIPTION
## Description

`Content.request()` was declared `async` but never awaited/returned `panel.api.post()`, so the `content.save` event fired before the content was persisted. The live preview iframe then reloaded stale content, lagging one keystroke behind. This is a regression from the TypeScript migration (#8079), which dropped the original `return`.

Fix: `await` the request so the save event is emitted only after the content is actually saved.

## Changelog

### 🐛 Bug fixes

- Fix live editor preview lagging one keystroke behind #8272