### PR TITLE
perf: Cache normalized blueprint

### DIFF
--- a/src/Blueprint/Blueprint.php
+++ b/src/Blueprint/Blueprint.php
@@ -12,7 +12,6 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
-use Kirby\Toolkit\Str;
 
 /**
  * The Blueprint class gives access to all settings

--- a/src/Blueprint/Blueprint.php
+++ b/src/Blueprint/Blueprint.php
@@ -26,6 +26,16 @@ class Blueprint
 {
 	public static array $loaded = [];
 
+	/**
+	 * Cache of blueprints with fully normalized props,
+	 * keyed by class, name and fallback. The normalized
+	 * props are model- and language-agnostic, so they can
+	 * be shared between all models of the same blueprint.
+	 *
+	 * @var array<string, static>
+	 */
+	public static array $normalized = [];
+
 	protected AcceptRules|null $acceptRules = null;
 
 	protected FieldsRegistry $fields;
@@ -39,6 +49,17 @@ class Blueprint
 	public function __call(string $key, array|null $arguments = null): mixed
 	{
 		return $this->props[$key] ?? null;
+	}
+
+	/**
+	 * Resets all caches that are bound to a single model
+	 *
+	 * @since 6.0.0
+	 */
+	public function __clone()
+	{
+		$this->acceptRules = null;
+		$this->tabs        = null;
 	}
 
 	/**
@@ -148,24 +169,43 @@ class Blueprint
 	 * Create a new blueprint for a model
 	 */
 	public static function factory(
+		ModelWithContent $model,
 		string $name,
-		string|null $fallback,
-		ModelWithContent $model
+		string|null $fallback = null
 	): static|null {
-		try {
-			$props = static::load($name);
-		} catch (Exception) {
-			$props = $fallback !== null ? static::load($fallback) : null;
+		$shared = static::class . '/' . $name . '/';
+		$key    = $shared;
+
+		// a blueprint that resolves by its own name never consults
+		// the fallback and is shared by all fallback variants
+		if (isset(static::$normalized[$shared]) === false) {
+			$key = $shared . $fallback;
 		}
 
-		if ($props === null) {
-			return null;
+		if (isset(static::$normalized[$key]) === false) {
+			try {
+				$props = static::load($name);
+				$key   = $shared;
+			} catch (Exception) {
+				$props = $fallback !== null ? static::load($fallback) : null;
+			}
+
+			if ($props === null) {
+				return null;
+			}
+
+			// inject the parent model
+			$props['model'] = $model;
+
+			static::$normalized[$key] = new static($props);
 		}
 
-		// inject the parent model
-		$props['model'] = $model;
+		// hand out a copy, so that the cached blueprint
+		// keeps its normalized props untouched
+		$blueprint        = clone static::$normalized[$key];
+		$blueprint->model = $model;
 
-		return new static($props);
+		return $blueprint;
 	}
 
 	/**
@@ -302,12 +342,6 @@ class Blueprint
 		// inject the filename as name if no name is set
 		$props['name'] ??= $name;
 
-		// normalize the title
-		$title = $props['title'] ?? Str::label($props['name']);
-
-		// translate the title
-		$props['title'] = I18n::translate($title) ?? $title;
-
 		return $props;
 	}
 
@@ -377,6 +411,17 @@ class Blueprint
 	}
 
 	/**
+	 * Clears all blueprint caches
+	 *
+	 * @since 6.0.0
+	 */
+	public static function reset(): void
+	{
+		static::$loaded     = [];
+		static::$normalized = [];
+	}
+
+	/**
 	 * Returns a single tab by name or the
 	 * first tab if no name is given
 	 */
@@ -408,7 +453,7 @@ class Blueprint
 	 */
 	public function title(): string
 	{
-		return $this->props['title'];
+		return $this->i18n($this->props['title']);
 	}
 
 	/**
@@ -418,7 +463,8 @@ class Blueprint
 	{
 		return [
 			...$this->props,
-			'tabs' => $this->tabs()->toArray()
+			'tabs'  => $this->tabs()->toArray(),
+			'title' => $this->title()
 		];
 	}
 }

--- a/src/Blueprint/Normalizer.php
+++ b/src/Blueprint/Normalizer.php
@@ -5,7 +5,6 @@ namespace Kirby\Blueprint;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Form\Field;
 use Kirby\Toolkit\A;
-use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
 use Throwable;
 
@@ -219,14 +218,6 @@ class Normalizer
 	}
 
 	/**
-	 * Used to translate any label, heading, etc.
-	 */
-	protected function i18n(mixed $value, mixed $fallback = null): mixed
-	{
-		return I18n::translate($value, $fallback) ?? $value;
-	}
-
-	/**
 	 * Normalizes the raw props of the blueprint
 	 */
 	protected function normalize(array $props): array
@@ -237,9 +228,9 @@ class Normalizer
 		// normalize the name
 		$props['name'] ??= 'default';
 
-		// normalize and translate the title
+		// normalize the title, the translation happens
+		// in `Blueprint::title()`
 		$props['title'] ??= Str::label($props['name']);
-		$props['title']   = $this->i18n($props['title']);
 
 		// extract global field definitions before normalization
 		$props = $this->extractFieldReferences($props);
@@ -438,7 +429,7 @@ class Normalizer
 				...$props,
 				'columns' => $this->normalizeColumns($name, $props['columns'] ?? []),
 				'icon'    => $props['icon'] ?? null,
-				'label'   => $this->i18n($props['label'] ?? Str::label($name)),
+				'label'   => $props['label'] ?? null,
 				'name'    => $name,
 			];
 		}

--- a/src/Blueprint/PageBlueprint.php
+++ b/src/Blueprint/PageBlueprint.php
@@ -86,18 +86,19 @@ class PageBlueprint extends Blueprint
 	 */
 	protected function normalizeStatus($status): array
 	{
+		// the i18n keys are resolved in `status()`
 		$defaults = [
 			'draft'    => [
-				'label' => $this->i18n('page.status.draft'),
-				'text'  => $this->i18n('page.status.draft.description'),
+				'label' => 'page.status.draft',
+				'text'  => 'page.status.draft.description',
 			],
 			'unlisted' => [
-				'label' => $this->i18n('page.status.unlisted'),
-				'text'  => $this->i18n('page.status.unlisted.description'),
+				'label' => 'page.status.unlisted',
+				'text'  => 'page.status.unlisted.description',
 			],
 			'listed' => [
-				'label' => $this->i18n('page.status.listed'),
-				'text'  => $this->i18n('page.status.listed.description'),
+				'label' => 'page.status.listed',
+				'text'  => 'page.status.listed.description',
 			]
 		];
 
@@ -137,20 +138,11 @@ class PageBlueprint extends Blueprint
 
 			// also make sure to have the text field set
 			$status[$key]['text'] ??= null;
-
-			// translate text and label if necessary
-			$status[$key]['label'] = $this->i18n($status[$key]['label'], $status[$key]['label']);
-			$status[$key]['text']  = $this->i18n($status[$key]['text'], $status[$key]['text']);
 		}
 
 		// the draft status is required
 		if (isset($status['draft']) === false) {
 			$status = ['draft' => $defaults['draft']] + $status;
-		}
-
-		// remove the draft status for the home and error pages
-		if ($this->model->isHomeOrErrorPage() === true) {
-			unset($status['draft']);
 		}
 
 		return $status;
@@ -187,6 +179,30 @@ class PageBlueprint extends Blueprint
 	 */
 	public function status(): array
 	{
-		return $this->props['status'];
+		$status = $this->props['status'];
+
+		// the home and error page can never be drafts
+		if ($this->model->isHomeOrErrorPage() === true) {
+			unset($status['draft']);
+		}
+
+		// translate the labels and description texts
+		foreach ($status as $key => $options) {
+			$status[$key]['label'] = $this->i18n($options['label'], $options['label']);
+			$status[$key]['text']  = $this->i18n($options['text'], $options['text']);
+		}
+
+		return $status;
+	}
+
+	/**
+	 * Converts the blueprint object to a plain array
+	 */
+	public function toArray(): array
+	{
+		return [
+			...parent::toArray(),
+			'status' => $this->status()
+		];
 	}
 }

--- a/src/Blueprint/UserBlueprint.php
+++ b/src/Blueprint/UserBlueprint.php
@@ -25,10 +25,6 @@ class UserBlueprint extends Blueprint
 	 */
 	public function __construct(array $props)
 	{
-		// normalize and translate the description
-		$props['description'] = $this->i18n($props['description'] ?? null);
-
-		// register the other props
 		parent::__construct($props);
 
 		// normalize all available page options
@@ -48,5 +44,26 @@ class UserBlueprint extends Blueprint
 				'update'         => null,
 			]
 		);
+	}
+
+	/**
+	 * Returns the translated role description
+	 *
+	 * @since 6.0.0
+	 */
+	public function description(): string|null
+	{
+		return $this->i18n($this->props['description'] ?? null);
+	}
+
+	/**
+	 * Converts the blueprint object to a plain array
+	 */
+	public function toArray(): array
+	{
+		return [
+			...parent::toArray(),
+			'description' => $this->description()
+		];
 	}
 }

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -602,8 +602,10 @@ class App
 	 */
 	public static function destroy(): void
 	{
-		static::$plugins  = [];
-		static::$instance = null;
+		static::$plugins         = [];
+		static::$instance        = null;
+		ModelWithContent::$kirby = null;
+		Language::$kirby         = null;
 	}
 
 	/**

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -6,6 +6,7 @@ use Closure;
 use Exception as GlobalException;
 use Generator;
 use Kirby\Api\Api;
+use Kirby\Blueprint\Blueprint;
 use Kirby\Cms\App\Resolver;
 use Kirby\Content\Storage;
 use Kirby\Content\VersionCache;
@@ -108,6 +109,7 @@ class App
 		$this->events = new Events($this);
 
 		// start with fresh caches
+		Blueprint::reset();
 		Snippet::$cache = [];
 		Stack::reset();
 		VersionCache::reset();

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -154,9 +154,9 @@ class File extends ModelWithContent
 	{
 		/** @var FileBlueprint */
 		return $this->blueprint ??= FileBlueprint::factory(
+			$this,
 			'files/' . $this->template(),
-			'files/default',
-			$this
+			'files/default'
 		);
 	}
 
@@ -195,7 +195,7 @@ class File extends ModelWithContent
 				continue;
 			}
 
-			if ($blueprint = FileBlueprint::factory('files/' . $template, null, $this)) {
+			if ($blueprint = FileBlueprint::factory($this, 'files/' . $template)) {
 				try {
 					// ensure that file matches `accept` option,
 					// if not remove template from available list

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -3,11 +3,9 @@
 namespace Kirby\Cms;
 
 use Closure;
-use Kirby\Blueprint\Blueprint;
 use Kirby\Blueprint\PageBlueprint;
 use Kirby\Content\Field;
 use Kirby\Content\VersionId;
-use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
@@ -207,9 +205,9 @@ class Page extends ModelWithContent
 	{
 		/** @var PageBlueprint */
 		return $this->blueprint ??= PageBlueprint::factory(
+			$this,
 			'pages/' . $this->intendedTemplate(),
-			'pages/default',
-			$this
+			'pages/default'
 		);
 	}
 
@@ -246,15 +244,29 @@ class Page extends ModelWithContent
 
 		foreach ($templates as $template) {
 			try {
-				$props = Blueprint::load('pages/' . $template);
-
+				// the full blueprint, so that a title inherited
+				// through `extends` is taken into account
+				$blueprint = PageBlueprint::factory($this, 'pages/' . $template);
+			} catch (Throwable) {
+				// a blueprint that cannot be created still needs an entry,
+				// based on its name, so the template stays selectable
 				$blueprints[] = [
-					'name'  => basename($props['name']),
-					'title' => $props['title'],
+					'name'  => basename($template),
+					'title' => ucfirst($template),
 				];
-			} catch (Exception) {
-				// skip invalid blueprints
+
+				continue;
 			}
+
+			// skip templates without a blueprint
+			if ($blueprint === null) {
+				continue;
+			}
+
+			$blueprints[] = [
+				'name'  => basename($blueprint->name()),
+				'title' => $blueprint->title(),
+			];
 		}
 
 		return $this->blueprints = $blueprints;

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -167,7 +167,7 @@ class Site extends ModelWithContent
 	public function blueprint(): SiteBlueprint
 	{
 		/** @var SiteBlueprint */
-		return $this->blueprint ??= SiteBlueprint::factory('site', null, $this);
+		return $this->blueprint ??= SiteBlueprint::factory($this, 'site');
 	}
 
 	/**

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -156,9 +156,9 @@ class User extends ModelWithContent
 		try {
 			/** @var UserBlueprint */
 			return $this->blueprint ??= UserBlueprint::factory(
+				$this,
 				'users/' . $this->role(),
-				'users/default',
-				$this
+				'users/default'
 			);
 		} catch (Exception) {
 			return $this->blueprint ??= new UserBlueprint([

--- a/src/Content/Content.php
+++ b/src/Content/Content.php
@@ -88,9 +88,9 @@ class Content
 		$old       = $this->parent->blueprint();
 		$subfolder = dirname($old->name());
 		$new       = Blueprint::factory(
+			$this->parent,
 			$subfolder . '/' . $to,
-			$subfolder . '/default',
-			$this->parent
+			$subfolder . '/default'
 		);
 
 		// forms

--- a/src/Form/Field/PageListField.php
+++ b/src/Form/Field/PageListField.php
@@ -2,7 +2,7 @@
 
 namespace Kirby\Form\Field;
 
-use Kirby\Blueprint\Blueprint;
+use Kirby\Blueprint\PageBlueprint;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
@@ -132,13 +132,9 @@ class PageListField extends ModelListField implements ProvidesAcceptedBlueprints
 
 		$statuses = [];
 
-		foreach ($this->blueprintNames() as $blueprint) {
-			try {
-				$props      = Blueprint::load('pages/' . $blueprint);
-				$statuses[] = $props['create']['status'] ?? 'draft';
-			} catch (Throwable) {
-				$statuses[] = 'draft';
-			}
+		foreach ($this->blueprintNames() as $name) {
+			$blueprint  = $this->blueprint($name);
+			$statuses[] = $blueprint?->create()['status'] ?? 'draft';
 		}
 
 		$statuses = array_unique($statuses);
@@ -148,26 +144,40 @@ class PageListField extends ModelListField implements ProvidesAcceptedBlueprints
 	}
 
 	/**
+	 * The blueprint for the given name or null, if the
+	 * blueprint cannot be loaded or is invalid
+	 */
+	protected function blueprint(string $name): PageBlueprint|null
+	{
+		try {
+			return PageBlueprint::factory($this->model(), 'pages/' . $name);
+		} catch (Throwable) {
+			return null;
+		}
+	}
+
+	/**
 	 * The blueprint options for the create dialog
 	 */
 	public function blueprints(): array
 	{
 		$blueprints = [];
 
-		foreach ($this->blueprintNames() as $blueprint) {
-			try {
-				$props = Blueprint::load('pages/' . $blueprint);
+		foreach ($this->blueprintNames() as $name) {
+			// the full blueprint, so that a title inherited
+			// through `extends` is taken into account
+			$blueprint = $this->blueprint($name);
 
-				$blueprints[] = [
-					'name'  => basename($props['name']),
-					'title' => $props['title'],
-				];
-			} catch (Throwable) {
-				$blueprints[] = [
-					'name'  => basename($blueprint),
-					'title' => ucfirst($blueprint),
-				];
-			}
+			$blueprints[] = match ($blueprint) {
+				null    => [
+					'name'  => basename($name),
+					'title' => ucfirst($name),
+				],
+				default => [
+					'name'  => basename($blueprint->name()),
+					'title' => $blueprint->title(),
+				]
+			};
 		}
 
 		return $blueprints;

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -5,7 +5,6 @@ namespace Kirby\Api;
 use Exception;
 use Kirby\Auth\Auth;
 use Kirby\Cms\App;
-use Kirby\Cms\Blueprint;
 use Kirby\Cms\Response;
 use Kirby\Cms\User;
 use Kirby\Exception\AuthException;
@@ -85,7 +84,6 @@ class ApiTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		Blueprint::$loaded = [];
 		setlocale(LC_ALL, 'C');
 		Dir::remove(static::TMP);
 	}

--- a/tests/Api/Routes/AccountRoutesTest.php
+++ b/tests/Api/Routes/AccountRoutesTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Api;
 
 use Kirby\Auth\Exception\RateLimitException;
-use Kirby\Blueprint\Blueprint;
 use Kirby\Cms\App;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
@@ -26,8 +25,6 @@ class AccountRoutesTest extends TestCase
 
 	protected function setUp(): void
 	{
-		Blueprint::$loaded = [];
-
 		$this->app = new App([
 			'options' => [
 				'api.allowImpersonation' => true

--- a/tests/Api/Routes/UsersRoutesTest.php
+++ b/tests/Api/Routes/UsersRoutesTest.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Api;
 
-use Kirby\Blueprint\Blueprint;
 use Kirby\Cms\App;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
@@ -28,8 +27,6 @@ class UsersRoutesTest extends TestCase
 
 	protected function setUp(): void
 	{
-		Blueprint::$loaded = [];
-
 		$this->app = new App([
 			'options' => [
 				'api.allowImpersonation' => true

--- a/tests/Api/UploadTest.php
+++ b/tests/Api/UploadTest.php
@@ -4,7 +4,6 @@ namespace Kirby\Api;
 
 use Closure;
 use Exception;
-use Kirby\Blueprint\Blueprint;
 use Kirby\Cms\App;
 use Kirby\Exception\DuplicateException;
 use Kirby\Exception\InvalidArgumentException;
@@ -35,7 +34,6 @@ class UploadTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		Blueprint::$loaded = [];
 		ini_restore('upload_max_filesize');
 		ini_restore('post_max_size');
 		unset($_SERVER['HTTP_CF_CONNECTING_IP']);

--- a/tests/Blueprint/BlueprintTest.php
+++ b/tests/Blueprint/BlueprintTest.php
@@ -475,15 +475,13 @@ class BlueprintTest extends TestCase
 
 	public function testFactory(): void
 	{
-		Blueprint::$loaded = [];
-
 		$this->app = $this->app->clone([
 			'blueprints' => [
 				'pages/test' => ['title' => 'Test']
 			]
 		]);
 
-		$blueprint = Blueprint::factory('pages/test', null, new Page(['slug' => 'test']));
+		$blueprint = Blueprint::factory(new Page(['slug' => 'test']), 'pages/test');
 
 		$this->assertSame('Test', $blueprint->title());
 		$this->assertSame('pages/test', $blueprint->name());
@@ -491,15 +489,13 @@ class BlueprintTest extends TestCase
 
 	public function testFactoryWithCallbackArray(): void
 	{
-		Blueprint::$loaded = [];
-
 		$this->app = $this->app->clone([
 			'blueprints' => [
 				'pages/test' => fn () => ['title' => 'Test']
 			]
 		]);
 
-		$blueprint = Blueprint::factory('pages/test', null, new Page(['slug' => 'test']));
+		$blueprint = Blueprint::factory(new Page(['slug' => 'test']), 'pages/test');
 
 		$this->assertSame('Test', $blueprint->title());
 		$this->assertSame('pages/test', $blueprint->name());
@@ -507,8 +503,6 @@ class BlueprintTest extends TestCase
 
 	public function testFactoryWithCallbackString(): void
 	{
-		Blueprint::$loaded = [];
-
 		$this->app = $this->app->clone([
 			'roots' => [
 				'index' => '/dev/null',
@@ -521,16 +515,141 @@ class BlueprintTest extends TestCase
 
 		Data::write(static::TMP . '/custom/test.yml', ['title' => 'Test']);
 
-		$blueprint = Blueprint::factory('pages/test', null, new Page(['slug' => 'test']));
+		$blueprint = Blueprint::factory(new Page(['slug' => 'test']), 'pages/test');
 
 		$this->assertSame('Test', $blueprint->title());
 		$this->assertSame('pages/test', $blueprint->name());
 	}
 
+	public function testFactoryWithExtends(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/base'  => ['title' => 'Base'],
+				'pages/child' => ['extends' => 'pages/base']
+			]
+		]);
+
+		// the title must be inherited through `extends`, which only
+		// works as long as `::load()` does not add its own fallback
+		// title before the mixin is merged in
+		$blueprint = Blueprint::factory(new Page(['slug' => 'test']), 'pages/child');
+
+		$this->assertSame('Base', $blueprint->title());
+		$this->assertSame('pages/child', $blueprint->name());
+	}
+
 	public function testFactoryForMissingBlueprint(): void
 	{
-		$blueprint = Blueprint::factory('notFound', null, new Page(['slug' => 'test']));
+		$blueprint = Blueprint::factory(new Page(['slug' => 'test']), 'notFound');
 		$this->assertNull($blueprint);
+	}
+
+	public function testFactoryCache(): void
+	{
+		Blueprint::$loaded['pages/test'] = ['title' => 'Test'];
+
+		$a = Blueprint::factory(new Page(['slug' => 'a']), 'pages/test');
+
+		// the raw props are only normalized once
+		Blueprint::$loaded['pages/test'] = ['title' => 'Changed'];
+
+		$b = Blueprint::factory(new Page(['slug' => 'b']), 'pages/test');
+
+		$this->assertSame('Test', $a->title());
+		$this->assertSame('Test', $b->title());
+
+		// every model still gets its own blueprint object
+		$this->assertNotSame($a, $b);
+	}
+
+	public function testFactoryCacheWithFallback(): void
+	{
+		Blueprint::$loaded['pages/test']    = ['title' => 'Test'];
+		Blueprint::$loaded['pages/default'] = ['title' => 'Default'];
+
+		// a name that resolves ignores the fallback, so both
+		// calls must share a single normalized blueprint
+		Blueprint::factory(new Page(['slug' => 'a']), 'pages/test');
+		Blueprint::factory(new Page(['slug' => 'b']), 'pages/test', 'pages/default');
+
+		$this->assertCount(1, Blueprint::$normalized);
+
+		// a name that does not resolve must not share the
+		// normalized blueprint between different fallbacks
+		$c = Blueprint::factory(new Page(['slug' => 'c']), 'pages/nope', 'pages/test');
+		$d = Blueprint::factory(new Page(['slug' => 'd']), 'pages/nope', 'pages/default');
+
+		$this->assertSame('Test', $c->title());
+		$this->assertSame('Default', $d->title());
+		$this->assertCount(3, Blueprint::$normalized);
+	}
+
+	public function testFactoryCacheWithLanguage(): void
+	{
+		$locale       = I18n::$locale;
+		$translations = I18n::$translations;
+
+		I18n::$translations = [
+			'de' => ['blueprint.title' => 'Artikel'],
+			'en' => ['blueprint.title' => 'Article'],
+		];
+
+		Blueprint::$loaded['pages/test'] = ['title' => 'blueprint.title'];
+
+		I18n::$locale = 'en';
+		$a = Blueprint::factory(new Page(['slug' => 'a']), 'pages/test');
+		$this->assertSame('Article', $a->title());
+
+		// the cached blueprint must not be bound to a language
+		I18n::$locale = 'de';
+		$b = Blueprint::factory(new Page(['slug' => 'b']), 'pages/test');
+		$this->assertSame('Artikel', $b->title());
+
+		// the title of a blueprint that was created before the
+		// language switch follows the current language as well
+		$this->assertSame('Artikel', $a->title());
+
+		I18n::$locale       = $locale;
+		I18n::$translations = $translations;
+	}
+
+	public function testFactoryCacheWithModel(): void
+	{
+		Blueprint::$loaded['pages/test'] = [
+			'title'  => 'Test',
+			'fields' => ['headline' => ['type' => 'text']]
+		];
+
+		$a = Blueprint::factory($pageA = new Page(['slug' => 'a']), 'pages/test');
+		$b = Blueprint::factory($pageB = new Page(['slug' => 'b']), 'pages/test');
+
+		// the normalized fields are shared …
+		$this->assertSame($a->fields(), $b->fields());
+
+		// … but every blueprint is bound to its own model
+		$this->assertSame($pageA, $a->model());
+		$this->assertSame($pageB, $b->model());
+
+		// and the model-specific caches are not shared
+		$this->assertNotSame($a->tabs(), $b->tabs());
+		$this->assertSame('/pages/a/?tab=main', $a->tab()->link());
+		$this->assertSame('/pages/b/?tab=main', $b->tab()->link());
+	}
+
+	public function testReset(): void
+	{
+		Blueprint::$loaded['pages/test'] = ['title' => 'Test'];
+
+		Blueprint::factory(new Page(['slug' => 'a']), 'pages/test');
+
+		$this->assertNotSame([], Blueprint::$loaded);
+		$this->assertNotSame([], Blueprint::$normalized);
+
+		Blueprint::reset();
+
+		$this->assertSame([], Blueprint::$loaded);
+		$this->assertSame([], Blueprint::$normalized);
 	}
 
 	public function testFields(): void

--- a/tests/Blueprint/FileBlueprintTest.php
+++ b/tests/Blueprint/FileBlueprintTest.php
@@ -11,11 +11,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 #[CoversClass(FileBlueprint::class)]
 class FileBlueprintTest extends TestCase
 {
-	protected function tearDown(): void
-	{
-		Blueprint::$loaded = [];
-	}
-
 	public static function acceptAttributeProvider()
 	{
 		return [

--- a/tests/Blueprint/NormalizerTest.php
+++ b/tests/Blueprint/NormalizerTest.php
@@ -5,7 +5,6 @@ namespace Kirby\Blueprint;
 use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
-use Kirby\Toolkit\I18n;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(Normalizer::class)]
@@ -815,18 +814,15 @@ class NormalizerTest extends TestCase
 		$this->assertSame('Blog post', $props['title']);
 	}
 
-	public function testPropsWithTranslatedTitle(): void
+	public function testPropsWithTranslatableTitle(): void
 	{
-		I18n::$locale       = 'de';
-		I18n::$translations = [
-			'de' => ['blueprint.title' => 'Artikel']
-		];
-
+		// the title is kept untranslated, so that the normalized
+		// props can be cached across languages
 		$props = $this->normalizer([
 			'title' => 'blueprint.title'
 		])->props();
 
-		$this->assertSame('Artikel', $props['title']);
+		$this->assertSame('blueprint.title', $props['title']);
 	}
 
 	public function testSections(): void
@@ -975,7 +971,8 @@ class NormalizerTest extends TestCase
 		$tab = $normalizer->tabs()['content'];
 
 		$this->assertSame('content', $tab['name']);
-		$this->assertSame('Content', $tab['label']);
+		// the label is resolved by `Tab::label()`
+		$this->assertNull($tab['label']);
 		$this->assertSame('text', $tab['icon']);
 		$this->assertSame([], $tab['columns']);
 	}

--- a/tests/Blueprint/PageBlueprintTest.php
+++ b/tests/Blueprint/PageBlueprintTest.php
@@ -10,11 +10,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 #[CoversClass(PageBlueprint::class)]
 class PageBlueprintTest extends TestCase
 {
-	protected function tearDown(): void
-	{
-		Blueprint::$loaded = [];
-	}
-
 	public function testOptions(): void
 	{
 		$blueprint = new PageBlueprint([
@@ -174,6 +169,44 @@ class PageBlueprintTest extends TestCase
 		];
 
 		$this->assertSame($expected, $blueprint->status());
+	}
+
+	public function testStatusForHomeAndErrorPage(): void
+	{
+		$app = new App([
+			'roots' => ['index' => '/dev/null'],
+			'site'  => [
+				'children' => [
+					['slug' => 'home'],
+					['slug' => 'error'],
+					['slug' => 'test'],
+				]
+			]
+		]);
+
+		// all three pages share the same cached `pages/default` blueprint
+		$this->assertArrayNotHasKey('draft', $app->page('home')->blueprint()->status());
+		$this->assertArrayNotHasKey('draft', $app->page('error')->blueprint()->status());
+		$this->assertArrayHasKey('draft', $app->page('test')->blueprint()->status());
+	}
+
+	public function testStatusForHomeAndErrorPageFromSharedCache(): void
+	{
+		$app = new App([
+			'roots' => ['index' => '/dev/null'],
+			'site'  => [
+				'children' => [
+					['slug' => 'test'],
+					['slug' => 'home'],
+				]
+			]
+		]);
+
+		// whichever page normalizes `pages/default` first must not bake
+		// its own status into the shared blueprint (the test above
+		// covers the same for the home page normalizing first)
+		$this->assertArrayHasKey('draft', $app->page('test')->blueprint()->status());
+		$this->assertArrayNotHasKey('draft', $app->page('home')->blueprint()->status());
 	}
 
 	public function testStatusWithCustomText(): void
@@ -533,5 +566,43 @@ class PageBlueprintTest extends TestCase
 		$app->setCurrentTranslation('fr');
 		$page = $app->page('test');
 		$this->assertSame('My title', $page->blueprint()->title());
+	}
+
+	public function testToArray(): void
+	{
+		new App([
+			'roots' => ['index' => '/dev/null']
+		]);
+
+		$blueprint = new PageBlueprint([
+			'model'  => new Page(['slug' => 'test']),
+			'status' => [
+				'draft' => [
+					'label' => ['en' => 'Draft Label'],
+					'text'  => ['en' => 'Draft Text']
+				]
+			]
+		]);
+
+		// the status must be resolved just like in `status()`
+		$this->assertSame($blueprint->status(), $blueprint->toArray()['status']);
+		$this->assertSame('Draft Label', $blueprint->toArray()['status']['draft']['label']);
+	}
+
+	public function testToArrayForHomePage(): void
+	{
+		$app = new App([
+			'roots' => ['index' => '/dev/null'],
+			'site'  => [
+				'children' => [
+					['slug' => 'home'],
+					['slug' => 'test'],
+				]
+			]
+		]);
+
+		// the home page can never be a draft
+		$this->assertArrayNotHasKey('draft', $app->page('home')->blueprint()->toArray()['status']);
+		$this->assertArrayHasKey('draft', $app->page('test')->blueprint()->toArray()['status']);
 	}
 }

--- a/tests/Blueprint/UserBlueprintTest.php
+++ b/tests/Blueprint/UserBlueprintTest.php
@@ -9,11 +9,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(UserBlueprint::class)]
 class UserBlueprintTest extends TestCase
 {
-	protected function tearDown(): void
-	{
-		Blueprint::$loaded = [];
-	}
-
 	public function testTranslatedDescription(): void
 	{
 		$blueprint = new UserBlueprint([
@@ -201,5 +196,19 @@ class UserBlueprintTest extends TestCase
 		$app->setCurrentTranslation('fr');
 		$user = $app->user('editor@getkirby.com');
 		$this->assertSame('Editor role', $user->role()->title());
+	}
+
+	public function testToArray(): void
+	{
+		$blueprint = new UserBlueprint([
+			'model'       => new User(['email' => 'test@getkirby.com']),
+			'description' => [
+				'en' => 'User',
+				'de' => 'Benutzer'
+			]
+		]);
+
+		// the description must be resolved just like in `description()`
+		$this->assertSame('User', $blueprint->toArray()['description']);
 	}
 }

--- a/tests/Cms/Page/PageBlueprintsTest.php
+++ b/tests/Cms/Page/PageBlueprintsTest.php
@@ -115,4 +115,70 @@ class PageBlueprintsTest extends ModelTestCase
 
 		$this->assertSame(['B'], array_column($page->blueprints('my-pages'), 'title'));
 	}
+
+	public function testBlueprintsWithInvalidBlueprint(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/a' => [
+					'title' => 'A'
+				],
+				'pages/broken' => [
+					'title'  => 'Not used',
+					// a scalar instead of a list of fields
+					// breaks the blueprint
+					'fields' => 'text'
+				]
+			]
+		]);
+
+		$page = new Page([
+			'slug'      => 'test',
+			'template'  => 'a',
+			'blueprint' => [
+				'options' => [
+					'template' => [
+						'a',
+						'broken'
+					]
+				]
+			]
+		]);
+
+		// a blueprint that cannot be created still needs an entry,
+		// based on its name, so the template stays selectable
+		$this->assertSame(
+			[
+				['name' => 'a', 'title' => 'A'],
+				['name' => 'broken', 'title' => 'Broken']
+			],
+			$page->blueprints()
+		);
+	}
+
+	public function testBlueprintsWithMissingBlueprint(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/a' => [
+					'title' => 'A'
+				]
+			]
+		]);
+
+		$page = new Page([
+			'slug'      => 'test',
+			'template'  => 'a',
+			'blueprint' => [
+				'options' => [
+					'template' => [
+						'a',
+						'does-not-exist'
+					]
+				]
+			]
+		]);
+
+		$this->assertSame(['A'], array_column($page->blueprints(), 'title'));
+	}
 }

--- a/tests/Cms/TestCase.php
+++ b/tests/Cms/TestCase.php
@@ -3,7 +3,6 @@
 namespace Kirby\Cms;
 
 use Closure;
-use Kirby\Blueprint\Blueprint;
 use Kirby\TestCase as BaseTestCase;
 use Kirby\Toolkit\I18n;
 
@@ -21,8 +20,6 @@ abstract class TestCase extends BaseTestCase
 			]
 		]);
 
-		Blueprint::$loaded = [];
-
 		I18n::$locale = null;
 	}
 
@@ -30,7 +27,6 @@ abstract class TestCase extends BaseTestCase
 	{
 		parent::tearDown();
 		App::destroy();
-		Blueprint::$loaded = [];
 
 		$this->tearDownTmp();
 

--- a/tests/Form/Field/PageListFieldTest.php
+++ b/tests/Form/Field/PageListFieldTest.php
@@ -71,6 +71,27 @@ class PageListFieldTest extends TestCase
 		]);
 	}
 
+	protected function pagelistWithInvalidBlueprint(array $attr = []): PageListField
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/broken' => [
+					// title and status would be used
+					// if the blueprint could be created
+					'title'  => 'Not used',
+					'create' => ['status' => 'listed'],
+					// a scalar instead of a list of fields
+					// breaks the blueprint
+					'fields' => 'text'
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		return $this->pagelist(['templates' => ['broken'], ...$attr]);
+	}
+
 	public function testType(): void
 	{
 		$this->assertSame('pagelist', $this->pagelist()->type());
@@ -227,6 +248,17 @@ class PageListFieldTest extends TestCase
 		], $field->blueprints());
 	}
 
+	public function testBlueprintsWithInvalidBlueprint(): void
+	{
+		// a blueprint that cannot be created still needs
+		// an entry for the create dialog, based on its name
+		$field = $this->pagelistWithInvalidBlueprint();
+
+		$this->assertSame([
+			['name' => 'broken', 'title' => 'Broken']
+		], $field->blueprints());
+	}
+
 	public function testBlueprintsWithMissingBlueprint(): void
 	{
 		// a blueprint that cannot be loaded still needs
@@ -282,6 +314,17 @@ class PageListFieldTest extends TestCase
 			'templates' => ['album', 'note']
 		]);
 
+		$this->assertFalse($field->add());
+	}
+
+	public function testAddWithInvalidBlueprint(): void
+	{
+		// a blueprint that cannot be created creates a draft,
+		// even though it defines a listed status
+		$field = $this->pagelistWithInvalidBlueprint(['status' => 'draft']);
+		$this->assertTrue($field->add());
+
+		$field = $this->pagelistWithInvalidBlueprint(['status' => 'listed']);
 		$this->assertFalse($field->add());
 	}
 

--- a/tests/Panel/Areas/AreaTestCase.php
+++ b/tests/Panel/Areas/AreaTestCase.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Panel\Areas;
 
-use Kirby\Blueprint\Blueprint;
 use Kirby\Cms\App;
 use Kirby\Cms\User;
 use Kirby\Exception\NotFoundException;
