### PR TITLE
lab: Do not lazy-load fields sections

### DIFF
--- a/panel/src/components/Sections/FieldsSection.vue
+++ b/panel/src/components/Sections/FieldsSection.vue
@@ -1,18 +1,18 @@
 <template>
 	<k-section
-		v-if="!isLoading"
 		:class="['k-fields-section', $attrs.class]"
-		:headline="issue ? $t('error') : null"
+		:headline="error ? $t('error') : null"
 		:style="$attrs.style"
 	>
 		<k-box
-			v-if="issue"
-			:text="issue.message"
+			v-if="error"
+			:text="error"
 			:html="false"
 			icon="alert"
 			theme="negative"
 		/>
 		<k-form
+			v-else
 			:fields="fieldsWithAdditionalData"
 			:validate="true"
 			:value="content"
@@ -34,16 +34,14 @@ export default {
 	mixins: [SectionMixin],
 	inheritAttrs: false,
 	props: {
-		content: Object
+		content: Object,
+		error: String,
+		fields: {
+			type: Object,
+			default: () => ({})
+		}
 	},
 	emits: ["input", "submit"],
-	data() {
-		return {
-			fields: {},
-			isLoading: true,
-			issue: null
-		};
-	},
 	computed: {
 		fieldsWithAdditionalData() {
 			const fields = {};
@@ -65,29 +63,9 @@ export default {
 			return fields;
 		}
 	},
-	watch: {
-		// Reload values and field definitions
-		// when the view has changed in the backend
-		timestamp() {
-			this.fetch();
-		}
-	},
-	mounted() {
-		this.fetch();
-	},
-	methods: {
-		async fetch() {
-			try {
-				const response = await this.load();
-				this.fields = response.fields;
-			} catch (error) {
-				this.issue = error;
-			} finally {
-				this.isLoading = false;
-				await this.$nextTick();
-				this.$events.emit("section.loaded", this);
-			}
-		}
+	async mounted() {
+		await this.$nextTick();
+		this.$events.emit("section.loaded", this);
 	}
 };
 </script>

--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -159,7 +159,8 @@ class Fieldset extends Item
 	{
 		$form = new Form(
 			fields: $fields,
-			model: $this->parent,
+			model:  $this->parent,
+			cache:  $this->siblings()->cache(),
 		);
 
 		$form->fill(

--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -23,12 +23,12 @@ class Fieldset extends Item
 
 	protected bool $disabled;
 	protected bool $editable;
-	protected array $fields = [];
+	protected array|null $fields = null;
 	protected string|null $icon;
 	protected string|null $label;
 	protected string $name;
 	protected string|bool|null $preview;
-	protected array $tabs;
+	protected array|null $tabs = null;
 	protected bool $translate;
 	protected string $type;
 	protected bool $unset;
@@ -56,7 +56,6 @@ class Fieldset extends Item
 		$this->name        = $this->createName($params['title']) ?? Str::label($this->type);
 		$this->label       = $this->createLabel($params['label'] ?? null);
 		$this->preview     = $params['preview'] ?? null;
-		$this->tabs        = $this->createTabs($params);
 		$this->translate   = $params['translate'] ?? true;
 		$this->unset       = $params['unset'] ?? false;
 		$this->wysiwyg     = $params['wysiwyg'] ?? false;
@@ -78,7 +77,7 @@ class Fieldset extends Item
 		$fields = $this->form($fields)->fields()->toProps(defaults: true);
 
 		// collect all fields
-		$this->fields = [...$this->fields, ...$fields];
+		$this->fields = [...$this->fields ?? [], ...$fields];
 
 		return $fields;
 	}
@@ -140,7 +139,7 @@ class Fieldset extends Item
 			return false;
 		}
 
-		if ($this->fields === []) {
+		if ($this->fields() === []) {
 			return false;
 		}
 
@@ -149,7 +148,11 @@ class Fieldset extends Item
 
 	public function fields(): array
 	{
-		return $this->fields;
+		// the fields of all tabs are collected
+		// while creating the tabs, so ensure they are
+		$this->tabs();
+
+		return $this->fields ??= [];
 	}
 
 	/**
@@ -198,7 +201,7 @@ class Fieldset extends Item
 
 	public function tabs(): array
 	{
-		return $this->tabs;
+		return $this->tabs ??= $this->createTabs($this->params);
 	}
 
 	public function translate(): bool

--- a/src/Cms/Fieldsets.php
+++ b/src/Cms/Fieldsets.php
@@ -4,6 +4,7 @@ namespace Kirby\Cms;
 
 use Closure;
 use Kirby\Blueprint\Blueprint;
+use Kirby\Form\FieldsCache;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
@@ -104,6 +105,14 @@ class Fieldsets extends Items
 	public function groups(): array
 	{
 		return $this->options['groups'] ?? [];
+	}
+
+	/**
+	 * @since 6.0.0
+	 */
+	public function cache(): FieldsCache|null
+	{
+		return $this->options['cache'] ?? null;
 	}
 
 	public function toArray(Closure|null $map = null): array

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -266,7 +266,10 @@ class BlocksField extends InputField
 	{
 		return $this->fieldsetsCollection ??= Fieldsets::factory(
 			$this->fieldsets,
-			['parent' => $this->model()]
+			[
+				'cache'  => $this->siblings()->cache(),
+				'parent' => $this->model()
+			]
 		);
 	}
 
@@ -291,9 +294,10 @@ class BlocksField extends InputField
 	public function form(array $fields): Form
 	{
 		return new Form(
-			fields: $fields,
-			model: $this->model,
-			language: 'current'
+			fields:   $fields,
+			model:    $this->model,
+			language: 'current',
+			cache:    $this->siblings()->cache()
 		);
 	}
 

--- a/src/Form/Field/EntriesField.php
+++ b/src/Form/Field/EntriesField.php
@@ -117,7 +117,8 @@ class EntriesField extends InputField
 	{
 		return $this->form ??= new Form(
 			fields: [$this->field()],
-			model:  $this->model()
+			model:  $this->model(),
+			cache:  $this->siblings()->cache()
 		);
 	}
 

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -216,7 +216,8 @@ class LayoutField extends BlocksField
 	{
 		return new Form(
 			fields: $this->settings()?->fields() ?? [],
-			model:  $this->model()
+			model:  $this->model(),
+			cache:  $this->siblings()->cache()
 		);
 	}
 

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -23,6 +23,7 @@ use Kirby\Toolkit\Str;
  */
 class Fields extends Collection
 {
+	protected FieldsCache $cache;
 	protected Language $language;
 	protected ModelWithContent $model;
 	protected array $passthrough = [];
@@ -30,10 +31,12 @@ class Fields extends Collection
 	public function __construct(
 		array $fields = [],
 		ModelWithContent|null $model = null,
-		Language|string|null $language = null
+		Language|string|null $language = null,
+		FieldsCache|null $cache = null
 	) {
 		$this->model    = $model ?? App::instance()->site();
 		$this->language = Language::ensure($language ?? 'current');
+		$this->cache    = $cache ?? new FieldsCache();
 
 		foreach ($fields as $name => $field) {
 			$this->__set($name, $field);
@@ -67,6 +70,14 @@ class Fields extends Collection
 		}
 
 		parent::__set($field->name(), $field);
+	}
+
+	/**
+	 * @since 6.0.0
+	 */
+	public function cache(): FieldsCache
+	{
+		return $this->cache;
 	}
 
 	/**
@@ -217,12 +228,14 @@ class Fields extends Collection
 	 */
 	public static function for(
 		ModelWithContent $model,
-		Language|string|null $language = null
+		Language|string|null $language = null,
+		FieldsCache|null $cache = null
 	): static {
 		return new static(
-			fields: $model->blueprint()->fields(),
-			model: $model,
+			fields:   $model->blueprint()->fields(),
+			model:    $model,
 			language: $language,
+			cache:    $cache,
 		);
 	}
 
@@ -234,6 +247,24 @@ class Fields extends Collection
 	public function language(): Language
 	{
 		return $this->language;
+	}
+
+	/**
+	 * Resolves the options for a field once and shares the
+	 * result with all fields that use the same definition
+	 * @since 6.0.0
+	 */
+	public function options(string $key, Closure $resolve): array
+	{
+		// options can differ per model and language, while the cache
+		// is shared with nested forms, so both must be part of the key
+		$key =
+			$this->model::class . '/' .
+			$this->model->id() . '/' .
+			$this->language->code() . '/' .
+			$key;
+
+		return $this->cache->options($key, $resolve);
 	}
 
 	/**

--- a/src/Form/FieldsCache.php
+++ b/src/Form/FieldsCache.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Kirby\Form;
+
+use Closure;
+
+/**
+ * Store for values that are expensive to create and can be
+ * shared between all fields of a form and its nested forms.
+ *
+ * One instance is created per `Kirby\Form\Fields` collection
+ * and passed on to all nested forms, so that the work is only
+ * done once per form tree.
+ *
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class FieldsCache
+{
+	protected array $options = [];
+
+	/**
+	 * Returns the cached options for the given key
+	 * or resolves them once and stores the result
+	 */
+	public function options(string $key, Closure $resolve): array
+	{
+		return $this->options[$key] ??= $resolve();
+	}
+}

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -31,7 +31,8 @@ class Form
 		array $props = [],
 		array $fields = [],
 		ModelWithContent|null $model = null,
-		Language|string|null $language = null
+		Language|string|null $language = null,
+		FieldsCache|null $cache = null
 	) {
 		if ($props !== []) {
 			$this->legacyConstruct(...$props);
@@ -39,9 +40,10 @@ class Form
 		}
 
 		$this->fields = new Fields(
-			fields: $fields,
-			model: $model,
-			language: $language
+			fields:   $fields,
+			model:    $model,
+			language: $language,
+			cache:    $cache
 		);
 	}
 

--- a/src/Form/Mixin/Fields.php
+++ b/src/Form/Mixin/Fields.php
@@ -40,9 +40,10 @@ trait Fields
 	public function form(): Form
 	{
 		$this->form ??= new Form(
-			fields: $this->fields ?? [],
-			model: $this->model(),
-			language: 'current'
+			fields:   $this->fields ?? [],
+			model:    $this->model(),
+			language: 'current',
+			cache:    $this->siblings()->cache()
 		);
 
 		return $this->form->reset();

--- a/src/Form/Mixin/Fields.php
+++ b/src/Form/Mixin/Fields.php
@@ -23,6 +23,11 @@ trait Fields
 	protected Form|null $form = null;
 
 	/**
+	 * Cache for the props of all fields
+	 */
+	protected array|null $fieldsProps = null;
+
+	/**
 	 * Returns the props for all fields in the form
 	 */
 	public function fields(): array
@@ -31,7 +36,7 @@ trait Fields
 			return [];
 		}
 
-		return $this->form()->fields()->toProps(defaults: true);
+		return $this->fieldsProps ??= $this->form()->fields()->toProps(defaults: true);
 	}
 
 	/**

--- a/src/Form/Mixin/Options.php
+++ b/src/Form/Mixin/Options.php
@@ -27,6 +27,9 @@ trait Options
 
 	public function options(): array
 	{
-		return $this->optionsCache ??= $this->fetchOptions();
+		return $this->optionsCache ??= $this->siblings()->options(
+			static::class . ':' . json_encode($this->options),
+			$this->fetchOptions(...)
+		);
 	}
 }

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -21,6 +21,11 @@ use ReflectionProperty;
 trait Value
 {
 	/**
+	 * Cache for the empty value per field class
+	 */
+	protected static array $emptyValues = [];
+
+	/**
 	 * @deprecated 5.0.0 Use `::toStoredValue()` instead to receive
 	 * the value in the format that will be needed for content files.
 	 *
@@ -44,7 +49,13 @@ trait Value
 	 */
 	public function emptyValue(): mixed
 	{
-		return (new ReflectionProperty($this, 'value'))->getDefaultValue();
+		if (array_key_exists(static::class, static::$emptyValues) === false) {
+			$prop    = new ReflectionProperty($this, 'value');
+			$default = $prop->getDefaultValue();
+			static::$emptyValues[static::class] = $default;
+		}
+
+		return static::$emptyValues[static::class];
 	}
 
 	/**

--- a/src/Option/OptionsApi.php
+++ b/src/Option/OptionsApi.php
@@ -125,6 +125,10 @@ class OptionsApi extends OptionsProvider
 		$data    = Query::factory($this->query)->resolve($data);
 		$options = [];
 
+		// text is only a raw string when using {< >}
+		// or when the safe mode is explicitly disabled (select field)
+		$safeMethod = $safeMode === true ? 'toSafeString' : 'toString';
+
 		// create options by resolving text and value query strings
 		// for each item from the data
 		foreach ($data as $key => $item) {
@@ -132,8 +136,6 @@ class OptionsApi extends OptionsProvider
 			if (is_string($item) === true) {
 				$item = new Field(null, $key, $item);
 			}
-
-			$safeMethod = $safeMode === true ? 'toSafeString' : 'toString';
 
 			$options[] = [
 				// value is always a raw string

--- a/src/Option/OptionsQuery.php
+++ b/src/Option/OptionsQuery.php
@@ -24,6 +24,8 @@ use Kirby\Toolkit\Obj;
  */
 class OptionsQuery extends OptionsProvider
 {
+	protected array $defaults = [];
+
 	public function __construct(
 		public string $query,
 		public string|null $text = null,
@@ -71,7 +73,21 @@ class OptionsQuery extends OptionsProvider
 	 */
 	protected function itemToDefaults(array|object $item): array
 	{
-		return match (true) {
+		// all items of a query result usually share the same type,
+		// so the matching below only needs to run once per type;
+		// `Obj` is excluded, as its defaults also depend on the
+		// `hasStringKey` property of the individual item
+		$type = match (true) {
+			$item instanceof Obj => null,
+			is_object($item)     => $item::class,
+			default              => 'array'
+		};
+
+		if ($type !== null && isset($this->defaults[$type]) === true) {
+			return $this->defaults[$type];
+		}
+
+		$defaults = match (true) {
 			$item instanceof Obj && $item->hasStringKey === true => [
 				'arrayItem',
 				'{{ item.value }}',
@@ -121,6 +137,12 @@ class OptionsQuery extends OptionsProvider
 				'{{ item.value }}'
 			]
 		};
+
+		if ($type !== null) {
+			$this->defaults[$type] = $defaults;
+		}
+
+		return $defaults;
 	}
 
 	public static function polyfill(array|string $props = []): array
@@ -176,8 +198,12 @@ class OptionsQuery extends OptionsProvider
 			);
 		}
 
+		// text is only a raw string when using {< >}
+		// or when the safe mode is explicitly disabled (select field)
+		$safeMethod = $safeMode === true ? 'toSafeString' : 'toString';
+
 		// create options array
-		$options = $result->toArray(function ($item) use ($model, $safeMode) {
+		$options = $result->toArray(function ($item) use ($model, $safeMethod) {
 			// get defaults based on item type
 			[$alias, $text, $value] = $this->itemToDefaults($item);
 			$data = ['item' => $item, $alias => $item];
@@ -185,9 +211,6 @@ class OptionsQuery extends OptionsProvider
 			// value is always a raw string
 			$value = $model->toString($this->value ?? $value, $data);
 
-			// text is only a raw string when using {< >}
-			// or when the safe mode is explicitly disabled (select field)
-			$safeMethod = $safeMode === true ? 'toSafeString' : 'toString';
 			$text = $model->$safeMethod($this->text ?? $text, $data);
 
 			// additional data

--- a/src/Panel/Controller/View/ModelViewController.php
+++ b/src/Panel/Controller/View/ModelViewController.php
@@ -4,12 +4,15 @@ namespace Kirby\Panel\Controller\View;
 
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Exception\Exception;
 use Kirby\Form\Fields;
 use Kirby\Http\Uri;
 use Kirby\Panel\Controller\ViewController;
 use Kirby\Panel\Model;
 use Kirby\Panel\Ui\Button\ViewButtons;
 use Kirby\Panel\Ui\View;
+use Kirby\Toolkit\I18n;
+use Throwable;
 
 /**
  * Controls a model view
@@ -71,6 +74,40 @@ abstract class ModelViewController extends ViewController
 	public function next(): array|null
 	{
 		return null;
+	}
+
+	/**
+	 * Replaces the raw field definitions of each fields section
+	 * in the tab with their computed field props
+	 */
+	protected function preload(array $tab): array
+	{
+		foreach ($tab['columns'] ?? [] as $columnIndex => $column) {
+			foreach ($column['sections'] ?? [] as $name => $section) {
+				if (($section['type'] ?? null) !== 'fields') {
+					continue;
+				}
+
+				unset($tab['columns'][$columnIndex]['sections'][$name]['fields']);
+
+				try {
+					$fields = $this->model->blueprint()->section($name)?->toArray()['fields'] ?? null;
+				} catch (Throwable $e) {
+					$tab['columns'][$columnIndex]['sections'][$name]['error'] = match (true) {
+						$e instanceof Exception => $e->getMessage(),
+						$this->kirby->option('debug') === true => $this->kirby->disguiseFilePath($e->getMessage()),
+						default => I18n::translate('error.unexpected')
+					};
+					continue;
+				}
+
+				if ($fields !== null) {
+					$tab['columns'][$columnIndex]['sections'][$name]['fields'] = $fields;
+				}
+			}
+		}
+
+		return $tab;
 	}
 
 	public function prev(): array|null
@@ -142,7 +179,12 @@ abstract class ModelViewController extends ViewController
 		$tab   = $this->request->get('tab');
 		$tab   = $this->model->blueprint()->tab($tab);
 		$tab ??= $this->tabs()[0] ?? null;
-		return $tab;
+
+		if ($tab === null) {
+			return null;
+		}
+
+		return $this->preload($tab);
 	}
 
 	public function tabs(): array

--- a/src/Reflection/Constructor.php
+++ b/src/Reflection/Constructor.php
@@ -15,6 +15,8 @@ use ReflectionParameter;
  */
 class Constructor extends ReflectionMethod
 {
+	protected static array $names = [];
+
 	public function __construct(object|string $objectOrClass)
 	{
 		parent::__construct($objectOrClass, '__construct');
@@ -88,7 +90,10 @@ class Constructor extends ReflectionMethod
 	 */
 	public function getParameterNames(): array
 	{
-		return array_values(array_map(fn (ReflectionParameter $param) => $param->name, $this->getAllParameters()));
+		return static::$names[$this->class] ??= array_values(array_map(
+			fn (ReflectionParameter $param) => $param->name,
+			$this->getAllParameters()
+		));
 	}
 
 	/**

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1080,6 +1080,9 @@ class Str
 			$callback = null;
 		}
 
+		// whether the string contains any unescaped placeholders
+		$hasUnescaped = str_contains($string ?? '', '{<');
+
 		// replace and escape
 		$string = static::template($string, $data, [
 			'start'    => '{{',
@@ -1095,12 +1098,14 @@ class Str
 		]);
 
 		// replace unescaped (specifically marked placeholders)
-		$string = static::template($string, $data, [
-			'start'    => '{<',
-			'end'      => '>}',
-			'callback' => $callback,
-			'fallback' => $fallback
-		]);
+		if ($hasUnescaped === true) {
+			$string = static::template($string, $data, [
+				'start'    => '{<',
+				'end'      => '>}',
+				'callback' => $callback,
+				'fallback' => $fallback
+			]);
+		}
 
 		return $string;
 	}

--- a/tests/Cms/Fieldsets/FieldsetTest.php
+++ b/tests/Cms/Fieldsets/FieldsetTest.php
@@ -102,6 +102,20 @@ class FieldsetTest extends TestCase
 		$this->assertSame('text', $fieldset->fields()['text']['type']);
 	}
 
+	public function testFieldsWithDisabledTabs(): void
+	{
+		$fieldset = new Fieldset([
+			'type' => 'test',
+			'tabs' => [
+				'content' => false
+			]
+		]);
+
+		$this->assertSame([], $fieldset->tabs());
+		$this->assertSame([], $fieldset->fields());
+		$this->assertFalse($fieldset->editable());
+	}
+
 	public function testForm(): void
 	{
 		$fieldset = new Fieldset([

--- a/tests/Form/Field/BlocksFieldTest.php
+++ b/tests/Form/Field/BlocksFieldTest.php
@@ -175,6 +175,34 @@ class BlocksFieldTest extends TestCase
 		$this->assertSame(['image', 'video'], $groups['media']['sets']);
 	}
 
+	public function testFormSharesCacheWithSiblings(): void
+	{
+		$fields = new Fields([
+			'blocks' => [
+				'type'      => 'blocks',
+				'fieldsets' => [
+					'text' => [
+						'fields' => [
+							'text' => ['type' => 'text']
+						]
+					]
+				]
+			]
+		], new Page(['slug' => 'test']));
+
+		$field = $fields->get('blocks');
+		$cache = $fields->cache();
+
+		// the block forms and all fieldsets must resolve their
+		// options through the cache of the surrounding form
+		$this->assertSame($cache, $field->form([])->fields()->cache());
+		$this->assertSame($cache, $field->fieldsets()->cache());
+		$this->assertSame(
+			$cache,
+			$field->fieldset('text')->form([])->fields()->cache()
+		);
+	}
+
 	public function testMax(): void
 	{
 		$field = $this->field('blocks', [

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Form\Field;
 
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
+use Kirby\Form\Fields;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(StructureField::class)]
@@ -190,6 +191,25 @@ class StructureFieldTest extends TestCase
 			'empty' => ['en' => 'Test', 'de' => 'Töst']
 		]);
 		$this->assertSame('Test', $field->empty());
+	}
+
+	public function testFormSharesCacheWithSiblings(): void
+	{
+		$fields = new Fields([
+			'structure' => [
+				'type'   => 'structure',
+				'fields' => [
+					'a' => ['type' => 'text']
+				]
+			]
+		], new Page(['slug' => 'test']));
+
+		// the nested form must resolve its options through the
+		// same cache as the form the structure field belongs to
+		$this->assertSame(
+			$fields->cache(),
+			$fields->get('structure')->form()->fields()->cache()
+		);
 	}
 
 	public function testIsValid(): void

--- a/tests/Form/FieldsCacheTest.php
+++ b/tests/Form/FieldsCacheTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Kirby\Form;
+
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(FieldsCache::class)]
+class FieldsCacheTest extends TestCase
+{
+	public function testOptions(): void
+	{
+		$cache = new FieldsCache();
+
+		$this->assertSame(['a'], $cache->options('a', fn () => ['a']));
+	}
+
+	public function testOptionsWithDifferentKeys(): void
+	{
+		$cache = new FieldsCache();
+
+		$this->assertSame(['a'], $cache->options('a', fn () => ['a']));
+		$this->assertSame(['b'], $cache->options('b', fn () => ['b']));
+	}
+
+	public function testOptionsWithEmptyResult(): void
+	{
+		$cache = new FieldsCache();
+
+		// an empty result is a valid result and must be kept
+		$this->assertSame([], $cache->options('a', fn () => []));
+		$this->assertSame([], $cache->options('a', fn () => ['later']));
+	}
+
+	public function testOptionsWithSameKey(): void
+	{
+		$cache = new FieldsCache();
+
+		$this->assertSame(['a'], $cache->options('a', fn () => ['a']));
+
+		// the stored result is returned, the second closure is never used
+		$this->assertSame(['a'], $cache->options('a', fn () => ['b']));
+	}
+}

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -69,6 +69,20 @@ class FieldsTest extends TestCase
 		$this->assertSame($this->app->site(), $fields->last()->model());
 	}
 
+	public function testCache(): void
+	{
+		$fields = new Fields(model: $this->model);
+		$this->assertInstanceOf(FieldsCache::class, $fields->cache());
+	}
+
+	public function testCacheWithPassedCache(): void
+	{
+		$cache  = new FieldsCache();
+		$fields = new Fields(model: $this->model, cache: $cache);
+
+		$this->assertSame($cache, $fields->cache());
+	}
+
 	public function testDefaults(): void
 	{
 		$fields = new Fields([
@@ -440,6 +454,49 @@ class FieldsTest extends TestCase
 		// language code passed
 		$fields = new Fields(fields: [], language: 'en');
 		$this->assertSame('en', $fields->language()->code());
+	}
+
+	public function testOptions(): void
+	{
+		$fields = new Fields(model: $this->model);
+
+		$this->assertSame(['a'], $fields->options('a', fn () => ['a']));
+
+		// the stored result is returned for the same key
+		$this->assertSame(['a'], $fields->options('a', fn () => ['b']));
+
+		// a different key gets its own result
+		$this->assertSame(['b'], $fields->options('b', fn () => ['b']));
+	}
+
+	public function testOptionsWithSharedCacheAndDifferentLanguages(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$cache = new FieldsCache();
+		$model = new Page(['slug' => 'test']);
+
+		$en = new Fields(model: $model, language: 'en', cache: $cache);
+		$de = new Fields(model: $model, language: 'de', cache: $cache);
+
+		// options can be translated, so each language keeps its own result
+		$this->assertSame(['en'], $en->options('a', fn () => ['en']));
+		$this->assertSame(['de'], $de->options('a', fn () => ['de']));
+		$this->assertSame(['en'], $en->options('a', fn () => ['other']));
+	}
+
+	public function testOptionsWithSharedCacheAndDifferentModels(): void
+	{
+		$cache = new FieldsCache();
+
+		$a = new Fields(model: new Page(['slug' => 'a']), cache: $cache);
+		$b = new Fields(model: new Page(['slug' => 'b']), cache: $cache);
+
+		// options are resolved against the model, so each model
+		// keeps its own result even with a shared cache
+		$this->assertSame(['a'], $a->options('key', fn () => ['a']));
+		$this->assertSame(['b'], $b->options('key', fn () => ['b']));
+		$this->assertSame(['a'], $a->options('key', fn () => ['other']));
 	}
 
 	public function testPassthrough(): void

--- a/tests/Panel/Controller/View/ModelViewControllerTest.php
+++ b/tests/Panel/Controller/View/ModelViewControllerTest.php
@@ -92,6 +92,80 @@ class ModelViewControllerTest extends TestCase
 		$this->assertNull($next);
 	}
 
+	public function testPreload(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/test' => [
+					'sections' => [
+						'content' => [
+							'type'   => 'fields',
+							'fields' => [
+								'text' => [
+									'type' => 'textarea'
+								]
+							]
+						],
+						'subpages' => [
+							'type' => 'pages'
+						]
+					]
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+		$this->model = $this->app->page('test');
+
+		$controller = new TestModelViewController($this->model);
+		$sections   = $controller->tab()['columns'][0]['sections'];
+
+		// the raw field definitions have been replaced
+		// with the computed field props
+		$fields = $sections['content']['fields'];
+		$this->assertSame('textarea', $fields['text']['type']);
+		$this->assertArrayHasKey('hidden', $fields['text']);
+		$this->assertArrayHasKey('saveable', $fields['text']);
+
+		// other section types are not touched
+		$this->assertArrayNotHasKey('fields', $sections['subpages']);
+	}
+
+	public function testPreloadWithInvalidField(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/test' => [
+					'sections' => [
+						'content' => [
+							'type'   => 'fields',
+							'fields' => [
+								'category' => [
+									'type'    => 'select',
+									'options' => [
+										'type'  => 'query',
+										'query' => 'kirby.doesNotExist'
+									]
+								]
+							]
+						]
+					]
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+		$this->model = $this->app->page('test');
+
+		$controller = new TestModelViewController($this->model);
+		$sections   = $controller->tab()['columns'][0]['sections'];
+
+		// when the field props cannot be computed, the raw definitions
+		// are removed and the error is passed to the section instead
+		$this->assertArrayNotHasKey('fields', $sections['content']);
+		$this->assertArrayHasKey('error', $sections['content']);
+	}
+
 	public function testPrev(): void
 	{
 		$controller = new TestModelViewController($this->model);

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -974,10 +974,21 @@ class StrTest extends TestCase
 			]
 		));
 
-		// prevent arbitrary code execution attacks from query placeholders in the untrusted data
+		// prevent arbitrary code execution attacks
+		// from query placeholders in the untrusted data
 		$this->assertSame(
 			'{{ dangerous }},{&lt; dangerous &gt;};{{ dangerous }},{< dangerous >}',
 			Str::safeTemplate('{{ malicious1 }},{{ malicious2 }};{< malicious1 >},{< malicious2 >}', [
+				'malicious1' => '{{ dangerous }}',
+				'malicious2' => '{< dangerous >}',
+				'dangerous' => '*deleting all of the content or something*'
+			])
+		);
+
+		// … also when the template itself has no unescaped placeholders
+		$this->assertSame(
+			'{{ dangerous }},{&lt; dangerous &gt;}',
+			Str::safeTemplate('{{ malicious1 }},{{ malicious2 }}', [
 				'malicious1' => '{{ dangerous }}',
 				'malicious2' => '{< dangerous >}',
 				'dangerous' => '*deleting all of the content or something*'


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

At least locally this feels a lot better than the flicker from loading sections lazily. 

Not sure if `ModelViewController` is the right place for resolving/preloading them. But could be.

Not sure if we should go ahead with this already or if this rather should be a step after getting rid of sections - cause then everything is fields and we can just do it directly.

### Merge first

- [ ] https://github.com/getkirby/kirby/pull/8333
