### PR TITLE
refact!: Remove `ModelPermission::canFromCache()`

### DIFF
--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -112,7 +112,6 @@ class App
 		Snippet::$cache = [];
 		Stack::reset();
 		VersionCache::reset();
-		ModelPermissions::$cache = [];
 
 		// start with a fresh Query runner option
 		Query::$runner = null;

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -328,7 +328,7 @@ class File extends ModelWithContent
 			return false;
 		}
 
-		return FilePermissions::canFromCache($this, 'access');
+		return $this->permissions()->can('access');
 	}
 
 	/**
@@ -347,7 +347,7 @@ class File extends ModelWithContent
 			return false;
 		}
 
-		return FilePermissions::canFromCache($this, 'list');
+		return $this->permissions()->can('list');
 	}
 
 	/**
@@ -357,12 +357,7 @@ class File extends ModelWithContent
 	 */
 	public function isReadable(): bool
 	{
-		static $readable   = [];
-		$role              = $this->kirby()->role()?->id() ?? '__none__';
-		$template          = $this->template() ?? '__none__';
-		$readable[$role] ??= [];
-
-		return $readable[$role][$template] ??= $this->permissions()->can('read');
+		return $this->permissions()->can('read');
 	}
 
 	/**

--- a/src/Cms/FilePermissions.php
+++ b/src/Cms/FilePermissions.php
@@ -14,18 +14,6 @@ class FilePermissions extends ModelPermissions
 {
 	protected const string CATEGORY = 'files';
 
-	/**
-	 * Used to cache once determined permissions in memory
-	 *
-	 * @param \Kirby\Cms\File $model
-	 * @psalm-suppress MoreSpecificImplementedParamType
-	 */
-	protected static function cacheKey(
-		ModelWithContent|Language $model
-	): string {
-		return $model->template() ?? '__none__';
-	}
-
 	protected function canChangeTemplate(): bool
 	{
 		if (count($this->model->blueprints()) <= 1) {

--- a/src/Cms/ModelPermissions.php
+++ b/src/Cms/ModelPermissions.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Exception\LogicException;
 use Kirby\Toolkit\A;
 
 /**
@@ -16,9 +15,8 @@ use Kirby\Toolkit\A;
 abstract class ModelPermissions
 {
 	protected const string CATEGORY = 'model';
-	protected array $options;
 
-	public static array $cache = [];
+	protected array|null $options = null;
 
 	/**
 	 * @var TModel
@@ -30,11 +28,7 @@ abstract class ModelPermissions
 	 */
 	public function __construct(ModelWithContent|Language $model)
 	{
-		$this->model   = $model;
-		$this->options = match (true) {
-			$model instanceof ModelWithContent => $model->blueprint()->options(),
-			default                            => []
-		};
+		$this->model = $model;
 	}
 
 	public function __call(string $method, array $arguments = []): bool
@@ -49,19 +43,6 @@ abstract class ModelPermissions
 	public function __debugInfo(): array
 	{
 		return $this->toArray();
-	}
-
-	/**
-	 * Can be overridden by specific child classes
-	 * to return a model-specific value used to
-	 * cache a once determined permission in memory
-	 *
-	 * @codeCoverageIgnore
-	 */
-	protected static function cacheKey(
-		ModelWithContent|Language $model
-	): string {
-		return '';
 	}
 
 	/**
@@ -100,9 +81,9 @@ abstract class ModelPermissions
 		}
 
 		// evaluate the blueprint options block
-		if (isset($this->options[$action]) === true) {
-			$options = $this->options[$action];
+		$options = $this->options()[$action] ?? null;
 
+		if ($options !== null) {
 			if ($options === false) {
 				return false;
 			}
@@ -135,30 +116,6 @@ abstract class ModelPermissions
 	}
 
 	/**
-	 * Quickly determines a permission for the current user role
-	 * and model blueprint unless dynamic checking is required
-	 */
-	public static function canFromCache(
-		ModelWithContent|Language $model,
-		string $action,
-		bool $default = false
-	): bool {
-		$role     = $model->kirby()->role()?->id() ?? '__none__';
-		$category = static::category($model);
-		$cacheKey = $category . '.' . $action . '/' . static::cacheKey($model) . '/' . $role . '/' . ($default === true ? 'true' : 'false');
-
-		if (isset(static::$cache[$cacheKey]) === true) {
-			return static::$cache[$cacheKey];
-		}
-
-		if (method_exists(static::class, 'can' . $action) === true) {
-			throw new LogicException('Cannot use permission cache for dynamically-determined permission');
-		}
-
-		return static::$cache[$cacheKey] = $model->permissions()->can($action, $default);
-	}
-
-	/**
 	 * Returns whether the current user is not allowed to do
 	 * a certain action on the model
 	 *
@@ -180,11 +137,23 @@ abstract class ModelPermissions
 		return static::CATEGORY;
 	}
 
+	/**
+	 * The normalized options block of the model's blueprint
+	 * @since 6.0.0
+	 */
+	public function options(): array
+	{
+		return $this->options ??= match (true) {
+			$this->model instanceof ModelWithContent => $this->model->blueprint()->options(),
+			default                                  => []
+		};
+	}
+
 	public function toArray(): array
 	{
 		$array = [];
 
-		foreach ($this->options as $key => $value) {
+		foreach ($this->options() as $key => $value) {
 			$array[$key] = $this->can($key);
 		}
 

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -522,7 +522,7 @@ class Page extends ModelWithContent
 			return false;
 		}
 
-		return PagePermissions::canFromCache($this, 'access');
+		return $this->permissions()->can('access');
 	}
 
 	/**
@@ -689,7 +689,7 @@ class Page extends ModelWithContent
 			return false;
 		}
 
-		return PagePermissions::canFromCache($this, 'list');
+		return $this->permissions()->can('list');
 	}
 
 	/**
@@ -742,12 +742,7 @@ class Page extends ModelWithContent
 	 */
 	public function isReadable(): bool
 	{
-		static $readable   = [];
-		$role              = $this->kirby()->role()?->id() ?? '__none__';
-		$template          = $this->intendedTemplate()->name();
-		$readable[$role] ??= [];
-
-		return $readable[$role][$template] ??= $this->permissions()->can('read');
+		return $this->permissions()->can('read');
 	}
 
 	/**

--- a/src/Cms/PagePermissions.php
+++ b/src/Cms/PagePermissions.php
@@ -14,18 +14,6 @@ class PagePermissions extends ModelPermissions
 {
 	protected const string CATEGORY = 'pages';
 
-	/**
-	 * Used to cache once determined permissions in memory
-	 *
-	 * @param \Kirby\Cms\Page $model
-	 * @psalm-suppress MoreSpecificImplementedParamType
-	 */
-	protected static function cacheKey(
-		ModelWithContent|Language $model
-	): string {
-		return $model->intendedTemplate()->name();
-	}
-
 	protected function canChangeSlug(): bool
 	{
 		return $this->model->isHomeOrErrorPage() !== true;

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -277,7 +277,7 @@ class Site extends ModelWithContent
 	 */
 	public function isAccessible(): bool
 	{
-		return SitePermissions::canFromCache($this, 'access');
+		return $this->permissions()->can('access');
 	}
 
 	/**

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -292,7 +292,7 @@ class User extends ModelWithContent
 	 */
 	public function isAccessible(): bool
 	{
-		return UserPermissions::canFromCache($this, 'access');
+		return $this->permissions()->can('access');
 	}
 
 	/**
@@ -323,7 +323,7 @@ class User extends ModelWithContent
 			return false;
 		}
 
-		return UserPermissions::canFromCache($this, 'list');
+		return $this->permissions()->can('list');
 	}
 
 	/**

--- a/src/Cms/UserPermissions.php
+++ b/src/Cms/UserPermissions.php
@@ -12,18 +12,6 @@ namespace Kirby\Cms;
  */
 class UserPermissions extends ModelPermissions
 {
-	/**
-	 * Used to cache once determined permissions in memory
-	 *
-	 * @param \Kirby\Cms\User $model
-	 * @psalm-suppress MoreSpecificImplementedParamType
-	 */
-	protected static function cacheKey(
-		ModelWithContent|Language $model
-	): string {
-		return $model->role()->id();
-	}
-
 	protected function canChangeRole(): bool
 	{
 		// protect admin from role changes by non-admin

--- a/tests/Cms/File/FilePermissionsTest.php
+++ b/tests/Cms/File/FilePermissionsTest.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Exception\LogicException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -53,16 +52,7 @@ class FilePermissionsTest extends ModelTestCase
 	}
 
 	#[DataProvider('actionProvider')]
-	public function testWithNobody(string $action): void
-	{
-		$page  = new Page(['slug' => 'test']);
-		$file  = new File(['filename' => 'test.jpg', 'parent' => $page]);
-		$perms = $file->permissions();
-
-		$this->assertFalse($perms->can($action));
-	}
-
-	public function testCanFromCache(): void
+	public function testWithAdminButDisabledOption(string $action): void
 	{
 		$this->app->impersonate('admin');
 
@@ -72,33 +62,24 @@ class FilePermissionsTest extends ModelTestCase
 			'parent'    => $page,
 			'template'  => 'some-template',
 			'blueprint' => [
-				'name' => 'files/some-template',
+				'name'    => 'files/some-template',
 				'options' => [
-					'access' => false,
-					'list'   => false
+					$action => false
 				]
 			]
 		]);
 
-		$this->assertFalse(FilePermissions::canFromCache($file, 'access'));
-		$this->assertFalse(FilePermissions::canFromCache($file, 'access'));
-		$this->assertFalse(FilePermissions::canFromCache($file, 'list'));
-		$this->assertFalse(FilePermissions::canFromCache($file, 'list'));
+		$this->assertFalse($file->permissions()->can($action));
 	}
 
-	public function testCanFromCacheDynamic(): void
+	#[DataProvider('actionProvider')]
+	public function testWithNobody(string $action): void
 	{
-		$this->expectException(LogicException::class);
-		$this->expectExceptionMessage('Cannot use permission cache for dynamically-determined permission');
+		$page  = new Page(['slug' => 'test']);
+		$file  = new File(['filename' => 'test.jpg', 'parent' => $page]);
+		$perms = $file->permissions();
 
-		$page = new Page(['slug' => 'test']);
-		$file = new File([
-			'filename' => 'test.jpg',
-			'parent'   => $page,
-			'template' => 'some-template',
-		]);
-
-		FilePermissions::canFromCache($file, 'changeTemplate');
+		$this->assertFalse($perms->can($action));
 	}
 
 	public function testCannotChangeTemplate(): void

--- a/tests/Cms/Page/PagePermissionsTest.php
+++ b/tests/Cms/Page/PagePermissionsTest.php
@@ -2,10 +2,8 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Exception\LogicException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use ReflectionProperty;
 
 #[CoversClass(PagePermissions::class)]
 class PagePermissionsTest extends ModelTestCase
@@ -26,12 +24,6 @@ class PagePermissionsTest extends ModelTestCase
 				['id' => 'editor', 'role' => 'editor']
 			],
 		]);
-	}
-
-	protected function tearDown(): void
-	{
-		$prop = new ReflectionProperty(PagePermissions::class, 'cache');
-		$prop->setValue(null, []);
 	}
 
 	public static function actionProvider(): array
@@ -223,43 +215,6 @@ class PagePermissionsTest extends ModelTestCase
 		$perms = $page->permissions();
 
 		$this->assertFalse($perms->can($action));
-	}
-
-	public function testCanFromCache(): void
-	{
-		$this->app->impersonate('admin');
-
-		$page = new Page([
-			'slug'      => 'test',
-			'num'       => 1,
-			'template'  => 'some-template',
-			'blueprint' => [
-				'name' => 'some-template',
-				'options' => [
-					'access' => false,
-					'list'   => false
-				]
-			]
-		]);
-
-		$this->assertFalse(PagePermissions::canFromCache($page, 'access'));
-		$this->assertFalse(PagePermissions::canFromCache($page, 'access'));
-		$this->assertFalse(PagePermissions::canFromCache($page, 'list'));
-		$this->assertFalse(PagePermissions::canFromCache($page, 'list'));
-	}
-
-	public function testCanFromCacheDynamic(): void
-	{
-		$this->expectException(LogicException::class);
-		$this->expectExceptionMessage('Cannot use permission cache for dynamically-determined permission');
-
-		$page = new Page([
-			'slug'     => 'test',
-			'num'      => 1,
-			'template' => 'some-template',
-		]);
-
-		PagePermissions::canFromCache($page, 'changeTemplate');
 	}
 
 	public function testCannotChangeTemplate(): void

--- a/tests/Cms/Page/PagePickerTest.php
+++ b/tests/Cms/Page/PagePickerTest.php
@@ -68,8 +68,6 @@ class PagePickerTest extends ModelTestCase
 
 	public function testParentAccessibleButNotListable(): void
 	{
-		ModelPermissions::$cache = [];
-
 		$this->app = $this->app->clone([
 			'blueprints' => [
 				'pages/limited' => [
@@ -109,8 +107,6 @@ class PagePickerTest extends ModelTestCase
 
 	public function testParentNotAccessibleFallsBackToSite(): void
 	{
-		ModelPermissions::$cache = [];
-
 		$this->app = $this->app->clone([
 			'blueprints' => [
 				'pages/forbidden' => [
@@ -150,8 +146,6 @@ class PagePickerTest extends ModelTestCase
 
 	public function testParentAndSiteNotAccessibleThrows(): void
 	{
-		ModelPermissions::$cache = [];
-
 		$this->app = $this->app->clone([
 			'blueprints' => [
 				'pages/forbidden' => [

--- a/tests/Cms/Site/SitePermissionsTest.php
+++ b/tests/Cms/Site/SitePermissionsTest.php
@@ -41,62 +41,52 @@ class SitePermissionsTest extends ModelTestCase
 		$this->assertFalse($permissions->can($action));
 	}
 
-	public function testCanFromCache()
+	#[DataProvider('actionProvider')]
+	public function testWithEditorAndDisabledPermission(string $action): void
 	{
-		$app = new App([
+		$this->app = $this->app->clone([
 			'roles' => [
 				[
 					'name' => 'editor',
 					'permissions' => [
 						'site' => [
-							'access' => false
-						],
+							$action => false
+						]
 					]
 				]
 			],
-			'roots' => [
-				'index' => '/dev/null'
-			],
 			'users' => [
-				['id' => 'bastian', 'role' => 'editor'],
+				['id' => 'bastian', 'role' => 'editor']
 			]
 		]);
 
-		$app->impersonate('bastian');
+		$this->app->impersonate('bastian');
 
-		$site = $app->site();
+		$permissions = $this->app->site()->permissions();
 
-		$this->assertFalse(SitePermissions::canFromCache($site, 'access'));
-		$this->assertFalse(SitePermissions::canFromCache($site, 'access'));
+		$this->assertFalse($permissions->can($action));
 	}
 
-	public function testCanFromCacheWithDefault()
+	public function testCanWithDefault(): void
 	{
-		// reset the process-wide in-memory permission cache
-		ModelPermissions::$cache = [];
-
-		$app = new App([
+		$this->app = $this->app->clone([
 			'roles' => [
 				['name' => 'editor']
 			],
-			'roots' => [
-				'index' => '/dev/null'
-			],
 			'users' => [
-				['id' => 'bastian', 'role' => 'editor'],
+				['id' => 'bastian', 'role' => 'editor']
 			]
 		]);
 
-		$app->impersonate('bastian');
+		$this->app->impersonate('bastian');
 
-		$site = $app->site();
+		$permissions = $this->app->site()->permissions();
 
 		// an action that is not defined in the permissions map
 		// falls back to the passed default…
-		$this->assertTrue(SitePermissions::canFromCache($site, 'undefined', true));
+		$this->assertTrue($permissions->can('undefined', true));
 
-		// …and a different default for the same action
-		// must not be served from the cache
-		$this->assertFalse(SitePermissions::canFromCache($site, 'undefined', false));
+		// …as well as a different default for the same action
+		$this->assertFalse($permissions->can('undefined', false));
 	}
 }

--- a/tests/Cms/User/UserPermissionsTest.php
+++ b/tests/Cms/User/UserPermissionsTest.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Cms;
 
-use Kirby\Exception\LogicException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -31,7 +30,6 @@ class UserPermissionsTest extends ModelTestCase
 	public function testWithAdmin(string $action): void
 	{
 		$this->app = $this->app->clone([
-
 			'roles' => [
 				['name' => 'admin'],
 				['name' => 'editor']
@@ -44,6 +42,35 @@ class UserPermissionsTest extends ModelTestCase
 		$perms = $user->permissions();
 
 		$this->assertTrue($perms->can($action));
+	}
+
+	#[DataProvider('actionProvider')]
+	public function testWithAdminButDisabledOption(string $action): void
+	{
+		$this->app = $this->app->clone([
+			'roles' => [
+				['name' => 'admin'],
+				['name' => 'editor']
+			],
+			'users' => [
+				['id' => 'admin', 'role' => 'admin']
+			]
+		]);
+
+		$this->app->impersonate('admin');
+
+		$user = new User([
+			'email'     => 'test@getkirby.com',
+			'role'      => 'editor',
+			'blueprint' => [
+				'name'    => 'users/editor',
+				'options' => [
+					$action => false
+				]
+			]
+		]);
+
+		$this->assertFalse($user->permissions()->can($action));
 	}
 
 	#[DataProvider('actionProvider')]
@@ -116,46 +143,6 @@ class UserPermissionsTest extends ModelTestCase
 		$this->assertTrue($perms2->can($action));
 
 		$user1->logout();
-	}
-
-	public function testCanFromCache()
-	{
-		$app = new App([
-			'roots' => [
-				'index' => '/dev/null'
-			],
-			'users' => [
-				['id' => 'bastian', 'role' => 'admin'],
-			]
-		]);
-
-		$app->impersonate('bastian');
-
-		$user = new User([
-			'role'      => 'editor',
-			'blueprint' => [
-				'name' => 'users/editor',
-				'options' => [
-					'access' => false,
-					'list'   => false
-				]
-			]
-		]);
-
-		$this->assertFalse(UserPermissions::canFromCache($user, 'access'));
-		$this->assertFalse(UserPermissions::canFromCache($user, 'access'));
-		$this->assertFalse(UserPermissions::canFromCache($user, 'list'));
-		$this->assertFalse(UserPermissions::canFromCache($user, 'list'));
-	}
-
-	public function testCanFromCacheDynamic()
-	{
-		$this->expectException(LogicException::class);
-		$this->expectExceptionMessage('Cannot use permission cache for dynamically-determined permission');
-
-		$user = new User(['role' => 'admin']);
-
-		UserPermissions::canFromCache($user, 'delete');
 	}
 
 	public function testChangeSingleRole(): void

--- a/tests/Panel/Controller/Dialog/PagePickerDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/PagePickerDialogControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Panel\Controller\Dialog;
 
-use Kirby\Cms\ModelPermissions;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Exception\PermissionException;
@@ -209,8 +208,6 @@ class PagePickerDialogControllerTest extends TestCase
 
 	public function testParentAccessibleButNotListable(): void
 	{
-		ModelPermissions::$cache = [];
-
 		$this->app = $this->app->clone([
 			'blueprints' => [
 				'pages/limited' => [
@@ -268,8 +265,6 @@ class PagePickerDialogControllerTest extends TestCase
 
 	public function testParentNotAccessibleFallsBackToRoot(): void
 	{
-		ModelPermissions::$cache = [];
-
 		$this->app = $this->app->clone([
 			'blueprints' => [
 				'pages/forbidden' => [
@@ -325,8 +320,6 @@ class PagePickerDialogControllerTest extends TestCase
 
 	public function testParentAndRootNotAccessibleThrows(): void
 	{
-		ModelPermissions::$cache = [];
-
 		$this->app = $this->app->clone([
 			'blueprints' => [
 				'pages/forbidden' => [


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

### Merge first

- [ ] https://github.com/getkirby/kirby/pull/8304
- [ ] https://github.com/getkirby/kirby/pull/8295


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### 🚨 Breaking changes
<!-- 
e.g. Method X has been removed
-->
- Removed `Kirby\Cms\ModelPermissions::canFromCache()`. Use `$permissions->can()` instead.
- Removed `Kirby\Cms\ModelPermissions::$cache`


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion