### PR TITLE
fix: Disable undefined permission deprecation by default

### DIFF
--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -38,7 +38,11 @@ class Helpers
 		// Setting undefined permission categories or actions is deprecated
 		// and will be ignored in a future version. Custom permissions should
 		// be registered via the `permissions` extension instead.
-		'permissions-undefined' => true,
+		// The warning is disabled by default for now, as it is triggered
+		// while loading roles and would thus break the Panel on every request
+		// even though the permission is still applied.
+		// TODO: switch to true in v6
+		'permissions-undefined' => false,
 
 		// Passing an `info` array inside the `extends` array
 		// has been deprecated. Pass the individual entries (e.g. root, version)

--- a/tests/Cms/Permissions/PermissionsTest.php
+++ b/tests/Cms/Permissions/PermissionsTest.php
@@ -10,11 +10,20 @@ use PHPUnit\Framework\Attributes\DataProvider;
 #[CoversClass(Permissions::class)]
 class PermissionsTest extends TestCase
 {
+	protected array $deprecations = [];
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->deprecations = Helpers::$deprecations;
+	}
+
 	protected function tearDown(): void
 	{
 		parent::tearDown();
 		Permissions::$extendedActions = [];
 		Permissions::$extendedAreas = [];
+		Helpers::$deprecations = $this->deprecations;
 	}
 
 	public static function actionsProvider(): array
@@ -349,6 +358,8 @@ class PermissionsTest extends TestCase
 
 	public function testUnknownCategoryDeprecated(): void
 	{
+		Helpers::$deprecations['permissions-undefined'] = true;
+
 		$this->assertError(
 			E_USER_DEPRECATED,
 			'Setting undefined permission category "nonexistent" is deprecated and will be ignored in a future version. Please use https://getkirby.com/docs/reference/plugins/extensions/permissions to register custom permissions.',
@@ -360,8 +371,26 @@ class PermissionsTest extends TestCase
 		);
 	}
 
+	public function testUnknownCategoryNotDeprecatedByDefault(): void
+	{
+		$this->assertError(
+			E_USER_DEPRECATED,
+			'Setting undefined permission category "nonexistent" is deprecated and will be ignored in a future version. Please use https://getkirby.com/docs/reference/plugins/extensions/permissions to register custom permissions.',
+			function () {
+				$p = new Permissions(['nonexistent' => ['foo' => false]]);
+
+				// the undefined permission is still applied
+				$this->assertFalse($p->for('nonexistent', 'foo'));
+				$this->assertTrue($p->for('pages', 'read'));
+			},
+			expectedFailure: false
+		);
+	}
+
 	public function testUnknownActionDeprecated(): void
 	{
+		Helpers::$deprecations['permissions-undefined'] = true;
+
 		$this->assertError(
 			E_USER_DEPRECATED,
 			'Setting undefined permission "pages.nonexistent" is deprecated and will be ignored in a future version. Please use https://getkirby.com/docs/reference/plugins/extensions/permissions to register custom permissions.',
@@ -372,5 +401,31 @@ class PermissionsTest extends TestCase
 				$this->assertFalse($p->for('pages', 'nonexistent'));
 			}
 		);
+	}
+
+	public function testUnknownActionNotDeprecatedByDefault(): void
+	{
+		$this->assertError(
+			E_USER_DEPRECATED,
+			'Setting undefined permission "pages.nonexistent" is deprecated and will be ignored in a future version. Please use https://getkirby.com/docs/reference/plugins/extensions/permissions to register custom permissions.',
+			function () {
+				$p = new Permissions(['pages' => ['nonexistent' => false]]);
+
+				// the undefined permission is still applied
+				$this->assertFalse($p->for('pages', 'nonexistent'));
+				$this->assertTrue($p->for('pages', 'read'));
+			},
+			expectedFailure: false
+		);
+	}
+
+	public function testUnknownActionWithNonBoolValueStillThrows(): void
+	{
+		$this->expectException(LogicException::class);
+		$this->expectExceptionMessage(
+			'The value for the permission "access.user" must be of type bool, array given'
+		);
+
+		new Permissions(['access' => ['user' => ['changeRole' => false]]]);
 	}
 }


### PR DESCRIPTION
## Description

The deprecation warning for undefined permissions fires while roles are loaded, so it hits almost every Panel request. With debug on, Whoops turns it into a full error page — people can't even open the Panel to fix their blueprint, while the permission itself still works.

This disables it by default for now, same as `plugin-extends-root`. Undefined permissions are still applied, real syntax errors still throw, and the warning can be re-enabled via `Helpers::$deprecations['permissions-undefined'] = true`.

## Changelog

### 🐛 Bug fixes

- The Panel is no longer blocked by a deprecation warning when a user blueprint sets an undefined permission #8275

## Docs

The permissions reference should list the valid keys:

- available `access.*` keys, plus the id of every custom Panel area
- `access.settings` no longer does anything — it was replaced by `access.system`
- custom Panel areas get an `access.<areaId>` permission automatically, no `permissions` extension needed

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion