### PR TITLE
fix: Prevent call stack overflow when opening the block drawer

### DIFF
--- a/panel/src/components/Drawers/BlockDrawer.vue
+++ b/panel/src/components/Drawers/BlockDrawer.vue
@@ -39,15 +39,9 @@ import { props as FieldsProps } from "./Elements/Fields.vue";
 
 export const props = {
 	props: {
-		hidden: {
-			type: Boolean
-		},
-		next: {
-			type: Object
-		},
-		prev: {
-			type: Object
-		}
+		hidden: Boolean,
+		next: Boolean,
+		prev: Boolean
 	}
 };
 

--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -337,8 +337,8 @@ export default {
 				props: {
 					hidden: this.isHidden,
 					icon: this.fieldset.icon ?? "box",
-					next: this.next,
-					prev: this.prev,
+					next: Boolean(this.next),
+					prev: Boolean(this.prev),
 					tabs: this.tabs,
 					title: this.fieldset.name,
 					value: this.content

--- a/panel/src/panel/html.test.ts
+++ b/panel/src/panel/html.test.ts
@@ -106,6 +106,39 @@ describe("HtmlString class", () => {
 			warn.mockRestore();
 		});
 
+		it("passes class instances through untouched", () => {
+			class Component {
+				name = "block";
+			}
+
+			const instance = new Component();
+			const result = HtmlString.resolve({ next: instance }) as {
+				next: Component;
+			};
+
+			expect(result.next).toBe(instance);
+		});
+
+		it("keeps already resolved HtmlString values intact", () => {
+			const safe = new HtmlString("<b>x</b>");
+			const result = HtmlString.resolve({ help: safe }) as { help: HtmlString };
+
+			expect(result.help).toBe(safe);
+		});
+
+		it("does not recurse into cyclic values", () => {
+			const parent: Record<string, unknown> = { name: "parent" };
+			const child = { name: "child", parent };
+			parent.child = child;
+
+			// a component instance holding cyclic references must not be walked
+			class Component {
+				tree = parent;
+			}
+
+			expect(() => HtmlString.resolve({ next: new Component() })).not.toThrow();
+		});
+
 		it("wraps non-string values under <key> by recursing", () => {
 			// Pragmatic edge case: if backend wraps an array under <key>,
 			// don't blindly stringify - recurse into it.

--- a/panel/src/panel/html.ts
+++ b/panel/src/panel/html.ts
@@ -1,3 +1,5 @@
+import { isObject } from "@/helpers/object";
+
 /**
  * Wraps and marks a string as trusted, pre-escaped HTML.
  *
@@ -29,7 +31,9 @@ export class HtmlString extends String {
 	/**
 	 * Recursively walks `data` and rewraps any value whose parent key
 	 * matches `<key>` into an `HtmlString`, stripping the brackets. Plain
-	 * keys are kept as-is. Arrays are walked element by element.
+	 * keys are kept as-is. Arrays are walked element by element.Class
+	 * instances (e.g. component  instances passed as props) are passed
+	 * through untouched.
 	 *
 	 * Returns a new object/array; does not mutate the input.
 	 */
@@ -38,7 +42,7 @@ export class HtmlString extends String {
 			return data.map((value) => HtmlString.resolve(value)) as T;
 		}
 
-		if (data !== null && typeof data === "object") {
+		if (isObject(data) === true) {
 			const result: Record<string, unknown> = {};
 			const rawData = data as Record<string, unknown>;
 


### PR DESCRIPTION
## Description

`HtmlString.resolve()` walks state to rewrap `<key>` payloads, but its guard (`typeof data === "object"`) matched every non-primitive, not just the plain objects and arrays JSON can produce. Since `Blocks.vue` passes the neighbouring block components as the drawer's `next`/`prev` props, the walk descended into a Vue component instance — a cyclic graph — and never terminated.

Now guarded with the existing `isObject()` helper, so only plain objects and arrays are walked. That's what `resolve()` always meant: the bracketed-key convention only ever comes from backend JSON.

## Changelog

### 🐛 Bug fixes

- Fix `Maximum call stack size exceeded` error when editing a block #8298

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion