### PR TITLE
fix: Strict `dayjs.iso()` parsing

### DIFF
--- a/panel/lab/internals/library.dayjs/4_iso/index.vue
+++ b/panel/lab/internals/library.dayjs/4_iso/index.vue
@@ -2,117 +2,80 @@
 	<k-lab-examples>
 		<k-box theme="text">
 			<k-text>
-				Parse an ISO datetime, date or time string as a
-				<code>dayjs</code> object. Or convert a <code>dayjs</code> object to an
-				ISO string.
+				<p>
+					<code>dayjs.iso()</code> parses an ISO datetime, date or time string
+					as a <code>dayjs</code> object, <code>dayjs().toISO()</code> converts
+					a <code>dayjs</code> object back to an ISO string. The three supported
+					formats are datetime (<code>YYYY-MM-DD HH:mm:ss</code>), date
+					(<code>YYYY-MM-DD</code>) and time (<code>HH:mm:ss</code>).
+				</p>
 			</k-text>
 		</k-box>
 
 		<k-lab-example label="dayjs.iso()" :code="false">
-			<k-code language="javascript">this.$library.dayjs.iso("2023-09-12", "date"): dayjs</k-code>
+			<!-- prettier-ignore -->
+			<k-code language="javascript">this.$library.dayjs.iso(input{{ format ? ', "' + format + '"' : null }}): dayjs|null</k-code>
 
 			<k-grid variant="fields">
-				<k-column width="1/4">
+				<k-column width="1/3">
+					<k-label>Input</k-label>
 					<k-input
 						type="text"
-						:placeholder="stringPlaceholder"
+						:placeholder="placeholder"
+						:value="string"
 						style="min-width: 12rem"
-						@input="parse"
+						@input="string = $event"
 					/>
 				</k-column>
-				<k-column width="1/4">
+				<k-column width="1/3">
+					<k-label>Format</k-label>
 					<k-input
 						type="select"
-						:options="[
-							{ text: 'datetime', value: 'full' },
-							{ text: 'date', value: 'date' },
-							{ text: 'time', value: 'time' }
-						]"
+						:options="inputFormats"
+						:required="true"
 						:empty="false"
-						:value="mode"
-						@input="mode = $event"
+						:value="format"
+						@input="format = $event"
 					/>
 				</k-column>
-				<k-column width="1/2">
-					<k-box theme="code">{{ string ?? "-" }}</k-box>
+				<k-column width="1/3">
+					<k-label>Result</k-label>
+					<k-box theme="code">{{ parsed?.toISO(selected) ?? "null" }}</k-box>
 				</k-column>
 			</k-grid>
 		</k-lab-example>
 
-		<k-lab-example label="dayjs.toISO()" :code="false">
-			<k-code language="javascript">myDayjsObject.toIso("date"): string</k-code>
+		<k-lab-example label="dayjs().toISO()" :code="false">
+			<!-- prettier-ignore -->
+			<k-code language="javascript">myDayjsObject.toISO("date"): string</k-code>
 
-			<k-input
-				type="number"
-				placeholder="Year"
-				:value="year"
-				@input="
-					year = $event;
-					generate();
-				"
-			/>
-			<k-input
-				type="number"
-				placeholder="Month"
-				:value="month"
-				@input="
-					month = $event;
-					generate();
-				"
-			/>
-			<k-input
-				type="number"
-				placeholder="Day"
-				:value="day"
-				@input="
-					day = $event;
-					generate();
-				"
-			/>
-			<k-input
-				type="number"
-				placeholder="Hour"
-				:value="hour"
-				@input="
-					hour = $event;
-					generate();
-				"
-			/>
-			<k-input
-				type="number"
-				placeholder="Minute"
-				:value="minute"
-				@input="
-					minute = $event;
-					generate();
-				"
-			/>
-			<k-input
-				type="number"
-				placeholder="Second"
-				:value="second"
-				@input="
-					second = $event;
-					generate();
-				"
-			/>
-
-			<k-input
-				type="select"
-				:options="[
-					{ text: 'datetime', value: 'full' },
-					{ text: 'date', value: 'date' },
-					{ text: 'time', value: 'time' }
-				]"
-				:empty="false"
-				:value="mode"
-				@input="
-					mode = $event;
-					generate();
-				"
-			/>
-
-			<k-box theme="code">{{ iso ?? "-" }}</k-box>
+			<k-grid variant="fields">
+				<k-column v-for="unit in units" :key="unit.name" width="1/6">
+					<k-label>{{ unit.label }}</k-label>
+					<k-input
+						type="number"
+						:min="unit.min"
+						:max="unit.max"
+						:value="datetime[unit.name]"
+						@input="datetime[unit.name] = $event"
+					/>
+				</k-column>
+				<k-column width="1/2">
+					<k-label>Format</k-label>
+					<k-input
+						type="select"
+						:options="formats"
+						:required="true"
+						:empty="false"
+						:value="output"
+						@input="output = $event"
+					/>
+				</k-column>
+				<k-column width="1/2">
+					<k-label>Result</k-label>
+					<k-box theme="code">{{ iso }}</k-box>
+				</k-column>
+			</k-grid>
 		</k-lab-example>
 	</k-lab-examples>
 </template>
@@ -121,50 +84,69 @@
 export default {
 	data() {
 		return {
-			mode: "full",
-			string: null,
-			year: 2023,
-			month: 1,
-			day: 1,
-			hour: 0,
-			minute: 0,
-			second: 0,
-			iso: null
+			datetime: {
+				year: 2023,
+				month: 1,
+				day: 1,
+				hour: 0,
+				minute: 0,
+				second: 0
+			},
+			format: "datetime",
+			formats: [
+				{ text: "datetime", value: "datetime" },
+				{ text: "date", value: "date" },
+				{ text: "time", value: "time" }
+			],
+			output: "datetime",
+			string: "",
+			units: [
+				{ name: "year", label: "Year", min: 1000, max: 9999 },
+				{ name: "month", label: "Month", min: 1, max: 12 },
+				{ name: "day", label: "Day", min: 1, max: 31 },
+				{ name: "hour", label: "Hour", min: 0, max: 23 },
+				{ name: "minute", label: "Minute", min: 0, max: 59 },
+				{ name: "second", label: "Second", min: 0, max: 59 }
+			]
 		};
 	},
 	computed: {
-		stringPlaceholder() {
-			if (this.mode === "full") {
-				return "2023-01-01 00:00:00";
-			}
-
-			if (this.mode === "date") {
-				return "2023-01-01";
-			}
-
-			return "00:00:00";
-		}
-	},
-	mounted() {
-		this.generate();
-	},
-	methods: {
-		parse(input) {
-			this.string = this.$library.dayjs.iso(input, this.mode);
+		inputFormats() {
+			return [{ text: "any", value: "" }, ...this.formats];
 		},
-		generate() {
-			this.iso = this.$library
+		iso() {
+			const { year, month, day, hour, minute, second } = this.datetime;
+
+			return this.$library
 				.dayjs(
+					// the month of `Date` is zero-based
 					new Date(
-						this.year,
-						this.month,
-						this.day,
-						this.hour,
-						this.minute,
-						this.second
+						Number(year),
+						Number(month) - 1,
+						Number(day),
+						Number(hour),
+						Number(minute),
+						Number(second)
 					)
 				)
-				.toISO(this.mode);
+				.toISO(this.output);
+		},
+		parsed() {
+			return this.$library.dayjs.iso(this.string, this.selected);
+		},
+		selected() {
+			return this.format === "" ? undefined : this.format;
+		},
+		placeholder() {
+			if (this.format === "date") {
+				return "2027-01-01";
+			}
+
+			if (this.format === "time") {
+				return "00:00:00";
+			}
+
+			return "2027-01-01 00:00:00";
 		}
 	}
 };

--- a/panel/src/components/Forms/Field/DateField.vue
+++ b/panel/src/components/Forms/Field/DateField.vue
@@ -10,6 +10,7 @@
 			<k-input
 				ref="dateInput"
 				v-bind="$props"
+				:value="iso.date"
 				type="date"
 				@input="onDateInput"
 				@submit="$emit('submit')"
@@ -219,7 +220,7 @@ export default {
 		 */
 		onTimesInput(value) {
 			this.$refs.times?.close();
-			this.onTimeInput(value + ":00");
+			this.onTimeInput(value);
 		},
 		/**
 		 * Convert an ISO string into an object

--- a/panel/src/components/Forms/Input/CalendarInput.vue
+++ b/panel/src/components/Forms/Input/CalendarInput.vue
@@ -206,21 +206,17 @@ export default {
 	watch: {
 		max: {
 			handler(newValue, oldValue) {
-				if (newValue === oldValue) {
-					return;
+				if (newValue !== oldValue) {
+					this.maxdate = this.$library.dayjs.iso(newValue);
 				}
-
-				this.maxdate = this.$library.dayjs.interpret(newValue, "date");
 			},
 			immediate: true
 		},
 		min: {
 			handler(newValue, oldValue) {
-				if (newValue === oldValue) {
-					return;
+				if (newValue !== oldValue) {
+					this.mindate = this.$library.dayjs.iso(newValue);
 				}
-
-				this.mindate = this.$library.dayjs.interpret(newValue, "date");
 			},
 			immediate: true
 		},
@@ -231,7 +227,7 @@ export default {
 				}
 
 				// set the selected date
-				this.selected = this.$library.dayjs.interpret(newValue, "date");
+				this.selected = this.$library.dayjs.iso(newValue, "date");
 				this.show(this.selected);
 			},
 			immediate: true

--- a/panel/src/libraries/dayjs-iso.test.ts
+++ b/panel/src/libraries/dayjs-iso.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { ISOFormat } from "./dayjs-iso";
 import type { UnitType } from "dayjs";
 import dayjs from "./dayjs";
+import type { ISOFormat } from "./dayjs-iso";
 
 describe("dayjs.iso()", () => {
 	const data: {
@@ -22,6 +22,19 @@ describe("dayjs.iso()", () => {
 			input: "16:05:15",
 			units: { hour: 16, minute: 5, second: 15 },
 			format: "time"
+		},
+		// without a format, any of the three ISO formats is accepted
+		{
+			input: "2020-02-29 16:05:15",
+			units: { year: 2020, month: 1, date: 29, hour: 16, minute: 5, second: 15 }
+		},
+		{
+			input: "2020-02-29",
+			units: { year: 2020, month: 1, date: 29, hour: 0, minute: 0, second: 0 }
+		},
+		{
+			input: "16:05:15",
+			units: { hour: 16, minute: 5, second: 15 }
 		}
 	];
 
@@ -35,6 +48,25 @@ describe("dayjs.iso()", () => {
 
 	it("should return null for an invalid date", () => {
 		expect(dayjs.iso("not a date")).toBeNull();
+	});
+
+	// parsing is strict: out-of-range values must not silently roll over
+	const invalid: [string, ISOFormat | undefined][] = [
+		["2020-02-30", "date"],
+		["2020-02-30", undefined],
+		["2020-13-05", "date"],
+		["2020-13-05", undefined],
+		["24:00:00", "time"],
+		["24:00:00", undefined],
+		["25:61:00", "time"],
+		["2020-01-01", "time"],
+		["16:05:15", "date"],
+		["2020-01-01 00:00:00+00:00", undefined],
+		["", undefined]
+	];
+
+	it.each(invalid)("%s (%s) should be null", (input, format) => {
+		expect(dayjs.iso(input, format)).toBeNull();
 	});
 });
 

--- a/panel/src/libraries/dayjs-iso.test.ts
+++ b/panel/src/libraries/dayjs-iso.test.ts
@@ -68,6 +68,15 @@ describe("dayjs.iso()", () => {
 	it.each(invalid)("%s (%s) should be null", (input, format) => {
 		expect(dayjs.iso(input, format)).toBeNull();
 	});
+
+	it("should fall back to datetime for an unknown format", () => {
+		const format = "nope" as ISOFormat;
+
+		expect(dayjs.iso("2020-02-29 16:05:15", format)!.get("date")).toStrictEqual(
+			29
+		);
+		expect(dayjs.iso("2020-02-30 16:05:15", format)).toBeNull();
+	});
 });
 
 describe("dayjs.toISO()", () => {
@@ -94,5 +103,11 @@ describe("dayjs.toISO()", () => {
 
 	it.each(data)("$expected", ({ date, expected, format }) => {
 		expect(dayjs(date).toISO(format)).toStrictEqual(expected);
+	});
+
+	it("should fall back to datetime for an unknown format", () => {
+		const date = new Date(2020, 6, 3, 17, 24, 11);
+		const format = "nope" as ISOFormat;
+		expect(dayjs(date).toISO(format)).toStrictEqual("2020-07-03 17:24:11");
 	});
 });

--- a/panel/src/libraries/dayjs-iso.ts
+++ b/panel/src/libraries/dayjs-iso.ts
@@ -1,50 +1,60 @@
+/**
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+
 import type { Dayjs, PluginFunc } from "dayjs";
 
 export type ISOFormat = "date" | "time" | "datetime";
 
-const dayjsISOformat = (format: string): string => {
-	if (format === "date") {
-		return "YYYY-MM-DD";
-	}
-
-	if (format === "time") {
-		return "HH:mm:ss";
-	}
-
-	return "YYYY-MM-DD HH:mm:ss";
-};
-
 declare module "dayjs" {
 	interface Dayjs {
+		/**
+		 * Formats the datetime as the ISO string that values
+		 * are stored as, e.g. `2024-06-23 14:30:00`
+		 *
+		 * @param format which part of the datetime to write
+		 */
 		toISO(format?: ISOFormat): string;
 	}
+
+	/**
+	 * Parses from an ISO string
+	 *
+	 * @param string ISO string to parse
+	 * @param format which datetime format to expect
+	 */
 	function iso(string: string, format?: ISOFormat): Dayjs | null;
 }
+
+const formats: Record<ISOFormat, string> = {
+	date: "YYYY-MM-DD",
+	time: "HH:mm:ss",
+	datetime: "YYYY-MM-DD HH:mm:ss"
+};
 
 const plugin: PluginFunc = (option, Dayjs, dayjs) => {
 	Dayjs.prototype.toISO = function (
 		this: Dayjs,
 		format: ISOFormat = "datetime"
 	): string {
-		return this.format(dayjsISOformat(format));
+		return this.format(formats[format]);
 	};
 
 	Object.assign(dayjs, {
 		iso(string: string, format?: ISOFormat): Dayjs | null {
-			let fmt: string | string[] | undefined = format
-				? dayjsISOformat(format)
-				: undefined;
+			// if no format is provided, try all of them; strict parsing
+			// requires an exact round-trip, so at most one of them can
+			// match and the order they are tried in does not matter
+			const fmt =
+				format !== undefined ? formats[format] : Object.values(formats);
 
-			// if no format is provided, try to parse any of the three ISO formats
-			fmt ??= [
-				dayjsISOformat("datetime"),
-				dayjsISOformat("date"),
-				dayjsISOformat("time")
-			];
+			// parse strictly: ISO strings are machine-generated, so anything
+			// that doesn't match exactly is corrupt and must fail loudly
+			// instead of being silently shifted to a different date
+			const dt = dayjs(string, fmt, true);
 
-			const dt = dayjs(string, fmt);
-
-			if (!dt || dt.isValid() === false) {
+			if (dt.isValid() === false) {
 				return null;
 			}
 

--- a/panel/src/libraries/dayjs-iso.ts
+++ b/panel/src/libraries/dayjs-iso.ts
@@ -33,12 +33,19 @@ const formats: Record<ISOFormat, string> = {
 	datetime: "YYYY-MM-DD HH:mm:ss"
 };
 
+/**
+ * Returns the dayjs pattern for an ISO format
+ */
+function pattern(format: ISOFormat): string {
+	return formats[format] ?? formats.datetime;
+}
+
 const plugin: PluginFunc = (option, Dayjs, dayjs) => {
 	Dayjs.prototype.toISO = function (
 		this: Dayjs,
 		format: ISOFormat = "datetime"
 	): string {
-		return this.format(formats[format]);
+		return this.format(pattern(format));
 	};
 
 	Object.assign(dayjs, {
@@ -47,7 +54,7 @@ const plugin: PluginFunc = (option, Dayjs, dayjs) => {
 			// requires an exact round-trip, so at most one of them can
 			// match and the order they are tried in does not matter
 			const fmt =
-				format !== undefined ? formats[format] : Object.values(formats);
+				format !== undefined ? pattern(format) : Object.values(formats);
 
 			// parse strictly: ISO strings are machine-generated, so anything
 			// that doesn't match exactly is corrupt and must fail loudly

--- a/src/Form/Field/DateField.php
+++ b/src/Form/Field/DateField.php
@@ -88,6 +88,16 @@ class DateField extends DateTimeField
 		$this->time     = $time;
 	}
 
+	/**
+	 * Cuts a boundary down to the precision of the field, so that it
+	 * can never carry more information than the field is able to produce.
+	 */
+	protected function boundary(string|null $boundary): string|null
+	{
+		$format = $this->time() === false ? 'Y-m-d' : static::ISO;
+		return Date::optional($boundary)?->format($format);
+	}
+
 	public function calendar(): bool
 	{
 		return $this->calendar ?? true;
@@ -114,6 +124,16 @@ class DateField extends DateTimeField
 	public function icon(): string
 	{
 		return $this->icon ?? 'calendar';
+	}
+
+	public function max(): string|null
+	{
+		return $this->boundary($this->max);
+	}
+
+	public function min(): string|null
+	{
+		return $this->boundary($this->min);
 	}
 
 	public function props(): array

--- a/src/Form/Field/DateTimeField.php
+++ b/src/Form/Field/DateTimeField.php
@@ -97,12 +97,12 @@ abstract class DateTimeField extends InputField
 
 	public function max(): string|null
 	{
-		return Date::optional($this->max);
+		return Date::optional($this->max)?->format(static::ISO);
 	}
 
 	public function min(): string|null
 	{
-		return Date::optional($this->min);
+		return Date::optional($this->min)?->format(static::ISO);
 	}
 
 	public function props(): array

--- a/tests/Form/Field/DateFieldTest.php
+++ b/tests/Form/Field/DateFieldTest.php
@@ -10,6 +10,52 @@ use PHPUnit\Framework\Attributes\DataProvider;
 #[CoversClass(DateTimeField::class)]
 class DateFieldTest extends TestCase
 {
+	public function testMax(): void
+	{
+		// a date-only field cuts it down to its own precision
+		$field = $this->field('date', [
+			'max' => '2020-10-31 08:15'
+		]);
+
+		$this->assertSame('2020-10-31', $field->max());
+
+		// with a time part, the full precision is kept
+		$field = $this->field('date', [
+			'time' => true,
+			'max'  => '2020-10-31 08:15'
+		]);
+
+		$this->assertSame('2020-10-31 08:15:00', $field->max());
+
+		// without a boundary
+		$field = $this->field('date');
+
+		$this->assertNull($field->max());
+	}
+
+	public function testMin(): void
+	{
+		// a date-only field cuts it down to its own precision
+		$field = $this->field('date', [
+			'min' => '2020-10-01 09:00'
+		]);
+
+		$this->assertSame('2020-10-01', $field->min());
+
+		// with a time part, the full precision is kept
+		$field = $this->field('date', [
+			'time' => true,
+			'min'  => '2020-10-01 09:00'
+		]);
+
+		$this->assertSame('2020-10-01 09:00:00', $field->min());
+
+		// without a boundary
+		$field = $this->field('date');
+
+		$this->assertNull($field->min());
+	}
+
 	public function testMinMax(): void
 	{
 		// empty

--- a/tests/Form/Field/TimeFieldTest.php
+++ b/tests/Form/Field/TimeFieldTest.php
@@ -27,6 +27,36 @@ class TimeFieldTest extends TestCase
 		$this->assertSame('HH:mm:ss', $field->display());
 	}
 
+	public function testMax(): void
+	{
+		// a plain ISO time without a date or timezone offset
+		$field = $this->field('time', [
+			'max' => '11:30:15'
+		]);
+
+		$this->assertSame('11:30:15', $field->max());
+
+		// without a boundary
+		$field = $this->field('time');
+
+		$this->assertNull($field->max());
+	}
+
+	public function testMin(): void
+	{
+		// a plain ISO time without a date or timezone offset
+		$field = $this->field('time', [
+			'min' => '09:00'
+		]);
+
+		$this->assertSame('09:00:00', $field->min());
+
+		// without a boundary
+		$field = $this->field('time');
+
+		$this->assertNull($field->min());
+	}
+
 	public function testMinMax(): void
 	{
 		// no value


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

`dayjs.iso()` fell back to dayjs' loose parsing. A corrupt string was silently just shifted to some other date instead of failing. It now parses strictly. 

The date field and calendar are adjusted to pass values that survive that: the date input gets `iso.date` rather than the full datetime, the calendar parses its bounds with `iso()` instead of guessing with `interpret()`, and the times dropdown stops appending a redundant ":00".

Lab example: https://sandbox.test/panel/lab/internals/library.dayjs/4_iso

### Merge first

- [x] https://github.com/getkirby/kirby/pull/8324