### PR TITLE
feat: New SectionField

### DIFF
--- a/panel/src/components/Forms/Field/SectionField.vue
+++ b/panel/src/components/Forms/Field/SectionField.vue
@@ -1,0 +1,40 @@
+<template>
+	<component
+		:is="component"
+		v-if="$helper.isComponent(component)"
+		:class="'k-section-name-' + name"
+		:column="width"
+		:content="formData"
+		:lock="$panel.view.props.lock"
+		:name="name"
+		:parent="endpoints?.model ?? $panel.view.props.api"
+		:timestamp="$panel.view.timestamp"
+		@input="$emit('input', $event)"
+		@submit="$emit('submit', $event)"
+	/>
+	<k-box
+		v-else
+		:text="$t('error.section.type.invalid', { type: sectionType })"
+		icon="alert"
+		theme="negative"
+	/>
+</template>
+
+<script>
+export default {
+	inheritAttrs: false,
+	props: {
+		endpoints: Object,
+		formData: Object,
+		name: String,
+		sectionType: String,
+		width: String
+	},
+	emits: ["input", "submit"],
+	computed: {
+		component() {
+			return "k-" + this.sectionType + "-section";
+		}
+	}
+};
+</script>

--- a/panel/src/components/Forms/Field/index.js
+++ b/panel/src/components/Forms/Field/index.js
@@ -20,6 +20,7 @@ import PagePickerField from "./PagePickerField.vue";
 import PasswordField from "./PasswordField.vue";
 import RadioField from "./RadioField.vue";
 import RangeField from "./RangeField.vue";
+import SectionField from "./SectionField.vue";
 import SelectField from "./SelectField.vue";
 import SlugField from "./SlugField.vue";
 import StatsField from "./StatsField.vue";
@@ -65,6 +66,7 @@ export default {
 		app.component("k-password-field", PasswordField);
 		app.component("k-radio-field", RadioField);
 		app.component("k-range-field", RangeField);
+		app.component("k-section-field", SectionField);
 		app.component("k-select-field", SelectField);
 		app.component("k-slug-field", SlugField);
 		app.component("k-stats-field", StatsField);

--- a/src/Blueprint/Blueprint.php
+++ b/src/Blueprint/Blueprint.php
@@ -10,6 +10,7 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\F;
 use Kirby\Form\Field;
+use Kirby\Form\Field\SectionField;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
@@ -823,7 +824,7 @@ class Blueprint
 	public function section(string $name): Section|null
 	{
 		if (empty($this->sections[$name]) === true) {
-			return null;
+			return $this->sectionFromField($name);
 		}
 
 		if ($this->sections[$name] instanceof Section) {
@@ -841,19 +842,50 @@ class Blueprint
 	}
 
 	/**
+	 * Creates a section from a field with the `section` type
+	 * @since 6.0.0
+	 */
+	protected function sectionFromField(string $name): Section|null
+	{
+		$props = $this->field($name);
+
+		if ($props === null || $props['type'] !== 'section') {
+			return null;
+		}
+
+		unset($props['type']);
+
+		$field = new SectionField(...$props);
+		$field->setModel($this->model());
+
+		// cache the section under the original field name
+		return $this->sections[$props['name']] = $field->section();
+	}
+
+	/**
 	 * Returns all sections
 	 *
 	 * @return array<string, Section>
 	 */
 	public function sections(): array
 	{
-		return A::map(
+		$sections = A::map(
 			$this->sections,
 			fn ($section) => match (true) {
 				$section instanceof Section => $section,
 				default                     => $this->section($section['name'])
 			}
 		);
+
+		// sections that are defined as fields are not part of the
+		// section definitions and need to be collected separately
+		foreach ($this->fields as $name => $field) {
+			if ($field['type'] === 'section') {
+				$sections[$name] ??= $this->section($name);
+			}
+		}
+
+		return $sections;
 	}
 
 	/**

--- a/src/Blueprint/Section.php
+++ b/src/Blueprint/Section.php
@@ -6,6 +6,7 @@ use Closure;
 use Kirby\Cms\App;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Form\Field\SectionField;
 use Kirby\Toolkit\Component;
 
 /**
@@ -25,6 +26,13 @@ class Section extends Component
 	 * Registry for all component types
 	 */
 	public static array $types = [];
+
+	/**
+	 * The field that wraps this section, if the section
+	 * has been defined as a `section` field
+	 * @since 6.0.0
+	 */
+	protected SectionField|null $field = null;
 
 	/**
 	 * @throws \Kirby\Exception\InvalidArgumentException
@@ -112,6 +120,16 @@ class Section extends Component
 		return $this->errors ?? [];
 	}
 
+	/**
+	 * Returns the wrapping field, if the section has been
+	 * defined as a `section` field
+	 * @since 6.0.0
+	 */
+	public function field(): SectionField|null
+	{
+		return $this->field;
+	}
+
 	public function kirby(): App
 	{
 		return $this->model()->kirby();
@@ -126,7 +144,7 @@ class Section extends Component
 	{
 		$array = parent::toArray();
 
-		unset($array['model']);
+		unset($array['field'], $array['model']);
 
 		return $array;
 	}

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -38,6 +38,7 @@ use Kirby\Form\Field\PagePickerField;
 use Kirby\Form\Field\PasswordField;
 use Kirby\Form\Field\RadioField;
 use Kirby\Form\Field\RangeField;
+use Kirby\Form\Field\SectionField;
 use Kirby\Form\Field\SelectField;
 use Kirby\Form\Field\SlugField;
 use Kirby\Form\Field\StatsField;
@@ -295,6 +296,7 @@ class Core
 			'password'    => PasswordField::class,
 			'radio'       => RadioField::class,
 			'range'       => RangeField::class,
+			'section'     => SectionField::class,
 			'select'      => SelectField::class,
 			'slug'        => SlugField::class,
 			'stats'       => StatsField::class,

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -297,6 +297,13 @@ abstract class ModelWithContent implements Identifiable, Stringable
 		$errors = [];
 
 		foreach ($this->blueprint()->sections() as $section) {
+			// sections that are wrapped in a `section` field are
+			// validated as part of the form, where `when` conditions
+			// can be evaluated against the other fields
+			if ($section->field() !== null) {
+				continue;
+			}
+
 			$errors = [...$errors, ...$section->errors()];
 		}
 

--- a/src/Form/Field/SectionField.php
+++ b/src/Form/Field/SectionField.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Blueprint\Section;
+
+/**
+ * Section Field
+ *
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class SectionField extends BaseField
+{
+	protected array $props;
+	protected string $section;
+
+	public function __construct(
+		string|null $section = null,
+		string|null $name = null,
+		array|null $when = null,
+		string|null $width = null,
+		...$props
+	) {
+		parent::__construct(
+			name: $name,
+			when: $when,
+			width: $width
+		);
+
+		$this->props = $props;
+
+		// fall back to the field name as section type
+		$this->section = $section ?? $this->name();
+	}
+
+	public function props(): array
+	{
+		return [
+			...parent::props(),
+			'sectionType' => $this->section,
+		];
+	}
+
+	public function section(): Section
+	{
+		return new Section($this->section, [
+			'model' => $this->model(),
+			'name'  => $this->name(),
+			...$this->props
+		]);
+	}
+}

--- a/src/Form/Field/SectionField.php
+++ b/src/Form/Field/SectionField.php
@@ -3,6 +3,7 @@
 namespace Kirby\Form\Field;
 
 use Kirby\Blueprint\Section;
+use Kirby\Form\Fields;
 
 /**
  * Section Field
@@ -13,6 +14,7 @@ use Kirby\Blueprint\Section;
  */
 class SectionField extends BaseField
 {
+	protected Section|null $instance = null;
 	protected array $props;
 	protected string $section;
 
@@ -35,6 +37,51 @@ class SectionField extends BaseField
 		$this->section = $section ?? $this->name();
 	}
 
+	/**
+	 * Returns the validation errors of the wrapped section.
+	 * Inactive sections – hidden by a `when` condition –
+	 * never have errors, just like regular fields.
+	 */
+	public function errors(): array
+	{
+		if ($this->isActive() === false) {
+			return [];
+		}
+
+		return $this->sectionErrors()['message'] ?? [];
+	}
+
+	/**
+	 * All props that are not part of the constructor signature
+	 * are passed on to the section and must not be filtered out
+	 * by the default factory
+	 */
+	public static function factory(
+		array $props,
+		Fields|null $siblings = null
+	): static {
+		$model = $props['model'] ?? null;
+
+		unset($props['model'], $props['type'], $props['value']);
+
+		$field = new static(...$props);
+		$field->setSiblings($siblings);
+
+		if ($model !== null) {
+			$field->setModel($model);
+		}
+
+		return $field;
+	}
+
+	/**
+	 * The section headline is used as label for error messages
+	 */
+	public function label(): string|null
+	{
+		return $this->sectionErrors()['label'] ?? null;
+	}
+
 	public function props(): array
 	{
 		return [
@@ -45,10 +92,20 @@ class SectionField extends BaseField
 
 	public function section(): Section
 	{
-		return new Section($this->section, [
+		return $this->instance ??= new Section($this->section, [
+			'field' => $this,
 			'model' => $this->model(),
 			'name'  => $this->name(),
 			...$this->props
 		]);
+	}
+
+	/**
+	 * The raw error entry of the wrapped section,
+	 * with its own `label` and `message` keys
+	 */
+	protected function sectionErrors(): array
+	{
+		return $this->section()->errors()[$this->name()] ?? [];
 	}
 }

--- a/tests/Blueprint/BlueprintTest.php
+++ b/tests/Blueprint/BlueprintTest.php
@@ -582,6 +582,234 @@ class BlueprintTest extends TestCase
 		$this->assertSame('info', $blueprint->sections()['info']->type());
 	}
 
+	public function testSectionFromField(): void
+	{
+		// with options
+		$blueprint = new Blueprint([
+			'model' => $this->model,
+			'fields' => [
+				'info' => [
+					'type'    => 'section',
+					'section' => 'info'
+				]
+			]
+		]);
+
+		$this->assertSame('info', $blueprint->section('info')->type());
+	}
+
+	public function testSectionFromFieldWithDifferentName(): void
+	{
+		$blueprint = new Blueprint([
+			'model'  => $this->model,
+			'fields' => [
+				'notes' => [
+					'type'    => 'section',
+					'section' => 'info'
+				]
+			]
+		]);
+
+		$section = $blueprint->section('notes');
+
+		$this->assertSame('info', $section->type());
+		$this->assertSame('notes', $section->name());
+	}
+
+	public function testSectionFromFieldWithLowercaseName(): void
+	{
+		$blueprint = new Blueprint([
+			'model'  => $this->model,
+			'fields' => [
+				'infoBox' => [
+					'type'    => 'section',
+					'section' => 'info'
+				]
+			]
+		]);
+
+		$section = $blueprint->section('infobox');
+
+		$this->assertSame('info', $section->type());
+		$this->assertSame('infobox', $section->name());
+	}
+
+	public function testSectionFromFieldWithMissingSectionType(): void
+	{
+		$blueprint = new Blueprint([
+			'model'  => $this->model,
+			'fields' => [
+				'info' => [
+					'type' => 'section'
+				]
+			]
+		]);
+
+		// the field name is used as fallback for the section type
+		$this->assertSame('info', $blueprint->section('info')->type());
+	}
+
+	public function testSectionFromFieldWithMissingField(): void
+	{
+		$blueprint = new Blueprint([
+			'model' => $this->model,
+		]);
+
+		$this->assertNull($blueprint->section('info'));
+	}
+
+	public function testSectionFromFieldWithModel(): void
+	{
+		$blueprint = new Blueprint([
+			'model'  => $this->model,
+			'fields' => [
+				'info' => [
+					'type'    => 'section',
+					'section' => 'info'
+				]
+			]
+		]);
+
+		$this->assertSame($this->model, $blueprint->section('info')->model());
+	}
+
+	public function testSectionFromFieldWithNonSectionField(): void
+	{
+		$blueprint = new Blueprint([
+			'model'  => $this->model,
+			'fields' => [
+				'info' => [
+					'type' => 'text'
+				]
+			]
+		]);
+
+		$this->assertNull($blueprint->section('info'));
+	}
+
+	public function testSectionFromFieldWithProps(): void
+	{
+		$blueprint = new Blueprint([
+			'model'  => $this->model,
+			'fields' => [
+				'info' => [
+					'type'    => 'section',
+					'section' => 'info',
+					'label'   => 'Notes',
+					'text'    => 'Some info',
+					'theme'   => 'negative'
+				]
+			]
+		]);
+
+		$section = $blueprint->section('info')->toArray();
+
+		$this->assertSame('Notes', $section['label']);
+		$this->assertSame('<p>Some info</p>', trim($section['text']));
+		$this->assertSame('negative', $section['theme']);
+	}
+
+	public function testSectionFromFieldWithAutomaticLabel(): void
+	{
+		$blueprint = new Blueprint([
+			'model'  => $this->model,
+			'fields' => [
+				'infoBox' => [
+					'type'    => 'section',
+					'section' => 'info'
+				]
+			]
+		]);
+
+		// the automatic field label is passed on to the section
+		$this->assertSame(
+			'Info box',
+			$blueprint->section('infoBox')->toArray()['label']
+		);
+	}
+
+	public function testSectionFromFieldWithSectionOfSameName(): void
+	{
+		$blueprint = new Blueprint([
+			'model'    => $this->model,
+			'fields'   => [
+				'info' => [
+					'type'    => 'section',
+					'section' => 'info',
+					'text'    => 'From the field'
+				]
+			],
+			'sections' => [
+				'info' => [
+					'type' => 'info',
+					'text' => 'From the section'
+				]
+			]
+		]);
+
+		// the section definition takes precedence over the field
+		$this->assertSame(
+			'<p>From the section</p>',
+			trim($blueprint->section('info')->toArray()['text'])
+		);
+	}
+
+	public function testSectionsFromFields(): void
+	{
+		$blueprint = new Blueprint([
+			'model'  => $this->model,
+			'fields' => [
+				'text'   => [
+					'type' => 'text'
+				],
+				'drafts' => [
+					'type'    => 'section',
+					'section' => 'pages',
+					'status'  => 'drafts'
+				],
+				'listed' => [
+					'type'    => 'section',
+					'section' => 'pages',
+					'status'  => 'listed'
+				]
+			]
+		]);
+
+		$sections = $blueprint->sections();
+
+		// the fields section and both section fields
+		$this->assertSame(
+			['main-fields', 'drafts', 'listed'],
+			array_keys($sections)
+		);
+
+		// each section keeps its own field name
+		$this->assertSame('drafts', $sections['drafts']->name());
+		$this->assertSame('listed', $sections['listed']->name());
+		$this->assertSame('pages', $sections['drafts']->type());
+		$this->assertSame('pages', $sections['listed']->type());
+	}
+
+	public function testSectionsFromFieldsInGroup(): void
+	{
+		$blueprint = new Blueprint([
+			'model'  => $this->model,
+			'fields' => [
+				'group' => [
+					'type'   => 'group',
+					'fields' => [
+						'drafts' => [
+							'type'    => 'section',
+							'section' => 'pages'
+						]
+					]
+				]
+			]
+		]);
+
+		$this->assertArrayHasKey('drafts', $blueprint->sections());
+	}
+
 	public function testPreset(): void
 	{
 		$blueprint = new Blueprint([

--- a/tests/Blueprint/Sections/SectionTest.php
+++ b/tests/Blueprint/Sections/SectionTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Blueprint;
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Form\Field\SectionField;
 use Kirby\TestCase;
 
 class SectionTest extends TestCase
@@ -169,6 +170,52 @@ class SectionTest extends TestCase
 		$model = new Page(['slug' => 'test']);
 		$section = new Section('test', ['model' => $model]);
 		$section->drawers();
+	}
+
+	public function testErrors(): void
+	{
+		// no errors method defined as default
+		Section::$types['test'] = [];
+
+		$section = new Section('test', [
+			'model' => new Page(['slug' => 'test'])
+		]);
+
+		$this->assertSame([], $section->errors());
+
+		// return errors from the defined method
+		Section::$types['test'] = [
+			'methods' => [
+				'errors' => fn () => ['min' => 'Not enough']
+			]
+		];
+
+		$section = new Section('test', [
+			'model' => new Page(['slug' => 'test'])
+		]);
+
+		$this->assertSame(['min' => 'Not enough'], $section->errors());
+	}
+
+	public function testField(): void
+	{
+		Section::$types['test'] = [];
+
+		$model = new Page(['slug' => 'test']);
+
+		// no wrapping field as default
+		$section = new Section('test', ['model' => $model]);
+
+		$this->assertNull($section->field());
+
+		// return the wrapping field
+		$field   = new SectionField(section: 'pages', name: 'drafts');
+		$section = new Section('test', [
+			'model' => $model,
+			'field' => $field
+		]);
+
+		$this->assertSame($field, $section->field());
 	}
 
 	public function testMissingModel(): void

--- a/tests/Cms/CoreTest.php
+++ b/tests/Cms/CoreTest.php
@@ -149,6 +149,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('pages', $fields);
 		$this->assertArrayHasKey('radio', $fields);
 		$this->assertArrayHasKey('range', $fields);
+		$this->assertArrayHasKey('section', $fields);
 		$this->assertArrayHasKey('select', $fields);
 		$this->assertArrayHasKey('slug', $fields);
 		$this->assertArrayHasKey('structure', $fields);

--- a/tests/Cms/Page/PageErrorsTest.php
+++ b/tests/Cms/Page/PageErrorsTest.php
@@ -34,6 +34,52 @@ class PageErrorsTest extends ModelTestCase
 		$this->assertSame([], $page->errors());
 	}
 
+	public function testErrorsWithInfoField(): void
+	{
+		$page = new Page([
+			'slug' => 'test',
+			'blueprint' => [
+				'name'   => 'test',
+				'fields' => [
+					'info' => [
+						'type' => 'info',
+						'text' => 'info'
+					]
+				]
+			]
+		]);
+
+		// fields without a value don't have errors
+		$this->assertSame([], $page->errors());
+	}
+
+	public function testErrorsWithPagesSectionField(): void
+	{
+		$page = new Page([
+			'slug' => 'test',
+			'blueprint' => [
+				'name' => 'test',
+				'fields' => [
+					'drafts' => [
+						'type'    => 'section',
+						'section' => 'pages',
+						'status'  => 'drafts',
+						'min'     => 1
+					]
+				]
+			]
+		]);
+
+		$this->assertSame([
+			'drafts' => [
+				'label'   => 'Drafts',
+				'message' => [
+					'min' => 'The "Drafts" section requires at least one page'
+				]
+			]
+		], $page->errors());
+	}
+
 	public function testErrorsWithRequiredField(): void
 	{
 		$page = new Page([

--- a/tests/Cms/Page/PageErrorsTest.php
+++ b/tests/Cms/Page/PageErrorsTest.php
@@ -80,6 +80,33 @@ class PageErrorsTest extends ModelTestCase
 		], $page->errors());
 	}
 
+	public function testErrorsWithPagesSectionFieldWhenInactive(): void
+	{
+		$page = new Page([
+			'slug' => 'test',
+			'blueprint' => [
+				'name' => 'test',
+				'fields' => [
+					'toggle' => [
+						'type'    => 'toggle',
+						'default' => false
+					],
+					'drafts' => [
+						'type'    => 'section',
+						'section' => 'pages',
+						'status'  => 'drafts',
+						'min'     => 1,
+						'when'    => ['toggle' => true]
+					]
+				]
+			]
+		]);
+
+		// the section is hidden by the `when` condition
+		// and must not block changing the page status
+		$this->assertSame([], $page->errors());
+	}
+
 	public function testErrorsWithRequiredField(): void
 	{
 		$page = new Page([

--- a/tests/Form/Field/SectionFieldTest.php
+++ b/tests/Form/Field/SectionFieldTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Kirby\Form\Field;
+
+use Kirby\Blueprint\Section;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(SectionField::class)]
+class SectionFieldTest extends TestCase
+{
+	public function testProps(): void
+	{
+		$field = $this->field('section', [
+			'section' => 'pages'
+		]);
+
+		$props = $field->props();
+
+		ksort($props);
+
+		$expected = [
+			'hidden'      => false,
+			'name'        => 'section',
+			'saveable'    => false,
+			'sectionType' => 'pages',
+			'type'        => 'section',
+			'when'        => null,
+			'width'       => '1/1'
+		];
+
+		$this->assertSame($expected, $props);
+	}
+
+	public function testSection(): void
+	{
+		$field = $this->field('section', [
+			'name'    => 'drafts',
+			'section' => 'pages'
+		]);
+
+		$section = $field->section();
+
+		$this->assertInstanceOf(Section::class, $section);
+		$this->assertSame('drafts', $section->name());
+		$this->assertSame('pages', $section->type());
+	}
+
+	public function testSectionWithMissingSectionType(): void
+	{
+		$field = $this->field('section', [
+			'name' => 'pages'
+		]);
+
+		// the field name is used as fallback for the section type
+		$this->assertSame('pages', $field->props()['sectionType']);
+		$this->assertSame('pages', $field->section()->type());
+	}
+}

--- a/tests/Form/Field/SectionFieldTest.php
+++ b/tests/Form/Field/SectionFieldTest.php
@@ -3,11 +3,63 @@
 namespace Kirby\Form\Field;
 
 use Kirby\Blueprint\Section;
+use Kirby\Cms\Page;
+use Kirby\Form\Fields;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(SectionField::class)]
 class SectionFieldTest extends TestCase
 {
+	public function testErrors(): void
+	{
+		$field = $this->field('section', [
+			'name'    => 'drafts',
+			'section' => 'pages',
+			'status'  => 'drafts',
+			'min'     => 1
+		]);
+
+		$this->assertSame([
+			'min' => 'The "Drafts" section requires at least one page'
+		], $field->errors());
+	}
+
+	public function testErrorsWhenInactive(): void
+	{
+		$fields = new Fields([
+			'toggle' => [
+				'type'    => 'toggle',
+				'default' => false
+			],
+			'drafts' => [
+				'type'    => 'section',
+				'section' => 'pages',
+				'status'  => 'drafts',
+				'min'     => 1,
+				'when'    => ['toggle' => true]
+			]
+		], new Page(['slug' => 'test']));
+
+		// the section is hidden by the `when` condition
+		// and must not block saving or publishing
+		$this->assertSame([], $fields->get('drafts')->errors());
+		$this->assertSame([], $fields->errors());
+	}
+
+	public function testLabel(): void
+	{
+		$field = $this->field('section', [
+			'name'    => 'drafts',
+			'section' => 'pages',
+			'status'  => 'drafts',
+			'headline' => 'My drafts',
+			'min'     => 1
+		]);
+
+		// the section headline is used as error label
+		$this->assertSame('My drafts', $field->label());
+	}
+
 	public function testProps(): void
 	{
 		$field = $this->field('section', [

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -130,6 +130,33 @@ class FieldsTest extends TestCase
 		], $fields->errors());
 	}
 
+	public function testErrorsWithFieldsWithoutValue(): void
+	{
+		$fields = new Fields([
+			'a' => [
+				'type'     => 'text',
+				'required' => true
+			],
+			'b' => [
+				'type' => 'info',
+				'text' => 'Some info'
+			],
+			'c' => [
+				'type' => 'line'
+			],
+		], $this->model);
+
+		// fields without a value are skipped
+		$this->assertSame([
+			'a' => [
+				'label'   => 'A',
+				'message' => [
+					'required' => 'Please enter something'
+				]
+			]
+		], $fields->errors());
+	}
+
 	public function testErrorsWithoutErrors(): void
 	{
 		$fields = new Fields([


### PR DESCRIPTION
## Description

Implements parts of https://github.com/getkirby/kirby/pull/7859

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements

- New `Kirby\Form\Field\SectionField`, which serves as a wrapper around our old sections. This makes it possible to use any section in fields by simply writing something like: 
```yaml
fields: 
  drafts: 
    type: section
    section: pages
    status: drafts
    layout: cards
```
This enhancement is not just simplifying blueprint setups by being able to only use fields. Section fields can now also make use of `when` queries and field widths this way for even more options. 

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion