### PR TITLE
fix: Prevent Chromium crash when opening writer link/email dialog

### DIFF
--- a/panel/src/components/Forms/Input/WriterInput.vue
+++ b/panel/src/components/Forms/Input/WriterInput.vue
@@ -147,6 +147,13 @@ export default {
 			},
 			events: {
 				link: (editor) => {
+					// clear the DOM selection first, otherwise Chromium crashes
+					// when the scrollable modal dialog opens on top of the live
+					// editor selection (the mark uses the editor state selection,
+					// so the link still lands on the right range)
+					// TODO: remove once Chromium fixes the underlying crash
+					window.getSelection()?.removeAllRanges();
+
 					this.$panel.dialog.open({
 						component: "k-link-dialog",
 						props: {
@@ -162,6 +169,10 @@ export default {
 					});
 				},
 				email: (editor) => {
+					// same as in the link handler above
+					// TODO: remove once Chromium fixes the underlying crash
+					window.getSelection()?.removeAllRanges();
+
 					this.$panel.dialog.open({
 						component: "k-email-dialog",
 						props: {


### PR DESCRIPTION
## Description

Opening the link/email dialog from the Writer toolbar crashes the Chromium renderer (`STATUS_BREAKPOINT`); Firefox is fine. When the modal dialog's `k-scrollable` body opens over the editor's live DOM selection, Blink crashes on paint/selection reconciliation. Regressed on `develop-minor` via the `<div>` → `<k-scrollable>` dialog body switch (#8254).

Fix: clear the DOM selection before opening the dialog. The mark uses the ProseMirror state selection, not the DOM one, so the link/email still lands on the right range.

## Changelog

### 🐛 Bug fixes

- Fix a browser crash when opening the link or email dialog in the Writer field on Chromium browsers

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion