### PR TITLE
a11y: eslint rule for Vue files

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -681,6 +681,8 @@
 	"preview.browser.pin": "Toggle whether preview navigation should be in sync or independent",
 	"preview.browser.scroll": "Sync scroll",
 
+	"progress": "Progress",
+
 	"publish": "Publish",
 	"published": "Published",
 
@@ -848,6 +850,7 @@
 	"version.form": "Live editor",
 	"version.latest": "Latest version",
 	"versionInformation": "Version information",
+	"video": "Video",
 
 	"view": "View",
 	"view.account": "Your account",

--- a/panel/eslint.config.js
+++ b/panel/eslint.config.js
@@ -1,4 +1,5 @@
 import globals from "globals";
+import a11y from "eslint-plugin-vuejs-accessibility";
 import js from "@eslint/js";
 import prettier from "eslint-config-prettier";
 import vitest from "@vitest/eslint-plugin";
@@ -12,6 +13,25 @@ export default [
 		files: ["**/*.ts"]
 	})),
 	...vue.configs["flat/recommended"],
+	...a11y.configs["flat/recommended"],
+
+	{
+		files: ["**/*.vue"],
+		rules: {
+			//`:autofocus="autofocus"` not understood by static rule
+			"vuejs-accessibility/no-autofocus": "off",
+
+			// Panel previews uploaded files: there is no caption
+			// track it can currently provide for them
+			"vuejs-accessibility/media-has-caption": "off",
+
+			// TODO:
+			"vuejs-accessibility/click-events-have-key-events": "off",
+			"vuejs-accessibility/label-has-for": "off",
+			"vuejs-accessibility/mouse-events-have-key-events": "off",
+			"vuejs-accessibility/no-static-element-interactions": "off"
+		}
+	},
 
 	// Vitest rules for test files
 	{

--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -30,6 +30,7 @@
 				"eslint": "^10.7.0",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-vue": "^10.9.2",
+				"eslint-plugin-vuejs-accessibility": "^2.5.0",
 				"glob": "^13.0.6",
 				"globals": "^17.7.0",
 				"happy-dom": "^20.10.6",
@@ -1434,6 +1435,16 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/aria-query": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -2069,6 +2080,24 @@
 				"@typescript-eslint/parser": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/eslint-plugin-vuejs-accessibility": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.5.0.tgz",
+			"integrity": "sha512-oZ2fL4tS91Cm/ezH3BueNP+FtpbbeS627OSqqgp9/lsN//glmoPcLBT6D53xwGocLtyBybaT99tX4ThBh8+ytA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"aria-query": "^5.3.0",
+				"vue-eslint-parser": "^9.0.0 || ^10.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+				"globals": ">= 13.12.1"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -4899,7 +4928,6 @@
 			"integrity": "sha512-Gk6gRDj0n/fkRa3C3l0bBheoBckUq/Rs0F/TvMWIS6nzzx67amAViMe9CkNgsP2tXyQONvGiHQESHwFtZ3aYDA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"debug": "^4.4.0",
 				"eslint-scope": "^8.2.0 || ^9.0.0",
@@ -4924,7 +4952,6 @@
 			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},

--- a/panel/package.json
+++ b/panel/package.json
@@ -40,6 +40,7 @@
 		"eslint": "^10.7.0",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-vue": "^10.9.2",
+		"eslint-plugin-vuejs-accessibility": "^2.5.0",
 		"glob": "^13.0.6",
 		"globals": "^17.7.0",
 		"happy-dom": "^20.10.6",

--- a/panel/src/components/Forms/Field/ObjectField.vue
+++ b/panel/src/components/Forms/Field/ObjectField.vue
@@ -59,7 +59,9 @@
 			type="checkbox"
 			:checked="!isEmpty"
 			:required="required"
+			aria-hidden="true"
 			class="input-hidden"
+			tabindex="-1"
 		/>
 	</k-field>
 </template>

--- a/panel/src/components/Forms/Input/ColorpickerInput.vue
+++ b/panel/src/components/Forms/Input/ColorpickerInput.vue
@@ -46,6 +46,7 @@
 			:name="name"
 			:required="required"
 			:value="formatted"
+			aria-hidden="true"
 			class="input-hidden"
 			tabindex="-1"
 			type="text"

--- a/panel/src/components/Forms/Input/CoordsInput.vue
+++ b/panel/src/components/Forms/Input/CoordsInput.vue
@@ -25,6 +25,7 @@
 			:name="name"
 			:required="required"
 			:value="value ? [value.x, value.y] : null"
+			aria-hidden="true"
 			class="input-hidden"
 			tabindex="-1"
 			type="text"

--- a/panel/src/components/Forms/Input/NumberInput.vue
+++ b/panel/src/components/Forms/Input/NumberInput.vue
@@ -1,10 +1,10 @@
 <template>
 	<input
+		:id="id"
 		ref="input"
 		v-bind="{
 			autofocus,
 			disabled,
-			id,
 			max,
 			min,
 			name,

--- a/panel/src/components/Forms/Input/RangeInput.vue
+++ b/panel/src/components/Forms/Input/RangeInput.vue
@@ -126,7 +126,7 @@ export default {
 		},
 		/**
 		 * aria-valuetext that can be announced while
-		 * hiding <output> from a11n tree
+		 * hiding <output> from a11y tree
 		 */
 		valuetext() {
 			if (!this.tooltip) {

--- a/panel/src/components/Forms/Input/RangeInput.vue
+++ b/panel/src/components/Forms/Input/RangeInput.vue
@@ -5,22 +5,28 @@
 		:style="$attrs.style"
 	>
 		<input
+			:id="id"
 			ref="range"
 			v-bind="{
 				autofocus,
 				disabled,
-				id,
 				max,
 				min,
 				name,
 				required,
 				step
 			}"
+			:aria-valuetext="valuetext"
 			:value="position"
 			type="range"
 			@input="$emit('input', $event.target.valueAsNumber)"
 		/>
-		<output v-if="tooltip" :for="id" class="k-range-input-tooltip">
+		<output
+			v-if="tooltip"
+			:for="id"
+			aria-hidden="true"
+			class="k-range-input-tooltip"
+		>
 			<span v-if="tooltip.before" class="k-range-input-tooltip-before">{{
 				tooltip.before
 			}}</span>
@@ -117,6 +123,19 @@ export default {
 			return this.value || this.value === 0
 				? this.value
 				: (this.default ?? this.baseline);
+		},
+		/**
+		 * aria-valuetext that can be announced while
+		 * hiding <output> from a11n tree
+		 */
+		valuetext() {
+			if (!this.tooltip) {
+				return null;
+			}
+
+			return [this.tooltip.before, this.label, this.tooltip.after]
+				.filter(Boolean)
+				.join(" ");
 		}
 	},
 	watch: {

--- a/panel/src/components/Forms/Input/TextareaInput.vue
+++ b/panel/src/components/Forms/Input/TextareaInput.vue
@@ -16,11 +16,11 @@
 				@command="onCommand"
 			/>
 			<textarea
+				:id="id"
 				ref="input"
 				v-bind="{
 					autofocus,
 					disabled,
-					id,
 					minlength,
 					name,
 					placeholder,

--- a/panel/src/components/Forms/Input/WriterInput.vue
+++ b/panel/src/components/Forms/Input/WriterInput.vue
@@ -21,6 +21,7 @@
 			:name="name"
 			:required="required"
 			:value="value"
+			aria-hidden="true"
 			class="input-hidden"
 			tabindex="-1"
 		/>

--- a/panel/src/components/Layout/Frame/VideoFrame.vue
+++ b/panel/src/components/Layout/Frame/VideoFrame.vue
@@ -3,6 +3,7 @@
 		<iframe
 			v-if="url"
 			:src="$helper.embed.video(url, true)"
+			:title="$t('video')"
 			class="k-video"
 			referrerpolicy="strict-origin-when-cross-origin"
 		/>

--- a/panel/src/components/Misc/Fatal.test.ts
+++ b/panel/src/components/Misc/Fatal.test.ts
@@ -9,7 +9,8 @@ function mount(props = {}, attrs = {}, close = vi.fn()) {
 		attachTo: document.body,
 		global: {
 			mocks: {
-				$panel: { notification: { close } }
+				$panel: { notification: { close } },
+				$t: (key: string) => key
 			}
 		}
 	});

--- a/panel/src/components/Misc/Fatal.vue
+++ b/panel/src/components/Misc/Fatal.vue
@@ -5,7 +5,7 @@
 				<p>The JSON response could not be parsed</p>
 				<k-button icon="cancel" @click.stop="$panel.notification.close()" />
 			</div>
-			<iframe ref="iframe" class="k-fatal-iframe" />
+			<iframe ref="iframe" :title="$t('error')" class="k-fatal-iframe" />
 		</div>
 	</k-overlay>
 </template>

--- a/panel/src/components/Misc/Progress.test.ts
+++ b/panel/src/components/Misc/Progress.test.ts
@@ -1,35 +1,57 @@
 import { describe, it, expect } from "@test/unit";
-import { mount } from "@vue/test-utils";
+import { mount as vueMount } from "@vue/test-utils";
 import Progress from "./Progress.vue";
+
+function mount(props: Record<string, unknown> = {}) {
+	return vueMount(Progress, {
+		props: props as never,
+		global: {
+			mocks: {
+				$t: (key: string) => key
+			}
+		}
+	});
+}
+
+function bar(wrapper: ReturnType<typeof mount>) {
+	return wrapper.find("progress");
+}
 
 describe("Progress.vue", () => {
 	// $el
 	describe("element", () => {
-		it.rendersAs(Progress, "PROGRESS", "k-progress");
-		it.acceptsClass(Progress);
-		it.acceptsStyle(Progress);
+		it.rendersAs(mount, "LABEL", "k-progress");
+		it.acceptsClass(mount);
+		it.acceptsStyle(mount);
 
 		it("max attribute is always 100", () => {
-			const wrapper = mount(Progress);
-			expect(wrapper.attributes("max")).toBe("100");
+			expect(bar(mount()).attributes("max")).toBe("100");
 		});
 	});
 
 	// props
 	describe("value prop", () => {
 		it("defaults to 0", () => {
-			const wrapper = mount(Progress);
-			expect(wrapper.attributes("value")).toBe("0");
+			expect(bar(mount()).attributes("value")).toBe("0");
 		});
 
 		it("reflects the prop as attribute", () => {
-			const wrapper = mount(Progress, { props: { value: 42 } });
-			expect(wrapper.attributes("value")).toBe("42");
+			expect(bar(mount({ value: 42 })).attributes("value")).toBe("42");
 		});
 
 		it("renders value as percentage text", () => {
-			const wrapper = mount(Progress, { props: { value: 75 } });
-			expect(wrapper.text()).toBe("75%");
+			expect(bar(mount({ value: 75 })).text()).toBe("75%");
+		});
+	});
+
+	describe("label prop", () => {
+		it("names the bar for screen readers", () => {
+			const wrapper = mount({ label: "Upload" });
+			expect(wrapper.find(".sr-only").text()).toBe("Upload");
+		});
+
+		it("falls back to a generic label", () => {
+			expect(mount().find(".sr-only").text()).toBe("progress");
 		});
 	});
 });

--- a/panel/src/components/Misc/Progress.vue
+++ b/panel/src/components/Misc/Progress.vue
@@ -1,5 +1,8 @@
 <template>
-	<progress :value="value" max="100" class="k-progress">{{ value }}%</progress>
+	<label class="k-progress">
+		<span class="sr-only">{{ label ?? $t("progress") }}</span>
+		<progress :value="value" max="100">{{ value }}%</progress>
+	</label>
 </template>
 
 <script>
@@ -14,6 +17,10 @@
  */
 export default {
 	props: {
+		/**
+		 * @since 6.0.0
+		 */
+		label: String,
 		/**
 		 * Current value of the the progress bar
 		 * @values 0-100

--- a/panel/src/components/Uploads/UploadItem.vue
+++ b/panel/src/components/Uploads/UploadItem.vue
@@ -30,6 +30,7 @@
 			</p>
 			<k-progress
 				v-else-if="progress"
+				:label="$t('upload')"
 				:value="progress"
 				class="k-upload-item-progress"
 			/>

--- a/panel/src/components/Uploads/UploadItemPreview.vue
+++ b/panel/src/components/Uploads/UploadItemPreview.vue
@@ -1,5 +1,10 @@
 <template>
-	<a :href="url" class="k-upload-item-preview" target="_blank">
+	<a
+		:aria-label="$t('open.newWindow')"
+		:href="url"
+		class="k-upload-item-preview"
+		target="_blank"
+	>
 		<k-image
 			v-if="isPreviewable"
 			:cover="cover"

--- a/panel/src/components/Views/Files/ImageFilePreview.vue
+++ b/panel/src/components/Views/Files/ImageFilePreview.vue
@@ -9,7 +9,7 @@
 				:value="focus"
 				@input="setFocus($event)"
 			>
-				<img v-bind="image" @dragstart.prevent />
+				<img alt="" v-bind="image" @dragstart.prevent />
 			</k-coords-input>
 		</k-file-preview-frame>
 

--- a/panel/src/components/Views/Files/PdfFilePreview.vue
+++ b/panel/src/components/Views/Files/PdfFilePreview.vue
@@ -4,12 +4,13 @@
 		:data-supported="supported"
 	>
 		<object
+			:aria-label="$t('preview')"
 			:data="url"
 			type="application/pdf"
 			class="k-pdf-file-preview-object"
 		>
 			<k-file-preview-frame>
-				<a :href="url">
+				<a :aria-label="$t('open')" :href="url">
 					<k-icon
 						:color="$helper.color(image.color)"
 						:type="image.icon"

--- a/panel/src/components/Views/Preview/PreviewBrowser.vue
+++ b/panel/src/components/Views/Preview/PreviewBrowser.vue
@@ -50,13 +50,17 @@
 			<iframe
 				ref="browserA"
 				:class="['k-preview-browser-iframe', active === 0 ? 'is-active' : null]"
+				:inert="active !== 0"
 				:src="srcs[0]"
+				:title="label ?? $t('preview')"
 				@load="onLoad(0)"
 			/>
 			<iframe
 				ref="browserB"
 				:class="['k-preview-browser-iframe', active === 1 ? 'is-active' : null]"
+				:inert="active !== 1"
 				:src="srcs[1]"
+				:title="label ?? $t('preview')"
 				@load="onLoad(1)"
 			/>
 		</div>


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

More an idea whether this tool could help us control for some basic a11n rules in Vue components.

Wanted to keep existing, unresolved issues and warn about them until we one by one eliminate them. But currently, the CI also fails on warnings, so had to turn them off as well.


## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### Breaking changes
<!-- 
e.g. Update JS dependencies
-->
- `<k-progress>`: the actual `<progress>` element if now wrapped in a `<label>`

### 🧹 Housekeeping
<!-- 
e.g. Update JS dependencies
-->
- Added eslint rules for a11n in Vue components


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion