### PR TITLE
fix: Resolve UUIDs when batch-deleting files and pages

### DIFF
--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -104,12 +104,17 @@ class Files extends Collection
 	{
 		$exceptions = [];
 
-		// delete all pages and collect errors
+		// delete all files and collect errors
 		foreach ($ids as $id) {
 			try {
-				$model = $this->get($id);
+				// resolve the id or UUID and make sure
+				// the file is part of this collection
+				$model = $this->get($id) ?? $this->find($id);
 
-				if ($model instanceof File === false) {
+				if (
+					$model instanceof File === false ||
+					$this->has($model) === false
+				) {
 					throw new NotFoundException(
 						key: 'file.undefined'
 					);

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -144,14 +144,14 @@ class Pages extends Collection
 				// as we move away from our immutable object architecture.
 				$page = $kirby->page($id);
 
-				if ($page === null || $this->get($id) instanceof Page === false) {
+				if ($page === null || $this->has($page) === false) {
 					throw new NotFoundException(
 						key: 'page.undefined',
 					);
 				}
 
 				$page->delete();
-				$this->remove($id);
+				$this->remove($page->id());
 			} catch (Throwable $e) {
 				$exceptions[$id] = $e;
 			}

--- a/tests/Cms/Files/FilesTest.php
+++ b/tests/Cms/Files/FilesTest.php
@@ -158,6 +158,87 @@ class FilesTest extends TestCase
 		$this->assertFileDoesNotExist($b);
 	}
 
+	public function testDeleteWithUuids(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'site' => [
+				'files' => [
+					['filename' => 'a.jpg', 'content' => ['uuid' => 'test-a']],
+					['filename' => 'b.jpg', 'content' => ['uuid' => 'test-b']]
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$files = $app->site()->files();
+
+		$a = $files->get('a.jpg')->root();
+		$b = $files->get('b.jpg')->root();
+
+		// pretend the files exist
+		F::write($a, '');
+		F::write($b, '');
+
+		// the Panel sends the selection as UUIDs
+		$files->delete([
+			'file://test-a',
+			'file://test-b',
+		]);
+
+		$this->assertCount(0, $files);
+		$this->assertFileDoesNotExist($a);
+		$this->assertFileDoesNotExist($b);
+
+		Uuids::cache()->flush();
+	}
+
+	public function testDeleteWithForeignUuid(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'  => 'a',
+						'files' => [
+							['filename' => 'a.jpg', 'content' => ['uuid' => 'test-a']]
+						]
+					],
+					[
+						'slug'  => 'b',
+						'files' => [
+							['filename' => 'b.jpg', 'content' => ['uuid' => 'test-b']]
+						]
+					]
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$files = $app->page('a')->files();
+		$b     = $app->page('b')->file('b.jpg')->root();
+		F::write($b, '');
+
+		// deleting a file that is not part of the collection must fail,
+		// even if the UUID resolves to a valid file elsewhere
+		try {
+			$files->delete(['file://test-b']);
+		} catch (Exception $e) {
+			$this->assertSame('Not all files could be deleted. Try each remaining file individually to see the specific error that prevents deletion.', $e->getMessage());
+		}
+
+		$this->assertFileExists($b);
+
+		Uuids::cache()->flush();
+	}
+
 	public function testDeleteWithInvalidIds(): void
 	{
 		$app = new App([

--- a/tests/Cms/Pages/PagesTest.php
+++ b/tests/Cms/Pages/PagesTest.php
@@ -6,6 +6,7 @@ use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
+use Kirby\Uuid\Uuids;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(Pages::class)]
@@ -232,6 +233,79 @@ class PagesTest extends TestCase
 		$this->assertDirectoryDoesNotExist($a->root());
 		$this->assertDirectoryDoesNotExist($b->root());
 		$this->assertDirectoryExists($c->root());
+	}
+
+	public function testDeleteWithUuids(): void
+	{
+		$this->app->impersonate('kirby');
+
+		$a = Page::create([
+			'slug'    => 'a',
+			'draft'   => false,
+			'content' => ['uuid' => 'test-a']
+		]);
+
+		$b = Page::create([
+			'slug'    => 'b',
+			'draft'   => false,
+			'content' => ['uuid' => 'test-b']
+		]);
+
+		$c = Page::create([
+			'slug'    => 'c',
+			'draft'   => false,
+			'content' => ['uuid' => 'test-c']
+		]);
+
+		$pages = $this->app->site()->children();
+
+		$this->assertCount(3, $pages);
+
+		// the Panel sends the selection as UUIDs
+		$pages->delete([
+			'page://test-a',
+			'page://test-b',
+		]);
+
+		$this->assertCount(1, $pages);
+
+		$this->assertDirectoryDoesNotExist($a->root());
+		$this->assertDirectoryDoesNotExist($b->root());
+		$this->assertDirectoryExists($c->root());
+
+		Uuids::cache()->flush();
+	}
+
+	public function testDeleteWithForeignUuid(): void
+	{
+		$this->app->impersonate('kirby');
+
+		Page::create([
+			'slug'    => 'a',
+			'draft'   => false,
+			'content' => ['uuid' => 'test-a']
+		]);
+
+		$b = Page::create([
+			'slug'    => 'b',
+			'draft'   => false,
+			'content' => ['uuid' => 'test-b']
+		]);
+
+		// a collection that only contains page a
+		$pages = $this->app->site()->children()->filterBy('slug', 'a');
+
+		// deleting a page that is not part of the collection must fail,
+		// even if the UUID resolves to a valid page elsewhere
+		try {
+			$pages->delete(['page://test-b']);
+		} catch (Exception $e) {
+			$this->assertSame('Not all pages could be deleted. Try each remaining page individually to see the specific error that prevents deletion.', $e->getMessage());
+		}
+
+		$this->assertDirectoryExists($b->root());
+
+		Uuids::cache()->flush();
 	}
 
 	public function testDeleteSortedAndFiltered(): void


### PR DESCRIPTION
## Description

Batch delete in file and page sections doesn't work — it fails with a 500 and says the items can't be found (#8314).

The reason: the Panel sends the selected items as UUIDs (`file://…`), but the delete code was still looking them up by their path, so it never found them. It worked in v5 because back then the selection used the path.

The fix teaches both `Files::delete()` and `Pages::delete()` to understand UUIDs. It still makes sure you can only delete items that are actually in the section.

## Changelog

### 🐛 Bug fixes

- Fix batch delete in file and page sections #8314

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion