### PR TITLE
fix: Preselect page link when reopening Writer link dialog

### DIFF
--- a/panel/src/api/pages.js
+++ b/panel/src/api/pages.js
@@ -54,7 +54,7 @@ export default (api) => ({
 		return page;
 	},
 	id(id) {
-		if (id.match(/^\/(.*\/)?@\/page\//) === true) {
+		if (id.match(/^\/(.*\/)?@\/page\//) !== null) {
 			return id.replace(/^\/(.*\/)?@\/page\//, "@");
 		}
 

--- a/panel/src/api/pages.test.js
+++ b/panel/src/api/pages.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import pages from "./pages.js";
+
+const api = pages({});
+
+describe("api.pages.id()", () => {
+	it("should convert page permalink", () => {
+		expect(api.id("/@/page/D1yCxHPlHzgzBJI5")).toBe("@D1yCxHPlHzgzBJI5");
+	});
+
+	it("should convert language-prefixed page permalink", () => {
+		expect(api.id("/de/@/page/D1yCxHPlHzgzBJI5")).toBe("@D1yCxHPlHzgzBJI5");
+	});
+
+	it("should convert page UUID", () => {
+		expect(api.id("page://D1yCxHPlHzgzBJI5")).toBe("@D1yCxHPlHzgzBJI5");
+	});
+
+	it("should escape slashes in a plain id", () => {
+		expect(api.id("blog/article")).toBe("blog+article");
+	});
+});


### PR DESCRIPTION
## Description

The Writer stores page links as permalinks (`/@/page/uuid`). In `panel/src/api/pages.js`, `id()` used `id.match(...) === true` to detect them, which is always `false` (`match()` returns an array/`null`, never `true`), so the permalink was never resolved and the link dialog's preview lookup 404'd — the type showed "Page" but no page was preselected. Replaced `=== true` with `!== null` and added a regression test.

## Changelog

### 🐛 Bug fixes

- Fix page/file link not being preselected when reopening the Writer link dialog #8289

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion