### PR TITLE
fix: Match preview token for custom preview URLs

### DIFF
--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -1025,9 +1025,12 @@ class Page extends ModelWithContent
 			$versionId = VersionId::latest();
 		}
 
-		// authenticated requests can always be trusted
-		$expectedToken = $this->version($versionId)->previewToken();
-		if ($token !== '' && hash_equals($expectedToken, $token) === true) {
+		// authenticated requests can always be trusted;
+		// only resolve the expected token when one was sent
+		if (
+			$token !== '' &&
+			hash_equals($this->version($versionId)->previewToken(), $token) === true
+		) {
 			return $versionId;
 		}
 

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -420,7 +420,12 @@ class Version
 			throw new LogicException('Invalid model type');
 		}
 
-		return $this->previewTokenFromUrl($this->model->url());
+		// bind the token to the custom preview URL so it still matches
+		// when the version is rendered, otherwise use the page URL
+		$preview = $this->model->blueprint()->preview();
+		$url     = is_string($preview) === true ? $preview : $this->model->url();
+
+		return $this->previewTokenFromUrl($url);
 	}
 
 	/**

--- a/tests/Cms/Page/PageRenderTest.php
+++ b/tests/Cms/Page/PageRenderTest.php
@@ -657,6 +657,45 @@ class PageRenderTest extends ModelTestCase
 		$this->assertSame('changes', $page->renderVersionFromRequest()->value());
 	}
 
+	public function testRenderVersionFromRequestCustomPreviewUrl(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'custom-preview',
+						'template' => 'custom-preview'
+					]
+				]
+			],
+			'blueprints' => [
+				'pages/custom-preview' => [
+					'options' => [
+						'preview' => '{{ page.url }}.json'
+					]
+				]
+			]
+		]);
+
+		$page = $app->page('custom-preview');
+
+		// the token the panel embeds in the custom preview link
+		$url   = $page->version('changes')->url();
+		$query = [];
+		parse_str(parse_url($url, PHP_URL_QUERY), $query);
+
+		$app->clone([
+			'request' => [
+				'query' => [
+					'_token'   => $query['_token'],
+					'_version' => 'changes'
+				]
+			]
+		]);
+
+		$this->assertSame('changes', $page->renderVersionFromRequest()->value());
+	}
+
 	public function testRenderVersionFromRequestAuthenticatedDraft(): void
 	{
 		$page = $this->app->page('version-draft');

--- a/tests/Content/VersionTest.php
+++ b/tests/Content/VersionTest.php
@@ -816,6 +816,44 @@ class VersionTest extends TestCase
 		$this->assertSame($expected, $version->previewToken());
 	}
 
+	public function testPreviewTokenCustomPreviewUrl(): void
+	{
+		$this->setUpSingleLanguage();
+
+		$this->app = $this->app->clone([
+			'options' => [
+				'content' => [
+					'salt' => 'testsalt'
+				]
+			]
+		]);
+
+		$page = new Page([
+			'slug' => 'test',
+			'blueprint' => [
+				'name'    => 'test',
+				'options' => [
+					'preview' => '{{ page.url }}.json'
+				]
+			]
+		]);
+
+		$version = new Version(
+			model: $page,
+			id: VersionId::changes()
+		);
+
+		// the token must be bound to the custom preview URL, so it still
+		// matches when the changed version is rendered
+		$expected = substr(
+			hash_hmac('sha1', '{"url":"' . $page->url() . '.json","versionId":"changes"}', 'testsalt'),
+			0,
+			10
+		);
+
+		$this->assertSame($expected, $version->previewToken());
+	}
+
 	public function testPreviewTokenCustomSalt(): void
 	{
 		$this->setUpSingleLanguage();


### PR DESCRIPTION
## Description

When a page blueprint has a custom preview URL (like `preview: "{{ page.url }}.json"`), the Changes view was showing the latest saved version instead of the unsaved changes.

The problem is that the preview token didn't match. The panel creates the token from the custom URL (`…/page.json`), but when the page is rendered the token is checked against the plain page URL (`…/page`). Since they're different, the token never matches and it falls back to the latest version.

So the fix makes `Version::previewToken()` use the custom preview URL too, so both sides use the same URL. On top of that, `Page::renderVersionFromRequest()` now only builds the expected token when a `_token` is actually there. This skips some unnecessary work (and a session side effect) on normal renders. The behavior stays the same, because the `&&` already short-circuited on empty tokens anyway.

## Changelog

### 🐛 Bug fixes

- Fix Changes view for custom preview URLs #8317

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion