### PR TITLE
fix: Validate slug when duplicating page

### DIFF
--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -319,6 +319,8 @@ class PageRules
 			throw new LogicException(key: 'page.move.ancestor');
 		}
 
+		self::validateSlugProtectedPaths($page, $page->slug(), $parent);
+
 		// check for duplicates
 		if ($parent->childrenAndDrafts()->find($page->slug())) {
 			throw new DuplicateException(
@@ -447,9 +449,12 @@ class PageRules
 	 */
 	protected static function validateSlugProtectedPaths(
 		Page $page,
-		string $slug
+		string $slug,
+		Site|Page|null $parent = null
 	): void {
-		if ($page->parent() === null) {
+		$parent ??= $page->parent();
+
+		if ($parent instanceof Page === false) {
 			$paths = A::map(
 				['api', 'assets', 'media', 'panel'],
 				fn ($url) => $page->kirby()->url($url, true)->path()->toString()

--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -287,6 +287,7 @@ class PageRules
 		}
 
 		self::validateSlugLength($slug);
+		self::validateSlugProtectedPaths($page, $slug);
 	}
 
 	/**

--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -454,20 +454,22 @@ class PageRules
 	): void {
 		$parent ??= $page->parent();
 
-		if ($parent instanceof Page === false) {
-			$paths = A::map(
-				['api', 'assets', 'media', 'panel'],
-				fn ($url) => $page->kirby()->url($url, true)->path()->toString()
+		if ($parent instanceof Page === true) {
+			return;
+		}
+
+		$paths = A::map(
+			['api', 'assets', 'media', 'panel'],
+			fn ($url) => $page->kirby()->url($url, true)->path()->toString()
+		);
+
+		$index = array_search($slug, $paths);
+
+		if ($index !== false) {
+			throw new InvalidArgumentException(
+				key: 'page.changeSlug.reserved',
+				data: ['path' => $paths[$index]]
 			);
-
-			$index = array_search($slug, $paths);
-
-			if ($index !== false) {
-				throw new InvalidArgumentException(
-					key: 'page.changeSlug.reserved',
-					data: ['path' => $paths[$index]]
-				);
-			}
 		}
 	}
 

--- a/tests/Cms/Page/PageRulesTest.php
+++ b/tests/Cms/Page/PageRulesTest.php
@@ -719,6 +719,33 @@ class PageRulesTest extends ModelTestCase
 		PageRules::move($page, new Page(['slug' => 'test']));
 	}
 
+	public function testMoveToReservedPath(): void
+	{
+		$this->app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'parent-a',
+						'children' => [
+							[
+								'slug' => 'panel'
+							]
+						]
+					]
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		$child = $this->app->page('parent-a/panel');
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionCode('error.page.changeSlug.reserved');
+
+		PageRules::move($child, $this->app->site());
+	}
+
 	public function testMoveWithDuplicate(): void
 	{
 		$this->app = $this->app->clone([

--- a/tests/Cms/Page/PageRulesTest.php
+++ b/tests/Cms/Page/PageRulesTest.php
@@ -576,6 +576,32 @@ class PageRulesTest extends ModelTestCase
 		PageRules::duplicate($page, 'panel');
 	}
 
+	public function testDuplicateReservedPathInSubpage(): void
+	{
+		$this->app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'parent-a',
+						'children' => [
+							[
+								'slug' => 'child'
+							]
+						]
+					]
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		$this->expectNotToPerformAssertions();
+
+		$child = $this->app->page('parent-a/child');
+
+		PageRules::duplicate($child, 'panel');
+	}
+
 	public function testUpdate(): void
 	{
 		$page = new Page([
@@ -744,6 +770,49 @@ class PageRulesTest extends ModelTestCase
 		$this->expectExceptionCode('error.page.changeSlug.reserved');
 
 		PageRules::move($child, $this->app->site());
+	}
+
+	public function testMoveToReservedPathInSubpage(): void
+	{
+		$this->app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'parent-a',
+						'template' => 'parent',
+						'children' => [
+							[
+								'slug'     => 'panel',
+								'template' => 'child'
+							]
+						]
+					],
+					[
+						'slug'     => 'parent-b',
+						'template' => 'parent',
+					]
+				]
+			],
+			'blueprints' => [
+				'pages/parent' => [
+					'sections' => [
+						'subpages' => [
+							'type'     => 'pages',
+							'template' => 'child'
+						]
+					]
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		$this->expectNotToPerformAssertions();
+
+		$parentB = $this->app->page('parent-b');
+		$child   = $this->app->page('parent-a/panel');
+
+		PageRules::move($child, $parentB);
 	}
 
 	public function testMoveWithDuplicate(): void

--- a/tests/Cms/Page/PageRulesTest.php
+++ b/tests/Cms/Page/PageRulesTest.php
@@ -564,6 +564,18 @@ class PageRulesTest extends ModelTestCase
 		PageRules::duplicate($page, 'something');
 	}
 
+	public function testDuplicateReservedPath(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionCode('error.page.changeSlug.reserved');
+
+		$page = new Page([
+			'slug' => 'test',
+		]);
+
+		PageRules::duplicate($page, 'panel');
+	}
+
 	public function testUpdate(): void
 	{
 		$page = new Page([


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Mirroring what we do in `::changeSlug` and `::create`

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Validating slug against protected paths when duplicating or moving a page



## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion