### PR TITLE
fix: Prevent error when clicking a radio field option

### DIFF
--- a/panel/src/components/Forms/Input/RadioInput.vue
+++ b/panel/src/components/Forms/Input/RadioInput.vue
@@ -15,7 +15,6 @@
 				<li v-for="(choice, index) in choices" :key="index">
 					<k-choice-input
 						v-bind="choice"
-						@click="toggle(choice.value)"
 						@input="$emit('input', choice.value)"
 					/>
 				</li>


### PR DESCRIPTION
## Description
Clicking an option in a `radio` field (e.g. the page status change dialog) threw `TypeError: e.toggle is not a function`. `RadioInput` still bound `@click="toggle(...)"`, but `toggle` was removed in #7385 and later reintroduced into the template without the method during a merge conflict. Selection is already handled by `@input`, so the leftover binding is removed.

## Changelog

### 🐛 Bug fixes
- Fix error when clicking a radio field option, e.g. when changing a page's status #8301