### PR TITLE
feat: Delay showing topbar loading spinner

### DIFF
--- a/panel/src/components/View/Topbar.vue
+++ b/panel/src/components/View/Topbar.vue
@@ -25,6 +25,11 @@ export default {
 		breadcrumb: Array,
 		view: Object
 	},
+	data() {
+		return {
+			isLoading: false
+		};
+	},
 	computed: {
 		crumbs() {
 			return [
@@ -32,11 +37,28 @@ export default {
 					link: this.view.link,
 					label: this.view.label ?? this.view.breadcrumbLabel,
 					icon: this.view.icon,
-					loading: this.$panel.isLoading
+					loading: this.isLoading
 				},
 				...this.breadcrumb
 			];
 		}
+	},
+	watch: {
+		// only show the loader once loading takes a noticeable
+		// moment, to avoid a flicker on fast responses
+		"$panel.isLoading"(isLoading) {
+			clearTimeout(this.timer);
+
+			if (isLoading === false) {
+				this.isLoading = false;
+				return;
+			}
+
+			this.timer = setTimeout(() => (this.isLoading = true), 300);
+		}
+	},
+	unmounted() {
+		clearTimeout(this.timer);
 	}
 };
 </script>


### PR DESCRIPTION
Small idea to only show the topper loading spinner if the loading takes a noticeable amount of time. And avoid spinner flicker on every (even fast resolving) navigation.

If a request takes 320 ms, it would still flicker with 20 ms now though.

We could go further and still show the spinner for at least x milliseconds, even if the loading actually already concluded - kinda lying that loading is still happening while it isn't anymore, but for a visually more pleasing experience:


```js
watch: {
	"$panel.isLoading"(isLoading) {
		clearTimeout(this.timer);

		if (isLoading === true) {
			// a previous spinner is still in its minimum
			// display window: just keep it visible
			if (this.isLoading === true) {
				return;
			}

			this.timer = setTimeout(() => {
				this.shownAt = Date.now();
				this.isLoading = true;
			}, DELAY);
			return;
		}

		// loading ended before the spinner ever appeared
		if (this.isLoading === false) {
			return;
		}

		// loading ended while the spinner is visible:
		// keep it up until it has been shown for MIN ms
		const remaining = this.shownAt + MIN - Date.now();

		if (remaining <= 0) {
			this.isLoading = false;
		} else {
			this.timer = setTimeout(() => (this.isLoading = false), remaining);
		}
	}
},
unmounted() {
	clearTimeout(this.timer);
}
```

Quite unsure about it, but wanted to put it out here to discuss and decide.