### PR TITLE
feat: Locale support for `dayjs`

### DIFF
--- a/panel/lab/internals/library.dayjs/7_locale/index.php
+++ b/panel/lab/internals/library.dayjs/7_locale/index.php
@@ -1,0 +1,20 @@
+<?php
+
+use Kirby\Cms\App;
+use Kirby\Cms\Translation;
+
+return [
+	'source' => 'panel/src/libraries/dayjs-locale.ts',
+	'codes'  => [
+		...App::instance()->translations()->values(
+			fn (Translation $translation) => [
+				'text'  => $translation->name() . ' [' . $translation->code() . ']',
+				'value' => $translation->code()
+			]
+		),
+		[
+			'text'  => 'Unknown [xx]',
+			'value' => 'xx'
+		]
+	]
+];

--- a/panel/lab/internals/library.dayjs/7_locale/index.vue
+++ b/panel/lab/internals/library.dayjs/7_locale/index.vue
@@ -1,0 +1,103 @@
+<template>
+	<k-lab-examples>
+		<k-lab-example label="dayjs.load()" :code="false">
+			<!-- prettier-ignore -->
+			<k-code language="javascript">this.$library.dayjs.locale("{{ code }}"): string</k-code>
+
+			<k-grid variant="fields">
+				<k-column width="1/2">
+					<k-label>Kirby translation code</k-label>
+					<k-input
+						type="select"
+						:options="codes"
+						:required="true"
+						:value="code"
+						@input="load($event)"
+					/>
+				</k-column>
+				<k-column width="1/2">
+					<k-label>Activated dayjs locale</k-label>
+					<k-box theme="code">{{ locale }}</k-box>
+				</k-column>
+			</k-grid>
+		</k-lab-example>
+
+		<k-lab-example label="Parsing" :code="false">
+			<!-- prettier-ignore -->
+			<k-code language="javascript">this.$library.dayjs.parse(input, { pattern: "{{ pattern }}" }): dayjs|null</k-code>
+
+			<k-grid variant="fields">
+				<k-column width="1/2">
+					<k-label>Input</k-label>
+					<k-input
+						type="text"
+						:value="input"
+						placeholder="Type date …"
+						style="min-width: 12rem"
+						@input="input = $event"
+					/>
+				</k-column>
+				<k-column width="1/2">
+					<k-label>Result</k-label>
+					<k-box theme="code">{{ parsed ?? "null" }}</k-box>
+				</k-column>
+			</k-grid>
+		</k-lab-example>
+
+		<k-lab-example label="Formatting" :code="false">
+			<!-- prettier-ignore -->
+			<k-code language="javascript">this.$library.dayjs.pattern("{{ pattern }}").format(parsed): string|null</k-code>
+
+			<k-box theme="code">{{ formatted ?? "null" }}</k-box>
+		</k-lab-example>
+	</k-lab-examples>
+</template>
+
+<script>
+export default {
+	props: {
+		codes: Array
+	},
+	data() {
+		return {
+			code: this.$panel.translation.code,
+			formatted: null,
+			input: "",
+			locale: null,
+			parsed: null,
+			pattern: "D MMMM YYYY"
+		};
+	},
+	watch: {
+		input() {
+			this.update();
+		}
+	},
+	created() {
+		this.load(this.code);
+	},
+	methods: {
+		load(code) {
+			this.code = code;
+			this.locale = this.$library.dayjs.locale(code);
+			this.update();
+		},
+		update() {
+			const dayjs = this.$library.dayjs;
+			const dt = dayjs.parse(this.input, { pattern: this.pattern });
+
+			this.parsed = dt?.toISO("date") ?? null;
+
+			this.formatted = dayjs
+				.pattern(this.pattern)
+				.format(this.input === "" ? dayjs() : dt);
+		}
+	}
+};
+</script>
+
+<style>
+.k-lab-example .k-code {
+	margin-bottom: var(--spacing-6);
+}
+</style>

--- a/panel/src/components/Forms/Input/CalendarInput.vue
+++ b/panel/src/components/Forms/Input/CalendarInput.vue
@@ -34,7 +34,7 @@
 			<thead>
 				<tr>
 					<th v-for="day in weekdays" :key="'weekday_' + day">
-						{{ $t("days." + day) }}
+						{{ day }}
 					</th>
 				</tr>
 			</thead>
@@ -94,8 +94,6 @@
 import { props as InputProps } from "@/mixins/input.js";
 import { IsoDateProps } from "./DateInput.vue";
 
-const days = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
-
 /**
  * The Calendar component is mainly used for our `DateInput` component,
  * but it could be used as stand-alone calendar as well with a little CSS love.
@@ -136,16 +134,21 @@ export default {
 		 * @returns {number}
 		 */
 		firstWeekday() {
-			const day = days[this.toDate().day()];
-			return this.weekdays.indexOf(day);
+			const first = this.$panel.translation.weekday;
+			return (this.toDate().day() - first + 7) % 7;
 		},
 		/**
-		 * Ordered weekday names abbreviations
+		 * Localized weekday abbreviations in the order they are
+		 * displayed in, starting with the first weekday of the
+		 * translation.
 		 * @returns {array}
 		 */
 		weekdays() {
 			const first = this.$panel.translation.weekday;
-			return [...days.slice(first), ...days.slice(0, first)];
+
+			return [...Array(7).keys()].map((day) =>
+				this.today.day((first + day) % 7).format("ddd")
+			);
 		},
 		/**
 		 * Weeks in the currently viewed month
@@ -157,24 +160,13 @@ export default {
 			return Math.ceil((this.numberOfDays + this.firstWeekday) / 7);
 		},
 		/**
-		 * Translated month names
+		 * Localized month names
 		 * @returns {array}
 		 */
 		monthnames() {
-			return [
-				"january",
-				"february",
-				"march",
-				"april",
-				"may",
-				"june",
-				"july",
-				"august",
-				"september",
-				"october",
-				"november",
-				"december"
-			].map((day) => this.$t("months." + day));
+			return [...Array(12).keys()].map((month) =>
+				this.toDate(1, month).format("MMMM")
+			);
 		},
 		/**
 		 * Select options for all months

--- a/panel/src/libraries/dayjs-locale.test.ts
+++ b/panel/src/libraries/dayjs-locale.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it } from "vitest";
+import dayjs from "./dayjs";
+import { toName } from "./dayjs-locale";
+
+afterEach(() => {
+	dayjs.locale("en");
+});
+
+describe("dayjs.locale()", () => {
+	it("builds and activates a locale", () => {
+		expect(dayjs.locale("de")).toStrictEqual("de");
+		expect(dayjs.locale()).toStrictEqual("de");
+		expect(dayjs.Ls.de).toBeDefined();
+		expect(dayjs("2024-03-01").format("MMMM")).toStrictEqual("März");
+	});
+
+	it("maps a Kirby code with a region to a locale", () => {
+		expect(dayjs.locale("pt_BR")).toStrictEqual("pt-br");
+		expect(dayjs.locale()).toStrictEqual("pt-br");
+	});
+
+	it("keeps a region the browser has data for", () => {
+		expect(dayjs.locale("es_419")).toStrictEqual("es-419");
+		expect(dayjs.locale("is_IS")).toStrictEqual("is-is");
+	});
+
+	it("keeps the script of a Kirby code", () => {
+		expect(dayjs.locale("sr@latin")).toStrictEqual("sr-latn");
+		expect(dayjs("2024-06-01").format("MMMM")).toStrictEqual("jun");
+	});
+
+	it("stays on English for an unknown language", () => {
+		expect(dayjs.locale("xx")).toStrictEqual("en");
+		expect(dayjs.locale()).toStrictEqual("en");
+	});
+
+	it("reads the active locale without a code", () => {
+		dayjs.locale("de");
+		expect(dayjs.locale()).toStrictEqual("de");
+		expect(dayjs.locale(undefined)).toStrictEqual("de");
+		expect(dayjs.locale("")).toStrictEqual("de");
+	});
+
+	it("still registers a locale object by hand", () => {
+		dayjs.locale("test", { name: "test", months: Array(12).fill("Test") });
+		expect(dayjs.locale()).toStrictEqual("test");
+		expect(dayjs("2024-06-01").format("MMMM")).toStrictEqual("Test");
+	});
+
+	it("localizes formatting", () => {
+		dayjs.locale("de");
+		expect(dayjs("2024-06-01").format("MMMM")).toStrictEqual("Juni");
+	});
+
+	it("keeps a CJK month name in one piece", () => {
+		dayjs.locale("ja");
+		expect(dayjs("2024-06-01").format("MMMM")).toStrictEqual("6月");
+	});
+
+	it("formats Persian in the Gregorian calendar", () => {
+		dayjs.locale("fa");
+		expect(dayjs("2024-01-01").format("MMMM")).toStrictEqual("ژانویهٔ");
+		expect(dayjs("2024-01-01").format("D")).toStrictEqual("1");
+	});
+
+	it("localizes the day period", () => {
+		dayjs.locale("ja");
+		expect(dayjs("2024-06-01 15:00").format("A")).toStrictEqual("午後");
+	});
+
+	it("maps every weekday width", () => {
+		dayjs.locale("en");
+
+		const dt = dayjs("2024-06-03");
+
+		expect(dt.format("dd")).toStrictEqual("M");
+		expect(dt.format("ddd")).toStrictEqual("Mon");
+		expect(dt.format("dddd")).toStrictEqual("Monday");
+	});
+});
+
+describe("dayjs.locale() with a declining language", () => {
+	it("declines the month name next to a day", () => {
+		dayjs.locale("ru");
+		expect(dayjs("2024-01-01").format("MMMM")).toStrictEqual("январь");
+		expect(dayjs("2024-01-01").format("D MMMM YYYY")).toStrictEqual(
+			"1 января 2024"
+		);
+	});
+
+	it("declines the month name for Greek", () => {
+		dayjs.locale("el");
+		expect(dayjs("2024-01-01").format("MMMM")).toStrictEqual("Ιανουάριος");
+		expect(dayjs("2024-01-01").format("D MMMM YYYY")).toStrictEqual(
+			"1 Ιανουαρίου 2024"
+		);
+	});
+
+	it("declines the month name for Czech", () => {
+		dayjs.locale("cs");
+		expect(dayjs("2024-01-01").format("MMMM")).toStrictEqual("leden");
+		expect(dayjs("2024-01-01").format("D. MMMM YYYY")).toStrictEqual(
+			"1. ledna 2024"
+		);
+	});
+});
+
+describe("dayjs.locale.toName()", () => {
+	const cases: [unknown, string][] = [
+		["de", "de"],
+		["en", "en"],
+		["pt_BR", "pt-BR"],
+		["pt_PT", "pt-PT"],
+		["es_419", "es-419"],
+		["es_ES", "es-ES"],
+		["is_IS", "is-IS"],
+		["sv_SE", "sv-SE"],
+		["sr@latin", "sr-Latn"],
+		["zh_TW", "zh-TW"],
+		["DE", "de"],
+		["de_XX", "de"],
+		["xx", "en"],
+		["", "en"],
+		[null, "en"],
+		[42, "en"]
+	];
+
+	for (const [code, expected] of cases) {
+		it(`maps ${JSON.stringify(code)} to ${expected}`, () => {
+			expect(toName(code as string)).toStrictEqual(expected);
+		});
+	}
+});

--- a/panel/src/libraries/dayjs-locale.ts
+++ b/panel/src/libraries/dayjs-locale.ts
@@ -1,0 +1,226 @@
+/**
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+
+import type { Dayjs, PluginFunc } from "dayjs";
+
+export type Meridiem = (
+	hour: number,
+	minute: number,
+	isLowercase: boolean
+) => string;
+
+export interface Months {
+	(dt: Dayjs, pattern: string): string;
+	f: string[];
+	s: string[];
+}
+
+export interface Locale {
+	meridiem?: Meridiem;
+	months?: Months | string[];
+	monthsShort?: Months | string[];
+	name: string;
+	ordinal?: (n: number) => number | string;
+	weekdays?: string[];
+	weekdaysMin?: string[];
+	weekdaysShort?: string[];
+}
+
+/**
+ * Matching strings that ask for the declined month name
+ */
+const declined = /D[oD]?(\[[^[\]]*\]|[^A-Za-z])+MMMM?/;
+
+/**
+ * Kirby appends the alphabet a language is written in with an
+ * `@`, e.g. `sr@latin`, where the browser expects it as part of
+ * the name instead: `sr-Latn`.
+ */
+const scripts: Record<string, string> = {
+	cyrillic: "-Cyrl",
+	latin: "-Latn"
+};
+
+function formatter(
+	name: string,
+	options: Intl.DateTimeFormatOptions
+): Intl.DateTimeFormat {
+	return new Intl.DateTimeFormat(name, {
+		// Options are pinned: `fa` would otherwise format
+		// in the Persian calendar and in Persian digits
+		calendar: "gregory",
+		numberingSystem: "latn",
+		...options
+	});
+}
+
+function locale(name: string): Locale {
+	return {
+		meridiem: meridiem(name),
+		months: months(name, "long"),
+		monthsShort: months(name, "short"),
+		name: name.toLowerCase(),
+		weekdays: weekdays(name, "long"),
+		weekdaysMin: weekdays(name, "narrow"),
+		weekdaysShort: weekdays(name, "short")
+	};
+}
+
+/**
+ * Returns day periods of a locale, e.g. `午前`/`午後` for `ja`
+ */
+function meridiem(name: string): Meridiem {
+	const format = formatter(name, { hour: "numeric", hour12: true });
+	const periods = [0, 12].map(
+		(hour) => part(format, new Date(2000, 0, 1, hour), "dayPeriod") ?? ""
+	);
+
+	function period(hour: number, minute: number, isLowercase: boolean): string {
+		const value = periods[hour < 12 ? 0 : 1];
+		return isLowercase === true ? value.toLowerCase() : value;
+	}
+
+	return period;
+}
+
+/**
+ * Returns twelve month names of a locale, as the callable dayjs
+ * expects for declining languages: it answers with the form a
+ * format string asks for, keeping the standalone names on `.s`
+ * and the ones a full date uses on `.f`
+ */
+function months(name: string, width: "long" | "short"): Months {
+	// CJK writes a month as a numeral plus a suffix, which
+	// `formatToParts()` splits in two. Asking for the month on
+	// its own keeps `1月` in one piece.
+	const alone = formatter(name, { month: width });
+
+	function read(inDate: boolean): string[] {
+		const format = formatter(name, {
+			day: inDate === true ? "numeric" : undefined,
+			month: width,
+			year: "numeric"
+		});
+
+		return [...Array(12).keys()].map((month) => {
+			const date = new Date(2000, month, 1);
+			const value = part(format, date, "month");
+
+			return value === undefined || /^\d+$/.test(value) === true
+				? alone.format(date)
+				: value;
+		});
+	}
+
+	const s = read(false);
+
+	// Catalan prepends a preposition inside a full date
+	// (`de gener`), which is not part of the month name.
+	// A declined form never merely prepends to the nominative.
+	const f = read(true).map((month, index) =>
+		month.endsWith(s[index]) === true ? s[index] : month
+	);
+
+	function pick(dt: Dayjs, pattern: string): string {
+		return declined.test(pattern) === true ? f[dt.month()] : s[dt.month()];
+	}
+
+	pick.s = s;
+	pick.f = f;
+
+	return pick;
+}
+
+function part(
+	format: Intl.DateTimeFormat,
+	date: Date,
+	type: string
+): string | undefined {
+	return format.formatToParts(date).find((entry) => entry.type === type)?.value;
+}
+
+/**
+ * Matches a Kirby translation code with a locale name the
+ * browser has data for, e.g. `pt_BR` to `pt-BR`
+ * or `sr@latin` to `sr-Latn`.
+ */
+export function toName(code: string): string {
+	if (typeof code !== "string") {
+		return "en";
+	}
+
+	const name = code
+		.replace(/@(\w+)$/, (match, script) => scripts[script.toLowerCase()] ?? "")
+		.replace(/_/g, "-");
+
+	// full name first, then base language
+	for (const candidate of [name, name.split("-")[0]]) {
+		try {
+			if (Intl.DateTimeFormat.supportedLocalesOf(candidate).length > 0) {
+				return new Intl.DateTimeFormat(candidate).resolvedOptions().locale;
+			}
+		} catch {
+			continue;
+		}
+	}
+
+	return "en";
+}
+
+/**
+ * Returns seven weekday names of a locale
+ */
+function weekdays(name: string, width: "long" | "short" | "narrow"): string[] {
+	const format = formatter(name, { weekday: width });
+
+	// January 2, 2000 was a Sunday
+	return [...Array(7).keys()].map((day) =>
+		format.format(new Date(2000, 0, 2 + day))
+	);
+}
+
+declare module "dayjs" {
+	/**
+	 * Activates a locale by Kirby translation code, e.g. `pt_BR`
+	 */
+	function locale(code: string): string;
+}
+
+const plugin: PluginFunc = (option, Dayjs, dayjs) => {
+	const parent = dayjs.locale;
+
+	function has(name: string): boolean {
+		return dayjs.Ls[name.toLowerCase()] !== undefined;
+	}
+
+	function register(name: string, data: Partial<Locale>): void {
+		parent(name, data as unknown as Partial<ILocale>, true);
+	}
+
+	function activate(
+		preset?: string | ILocale,
+		object?: Partial<ILocale>,
+		isLocal?: boolean
+	): string {
+		// reading active locale or registering by hand stays untouched
+		if (typeof preset !== "string" || preset === "" || object) {
+			return parent(preset, object, isLocal);
+		}
+
+		const name = has(preset) === true ? preset : toName(preset);
+
+		if (has(name) === false) {
+			register(name, locale(name));
+		}
+
+		return parent(name, undefined, isLocal);
+	}
+
+	Object.assign(dayjs, { locale: activate });
+
+	register("en", { ...dayjs.Ls.en, ...locale("en") });
+};
+
+export default plugin;

--- a/panel/src/libraries/dayjs-parse.test.ts
+++ b/panel/src/libraries/dayjs-parse.test.ts
@@ -34,6 +34,11 @@ function locale(name: string, data: Record<string, unknown>): void {
 	dayjs.locale(name);
 }
 
+function toMeridiem(token: string): number | null {
+	const dt = dayjs.parse("6 " + token, { pattern: "h a", strict: true });
+	return dt === null ? null : dt.hour();
+}
+
 function toMonth(token: string): number | null {
 	const dt = dayjs.parse(token, { pattern: "MMMM", strict: true });
 	return dt === null ? null : dt.month() + 1;
@@ -406,7 +411,8 @@ describe("dayjs.parse() with strict", () => {
 			["h:mm a", "5:12 pm", "17:12:00"],
 			["h:mm a", "12:00 am", "00:00:00"],
 			["h:mm a", "12:00 pm", "12:00:00"],
-			// only a/am and p/pm are a meridiem
+			// what counts as a meridiem is up to the locale,
+			// english knows a/am and p/pm
 			["h:mm a", "5:12 xx", null],
 			["h:mm a", "5:12 4", null],
 			// hours are limited to 1-12 with a meridiem
@@ -421,7 +427,7 @@ describe("dayjs.parse() with strict", () => {
 	});
 });
 
-describe("month names", () => {
+describe("dayjs.parse() with month names", () => {
 	afterEach(() => {
 		dayjs.locale("en");
 	});
@@ -473,6 +479,56 @@ describe("month names", () => {
 		});
 	});
 
+	describe("localized", () => {
+		const data: [string, string, number][] = [
+			["de", "März", 3],
+			["de", "Dezember", 12],
+			["de", "Sept.", 9],
+			["de", "Okt.", 10],
+			["de", "Okt", 10],
+			["fr", "février", 2],
+			["fr", "Février", 2],
+			["el", "Ιούνιος", 6]
+		];
+
+		it.each(data)("%s: %s", (code, token, month) => {
+			dayjs.locale(code);
+			expect(toMonth(token)).toBe(month);
+		});
+	});
+
+	describe("declined names", () => {
+		// these locales provide their month names as a function
+		// carrying the nominative forms on `s` and the forms used
+		// next to a day number on `f`; either may be typed
+		const data: [string, string, string, number][] = [
+			["uk", "червень", "червня", 6],
+			["ru", "июнь", "июня", 6],
+			["pl", "czerwiec", "czerwca", 6],
+			["lt", "birželis", "birželio", 6]
+		];
+
+		it.each(data)("%s: %s and %s", (code, nominative, declined, month) => {
+			dayjs.locale(code);
+			expect(toMonth(nominative)).toBe(month);
+			expect(toMonth(declined)).toBe(month);
+		});
+	});
+
+	describe("guessed", () => {
+		const data: [string, string, string | null][] = [
+			["uk", "23 червень 2024", "2024-06-23"],
+			["uk", "23 червня 2024", "2024-06-23"],
+			["de", "2. März 2024", "2024-03-02"],
+			["de", "2. Fooo 2024", null]
+		];
+
+		it.each(data)("%s: %s", (code, input, expected) => {
+			dayjs.locale(code);
+			expect(parse(input)?.toISO("date") ?? null).toBe(expected);
+		});
+	});
+
 	describe("casing", () => {
 		// dayjs matches `MMM` and `MMMM` case-sensitively,
 		// `parse()` must not: the names come from user input
@@ -510,11 +566,14 @@ describe("month names", () => {
 	});
 
 	describe("locale precedence", () => {
+		it("falls back to english", () => {
+			dayjs.locale("de");
+			expect(toMonth("Mar")).toBe(3);
+			expect(toMonth("March")).toBe(3);
+		});
+
 		it("prefers the active locale over english", () => {
 			locale("precedence", { months: [...nato.slice(1), "January"] });
-
-			// the active locale reads `January` as the twelfth month,
-			// which has to win over the english first month
 			expect(toMonth("January")).toBe(12);
 		});
 	});
@@ -579,5 +638,176 @@ describe("month names", () => {
 
 			expect(toMonth("Same")).toBe(1);
 		});
+	});
+});
+
+describe("dayjs.parse() with day periods", () => {
+	afterEach(() => {
+		dayjs.locale("en");
+	});
+
+	describe("english", () => {
+		const data: [string, number][] = [
+			["a", 6],
+			["A", 6],
+			["am", 6],
+			["AM", 6],
+			["p", 18],
+			["P", 18],
+			["pm", 18],
+			["PM", 18]
+		];
+
+		it.each(data)("%s", (token, hour) => {
+			expect(toMeridiem(token)).toBe(hour);
+		});
+	});
+
+	describe("localized", () => {
+		const codes = [
+			"cs",
+			"el",
+			"es_ES",
+			"is_IS",
+			"ja",
+			"ko",
+			"lt",
+			"nb",
+			"sv_SE",
+			"tr",
+			"uk",
+			"zh_TW"
+		];
+
+		it.each(codes)("%s", (code) => {
+			dayjs.locale(code);
+
+			expect(toMeridiem(dayjs("2024-06-23 09:00").format("A"))).toBe(6);
+			expect(toMeridiem(dayjs("2024-06-23 15:00").format("A"))).toBe(18);
+		});
+
+		it("reads them in any case", () => {
+			dayjs.locale("tr");
+
+			const pm = dayjs("2024-06-23 15:00").format("A");
+
+			expect(toMeridiem(pm.toLowerCase())).toBe(18);
+			expect(toMeridiem(pm.toUpperCase())).toBe(18);
+		});
+	});
+
+	describe("multiple tokens", () => {
+		it("joins a day period written with separators", () => {
+			locale("separated", {
+				meridiem: (hour: number) => (hour < 12 ? "v.m." : "n.m.")
+			});
+
+			expect(toMeridiem("v.m.")).toBe(6);
+			expect(toMeridiem("n.m.")).toBe(18);
+		});
+
+		it("joins them for english as well", () => {
+			expect(toMeridiem("a. m.")).toBe(6);
+			expect(toMeridiem("p. m.")).toBe(18);
+		});
+
+		it("only joins tokens into a meridiem", () => {
+			// without a meridiem to absorb them the extra tokens
+			// stay extra, so the count never matches the pattern
+			expect(dayjs.parse("5 12 30", { pattern: "HH:mm", strict: true })).toBe(
+				null
+			);
+		});
+	});
+
+	describe("locale precedence", () => {
+		it("keeps reading english in another locale", () => {
+			dayjs.locale("ja");
+
+			expect(toMeridiem("午後")).toBe(18);
+			expect(toMeridiem("pm")).toBe(18);
+		});
+	});
+
+	describe("invalid input", () => {
+		const tokens = ["", "xx", "4", "-", "午"];
+
+		it.each(tokens)("returns null for %s", (token) => {
+			expect(toMeridiem(token)).toBe(null);
+		});
+	});
+
+	describe("locale data", () => {
+		it("falls back to english without day periods", () => {
+			locale("noperiods", { months: nato });
+
+			expect(toMeridiem("pm")).toBe(18);
+			expect(toMeridiem("午後")).toBe(null);
+		});
+	});
+});
+
+describe("dayjs.parse() in every locale", () => {
+	const codes = [
+		"bg",
+		"bs",
+		"ca",
+		"cs",
+		"da",
+		"de",
+		"el",
+		"en",
+		"eo",
+		"es_419",
+		"es_ES",
+		"fa",
+		"fi",
+		"fr",
+		"hu",
+		"id",
+		"is_IS",
+		"it",
+		"ja",
+		"ko",
+		"lt",
+		"nb",
+		"nl",
+		"pl",
+		"pt_BR",
+		"pt_PT",
+		"ro",
+		"ru",
+		"sk",
+		"sr@latin",
+		"sv_SE",
+		"tr",
+		"uk",
+		"zh_TW"
+	];
+
+	afterAll(() => {
+		dayjs.locale("en");
+	});
+
+	it.each(codes)("%s", (code) => {
+		dayjs.locale(code);
+
+		const dt = dayjs("2024-06-23 15:30");
+
+		for (const [pattern, unit, expected] of [
+			["D. MMMM YYYY", "date", "2024-06-23"],
+			["D. MMM YYYY", "date", "2024-06-23"],
+			// the day period is written in every imaginable
+			// way, e.g. `odp.`, `μ.μ.`, `午後` or `ös`
+			["hh:mm a", "time", "15:30:00"],
+			["hh:mm A", "time", "15:30:00"]
+		] as [string, "date" | "time", string][]) {
+			const text = dayjs.pattern(pattern).format(dt) as string;
+			const parsed = dayjs.parse(text, { pattern, strict: true });
+
+			expect(parsed?.toISO(unit), `${pattern} (${text})`).toStrictEqual(
+				expected
+			);
+		}
 	});
 });

--- a/panel/src/libraries/dayjs-parse.ts
+++ b/panel/src/libraries/dayjs-parse.ts
@@ -5,6 +5,7 @@
 
 import type { Dayjs, PluginFunc } from "dayjs";
 import type { DatetimeType, DayjsFactory } from "./dayjs";
+import type { Locale } from "./dayjs-locale";
 import {
 	DayjsPattern,
 	type PatternPart,
@@ -114,6 +115,31 @@ function candidates(type: DatetimeType, target: PatternUnit[]): DayjsPattern[] {
 }
 
 /**
+ * Joins the tokens a day period was split into, so that the
+ * spaces and dots many locales do not count as
+ * separators, e.g. turn `p. m.` back into a single token
+ */
+function collapse(tokens: string[], parts: PatternPart[]): string[] {
+	const excess = tokens.length - parts.length;
+
+	if (excess <= 0) {
+		return tokens;
+	}
+
+	const index = parts.findIndex((part) => part.unit === "meridiem");
+
+	if (index === -1) {
+		return tokens;
+	}
+
+	return [
+		...tokens.slice(0, index),
+		tokens.slice(index, index + excess + 1).join(""),
+		...tokens.slice(index + excess + 1)
+	];
+}
+
+/**
  * Splits digit runs that were typed without any separator at all,
  * e.g. `02032024` for a `DD.MM.YYYY` source pattern
  */
@@ -169,7 +195,13 @@ function match(
 ): Dayjs | null {
 	const parts = pattern.parts;
 
-	tokens = expand(tokens, parts);
+	// a token count that misses the pattern is not wrong yet:
+	// too few means digits were typed without any separator,
+	// too many that a day period carries spaces or dots
+	tokens =
+		tokens.length < parts.length
+			? expand(tokens, parts)
+			: collapse(tokens, parts);
 
 	// only complete input matches,
 	// partial input is the job of the guess
@@ -189,12 +221,11 @@ function match(
 /**
  * All month names of a locale
  */
-function months(data?: ILocale): string[] {
-	const [full, short] = [data?.months, data?.monthsShort].map(
-		(names?: string[] | { f?: string[]; s?: string[] }) =>
-			Array.isArray(names) === true
-				? names
-				: [...(names?.s ?? []), ...(names?.f ?? [])]
+function months(data?: Locale): string[] {
+	const [full, short] = [data?.months, data?.monthsShort].map((names) =>
+		Array.isArray(names) === true
+			? names
+			: [...(names?.s ?? []), ...(names?.f ?? [])]
 	);
 
 	if (full.length === 0) {
@@ -215,7 +246,7 @@ function months(data?: ILocale): string[] {
  * dot (`Okt.`, `Sept.`) still match a dot-less input token
  */
 function normalize(value: string): string {
-	return value.toLowerCase().replace(separators, "");
+	return value.normalize("NFC").toLowerCase().replace(separators, "");
 }
 
 /**
@@ -268,6 +299,38 @@ function toDatetime(
 	}
 
 	return dt;
+}
+
+/**
+ * Resolves a day period to `0` (am) or `1` (pm)
+ */
+function toMeridiem(dayjs: DayjsFactory, token: string): number | null {
+	const needle = normalize(token);
+	const locale = dayjs.Ls[dayjs.locale()] as Locale;
+	const meridiem = locale?.meridiem;
+
+	if (typeof meridiem === "function") {
+		for (const index of [0, 1]) {
+			const periods = [
+				meridiem(index * 12, 0, true),
+				meridiem(index * 12, 0, false)
+			];
+
+			if (periods.some((period) => normalize(period) === needle) === true) {
+				return index;
+			}
+		}
+	}
+
+	if (/^(a|am)$/.test(needle) === true) {
+		return 0;
+	}
+
+	if (/^(p|pm)$/.test(needle) === true) {
+		return 1;
+	}
+
+	return null;
 }
 
 /**
@@ -364,15 +427,7 @@ function toValue(
 		case "second":
 			return toNumber(token, 0, 59);
 		case "meridiem":
-			if (/^(a|am)$/i.test(token) === true) {
-				return 0;
-			}
-
-			if (/^(p|pm)$/i.test(token) === true) {
-				return 1;
-			}
-
-			return null;
+			return toMeridiem(dayjs, token);
 	}
 }
 

--- a/panel/src/libraries/dayjs.ts
+++ b/panel/src/libraries/dayjs.ts
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import iso from "./dayjs-iso";
+import locale from "./dayjs-locale";
 import parse from "./dayjs-parse";
 import pattern from "./dayjs-pattern";
 import round from "./dayjs-round";
@@ -9,6 +10,7 @@ export type DayjsFactory = typeof dayjs;
 export type DatetimeType = "date" | "time" | "datetime";
 
 dayjs.extend(iso);
+dayjs.extend(locale);
 dayjs.extend(parse);
 dayjs.extend(pattern);
 dayjs.extend(round);

--- a/panel/src/panel/translation.test.ts
+++ b/panel/src/panel/translation.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import dayjs from "@/libraries/dayjs";
 import Translation from "./translation";
 
 describe("panel.translation", () => {
+	afterEach(() => {
+		dayjs.locale("en");
+	});
+
 	describe("reset()", () => {
 		it("restores all default values", () => {
 			const translation = Translation();
@@ -40,6 +45,23 @@ describe("panel.translation", () => {
 
 			translation.set({ code: "ar", direction: "rtl" });
 			expect(document.body.dir).toStrictEqual("rtl");
+		});
+
+		it("activates the dayjs locale of the new translation", () => {
+			const translation = Translation();
+
+			translation.set({ code: "de" });
+
+			expect(dayjs.locale()).toStrictEqual("de");
+		});
+
+		it("falls back to English without a code", () => {
+			const translation = Translation();
+
+			translation.set({ code: "de" });
+			translation.set({ code: null });
+
+			expect(dayjs.locale()).toStrictEqual("en");
 		});
 	});
 

--- a/panel/src/panel/translation.ts
+++ b/panel/src/panel/translation.ts
@@ -1,4 +1,5 @@
 import { reactive } from "vue";
+import dayjs from "@/libraries/dayjs";
 import { StringTemplateValues, template } from "@/helpers/string";
 import State from "./state";
 
@@ -79,6 +80,7 @@ export default function Translation() {
 		 * reading direction so the DOM reflects the active translation.
 		 * Direction is also set on <body> since some elements (e.g. drag
 		 * ghosts) are injected outside the Panel root.
+		 * The matching dayjs locale is activated as well.
 		 */
 		set(state: Partial<TranslationState>): TranslationState {
 			parent.set.call(this, state);
@@ -88,6 +90,8 @@ export default function Translation() {
 			}
 
 			document.body.dir = this.direction;
+
+			dayjs.locale(this.code ?? "en");
 
 			return this.state();
 		},


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

I started out with finally using dayjs locales support via chunking all locale files and lazy loading it. Worked quite well.

But then over some experiments, I realized that we can also get all that locale data from `Intl.DateTimeFormat` with not even that many lines of codes. And that felt a lot better than hard-coded matched chunks for 20-30 languages, and having all those files also in the Panel dist.

### Merge first

- [x] https://github.com/getkirby/kirby/pull/8328


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### ✨ Enhancements
<!-- 
e.g. Improve a11y of feature X
-->
- `$library.dayjs()` now follows the locale of the current Panel UI language

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Lab examples
  - https://sandbox.test/panel/lab/internals/library.dayjs/7_locale
- [x] Add changes & docs to release notes draft in Notion