@@ -42,9 +41,6 @@ abstract class AreaTestCase extends TestCase
 		$this->app->session()->destroy();
 
 		Dir::remove(static::TMP);
-
-		// clear blueprint cache
-		Blueprint::$loaded = [];
 
 		// clean up server software fakes
 		unset($_SERVER['SERVER_SOFTWARE']);

--- a/tests/Panel/TestCase.php
+++ b/tests/Panel/TestCase.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Panel;
 
-use Kirby\Blueprint\Blueprint;
 use Kirby\Cms\App;
 use Kirby\Filesystem\Dir;
 use Kirby\TestCase as BaseTestCase;
@@ -20,8 +19,6 @@ abstract class TestCase extends BaseTestCase
 				'index' => static::TMP,
 			]
 		]);
-
-		Blueprint::$loaded = [];
 	}
 
 	protected function tearDown(): void

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Panel;
 
-use Kirby\Blueprint\Blueprint;
 use Kirby\Cms\App;
 use Kirby\Cms\User as ModelUser;
 use Kirby\Content\Lock;
@@ -32,8 +31,6 @@ class UserTest extends TestCase
 
 	protected function setUp(): void
 	{
-		Blueprint::$loaded = [];
-
 		$this->app = new App([
 			'roots' => [
 				'index' => static::TMP,


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

### What it does
- Make normalized blueprint state independent of model and i18n
- Cache the normalized blueprint and reuse it 

### Why
- Some smaller general performance improvements (2-4% on some actions, e.g. `::index()`)
- Preparation to get rid of permission `::canFromCache()`

### TODO
- [ ] We should still make a proper bench to ensure we are not adding any performance regression

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### ♻️ Refactored
<!-- 
e.g. Rename method X to method Y.
-->
- Normalized blueprints are cached

### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- `Blueprint::factory()` requires now the `$model` to be passed as first argument
- Some blueprint props are lazily translated. Prefer `Blueprint::factory()` over `Blueprint::load()`



## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion