### PR TITLE
perf: Form field performance improvements

### DIFF
--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -159,7 +159,8 @@ class Fieldset extends Item
 	{
 		$form = new Form(
 			fields: $fields,
-			model: $this->parent,
+			model:  $this->parent,
+			cache:  $this->siblings()->cache(),
 		);
 
 		$form->fill(

--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -23,12 +23,12 @@ class Fieldset extends Item
 
 	protected bool $disabled;
 	protected bool $editable;
-	protected array $fields = [];
+	protected array|null $fields = null;
 	protected string|null $icon;
 	protected string|null $label;
 	protected string $name;
 	protected string|bool|null $preview;
-	protected array $tabs;
+	protected array|null $tabs = null;
 	protected bool $translate;
 	protected string $type;
 	protected bool $unset;
@@ -56,7 +56,6 @@ class Fieldset extends Item
 		$this->name        = $this->createName($params['title']) ?? Str::label($this->type);
 		$this->label       = $this->createLabel($params['label'] ?? null);
 		$this->preview     = $params['preview'] ?? null;
-		$this->tabs        = $this->createTabs($params);
 		$this->translate   = $params['translate'] ?? true;
 		$this->unset       = $params['unset'] ?? false;
 		$this->wysiwyg     = $params['wysiwyg'] ?? false;
@@ -78,7 +77,7 @@ class Fieldset extends Item
 		$fields = $this->form($fields)->fields()->toProps(defaults: true);
 
 		// collect all fields
-		$this->fields = [...$this->fields, ...$fields];
+		$this->fields = [...$this->fields ?? [], ...$fields];
 
 		return $fields;
 	}
@@ -140,7 +139,7 @@ class Fieldset extends Item
 			return false;
 		}
 
-		if ($this->fields === []) {
+		if ($this->fields() === []) {
 			return false;
 		}
 
@@ -149,7 +148,11 @@ class Fieldset extends Item
 
 	public function fields(): array
 	{
-		return $this->fields;
+		// the fields of all tabs are collected
+		// while creating the tabs, so ensure they are
+		$this->tabs();
+
+		return $this->fields ??= [];
 	}
 
 	/**
@@ -198,7 +201,7 @@ class Fieldset extends Item
 
 	public function tabs(): array
 	{
-		return $this->tabs;
+		return $this->tabs ??= $this->createTabs($this->params);
 	}
 
 	public function translate(): bool

--- a/src/Cms/Fieldsets.php
+++ b/src/Cms/Fieldsets.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Closure;
 use Kirby\Blueprint\Blueprint;
+use Kirby\Form\FieldsCache;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
@@ -104,6 +105,14 @@ class Fieldsets extends Items
 	public function groups(): array
 	{
 		return $this->options['groups'] ?? [];
+	}
+
+	/**
+	 * @since 6.0.0
+	 */
+	public function cache(): FieldsCache|null
+	{
+		return $this->options['cache'] ?? null;
 	}
 
 	public function toArray(Closure|null $map = null): array

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -267,7 +267,10 @@ class BlocksField extends InputField
 	{
 		return $this->fieldsetsCollection ??= Fieldsets::factory(
 			$this->fieldsets,
-			['parent' => $this->model()]
+			[
+				'cache'  => $this->siblings()->cache(),
+				'parent' => $this->model()
+			]
 		);
 	}
 
@@ -292,9 +295,10 @@ class BlocksField extends InputField
 	public function form(array $fields): Form
 	{
 		return new Form(
-			fields: $fields,
-			model: $this->model,
-			language: 'current'
+			fields:   $fields,
+			model:    $this->model,
+			language: 'current',
+			cache:    $this->siblings()->cache()
 		);
 	}
 

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -117,7 +117,8 @@ class EntriesField extends InputField
 	{
 		return $this->form ??= new Form(
 			fields: [$this->field()],
-			model:  $this->model()
+			model:  $this->model(),
+			cache:  $this->siblings()->cache()
 		);
 	}
 

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -217,7 +217,8 @@ class LayoutField extends BlocksField
 	{
 		return new Form(
 			fields: $this->settings()?->fields() ?? [],
-			model:  $this->model()
+			model:  $this->model(),
+			cache:  $this->siblings()->cache()
 		);
 	}
 

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -23,6 +23,7 @@ use Kirby\Toolkit\Str;
  */
 class Fields extends Collection
 {
+	protected FieldsCache $cache;
 	protected Language $language;
 	protected ModelWithContent $model;
 	protected array $passthrough = [];
@@ -30,10 +31,12 @@ class Fields extends Collection
 	public function __construct(
 		array $fields = [],
 		ModelWithContent|null $model = null,
-		Language|string|null $language = null
+		Language|string|null $language = null,
+		FieldsCache|null $cache = null
 	) {
 		$this->model    = $model ?? App::instance()->site();
 		$this->language = Language::ensure($language ?? 'current');
+		$this->cache    = $cache ?? new FieldsCache();
 
 		foreach ($fields as $name => $field) {
 			$this->__set($name, $field);
@@ -67,6 +70,14 @@ class Fields extends Collection
 		}
 
 		parent::__set($field->name(), $field);
+	}
+
+	/**
+	 * @since 6.0.0
+	 */
+	public function cache(): FieldsCache
+	{
+		return $this->cache;
 	}
 
 	/**
@@ -217,12 +228,14 @@ class Fields extends Collection
 	 */
 	public static function for(
 		ModelWithContent $model,
-		Language|string|null $language = null
+		Language|string|null $language = null,
+		FieldsCache|null $cache = null
 	): static {
 		return new static(
-			fields: $model->blueprint()->fields(),
-			model: $model,
+			fields:   $model->blueprint()->fields(),
+			model:    $model,
 			language: $language,
+			cache:    $cache,
 		);
 	}
 

--- a/src/Form/FieldsCache.php
+++ b/src/Form/FieldsCache.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Kirby\Form;
+
+use Closure;
+
+/**
+ * Store for values that are expensive to create and can be
+ * shared between all fields of a form and its nested forms.
+ *
+ * One instance is created per `Kirby\Form\Fields` collection
+ * and passed on to all nested forms, so that the work is only
+ * done once per form tree.
+ *
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class FieldsCache
+{
+	protected array $values = [];
+
+	public function getOrSet(string $key, Closure $result): mixed
+	{
+		if (array_key_exists($key, $this->values) === false) {
+			$this->values[$key] = $result();
+		}
+
+		return $this->values[$key];
+	}
+}

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -33,7 +33,8 @@ class Form
 		array $props = [],
 		array $fields = [],
 		ModelWithContent|null $model = null,
-		Language|string|null $language = null
+		Language|string|null $language = null,
+		FieldsCache|null $cache = null
 	) {
 		if ($props !== []) {
 			$this->legacyConstruct(...$props);
@@ -41,9 +42,10 @@ class Form
 		}
 
 		$this->fields = new Fields(
-			fields: $fields,
-			model: $model,
-			language: $language
+			fields:   $fields,
+			model:    $model,
+			language: $language,
+			cache:    $cache
 		);
 	}
 

--- a/src/Form/Mixin/Fields.php
+++ b/src/Form/Mixin/Fields.php
@@ -40,9 +40,10 @@ trait Fields
 	public function form(): Form
 	{
 		$this->form ??= new Form(
-			fields: $this->fields ?? [],
-			model: $this->model(),
-			language: 'current'
+			fields:   $this->fields ?? [],
+			model:    $this->model(),
+			language: 'current',
+			cache:    $this->siblings()->cache()
 		);
 
 		return $this->form->reset();

--- a/src/Form/Mixin/Fields.php
+++ b/src/Form/Mixin/Fields.php
@@ -23,6 +23,11 @@ trait Fields
 	protected Form|null $form = null;
 
 	/**
+	 * Cache for the props of all fields
+	 */
+	protected array|null $fieldsProps = null;
+
+	/**
 	 * Returns the props for all fields in the form
 	 */
 	public function fields(): array
@@ -31,7 +36,7 @@ trait Fields
 			return [];
 		}
 
-		return $this->form()->fields()->toProps(defaults: true);
+		return $this->fieldsProps ??= $this->form()->fields()->toProps(defaults: true);
 	}
 
 	/**

--- a/src/Form/Mixin/Options.php
+++ b/src/Form/Mixin/Options.php
@@ -27,6 +27,16 @@ trait Options
 
 	public function options(): array
 	{
-		return $this->optionsCache ??= $this->fetchOptions();
+		return $this->optionsCache ??= $this->siblings()->cache()->getOrSet(
+			key: implode('/', [
+				'options',
+				static::class,
+				$this->model()::class,
+				$this->model()->id(),
+				$this->kirby()->languageCode() ?? '',
+				json_encode($this->options)
+			]),
+			result: $this->fetchOptions(...)
+		);
 	}
 }

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -21,6 +21,11 @@ use ReflectionProperty;
 trait Value
 {
 	/**
+	 * Cache for the empty value per field class
+	 */
+	protected static array $emptyValues = [];
+
+	/**
 	 * @deprecated 5.0.0 Use `::toStoredValue()` instead to receive
 	 * the value in the format that will be needed for content files.
 	 *
@@ -44,7 +49,13 @@ trait Value
 	 */
 	public function emptyValue(): mixed
 	{
-		return (new ReflectionProperty($this, 'value'))->getDefaultValue();
+		if (array_key_exists(static::class, static::$emptyValues) === false) {
+			$prop    = new ReflectionProperty($this, 'value');
+			$default = $prop->getDefaultValue();
+			static::$emptyValues[static::class] = $default;
+		}
+
+		return static::$emptyValues[static::class];
 	}
 
 	/**

--- a/src/Option/OptionsApi.php
+++ b/src/Option/OptionsApi.php
@@ -125,6 +125,10 @@ class OptionsApi extends OptionsProvider
 		$data    = Query::factory($this->query)->resolve($data);
 		$options = [];
 
+		// text is only a raw string when using {< >}
+		// or when the safe mode is explicitly disabled (select field)
+		$safeMethod = $safeMode === true ? 'toSafeHtmlString' : 'toString';
+
 		// create options by resolving text and value query strings
 		// for each item from the data
 		foreach ($data as $key => $item) {
@@ -132,8 +136,6 @@ class OptionsApi extends OptionsProvider
 			if (is_string($item) === true) {
 				$item = new Field(null, $key, $item);
 			}
-
-			$safeMethod = $safeMode === true ? 'toSafeHtmlString' : 'toString';
 
 			$options[] = [
 				// value is always a raw string

--- a/src/Option/OptionsQuery.php
+++ b/src/Option/OptionsQuery.php
@@ -24,6 +24,8 @@ use Kirby\Toolkit\Obj;
  */
 class OptionsQuery extends OptionsProvider
 {
+	protected array $defaults = [];
+
 	public function __construct(
 		public string $query,
 		public string|null $text = null,
@@ -71,7 +73,21 @@ class OptionsQuery extends OptionsProvider
 	 */
 	protected function itemToDefaults(array|object $item): array
 	{
-		return match (true) {
+		// all items of a query result usually share the same type,
+		// so the matching below only needs to run once per type;
+		// `Obj` is excluded, as its defaults also depend on the
+		// `hasStringKey` property of the individual item
+		$type = match (true) {
+			$item instanceof Obj => null,
+			is_object($item)     => $item::class,
+			default              => 'array'
+		};
+
+		if ($type !== null && isset($this->defaults[$type]) === true) {
+			return $this->defaults[$type];
+		}
+
+		$defaults = match (true) {
 			$item instanceof Obj && $item->hasStringKey === true => [
 				'arrayItem',
 				'{{ item.value }}',
@@ -121,6 +137,12 @@ class OptionsQuery extends OptionsProvider
 				'{{ item.value }}'
 			]
 		};
+
+		if ($type !== null) {
+			$this->defaults[$type] = $defaults;
+		}
+
+		return $defaults;
 	}
 
 	public static function polyfill(array|string $props = []): array
@@ -176,8 +198,12 @@ class OptionsQuery extends OptionsProvider
 			);
 		}
 
+		// text is only a raw string when using {< >}
+		// or when the safe mode is explicitly disabled (select field)
+		$safeMethod = $safeMode === true ? 'toSafeHtmlString' : 'toString';
+
 		// create options array
-		$options = $result->toArray(function ($item) use ($model, $safeMode) {
+		$options = $result->toArray(function ($item) use ($model, $safeMethod) {
 			// get defaults based on item type
 			[$alias, $text, $value] = $this->itemToDefaults($item);
 			$data = ['item' => $item, $alias => $item];
@@ -185,9 +211,6 @@ class OptionsQuery extends OptionsProvider
 			// value is always a raw string
 			$value = $model->toString($this->value ?? $value, $data);
 
-			// text is only a raw string when using {< >}
-			// or when the safe mode is explicitly disabled (select field)
-			$safeMethod = $safeMode === true ? 'toSafeHtmlString' : 'toString';
 			$text = $model->$safeMethod($this->text ?? $text, $data);
 
 			// additional data

--- a/src/Reflection/Constructor.php
+++ b/src/Reflection/Constructor.php
@@ -15,6 +15,8 @@ use ReflectionParameter;
  */
 class Constructor extends ReflectionMethod
 {
+	protected static array $names = [];
+
 	public function __construct(object|string $objectOrClass)
 	{
 		parent::__construct($objectOrClass, '__construct');
@@ -88,7 +90,10 @@ class Constructor extends ReflectionMethod
 	 */
 	public function getParameterNames(): array
 	{
-		return array_values(array_map(fn (ReflectionParameter $param) => $param->name, $this->getAllParameters()));
+		return static::$names[$this->class] ??= array_values(array_map(
+			fn (ReflectionParameter $param) => $param->name,
+			$this->getAllParameters()
+		));
 	}
 
 	/**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1081,6 +1081,9 @@ class Str
 			$callback = null;
 		}
 
+		// whether the string contains any unescaped placeholders
+		$hasUnescaped = str_contains($string ?? '', '{<');
+
 		// replace and escape
 		$string = static::template($string, $data, [
 			'start'    => '{{',
@@ -1096,12 +1099,14 @@ class Str
 		]);
 
 		// replace unescaped (specifically marked placeholders)
-		$string = static::template($string, $data, [
-			'start'    => '{<',
-			'end'      => '>}',
-			'callback' => $callback,
-			'fallback' => $fallback
-		]);
+		if ($hasUnescaped === true) {
+			$string = static::template($string, $data, [
+				'start'    => '{<',
+				'end'      => '>}',
+				'callback' => $callback,
+				'fallback' => $fallback
+			]);
+		}
 
 		return $string;
 	}

--- a/tests/Cms/Fieldsets/FieldsetTest.php
+++ b/tests/Cms/Fieldsets/FieldsetTest.php
@@ -102,6 +102,20 @@ class FieldsetTest extends TestCase
 		$this->assertSame('text', $fieldset->fields()['text']['type']);
 	}
 
+	public function testFieldsWithDisabledTabs(): void
+	{
+		$fieldset = new Fieldset([
+			'type' => 'test',
+			'tabs' => [
+				'content' => false
+			]
+		]);
+
+		$this->assertSame([], $fieldset->tabs());
+		$this->assertSame([], $fieldset->fields());
+		$this->assertFalse($fieldset->editable());
+	}
+
 	public function testForm(): void
 	{
 		$fieldset = new Fieldset([

--- a/tests/Form/Field/BlocksFieldTest.php
+++ b/tests/Form/Field/BlocksFieldTest.php
@@ -175,6 +175,34 @@ class BlocksFieldTest extends TestCase
 		$this->assertSame(['image', 'video'], $groups['media']['sets']);
 	}
 
+	public function testFormSharesCacheWithSiblings(): void
+	{
+		$fields = new Fields([
+			'blocks' => [
+				'type'      => 'blocks',
+				'fieldsets' => [
+					'text' => [
+						'fields' => [
+							'text' => ['type' => 'text']
+						]
+					]
+				]
+			]
+		], new Page(['slug' => 'test']));
+
+		$field = $fields->get('blocks');
+		$cache = $fields->cache();
+
+		// the block forms and all fieldsets must resolve their
+		// options through the cache of the surrounding form
+		$this->assertSame($cache, $field->form([])->fields()->cache());
+		$this->assertSame($cache, $field->fieldsets()->cache());
+		$this->assertSame(
+			$cache,
+			$field->fieldset('text')->form([])->fields()->cache()
+		);
+	}
+
 	public function testMax(): void
 	{
 		$field = $this->field('blocks', [

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Form\Field;
 
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
+use Kirby\Form\Fields;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(StructureField::class)]
@@ -190,6 +191,25 @@ class StructureFieldTest extends TestCase
 			'empty' => ['en' => 'Test', 'de' => 'Töst']
 		]);
 		$this->assertSame('Test', $field->empty());
+	}
+
+	public function testFormSharesCacheWithSiblings(): void
+	{
+		$fields = new Fields([
+			'structure' => [
+				'type'   => 'structure',
+				'fields' => [
+					'a' => ['type' => 'text']
+				]
+			]
+		], new Page(['slug' => 'test']));
+
+		// the nested form must resolve its options through the
+		// same cache as the form the structure field belongs to
+		$this->assertSame(
+			$fields->cache(),
+			$fields->get('structure')->form()->fields()->cache()
+		);
 	}
 
 	public function testIsValid(): void

--- a/tests/Form/FieldsCacheTest.php
+++ b/tests/Form/FieldsCacheTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Kirby\Form;
+
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(FieldsCache::class)]
+class FieldsCacheTest extends TestCase
+{
+	public function testGetOrSet(): void
+	{
+		$cache = new FieldsCache();
+
+		$this->assertSame(['a'], $cache->getOrSet('a', fn () => ['a']));
+	}
+
+	public function testGetOrSetWithDifferentKeys(): void
+	{
+		$cache = new FieldsCache();
+
+		$this->assertSame(['a'], $cache->getOrSet('a', fn () => ['a']));
+		$this->assertSame(['b'], $cache->getOrSet('b', fn () => ['b']));
+	}
+
+	public function testGetOrSetWithEmptyResult(): void
+	{
+		$cache = new FieldsCache();
+
+		// an empty result is a valid result and must be kept
+		$this->assertSame([], $cache->getOrSet('a', fn () => []));
+		$this->assertSame([], $cache->getOrSet('a', fn () => ['later']));
+	}
+
+	public function testGetOrSetWithNullResult(): void
+	{
+		$cache = new FieldsCache();
+
+		// unlike `Kirby\Cache\Cache`, null is a valid result
+		$this->assertNull($cache->getOrSet('a', fn () => null));
+		$this->assertNull($cache->getOrSet('a', fn () => 'later'));
+	}
+
+	public function testGetOrSetWithSameKey(): void
+	{
+		$cache = new FieldsCache();
+
+		$this->assertSame(['a'], $cache->getOrSet('a', fn () => ['a']));
+
+		// the stored result is returned, the second closure is never used
+		$this->assertSame(['a'], $cache->getOrSet('a', fn () => ['b']));
+	}
+}

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -69,6 +69,20 @@ class FieldsTest extends TestCase
 		$this->assertSame($this->app->site(), $fields->last()->model());
 	}
 
+	public function testCache(): void
+	{
+		$fields = new Fields(model: $this->model);
+		$this->assertInstanceOf(FieldsCache::class, $fields->cache());
+	}
+
+	public function testCacheWithPassedCache(): void
+	{
+		$cache  = new FieldsCache();
+		$fields = new Fields(model: $this->model, cache: $cache);
+
+		$this->assertSame($cache, $fields->cache());
+	}
+
 	public function testDefaults(): void
 	{
 		$fields = new Fields([

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -995,10 +995,21 @@ class StrTest extends TestCase
 			]
 		));
 
-		// prevent arbitrary code execution attacks from query placeholders in the untrusted data
+		// prevent arbitrary code execution attacks
+		// from query placeholders in the untrusted data
 		$this->assertSame(
 			'{{ dangerous }},{&lt; dangerous &gt;};{{ dangerous }},{< dangerous >}',
 			Str::safeTemplate('{{ malicious1 }},{{ malicious2 }};{< malicious1 >},{< malicious2 >}', [
+				'malicious1' => '{{ dangerous }}',
+				'malicious2' => '{< dangerous >}',
+				'dangerous' => '*deleting all of the content or something*'
+			])
+		);
+
+		// … also when the template itself has no unescaped placeholders
+		$this->assertSame(
+			'{{ dangerous }},{&lt; dangerous &gt;}',
+			Str::safeTemplate('{{ malicious1 }},{{ malicious2 }}', [
 				'malicious1' => '{{ dangerous }}',
 				'malicious2' => '{< dangerous >}',
 				'dangerous' => '*deleting all of the content or something*'


### PR DESCRIPTION
## TODO

- [ ] Break up in individual PRs for v6-beta
  - [ ] https://github.com/getkirby/kirby/pull/8390
  - [ ] https://github.com/getkirby/kirby/pull/8391

## Description

Maybe the easiest to review commit by commit.

With `kirby sandbox:bench:fields` it improves from around `00:00.101` to `00:00.085`, however I think expensive dynamic options might be not that present in the bench.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### 🏎️ Performance
<!-- 
e.g. Improve a11y of feature X
-->
- Caching field options during the same request, so expensive dynamic options e.g. from API or Kirby queries across multiple fields do not hit as hard



## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion