### PR TITLE
fix: Prevent error when saving forms with display fields

### DIFF
--- a/src/Form/Field/BaseField.php
+++ b/src/Form/Field/BaseField.php
@@ -59,6 +59,16 @@ abstract class BaseField implements Stringable
 	}
 
 	/**
+	 * Fields without a value never have errors.
+	 * `Kirby\Form\Mixin\Validation` overwrites this
+	 * for all fields that can actually be validated.
+	 */
+	public function errors(): array
+	{
+		return [];
+	}
+
+	/**
 	 * Creates a new field instance from a $props array
 	 * @since 6.0.0
 	 */

--- a/tests/Form/Field/BaseFieldTest.php
+++ b/tests/Form/Field/BaseFieldTest.php
@@ -31,6 +31,27 @@ class BaseFieldTest extends TestCase
 		$this->assertSame([], $field->drawers());
 	}
 
+	public function testErrors(): void
+	{
+		// fields without a value cannot have errors
+		$field = new MockBaseField();
+		$this->assertSame([], $field->errors());
+	}
+
+	public function testErrorsWithValidation(): void
+	{
+		// `Kirby\Form\Mixin\Validation` overwrites the default
+		// for all fields that can hold a value
+		$field = $this->field('text', [
+			'name'     => 'test',
+			'required' => true
+		]);
+
+		$this->assertSame([
+			'required' => 'Please enter something'
+		], $field->errors());
+	}
+
 	public function testFactory(): void
 	{
 		$field = MockBaseField::factory(['name' => 'test']);

--- a/tests/Form/Field/BlocksFieldTest.php
+++ b/tests/Form/Field/BlocksFieldTest.php
@@ -510,6 +510,21 @@ class BlocksFieldTest extends TestCase
 	public function testValidations(): void
 	{
 		$field = $this->field('blocks', [
+			'fieldsets' => [
+				'heading' => true,
+				'video'   => true,
+				'note'    => [
+					'label'  => 'Note',
+					'fields' => [
+						'notice' => [
+							'type' => 'info'
+						],
+						'text' => [
+							'type' => 'text'
+						]
+					]
+				]
+			],
 			'value' => [
 				[
 					'type'    => 'heading',
@@ -521,6 +536,12 @@ class BlocksFieldTest extends TestCase
 					'type'    => 'video',
 					'content' => [
 						'url' => 'https://www.youtube.com/watch?v=EDVYjxWMecc',
+					]
+				],
+				[
+					'type'    => 'note',
+					'content' => [
+						'text' => 'A nice note',
 					]
 				]
 			],

--- a/tests/Form/Field/ObjectFieldTest.php
+++ b/tests/Form/Field/ObjectFieldTest.php
@@ -31,6 +31,9 @@ class ObjectFieldTest extends TestCase
 	{
 		$field = $this->field('object', [
 			'fields' => [
+				'notice' => [
+					'type' => 'info'
+				],
 				'url' => [
 					'type' => 'url',
 					'minlength' => 20

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -196,6 +196,9 @@ class StructureFieldTest extends TestCase
 	{
 		$field = $this->field('structure', [
 			'fields' => [
+				'notice' => [
+					'type' => 'info'
+				],
 				'title' => [
 					'type' => 'text'
 				]
@@ -206,6 +209,9 @@ class StructureFieldTest extends TestCase
 
 		$field = $this->field('structure', [
 			'fields' => [
+				'notice' => [
+					'type' => 'info'
+				],
 				'title' => [
 					'type' => 'text'
 				]

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -139,6 +139,14 @@ class FieldsTest extends TestCase
 			'b' => [
 				'type'  => 'text',
 			],
+			// fields without validation logic
+			'buttons'  => ['type' => 'buttons'],
+			'gap'      => ['type' => 'gap'],
+			'headline' => ['type' => 'headline'],
+			'hidden'   => ['type' => 'hidden'],
+			'info'     => ['type' => 'info'],
+			'line'     => ['type' => 'line'],
+			'stats'    => ['type' => 'stats'],
 		], $this->model);
 
 		$this->assertSame([], $fields->errors());


### PR DESCRIPTION
## Description

Saving a page with an `info` field in its blueprint failed in the Panel with a 500: `Call to undefined method Kirby\Form\Field\InfoField::errors()`.

The reason: in the new v6 field architecture, `errors()` lives in the `Mixin\Validation` trait, and only `InputField` uses that trait. But `Fields::errors()` calls `errors()` on *every* field in the collection. So any field that doesn't extend `InputField` blows up the moment it ends up in a form.

The fix adds a default `errors()` to `BaseField` that returns an empty array. Validation for value fields is completely unaffected, since a trait method takes precedence over an inherited parent method.

I could have put it on `DisplayField` instead, but that wouldn't have been enough: `gap`, `line` and `hidden` don't extend `DisplayField`, they extend `BaseField` directly. What these fields have in common isn't "being a display field", it's "having no validation logic" — so `BaseField` is the right place.

**Things that weren't in the issue but came up while digging:**

- The `hidden` field breaks the same way. The issue mentions `info`, `headline`, `line` and `gap`, but not `hidden` — which is a commonly used field, so the impact is wider than reported. `buttons` and `stats` are in the same boat.
- It's not just flat forms: `structure`, `object` and `blocks` also call `errors()` on every field of their nested forms. So an `info` field placed inside a structure row or a block hits the exact same error. There's an extra trap here — `validateRows()` returns early on an empty value, so it only triggers once the structure/blocks field actually has content, which makes it easy to miss.

Since the fix sits in one place, it covers all of these at once.

On the test side: a mixed collection at the `Fields::errors()` level (`buttons`, `gap`, `headline`, `hidden`, `info`, `line`, `stats` + `text`), a contract test for `BaseField`, and nested tests for structure/object/blocks. I verified one by one that each of them really does fail without the fix.

## Changelog

### 🐛 Bug fixes

- Fix error when saving pages with `info`, `headline`, `line`, `gap`, `hidden`, `buttons` or `stats` fields in the blueprint #8307

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion