### PR TITLE
fix: `dayjs.round()` milliseconds handling

### DIFF
--- a/panel/lab/internals/library.dayjs/5_round/index.php
+++ b/panel/lab/internals/library.dayjs/5_round/index.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+	'source' => 'panel/src/libraries/dayjs-round.ts'
+];

--- a/panel/lab/internals/library.dayjs/5_round/index.vue
+++ b/panel/lab/internals/library.dayjs/5_round/index.vue
@@ -1,0 +1,118 @@
+<template>
+	<k-lab-examples>
+		<k-box theme="text">
+			<k-text>
+				<p>
+					Rounds a <code>dayjs</code> object to the nearest step. All sub-units
+					of the step unit are cleared. The step size has to divide the ceiling
+					of the unit evenly, e.g. <code>15</code> of 60 minutes or
+					<code>4</code> of 24 hours. Calendar units (<code>date</code>,
+					<code>month</code>, <code>year</code>) have no divisible ceiling and
+					only support a size of <code>1</code>. Anything else throws an error.
+				</p>
+
+				<p>
+					Rounding cascades stepwise from the smallest sub-unit upwards, which
+					is not always the absolutely nearest step: <code>13:45</code> rounded
+					to a 4 hour step first carries the minutes over to
+					<code>14:00</code> and then rounds up to <code>16:00</code>, instead
+					of down to the nearer <code>12:00</code>. This is intended, as it
+					keeps the behavior predictable while typing.
+				</p>
+			</k-text>
+		</k-box>
+
+		<k-lab-example label="dayjs().round()" :code="false">
+			<!-- prettier-ignore -->
+			<k-code language="javascript">myDayjsObject.round("minute", 15): dayjs</k-code>
+
+			<k-grid variant="fields">
+				<k-column width="1/2">
+					<k-label>Datetime</k-label>
+					<k-input
+						type="text"
+						placeholder="2023-09-12 13:45:32.600"
+						:value="datetime"
+						style="min-width: 12rem"
+						@input="datetime = $event"
+					/>
+				</k-column>
+				<k-column width="1/4">
+					<k-label>Unit</k-label>
+					<k-input
+						type="select"
+						:options="units"
+						:required="true"
+						:empty="false"
+						:value="unit"
+						@input="unit = $event"
+					/>
+				</k-column>
+				<k-column width="1/4">
+					<k-label>Size</k-label>
+					<k-input type="number" min="1" :value="size" @input="size = $event" />
+				</k-column>
+				<k-column>
+					<k-label>Result</k-label>
+					<k-box :theme="result.error ? 'negative' : 'code'">
+						{{ result.error ?? result.value }}
+					</k-box>
+				</k-column>
+			</k-grid>
+		</k-lab-example>
+	</k-lab-examples>
+</template>
+
+<script>
+export default {
+	data() {
+		return {
+			datetime: "2023-09-12 13:45:32.600",
+			// the milliseconds are optional, but they have to be
+			// written in full, since `SSS` does not match `.4`
+			formats: ["YYYY-MM-DD HH:mm:ss.SSS", "YYYY-MM-DD HH:mm:ss", "YYYY-MM-DD"],
+			size: 15,
+			unit: "minute",
+			units: [
+				{ text: "millisecond", value: "millisecond" },
+				{ text: "second", value: "second" },
+				{ text: "minute", value: "minute" },
+				{ text: "hour", value: "hour" },
+				{ text: "date", value: "date" },
+				{ text: "month", value: "month" },
+				{ text: "year", value: "year" }
+			]
+		};
+	},
+	computed: {
+		result() {
+			// parsed here rather than with `dayjs.iso()`, which has no
+			// millisecond format — and they are the point of this page
+			const dt = this.$library.dayjs(this.datetime, this.formats, true);
+
+			if (dt.isValid() === false) {
+				return { error: "Not a valid datetime" };
+			}
+
+			try {
+				return {
+					// milliseconds are shown, since clearing and carrying
+					// them over is part of what rounding does, and `toISO()`
+					// would hide it
+					value: dt
+						.round(this.unit, Number(this.size))
+						.format("YYYY-MM-DD HH:mm:ss.SSS")
+				};
+			} catch (error) {
+				return { error: error.message };
+			}
+		}
+	}
+};
+</script>
+
+<style>
+.k-lab-example .k-code {
+	margin-bottom: var(--spacing-6);
+}
+</style>

--- a/panel/src/libraries/dayjs-round.test.ts
+++ b/panel/src/libraries/dayjs-round.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
-import type { UnitType } from "dayjs";
+import type { UnitTypeLong } from "dayjs";
 import dayjs from "./dayjs";
 
 describe("dayjs.round()", () => {
-	const data: Record<string, [UnitType, number, string, string]> = {
+	const data: Record<string, [UnitTypeLong, number, string, string]> = {
 		"1s: no change": [
 			"second",
 			1,
@@ -64,6 +64,77 @@ describe("dayjs.round()", () => {
 		}
 	);
 
+	const milliseconds: Record<string, [UnitTypeLong, number, string, string]> = {
+		"1ms: no change": [
+			"millisecond",
+			1,
+			"2020-02-29 16:05:15.499",
+			"2020-02-29 16:05:15.499"
+		],
+		"100ms: floor": [
+			"millisecond",
+			100,
+			"2020-02-29 16:05:15.440",
+			"2020-02-29 16:05:15.400"
+		],
+		"100ms: ceil": [
+			"millisecond",
+			100,
+			"2020-02-29 16:05:15.460",
+			"2020-02-29 16:05:15.500"
+		],
+		"500ms: carry": [
+			"millisecond",
+			500,
+			"2020-02-29 16:05:15.900",
+			"2020-02-29 16:05:16.000"
+		],
+		"1s: floor ms": [
+			"second",
+			1,
+			"2020-02-29 16:05:15.499",
+			"2020-02-29 16:05:15.000"
+		],
+		"1s: ceil ms": [
+			"second",
+			1,
+			"2020-02-29 16:05:15.500",
+			"2020-02-29 16:05:16.000"
+		],
+		"1s: ceil ms carry": [
+			"second",
+			1,
+			"2020-02-29 23:59:59.900",
+			"2020-03-01 00:00:00.000"
+		],
+		"5s: ceil ms": [
+			"second",
+			5,
+			"2020-02-29 16:05:12.500",
+			"2020-02-29 16:05:15.000"
+		],
+		"1m: clear ms": [
+			"minute",
+			1,
+			"2020-02-29 16:05:15.500",
+			"2020-02-29 16:05:00.000"
+		],
+		"1D: clear ms": [
+			"day",
+			1,
+			"2020-02-29 09:05:15.500",
+			"2020-02-29 00:00:00.000"
+		]
+	};
+
+	it.each(Object.entries(milliseconds))(
+		"%s",
+		(_name, [unit, size, input, expected]) => {
+			const result = dayjs(input).round(unit, size);
+			expect(result.format("YYYY-MM-DD HH:mm:ss.SSS")).toBe(expected);
+		}
+	);
+
 	it("Unsupported unit", () => {
 		expect(() => {
 			// @ts-expect-error - testing invalid input
@@ -82,7 +153,24 @@ describe("dayjs.round()", () => {
 
 	it.each(sizes)("Unsupported size: $unit", ({ unit, size }) => {
 		expect(() => {
-			dayjs("2020-01-01").round(unit as UnitType, size);
+			dayjs("2020-01-01").round(unit as UnitTypeLong, size);
+		}).toThrow("Invalid rounding size");
+	});
+
+	const invalidSizes = [
+		{ unit: "millisecond", size: 300 },
+		{ unit: "second", size: 0 },
+		{ unit: "minute", size: -15 },
+		{ unit: "hour", size: -4 },
+		{ unit: "date", size: -1 },
+		{ unit: "minute", size: 2.5 },
+		{ unit: "hour", size: 1.5 },
+		{ unit: "year", size: Number.NaN }
+	];
+
+	it.each(invalidSizes)("Invalid size: $size $unit", ({ unit, size }) => {
+		expect(() => {
+			dayjs("2020-01-01").round(unit as UnitTypeLong, size);
 		}).toThrow("Invalid rounding size");
 	});
 

--- a/panel/src/libraries/dayjs-round.ts
+++ b/panel/src/libraries/dayjs-round.ts
@@ -1,76 +1,128 @@
-import type { Dayjs, ManipulateType, PluginFunc, UnitType } from "dayjs";
+/**
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+
+import type { Dayjs, ManipulateType, PluginFunc, UnitTypeLong } from "dayjs";
 
 declare module "dayjs" {
 	interface Dayjs {
-		round(unit: UnitType, size: number): Dayjs;
+		/**
+		 * Rounds the datetime to the nearest step of a unit,
+		 * e.g. to the nearest 15 minutes
+		 *
+		 * All sub-units of the step unit are cleared, down to the
+		 * milliseconds. Their rounding cascades stepwise, from the
+		 * smallest sub-unit upwards, which is not always the
+		 * absolutely nearest step: e.g. 13:45 rounded to a 4 hour
+		 * step first carries the minutes over to 14:00 and then
+		 * rounds up to 16:00, instead of down to the nearer 12:00.
+		 * This is intended, as it keeps the behavior predictable
+		 * while typing.
+		 *
+		 * @param unit unit to round to; `day` is read as `date`
+		 * @param size how many of the unit make up one step; has to
+		 *             divide the unit evenly (e.g. 15 of 60 minutes),
+		 *             calendar units only support 1
+		 * @throws if the unit or the step size is not supported
+		 */
+		round(unit: UnitTypeLong, size: number): Dayjs;
 	}
 }
 
+/**
+ * Units a datetime can be rounded to, from the least to the
+ * most significant one. The order is what makes a unit's
+ * sub-units the entries before it.
+ *
+ * `day` is absent on purpose: it is normalized to `date`
+ * before the list is ever consulted.
+ */
+const units: Exclude<UnitTypeLong, "day">[] = [
+	"millisecond",
+	"second",
+	"minute",
+	"hour",
+	"date",
+	"month",
+	"year"
+];
+
+/**
+ * Ceilings of the units whose step sizes have to divide
+ * evenly; date, month and year have no divisible ceiling
+ */
+const ceilings: Partial<Record<UnitTypeLong, number>> = {
+	millisecond: 1000,
+	second: 60,
+	minute: 60,
+	hour: 24
+};
+
+/**
+ * Whether the step size is supported for the step unit:
+ * for time units the size has to divide the unit's ceiling
+ * evenly (e.g. 15 of 60 minutes, 4 of 24 hours), calendar
+ * units only support single steps
+ */
+function isValidSize(unit: UnitTypeLong, size: number): boolean {
+	if (Number.isInteger(size) === false || size < 1) {
+		return false;
+	}
+
+	const ceiling = ceilings[unit];
+
+	if (ceiling === undefined) {
+		return size === 1;
+	}
+
+	return ceiling % size === 0;
+}
+
 const plugin: PluginFunc = (_option, Dayjs) => {
-	/**
-	 * Rounds the current objec
-	 * to the nearest provided unit step
-	 */
 	Dayjs.prototype.round = function (
-		unit: UnitType = "date",
+		unit: UnitTypeLong = "date",
 		size: number = 1
 	): Dayjs {
-		// Validate step unit
-		const units: UnitType[] = [
-			"second",
-			"minute",
-			"hour",
-			"date",
-			"month",
-			"year"
-		];
-
 		if (unit === "day") {
 			unit = "date";
 		}
 
+		// Validate step unit
 		if (units.includes(unit) === false) {
 			throw new Error("Invalid rounding unit");
 		}
 
 		// Validate step size
-		if (
-			(["date", "month", "year"].includes(unit) && size !== 1) ||
-			(unit === "hour" && 24 % size !== 0) ||
-			(["second", "minute"].includes(unit) && 60 % size !== 0)
-		) {
-			throw "Invalid rounding size for " + unit;
+		if (isValidSize(unit, size) === false) {
+			throw new Error("Invalid rounding size for " + unit);
 		}
 
-		// clone immutable datetime object
-		let dt = this.clone();
-
-		// set all subunits (except the direct precessor)
-		// to its start
 		const index = units.indexOf(unit);
 		const subsubunits = units.slice(0, index);
 		const subunit = subsubunits.pop();
 
-		for (const unit of subsubunits) {
-			dt = dt.startOf(unit);
-		}
+		// set all subunits (except the direct predecessor) to its start
+		let dt = subsubunits.reduce<Dayjs>(
+			(dt, subsubunit) => dt.startOf(subsubunit),
+			this
+		);
 
-		// if a direct precessor subunit exists,
+		// if a direct predecessor subunit exists,
 		// check if rounding leads to a carry over
-		if (subunit) {
-			// define ceiling for direct precessor subunit
-			const map: Partial<Record<UnitType, number>> = {
-				month: 12,
-				date: dt.daysInMonth(),
-				hour: 24,
-				minute: 60,
-				second: 60
-			};
-			const ceiling = map[subunit]!;
+		if (subunit !== undefined) {
+			// ceiling of the direct predecessor subunit; the days
+			// of the month are the only dynamic one
+			const ceiling =
+				subunit === "month"
+					? 12
+					: subunit === "date"
+						? dt.daysInMonth()
+						: ceilings[subunit];
 
-			// check if subunit was rounded up (ceiling),
-			// if so manipulate datetime object to include carry over
-			if (Math.round(dt.get(subunit) / ceiling) * ceiling === ceiling) {
+			// check if the subunit rounds up to its ceiling,
+			// if so carry it over into the step unit
+			if (ceiling !== undefined && dt.get(subunit) * 2 >= ceiling) {
 				dt = dt.add(1, (unit === "date" ? "day" : unit) as ManipulateType);
 			}
 
@@ -79,9 +131,7 @@ const plugin: PluginFunc = (_option, Dayjs) => {
 		}
 
 		// round the main step unit
-		dt = dt.set(unit, Math.round(dt.get(unit) / size) * size);
-
-		return dt;
+		return dt.set(unit, Math.round(dt.get(unit) / size) * size);
 	};
 };
 


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

`dayjs.round()` didn't know about milliseconds. They were never cleared when rounding to seconds, so the result could keep a sub-second remainder. And millisecond itself was rejected as a rounding unit. Step size validation also accepted negative and fractional sizes, which silently produced nonsense.

Lab example: https://sandbox.test/panel/lab/internals/library.dayjs/5_round
