### PR TITLE
fix: Ensure proper ISO for date field min/max

### DIFF
--- a/src/Form/Field/DateField.php
+++ b/src/Form/Field/DateField.php
@@ -88,6 +88,16 @@ class DateField extends DateTimeField
 		$this->time     = $time;
 	}
 
+	/**
+	 * Cuts a boundary down to the precision of the field, so that it
+	 * can never carry more information than the field is able to produce.
+	 */
+	protected function boundary(string|null $boundary): string|null
+	{
+		$format = $this->time() === false ? 'Y-m-d' : static::ISO;
+		return Date::optional($boundary)?->format($format);
+	}
+
 	public function calendar(): bool
 	{
 		return $this->calendar ?? true;
@@ -114,6 +124,16 @@ class DateField extends DateTimeField
 	public function icon(): string
 	{
 		return $this->icon ?? 'calendar';
+	}
+
+	public function max(): string|null
+	{
+		return $this->boundary($this->max);
+	}
+
+	public function min(): string|null
+	{
+		return $this->boundary($this->min);
 	}
 
 	public function props(): array

--- a/src/Form/Field/DateTimeField.php
+++ b/src/Form/Field/DateTimeField.php
@@ -97,12 +97,12 @@ abstract class DateTimeField extends InputField
 
 	public function max(): string|null
 	{
-		return Date::optional($this->max);
+		return Date::optional($this->max)?->format(static::ISO);
 	}
 
 	public function min(): string|null
 	{
-		return Date::optional($this->min);
+		return Date::optional($this->min)?->format(static::ISO);
 	}
 
 	public function props(): array

--- a/tests/Form/Field/DateFieldTest.php
+++ b/tests/Form/Field/DateFieldTest.php
@@ -10,6 +10,52 @@ use PHPUnit\Framework\Attributes\DataProvider;
 #[CoversClass(DateTimeField::class)]
 class DateFieldTest extends TestCase
 {
+	public function testMax(): void
+	{
+		// a date-only field cuts it down to its own precision
+		$field = $this->field('date', [
+			'max' => '2020-10-31 08:15'
+		]);
+
+		$this->assertSame('2020-10-31', $field->max());
+
+		// with a time part, the full precision is kept
+		$field = $this->field('date', [
+			'time' => true,
+			'max'  => '2020-10-31 08:15'
+		]);
+
+		$this->assertSame('2020-10-31 08:15:00', $field->max());
+
+		// without a boundary
+		$field = $this->field('date');
+
+		$this->assertNull($field->max());
+	}
+
+	public function testMin(): void
+	{
+		// a date-only field cuts it down to its own precision
+		$field = $this->field('date', [
+			'min' => '2020-10-01 09:00'
+		]);
+
+		$this->assertSame('2020-10-01', $field->min());
+
+		// with a time part, the full precision is kept
+		$field = $this->field('date', [
+			'time' => true,
+			'min'  => '2020-10-01 09:00'
+		]);
+
+		$this->assertSame('2020-10-01 09:00:00', $field->min());
+
+		// without a boundary
+		$field = $this->field('date');
+
+		$this->assertNull($field->min());
+	}
+
 	public function testMinMax(): void
 	{
 		// empty

--- a/tests/Form/Field/TimeFieldTest.php
+++ b/tests/Form/Field/TimeFieldTest.php
@@ -27,6 +27,36 @@ class TimeFieldTest extends TestCase
 		$this->assertSame('HH:mm:ss', $field->display());
 	}
 
+	public function testMax(): void
+	{
+		// a plain ISO time without a date or timezone offset
+		$field = $this->field('time', [
+			'max' => '11:30:15'
+		]);
+
+		$this->assertSame('11:30:15', $field->max());
+
+		// without a boundary
+		$field = $this->field('time');
+
+		$this->assertNull($field->max());
+	}
+
+	public function testMin(): void
+	{
+		// a plain ISO time without a date or timezone offset
+		$field = $this->field('time', [
+			'min' => '09:00'
+		]);
+
+		$this->assertSame('09:00:00', $field->min());
+
+		// without a boundary
+		$field = $this->field('time');
+
+		$this->assertNull($field->min());
+	}
+
 	public function testMinMax(): void
 	{
 		// no value


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Ensure that we hand over proper ISO strings for `min`/`max` in date fields. And that the min/max doesn't include a time, when the field doesn't handle/store a time. Otherwise, the Panel validation could be thrown off if time is still included.