### PR TITLE
fix: Derive filename from source when filename prop is missing

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -379,9 +379,8 @@ trait FileActions
 		$template = $props['template'] ?? 'default';
 
 		// prefer the filename from the props
-		$filename   = $props['filename'] ?? null;
-		$filename ??= basename($props['source']);
-		$filename   = F::safeName($props['filename']);
+		$filename = $props['filename'] ?? basename($props['source']);
+		$filename = F::safeName($filename);
 
 		return [
 			...$props,

--- a/tests/Cms/File/FileCreateTest.php
+++ b/tests/Cms/File/FileCreateTest.php
@@ -39,6 +39,24 @@ class FileCreateTest extends ModelTestCase
 		$this->assertIsString($result->content()->get('uuid')->value());
 	}
 
+	public function testCreateWithoutFilename(): void
+	{
+		$parent = new Page(['slug' => 'test']);
+		$source = static::TMP . '/source.md';
+
+		// create the dummy source
+		F::write($source, '# Test');
+
+		// no filename prop, must be derived from the source basename
+		$result = File::create([
+			'source' => $source,
+			'parent' => $parent
+		]);
+
+		$this->assertSame('source.md', $result->filename());
+		$this->assertFileExists($parent->root() . '/source.md');
+	}
+
 	public function testCreateDuplicate(): void
 	{
 		$parent = new Page(['slug' => 'test']);


### PR DESCRIPTION
## Description

Small bug in `File::normalizeProps()`. The last line was running `F::safeName()` on `$props['filename']` directly instead of the `$filename` variable, so the `basename($source)` fallback was always discarded and a missing `filename` key threw an "undefined array key" warning.

## Changelog

### 🐛 Bug fixes

- The filename is now correctly derived from the source when no `filename` is provided to `File::create()`

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion