### PR TITLE
fix: Respect slug rules config in the Panel

### DIFF
--- a/panel/src/components/Forms/Input/SlugInput.vue
+++ b/panel/src/components/Forms/Input/SlugInput.vue
@@ -51,7 +51,9 @@ export default {
 	data() {
 		return {
 			slug: this.sluggify(this.value),
-			slugs: this.$panel.language.rules ?? this.$panel.system.slugs,
+			slugs: this.$helper.object.isEmpty(this.$panel.language.rules)
+				? this.$panel.system.slugs
+				: this.$panel.language.rules,
 			syncValue: null
 		};
 	},

--- a/panel/src/panel/language.test.ts
+++ b/panel/src/panel/language.test.ts
@@ -52,4 +52,41 @@ describe("panel.language", () => {
 			});
 		});
 	});
+
+	describe("rules", () => {
+		// the slug input uses these rules when the active language defines
+		// any; otherwise (no/empty `rules`, e.g. single-language or a
+		// `languages: true` setup without a language) it falls back to the
+		// system slug rules
+		it("is empty by default", () => {
+			const language = Language();
+			expect(language.rules).toStrictEqual({});
+		});
+
+		it("applies the rules of the active language", () => {
+			const language = Language();
+			const rules = { ä: "ae", ö: "oe", ü: "ue" };
+
+			language.set({ code: "de", name: "German", rules });
+
+			expect(language.rules).toStrictEqual(rules);
+		});
+
+		it("falls back to the empty default when set without rules", () => {
+			const language = Language();
+
+			language.set({ code: "de", name: "German" });
+
+			expect(language.rules).toStrictEqual({});
+		});
+
+		it("is restored to the empty default on reset()", () => {
+			const language = Language();
+
+			language.set({ code: "de", rules: { ü: "ue" } });
+			language.reset();
+
+			expect(language.rules).toStrictEqual({});
+		});
+	});
 });


### PR DESCRIPTION
## Description

The `slugs` config option was ignored in the Panel's slug generation. Since the TypeScript migration in #8032, `panel.language.rules` defaults to `{}` instead of `null`, so the `?? system.slugs` fallback in `SlugInput` never triggered. 

The input now uses the active language's rules only when it actually defines any, otherwise it falls back to the system slug rules — covering single-language setups and `languages: true` setups without a defined language.

## Changelog

### 🐛 Bug fixes

- Restore support for the `slugs` config option in the Panel #8300

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion