### PR TITLE
style: Use short class names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # cs fixer
 .php-cs-fixer.cache
+.php-cs-fixer.types.cache
 
 # editors
 *.sublime-project

--- a/.php-cs-fixer.types.php
+++ b/.php-cs-fixer.types.php
@@ -1,0 +1,30 @@
+<?php
+
+use PhpCsFixer\Finder;
+
+/**
+ * Shortens fully qualified class names in type declarations and docblocks
+ * to the imported or same-namespace name.
+ *
+ * This runs as a second pass on top of `.php-cs-fixer.dist.php`, because
+ * PHP CS Fixer applies one rule set per run and the rule must not reach
+ * templates, snippets and fixtures: those run in the global namespace,
+ * where the fixer would inject a `use` statement into the middle of the
+ * script instead of adding it to a header.
+ */
+
+$config = require __DIR__ . '/.php-cs-fixer.dist.php';
+
+$finder = Finder::create()
+	->in([__DIR__ . '/src', __DIR__ . '/tests'])
+	->filter(
+		fn ($file) => preg_match('/^namespace\s/m', $file->getContents()) === 1
+	);
+
+return $config
+	->setRules([
+		...$config->getRules(),
+		'fully_qualified_strict_types' => ['import_symbols' => true]
+	])
+	->setCacheFile('.php-cs-fixer.types.cache')
+	->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,12 @@
 			"@analyze",
 			"@test"
 		],
-		"fix": "cpx friendsofphp/php-cs-fixer:3.95.3 fix",
+		"fix": [
+			"@fix:style",
+			"@fix:types"
+		],
+		"fix:style": "cpx friendsofphp/php-cs-fixer:3.95.3 fix",
+		"fix:types": "cpx friendsofphp/php-cs-fixer:3.95.3 fix --config=.php-cs-fixer.types.php",
 		"test": "cpx brianium/paratest:7.20.0",
 		"test:coverage": [
 			"@putenv XDEBUG_MODE=coverage",

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -67,18 +67,18 @@
 		<UnusedFunctionCall errorLevel="suppress" />
 		<UnusedVariable errorLevel="suppress" />
 
-		<!-- Don't warn about the classes of optional PHP extensions -->
-		<UndefinedClass>
-			<errorLevel type="suppress">
-				<file name="src/Cache/ApcuCache.php" />
-			</errorLevel>
-		</UndefinedClass>
-
 		<!-- Don't warn about undefined magic methods/properties as Kirby resolves much of its API dynamically through __call/__callStatic/__get/__set, which Psalm cannot follow statically -->
 		<UndefinedMagicMethod errorLevel="suppress" />
 		<UndefinedMagicPropertyFetch errorLevel="suppress" />
 		<UndefinedMagicPropertyAssignment errorLevel="suppress" />
 	</issueHandlers>
+
+	<!-- Load Psalm's bundled stubs for optional extensions Kirby uses, so that analysis does not depend on which extensions the local PHP happens to have -->
+	<enableExtensions>
+		<extension name="apcu" />
+		<extension name="pdo" />
+		<extension name="redis" />
+	</enableExtensions>
 
 	<plugins>
 		<plugin filename="etc/psalm-plugins/HelperFunctionUsePlugin.php" />

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -66,7 +66,13 @@
 		<UnusedForeachValue errorLevel="suppress" />
 		<UnusedFunctionCall errorLevel="suppress" />
 		<UnusedVariable errorLevel="suppress" />
-		<UndefinedClass errorLevel="suppress" />
+
+		<!-- Don't warn about the classes of optional PHP extensions -->
+		<UndefinedClass>
+			<errorLevel type="suppress">
+				<file name="src/Cache/ApcuCache.php" />
+			</errorLevel>
+		</UndefinedClass>
 
 		<!-- Don't warn about undefined magic methods/properties as Kirby resolves much of its API dynamically through __call/__callStatic/__get/__set, which Psalm cannot follow statically -->
 		<UndefinedMagicMethod errorLevel="suppress" />

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -120,7 +120,7 @@ class Api
 	/**
 	 * Magic accessor for any given data
 	 *
-	 * @throws \Kirby\Exception\NotFoundException
+	 * @throws NotFoundException
 	 */
 	public function __call(string $method, array $args = [])
 	{
@@ -148,7 +148,7 @@ class Api
 	 * Execute an API call for the given path,
 	 * request method and optional request data
 	 *
-	 * @throws \Kirby\Exception\NotFoundException
+	 * @throws NotFoundException
 	 * @throws \Exception
 	 */
 	public function call(
@@ -218,7 +218,7 @@ class Api
 	/**
 	 * Setter and getter for an API collection
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If no collection for `$name` exists
+	 * @throws NotFoundException If no collection for `$name` exists
 	 * @throws \Exception
 	 */
 	public function collection(
@@ -248,7 +248,7 @@ class Api
 	 *
 	 * @psalm-return ($key is null ? array : mixed)
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If no data for `$key` exists
+	 * @throws NotFoundException If no data for `$key` exists
 	 */
 	public function data(string|null $key = null, ...$args): mixed
 	{
@@ -279,7 +279,7 @@ class Api
 	}
 
 	/**
-	 * @throws \Kirby\Exception\NotFoundException if the field type cannot be found or the field cannot be loaded
+	 * @throws NotFoundException if the field type cannot be found or the field cannot be loaded
 	 */
 	public function fieldApi(
 		ModelWithContent $model,
@@ -305,7 +305,7 @@ class Api
 	 * parent path and filename
 	 *
 	 * @param string $path Path to file's parent model
-	 * @throws \Kirby\Exception\NotFoundException if the file cannot be found
+	 * @throws NotFoundException if the file cannot be found
 	 */
 	public function file(
 		string $path,
@@ -318,7 +318,7 @@ class Api
 	 * Returns the all readable files for the parent
 	 *
 	 * @param string $path Path to file's parent model
-	 * @throws \Kirby\Exception\NotFoundException if the file cannot be found
+	 * @throws NotFoundException if the file cannot be found
 	 */
 	public function files(string $path): Files
 	{
@@ -386,7 +386,7 @@ class Api
 	/**
 	 * Returns an API model instance by name
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If no model for `$name` exists
+	 * @throws NotFoundException If no model for `$name` exists
 	 */
 	public function model(
 		string|null $name = null,
@@ -416,7 +416,7 @@ class Api
 	 * Returns the page object for the given id
 	 *
 	 * @param string $id Page's id
-	 * @throws \Kirby\Exception\NotFoundException if the page cannot be found
+	 * @throws NotFoundException if the page cannot be found
 	 */
 	public function page(string $id): Page|null
 	{
@@ -449,8 +449,8 @@ class Api
 	 * Returns the model's object for the given path
 	 *
 	 * @param string $path Path to parent model
-	 * @throws \Kirby\Exception\InvalidArgumentException if the model type is invalid
-	 * @throws \Kirby\Exception\NotFoundException if the model cannot be found
+	 * @throws InvalidArgumentException if the model type is invalid
+	 * @throws NotFoundException if the model cannot be found
 	 */
 	public function parent(string $path): ModelWithContent|null
 	{
@@ -533,7 +533,7 @@ class Api
 	 * Turns a Kirby object into an
 	 * API model or collection representation
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If `$object` cannot be resolved
+	 * @throws NotFoundException If `$object` cannot be resolved
 	 */
 	public function resolve($object): Model|Collection
 	{
@@ -730,7 +730,7 @@ class Api
 	}
 
 	/**
-	 * @throws \Kirby\Exception\NotFoundException if the section type cannot be found or the section cannot be loaded
+	 * @throws NotFoundException if the section type cannot be found or the section cannot be loaded
 	 */
 	public function sectionApi(
 		ModelWithContent $model,
@@ -848,7 +848,7 @@ class Api
 	/**
 	 * Returns the site object
 	 *
-	 * @throws \Kirby\Exception\NotFoundException if the site cannot be accessed
+	 * @throws NotFoundException if the site cannot be accessed
 	 * @since 5.4.0
 	 */
 	public function site(): Site
@@ -887,7 +887,7 @@ class Api
 	 * returns the current authenticated user if no
 	 * id is passed
 	 *
-	 * @throws \Kirby\Exception\NotFoundException if the user for the given id cannot be found
+	 * @throws NotFoundException if the user for the given id cannot be found
 	 */
 	public function user(string|null $id = null): User|null
 	{
@@ -913,7 +913,7 @@ class Api
 	/**
 	 * Validates that the acting user has access to the given area.
 	 *
-	 * @throws \Kirby\Exception\PermissionException
+	 * @throws PermissionException
 	 * @since 5.4.0
 	 */
 	public function validateAreaAccess(string $area): void

--- a/src/Api/Collection.php
+++ b/src/Api/Collection.php
@@ -4,6 +4,7 @@ namespace Kirby\Api;
 
 use Closure;
 use Exception;
+use Kirby\Exception\NotFoundException;
 use Kirby\Toolkit\Collection as BaseCollection;
 use Kirby\Toolkit\Str;
 
@@ -25,7 +26,7 @@ class Collection
 	/**
 	 * Collection constructor
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function __construct(
 		protected Api $api,
@@ -53,7 +54,7 @@ class Collection
 
 	/**
 	 * @return $this
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function select($keys = null): static
 	{
@@ -74,8 +75,8 @@ class Collection
 	}
 
 	/**
-	 * @throws \Kirby\Exception\NotFoundException
-	 * @throws \Exception
+	 * @throws NotFoundException
+	 * @throws Exception
 	 */
 	public function toArray(): array
 	{
@@ -99,8 +100,8 @@ class Collection
 	}
 
 	/**
-	 * @throws \Kirby\Exception\NotFoundException
-	 * @throws \Exception
+	 * @throws NotFoundException
+	 * @throws Exception
 	 */
 	public function toResponse(): array
 	{

--- a/src/Api/Model.php
+++ b/src/Api/Model.php
@@ -4,6 +4,7 @@ namespace Kirby\Api;
 
 use Closure;
 use Exception;
+use Kirby\Exception\NotFoundException;
 use Kirby\Toolkit\Str;
 
 /**
@@ -26,7 +27,7 @@ class Model
 	/**
 	 * Model constructor
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function __construct(
 		protected Api $api,
@@ -66,7 +67,7 @@ class Model
 
 	/**
 	 * @return $this
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function select($keys = null): static
 	{
@@ -87,7 +88,7 @@ class Model
 	}
 
 	/**
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function selection(): array
 	{
@@ -129,8 +130,8 @@ class Model
 	}
 
 	/**
-	 * @throws \Kirby\Exception\NotFoundException
-	 * @throws \Exception
+	 * @throws NotFoundException
+	 * @throws Exception
 	 */
 	public function toArray(): array
 	{
@@ -177,8 +178,8 @@ class Model
 	}
 
 	/**
-	 * @throws \Kirby\Exception\NotFoundException
-	 * @throws \Exception
+	 * @throws NotFoundException
+	 * @throws Exception
 	 */
 	public function toResponse(): array
 	{
@@ -202,7 +203,7 @@ class Model
 
 	/**
 	 * @return $this
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function view(string $name): static
 	{

--- a/src/Api/Upload.php
+++ b/src/Api/Upload.php
@@ -42,7 +42,7 @@ readonly class Upload
 	/**
 	 * Ensures a clean chunk ID by stripping forbidden characters
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException Too short ID string
+	 * @throws InvalidArgumentException Too short ID string
 	 */
 	public static function chunkId(string $id): string
 	{
@@ -104,7 +104,7 @@ readonly class Upload
 	/**
 	 * Throws an exception with the appropriate translated error message
 	 *
-	 * @throws \Exception Any upload error
+	 * @throws Exception Any upload error
 	 */
 	public static function error(int $error): never
 	{
@@ -151,7 +151,7 @@ readonly class Upload
 	/**
 	 * Upload the files and call closure for each file
 	 *
-	 * @throws \Exception Any upload error
+	 * @throws Exception Any upload error
 	 */
 	public function process(Closure $callback): array
 	{
@@ -226,10 +226,10 @@ readonly class Upload
 	 * in the tmp directory and only returning the new
 	 * $source path to the tmp file once complete
 	 *
-	 * @throws \Kirby\Exception\DuplicateException Duplicate first chunk (same filename and id)
+	 * @throws DuplicateException Duplicate first chunk (same filename and id)
 	 * @throws \Kirby\Exception\Exception Chunk offset does not match existing tmp file
-	 * @throws \Kirby\Exception\InvalidArgumentException Too short ID string
-	 * @throws \Kirby\Exception\NotFoundException Subsequent chunk has no  existing tmp file
+	 * @throws InvalidArgumentException Too short ID string
+	 * @throws NotFoundException Subsequent chunk has no  existing tmp file
 	 */
 	public function processChunk(
 		string $source,
@@ -380,11 +380,11 @@ readonly class Upload
 	/**
 	 * Ensures the sent chunk is valid
 	 *
-	 * @throws \Kirby\Exception\DuplicateException Duplicate first chunk (same filename and id)
-	 * @throws \Kirby\Exception\InvalidArgumentException Chunk offset does not match existing tmp file
-	 * @throws \Kirby\Exception\InvalidArgumentException The maximum file size for this blueprint was exceeded
-	 * @throws \Kirby\Exception\InvalidArgumentException Template or total length changed between chunks
-	 * @throws \Kirby\Exception\NotFoundException Subsequent chunk has no  existing tmp file
+	 * @throws DuplicateException Duplicate first chunk (same filename and id)
+	 * @throws InvalidArgumentException Chunk offset does not match existing tmp file
+	 * @throws InvalidArgumentException The maximum file size for this blueprint was exceeded
+	 * @throws InvalidArgumentException Template or total length changed between chunks
+	 * @throws NotFoundException Subsequent chunk has no  existing tmp file
 	 */
 	protected static function validateChunk(
 		string $source,
@@ -472,7 +472,7 @@ readonly class Upload
 	/**
 	 * Validate the files array for upload
 	 *
-	 * @throws \Exception No files were uploaded
+	 * @throws Exception No files were uploaded
 	 */
 	protected static function validateFiles(array $files): void
 	{

--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -11,6 +11,8 @@ use Kirby\Auth\User as AuthUser;
 use Kirby\Cms\App;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\LogicException;
+use Kirby\Exception\NotFoundException;
 use Kirby\Exception\PermissionException;
 use Kirby\Exception\UserNotFoundException;
 use Kirby\Http\Idn;
@@ -52,9 +54,9 @@ class Auth
 	 * Login a user with email and (maybe optional) password
 	 * as well as an auth challenge, if required by the auth method
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the rate limit was exceeded if any other error occurred with debug mode off
-	 * @throws \Kirby\Exception\NotFoundException If the email was invalid
-	 * @throws \Kirby\Exception\InvalidArgumentException If the password is not valid (via `$user->login()`)
+	 * @throws PermissionException If the rate limit was exceeded if any other error occurred with debug mode off
+	 * @throws NotFoundException If the email was invalid
+	 * @throws InvalidArgumentException If the password is not valid (via `$user->login()`)
 	 */
 	public function authenticate(
 		string $method,
@@ -94,9 +96,9 @@ class Auth
 	 * @param bool $long If `true`, a long session will be created
 	 * @param 'login'|'password-reset'|'2fa' $mode Purpose of the code
 	 *
-	 * @throws \Kirby\Exception\LogicException If there is no suitable authentication challenge (only in debug mode)
-	 * @throws \Kirby\Exception\NotFoundException If the user does not exist (only in debug mode)
-	 * @throws \Kirby\Exception\PermissionException If the rate limit is exceeded
+	 * @throws LogicException If there is no suitable authentication challenge (only in debug mode)
+	 * @throws NotFoundException If the user does not exist (only in debug mode)
+	 * @throws PermissionException If the rate limit is exceeded
 	 */
 	public function createChallenge(
 		string $email,
@@ -159,8 +161,8 @@ class Auth
 	 * Returns the logged in user by checking for a
 	 * basic authentication header with valid credentials
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException if the authorization header is invalid
-	 * @throws \Kirby\Exception\PermissionException if basic authentication is not allowed
+	 * @throws InvalidArgumentException if the authorization header is invalid
+	 * @throws PermissionException if basic authentication is not allowed
 	 */
 	public function currentUserFromBasicAuth(
 		BasicAuth|null $auth = null
@@ -201,8 +203,8 @@ class Auth
 	 * Throws an exception only in debug mode, otherwise falls back
 	 * to a public error without sensitive information
 	 *
-	 * @throws \Throwable Either the passed `$exception` or the `$fallback`
-	 *                    (no exception if debugging is disabled and no fallback was passed)
+	 * @throws Throwable Either the passed `$exception` or the `$fallback`
+	 *                   (no exception if debugging is disabled and no fallback was passed)
 	 */
 	protected function fail(
 		Throwable $exception,
@@ -245,7 +247,7 @@ class Auth
 	 * @since 6.0.0
 	 * @internal
 	 *
-	 * @throws \Throwable Fallback or the original error in debug mode
+	 * @throws Throwable Fallback or the original error in debug mode
 	 */
 	public function guard(
 		string|null $email,
@@ -288,7 +290,7 @@ class Auth
 	 *                         `null` to use the actual user again,
 	 *                         `'kirby'` for a virtual admin user or
 	 *                         `'nobody'` to disable the actual user
-	 * @throws \Kirby\Exception\NotFoundException if the given user cannot be found
+	 * @throws NotFoundException if the given user cannot be found
 	 */
 	public function impersonate(string|null $who = null): User|null
 	{
@@ -345,9 +347,9 @@ class Auth
 	/**
 	 * Login a user by email and password
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the rate limit was exceeded or if any other error occurred with debug mode off
-	 * @throws \Kirby\Exception\NotFoundException If the email was invalid
-	 * @throws \Kirby\Exception\InvalidArgumentException If the password is not valid (via `$user->login()`)
+	 * @throws PermissionException If the rate limit was exceeded or if any other error occurred with debug mode off
+	 * @throws NotFoundException If the email was invalid
+	 * @throws InvalidArgumentException If the password is not valid (via `$user->login()`)
 	 */
 	public function login(
 		string $email,
@@ -371,9 +373,9 @@ class Auth
 	 * Login a user by email, password and auth challenge
 	 * @since 3.5.0
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the rate limit was exceeded or if any other error occurred with debug mode off
-	 * @throws \Kirby\Exception\NotFoundException If the email was invalid
-	 * @throws \Kirby\Exception\InvalidArgumentException If the password is not valid (via `$user->login()`)
+	 * @throws PermissionException If the rate limit was exceeded or if any other error occurred with debug mode off
+	 * @throws NotFoundException If the email was invalid
+	 * @throws InvalidArgumentException If the password is not valid (via `$user->login()`)
 	 *
 	 * @deprecated 6.0.0 Use `self::authenticate()` instead
 	 */
@@ -536,7 +538,7 @@ class Auth
 	 * @param bool $allowImpersonation If set to false, only the actually
 	 *                                 logged in user will be returned
 	 *
-	 * @throws \Throwable If an authentication error occurred
+	 * @throws Throwable If an authentication error occurred
 	 */
 	public function user(
 		Session|array|null $session = null,
@@ -549,9 +551,9 @@ class Auth
 	 * Validates the user credentials and returns the user object on success;
 	 * otherwise logs the failed attempt
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the rate limit was exceeded or if any other error occurred with debug mode off
-	 * @throws \Kirby\Exception\NotFoundException If the email was invalid
-	 * @throws \Kirby\Exception\InvalidArgumentException If the password is not valid (via `$user->login()`)
+	 * @throws PermissionException If the rate limit was exceeded or if any other error occurred with debug mode off
+	 * @throws NotFoundException If the email was invalid
+	 * @throws InvalidArgumentException If the password is not valid (via `$user->login()`)
 	 */
 	public function validatePassword(
 		string $email,
@@ -594,13 +596,13 @@ class Auth
 	 * @since 3.5.0
 	 *
 	 * @param mixed $input User-provided auth code/input to verify
-	 * @return \Kirby\Cms\User User object of the logged-in user
+	 * @return User User object of the logged-in user
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the rate limit was exceeded, the challenge timed out, the code
-	 *                                              is incorrect or if any other error occurred with debug mode off
-	 * @throws \Kirby\Exception\NotFoundException If the user from the challenge doesn't exist
-	 * @throws \Kirby\Exception\InvalidArgumentException If no authentication challenge is active
-	 * @throws \Kirby\Exception\LogicException If the authentication challenge is invalid
+	 * @throws PermissionException If the rate limit was exceeded, the challenge timed out, the code
+	 *                             is incorrect or if any other error occurred with debug mode off
+	 * @throws NotFoundException If the user from the challenge doesn't exist
+	 * @throws InvalidArgumentException If no authentication challenge is active
+	 * @throws LogicException If the authentication challenge is invalid
 	 */
 	public function verifyChallenge(
 		#[SensitiveParameter]

--- a/src/Auth/Challenge.php
+++ b/src/Auth/Challenge.php
@@ -63,7 +63,7 @@ abstract class Challenge
 	 * Checks whether the challenge is available
 	 * for the specific user and purpose
 	 *
-	 * @param \Kirby\Cms\User $user User the code will be generated for
+	 * @param User $user User the code will be generated for
 	 * @param 'login'|'password-reset'|'2fa' $mode Purpose of the code
 	 */
 	public static function isAvailable(User $user, string $mode): bool

--- a/src/Auth/Challenges.php
+++ b/src/Auth/Challenges.php
@@ -53,7 +53,7 @@ class Challenges
 			($class = static::$challenges[$type] ?? null) &&
 			is_subclass_of($class, Challenge::class) === true
 		) {
-			/** @var class-string<\Kirby\Auth\Challenge> $class */
+			/** @var class-string<Challenge> $class */
 			return $class;
 		}
 
@@ -124,7 +124,7 @@ class Challenges
 	/**
 	 * Checks if an active challenge exists or fails otherwise
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	protected function ensureActiveChallenge(Session $session): string
 	{

--- a/src/Auth/Method/BasicAuthMethod.php
+++ b/src/Auth/Method/BasicAuthMethod.php
@@ -23,7 +23,7 @@ class BasicAuthMethod extends Method
 	 * Basic auth authenticates on every request,
 	 * so `$long` isn't relevant here
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the password is missing
+	 * @throws InvalidArgumentException If the password is missing
 	 */
 	public function authenticate(
 		string|null $email,
@@ -65,8 +65,8 @@ class BasicAuthMethod extends Method
 	 * Checks whether the current request attempts
 	 * to use HTTP basic authentication
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException if the authorization header is invalid
-	 * @throws \Kirby\Exception\PermissionException if basic authentication is not allowed
+	 * @throws InvalidArgumentException if the authorization header is invalid
+	 * @throws PermissionException if basic authentication is not allowed
 	 */
 	public static function isEnabled(
 		Auth $auth,
@@ -154,7 +154,7 @@ class BasicAuthMethod extends Method
 		// with the provided config
 		if (static::isEnabled($this->auth, $config, true) === true) {
 			/**
-			 * @var \Kirby\Http\Request\Auth\BasicAuth $auth
+			 * @var BasicAuth $auth
 			 */
 			$auth ??= $this->auth->kirby()->request()->auth();
 

--- a/src/Auth/Method/PasswordMethod.php
+++ b/src/Auth/Method/PasswordMethod.php
@@ -22,7 +22,7 @@ use SensitiveParameter;
 class PasswordMethod extends Method
 {
 	/**
-	 * @throws \Kirby\Exception\InvalidArgumentException If the password is missing
+	 * @throws InvalidArgumentException If the password is missing
 	 */
 	public function authenticate(
 		string|null $email,

--- a/src/Auth/Method/WebauthnMethod.php
+++ b/src/Auth/Method/WebauthnMethod.php
@@ -83,7 +83,7 @@ class WebauthnMethod extends Method
 	/**
 	 * Identifies the user behind the assertion
 	 *
-	 * @throws \Kirby\Exception\UserNotFoundException
+	 * @throws UserNotFoundException
 	 */
 	protected function findUser(mixed $payload): User
 	{

--- a/src/Auth/Methods.php
+++ b/src/Auth/Methods.php
@@ -35,7 +35,7 @@ class Methods
 	/**
 	 * Authenticates via the specific auth method
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If auth method type does not exists or is not available
+	 * @throws InvalidArgumentException If auth method type does not exists or is not available
 	 */
 	public function authenticate(
 		string $type,
@@ -66,7 +66,7 @@ class Methods
 			($class = static::$methods[$type] ?? null) &&
 			is_subclass_of($class, Method::class) === true
 		) {
-			/** @var class-string<\Kirby\Auth\Method> $class */
+			/** @var class-string<Method> $class */
 			return $class;
 		}
 
@@ -139,7 +139,7 @@ class Methods
 	 * Returns the first enabled auth method
 	 * for the current context
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If no auth method is enabled
+	 * @throws NotFoundException If no auth method is enabled
 	 */
 	public function firstEnabled(): Method
 	{

--- a/src/Auth/Passwords.php
+++ b/src/Auth/Passwords.php
@@ -123,7 +123,7 @@ class Passwords
 	 * Throws the configured custom error or a generic
 	 * policy error for the regex and callback modes
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	protected function fail(): never
 	{
@@ -203,7 +203,7 @@ class Passwords
 	/**
 	 * Validates a password against the policy
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function validate(
 		#[SensitiveParameter]
@@ -237,7 +237,7 @@ class Passwords
 	 * throw its own exception, while a `false` return value
 	 * triggers the generic policy error
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	protected function validateCallback(
 		Closure $rules,
@@ -261,7 +261,7 @@ class Passwords
 	 * Validates against the preset rules in a fixed order.
 	 * The first unmet rule throws its specific error.
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	protected function validatePresets(
 		array $rules,
@@ -313,7 +313,7 @@ class Passwords
 	/**
 	 * Validates against a regular expression
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	protected function validateRegex(
 		string $regex,

--- a/src/Auth/Service/Webauthn.php
+++ b/src/Auth/Service/Webauthn.php
@@ -43,7 +43,7 @@ class Webauthn extends BaseWebauthn
 	/**
 	 * Ensures the stored challenge is present and not empty
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	protected function challenge(mixed $challenge): string
 	{
@@ -59,7 +59,7 @@ class Webauthn extends BaseWebauthn
 	/**
 	 * Finds a stored credential by its id
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	protected function credential(array $credentials, string $id): array
 	{
@@ -147,7 +147,7 @@ class Webauthn extends BaseWebauthn
 	 * Turns the client payload (JSON string, object or array)
 	 * into an array
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	protected function payload(mixed $payload): array
 	{
@@ -195,7 +195,7 @@ class Webauthn extends BaseWebauthn
 	/**
 	 * Removes a credential by id and returns the remaining list
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function removeCredential(array $credentials, string $id): array
 	{
@@ -250,7 +250,7 @@ class Webauthn extends BaseWebauthn
 	 * returns the new signature counter. Every failure reports the
 	 * same generic error so it cannot be used as an oracle.
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	protected function verifyAssertion(
 		array $payload,
@@ -302,7 +302,7 @@ class Webauthn extends BaseWebauthn
 	 * Verifies a login and updates the matching credential's
 	 * signature counter
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function verifyLogin(
 		array $credentials,
@@ -341,7 +341,7 @@ class Webauthn extends BaseWebauthn
 	 * Verifies the registration of a new passkey and
 	 * returns the credential to store
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function verifyRegister(mixed $payload, string $challenge): array
 	{

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -2,9 +2,12 @@
 
 namespace Kirby\Auth;
 
+use Kirby\Auth\Method\BasicAuthMethod;
 use Kirby\Cms\App;
 use Kirby\Cms\User as CmsUser;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
+use Kirby\Exception\PermissionException;
 use Kirby\Http\Request\Auth\BasicAuth;
 use Kirby\Session\Session;
 use Throwable;
@@ -52,14 +55,14 @@ class User
 	 * Returns the logged in user by checking for a
 	 * basic authentication header with valid credentials
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException if the authorization header is invalid
-	 * @throws \Kirby\Exception\PermissionException if basic authentication is not allowed
+	 * @throws InvalidArgumentException if the authorization header is invalid
+	 * @throws PermissionException if basic authentication is not allowed
 	 */
 	public function fromBasicAuth(
 		BasicAuth|null $auth = null
 	): CmsUser|null {
 		/**
-		 * @var \Kirby\Auth\Method\BasicAuthMethod
+		 * @var BasicAuthMethod
 		 */
 		$basic = $this->auth->methods()->get('basic-auth');
 		return $basic->user($auth);
@@ -119,7 +122,7 @@ class User
 	 * @param bool $allowImpersonation If set to false, only the actually
 	 *                                 logged in user will be returned
 	 *
-	 * @throws \Throwable If an authentication error occurred
+	 * @throws Throwable If an authentication error occurred
 	 */
 	public function get(
 		Session|array|null $session = null,
@@ -162,7 +165,7 @@ class User
 	/**
 	 * Impersonates a user
 	 *
-	 * @throws \Kirby\Exception\NotFoundException if the given user cannot be found
+	 * @throws NotFoundException if the given user cannot be found
 	 */
 	public function impersonate(string|null $who = null): CmsUser|null
 	{

--- a/src/Blueprint/Blueprint.php
+++ b/src/Blueprint/Blueprint.php
@@ -56,7 +56,7 @@ class Blueprint
 	/**
 	 * Creates a new blueprint object with the given props
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the blueprint model is missing
+	 * @throws InvalidArgumentException If the blueprint model is missing
 	 */
 	public function __construct(array $props)
 	{
@@ -337,7 +337,7 @@ class Blueprint
 	/**
 	 * Normalize field props for a single field
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the filed name is missing or the field type is invalid
+	 * @throws InvalidArgumentException If the filed name is missing or the field type is invalid
 	 */
 	public static function fieldProps(array|string $props): array
 	{
@@ -465,7 +465,7 @@ class Blueprint
 	/**
 	 * Find a blueprint by name
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If the blueprint cannot be found
+	 * @throws NotFoundException If the blueprint cannot be found
 	 */
 	public static function find(string $name): array
 	{

--- a/src/Blueprint/FileBlueprint.php
+++ b/src/Blueprint/FileBlueprint.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Blueprint;
 
+use Kirby\Cms\File;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Filesystem\F;
 use Kirby\Filesystem\Mime;
@@ -16,7 +17,7 @@ use Kirby\Toolkit\Str;
  */
 class FileBlueprint extends Blueprint
 {
-	/** @var \Kirby\Cms\File */
+	/** @var File */
 	protected ModelWithContent $model;
 
 	/**

--- a/src/Blueprint/PageBlueprint.php
+++ b/src/Blueprint/PageBlueprint.php
@@ -3,6 +3,7 @@
 namespace Kirby\Blueprint;
 
 use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Page;
 
 /**
  * PageBlueprint
@@ -12,7 +13,7 @@ use Kirby\Cms\ModelWithContent;
  */
 class PageBlueprint extends Blueprint
 {
-	/** @var \Kirby\Cms\Page */
+	/** @var Page */
 	protected ModelWithContent $model;
 
 	/**

--- a/src/Blueprint/Section.php
+++ b/src/Blueprint/Section.php
@@ -35,7 +35,7 @@ class Section extends Component
 	protected SectionField|null $field = null;
 
 	/**
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function __construct(string $type, array $attrs = [])
 	{

--- a/src/Blueprint/SiteBlueprint.php
+++ b/src/Blueprint/SiteBlueprint.php
@@ -3,6 +3,7 @@
 namespace Kirby\Blueprint;
 
 use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Site;
 
 /**
  * Extension of the basic blueprint class
@@ -13,7 +14,7 @@ use Kirby\Cms\ModelWithContent;
  */
 class SiteBlueprint extends Blueprint
 {
-	/** @var \Kirby\Cms\Site */
+	/** @var Site */
 	protected ModelWithContent $model;
 
 	/**

--- a/src/Blueprint/UserBlueprint.php
+++ b/src/Blueprint/UserBlueprint.php
@@ -3,6 +3,8 @@
 namespace Kirby\Blueprint;
 
 use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\User;
+use Kirby\Exception\InvalidArgumentException;
 
 /**
  * Extension of the basic blueprint class
@@ -13,13 +15,13 @@ use Kirby\Cms\ModelWithContent;
  */
 class UserBlueprint extends Blueprint
 {
-	/** @var \Kirby\Cms\User */
+	/** @var User */
 	protected ModelWithContent $model;
 
 	/**
 	 * UserBlueprint constructor.
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function __construct(array $props)
 	{

--- a/src/Cache/RedisCache.php
+++ b/src/Cache/RedisCache.php
@@ -206,9 +206,11 @@ class RedisCache extends Cache
 		$value = (new Value($value, $minutes))->toJson();
 
 		if ($minutes > 0) {
-			return $this->connection->setex($key, $minutes * 60, $value);
+			$result = $this->connection->setex($key, $minutes * 60, $value);
+		} else {
+			$result = $this->connection->set($key, $value);
 		}
 
-		return $this->connection->set($key, $value);
+		return $result === true;
 	}
 }

--- a/src/Cms/App.php
+++ b/src/Cms/App.php
@@ -35,6 +35,7 @@ use Kirby\Template\Template;
 use Kirby\Text\KirbyTag;
 use Kirby\Text\KirbyTags;
 use Kirby\Toolkit\A;
+use Kirby\Toolkit\Collection;
 use Kirby\Toolkit\Config;
 use Kirby\Toolkit\Controller;
 use Kirby\Toolkit\LazyValue;
@@ -376,7 +377,7 @@ class App
 	 * by name. All relevant dependencies are
 	 * automatically injected
 	 *
-	 * @return \Kirby\Toolkit\Collection|null
+	 * @return Collection|null
 	 * @todo 6.0 Add return type declaration
 	 */
 	public function collection(string $name, array $options = [])
@@ -990,7 +991,7 @@ class App
 	 * Yields all models (site, pages, files and users) of this site
 	 * @since 4.0.0
 	 *
-	 * @return \Generator<string, \Kirby\Cms\ModelWithContent>
+	 * @return Generator<string, ModelWithContent>
 	 */
 	public function models(): Generator
 	{
@@ -1182,7 +1183,7 @@ class App
 		if ($page = $parent->find($id)) {
 			/**
 			 * We passed a single $id, we can be sure that the result is
-			 * @var \Kirby\Cms\Page $page
+			 * @var Page $page
 			 */
 			return $page;
 		}
@@ -1256,7 +1257,7 @@ class App
 	 * Path resolver for the router
 	 *
 	 * @unstable
-	 * @throws \Kirby\Exception\LogicException if the home page cannot be found
+	 * @throws LogicException if the home page cannot be found
 	 */
 	public function resolve(
 		string|null $path = null,
@@ -1639,7 +1640,7 @@ class App
 	 * Returns a system url
 	 *
 	 * @param bool $object If set to `true`, the URL is converted to an object
-	 * @psalm-return ($object is false ? string|null : \Kirby\Http\Uri)
+	 * @psalm-return ($object is false ? string|null : Uri)
 	 */
 	public function url(
 		string $type = 'index',
@@ -1674,7 +1675,7 @@ class App
 	 * Returns the current version number from
 	 * the composer.json (Keep that up to date! :))
 	 *
-	 * @throws \Kirby\Exception\LogicException if the Kirby version cannot be detected
+	 * @throws LogicException if the Kirby version cannot be detected
 	 */
 	public static function version(): string|null
 	{

--- a/src/Cms/App/Resolver.php
+++ b/src/Cms/App/Resolver.php
@@ -79,7 +79,7 @@ class Resolver
 	/**
 	 * Used in routes to resolve request paths
 	 *
-	 * @throws \Kirby\Exception\NotFoundException if the page does not exist
+	 * @throws NotFoundException if the page does not exist
 	 */
 	public function resolve(string|null $path = null): File|Page|Responder|Response
 	{
@@ -124,7 +124,7 @@ class Resolver
 	}
 
 	/**
-	 * @throws \Kirby\Exception\NotFoundException if the draft cannot be accessed
+	 * @throws NotFoundException if the draft cannot be accessed
 	 */
 	protected function resolveDraft(Page $draft, string|null $extension = null): Page|Responder|Response
 	{
@@ -138,7 +138,7 @@ class Resolver
 	}
 
 	/**
-	 * @throws \Kirby\Exception\NotFoundException if the file cannot be found or accessed
+	 * @throws NotFoundException if the file cannot be found or accessed
 	 */
 	protected function resolveFile(File|null $file): File
 	{
@@ -152,7 +152,7 @@ class Resolver
 	}
 
 	/**
-	 * @throws \Kirby\Exception\LogicException if the home page does not exist
+	 * @throws LogicException if the home page does not exist
 	 */
 	protected function resolveHomePage(): Page|Responder|Response
 	{
@@ -169,7 +169,7 @@ class Resolver
 	}
 
 	/**
-	 * @throws \Kirby\Exception\NotFoundException if the page cannot be found
+	 * @throws NotFoundException if the page cannot be found
 	 */
 	protected function resolvePage(Page $page, string|null $extension = null): Page|Responder|Response
 	{
@@ -191,7 +191,7 @@ class Resolver
 	}
 
 	/**
-	 * @throws \Kirby\Exception\NotFoundException if the file cannot be found or accessed
+	 * @throws NotFoundException if the file cannot be found or accessed
 	 */
 	protected function resolvePageFile(string $path): File
 	{
@@ -271,7 +271,7 @@ class Resolver
 	}
 
 	/**
-	 * @throws \Kirby\Exception\NotFoundException if the file cannot be found or accessed
+	 * @throws NotFoundException if the file cannot be found or accessed
 	 */
 	protected function resolveSiteFile(string $path): File
 	{

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -98,7 +98,7 @@ trait AppPlugins
 	/**
 	 * Register all given extensions
 	 *
-	 * @param \Kirby\Plugin\Plugin|null $plugin The plugin which defined those extensions
+	 * @param Plugin|null $plugin The plugin which defined those extensions
 	 */
 	public function extend(
 		array $extensions,
@@ -868,7 +868,7 @@ trait AppPlugins
 	 * Kirby plugin factory and getter
 	 *
 	 * @param array|null $extends If null is passed it will be used as getter. Otherwise as factory.
-	 * @throws \Kirby\Exception\DuplicateException
+	 * @throws DuplicateException
 	 */
 	public static function plugin(
 		string $name,

--- a/src/Cms/AppUsers.php
+++ b/src/Cms/AppUsers.php
@@ -38,7 +38,7 @@ trait AppUsers
 	 *                               impersonation will be reset afterwards
 	 * @return mixed If called without callback: User that was impersonated;
 	 *               if called with callback: Return value from the callback
-	 * @throws \Throwable
+	 * @throws Throwable
 	 */
 	public function impersonate(
 		string|null $who = null,

--- a/src/Cms/Block.php
+++ b/src/Cms/Block.php
@@ -19,7 +19,7 @@ use Throwable;
  * @license   https://getkirby.com/license
  * @since     3.5.0
  *
- * @extends \Kirby\Cms\Item<\Kirby\Cms\Blocks>
+ * @extends Item<Blocks>
  */
 class Block extends Item implements Stringable
 {
@@ -48,7 +48,7 @@ class Block extends Item implements Stringable
 	/**
 	 * Creates a new block object
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function __construct(array $params)
 	{
@@ -126,7 +126,7 @@ class Block extends Item implements Stringable
 	/**
 	 * Constructs a block object with registering blocks models
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function factory(array $params): static
 	{

--- a/src/Cms/Blocks.php
+++ b/src/Cms/Blocks.php
@@ -18,7 +18,7 @@ use Throwable;
  * @license   https://getkirby.com/license
  * @since     3.5.0
  *
- * @extends \Kirby\Cms\Items<\Kirby\Cms\Block>
+ * @extends Items<Block>
  */
 class Blocks extends Items
 {

--- a/src/Cms/Collection.php
+++ b/src/Cms/Collection.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Closure;
+use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\Collection as BaseCollection;
 use Kirby\Toolkit\Str;
@@ -22,14 +23,14 @@ use Throwable;
  * @license   https://getkirby.com/license
  *
  * @template TValue
- * @extends \Kirby\Toolkit\Collection<TValue>
+ * @extends BaseCollection<TValue>
  */
 class Collection extends BaseCollection
 {
 	use HasMethods;
 
 	/**
-	 * @var \Kirby\Cms\Pagination|null
+	 * @var Pagination|null
 	 */
 	protected $pagination;
 
@@ -87,7 +88,7 @@ class Collection extends BaseCollection
 	 * an entire second collection to the
 	 * current collection
 	 *
-	 * @param \Kirby\Cms\Collection<TValue>|array<TValue>|TValue $object
+	 * @param Collection<TValue>|array<TValue>|TValue $object
 	 * @return $this
 	 */
 	public function add($object): static
@@ -160,9 +161,9 @@ class Collection extends BaseCollection
 	 * Groups the items by a given field or callback. Returns a collection
 	 * with an item for each group and a collection for each group.
 	 *
-	 * @param string|\Closure $field
+	 * @param string|Closure $field
 	 * @param bool $caseInsensitive Ignore upper/lowercase for group names
-	 * @throws \Kirby\Exception\Exception
+	 * @throws Exception
 	 */
 	public function group(
 		$field,

--- a/src/Cms/Collections.php
+++ b/src/Cms/Collections.php
@@ -5,6 +5,7 @@ namespace Kirby\Cms;
 use Closure;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\F;
+use Kirby\Toolkit\Collection;
 use Kirby\Toolkit\Controller;
 
 /**
@@ -37,7 +38,7 @@ class Collections
 	 * Magic caller to enable something like
 	 * `$collections->myCollection()`
 	 *
-	 * @return \Kirby\Toolkit\Collection|null
+	 * @return Collection|null
 	 * @todo 6.0 Add return type declaration
 	 */
 	public function __call(string $name, array $arguments = [])
@@ -48,7 +49,7 @@ class Collections
 	/**
 	 * Loads a collection by name if registered
 	 *
-	 * @return \Kirby\Toolkit\Collection|null
+	 * @return Collection|null
 	 * @todo 6.0 Add deprecation warning when anything else than a Collection is returned
 	 * @todo 7.0 Add PHP return type declaration for `Toolkit\Collection`
 	 */
@@ -96,7 +97,7 @@ class Collections
 	 * Loads collection from php file in a
 	 * given directory or from plugin extension.
 	 *
-	 * @throws \Kirby\Exception\NotFoundException
+	 * @throws NotFoundException
 	 */
 	public function load(string $name): mixed
 	{

--- a/src/Cms/Email.php
+++ b/src/Cms/Email.php
@@ -64,7 +64,7 @@ class Email
 	 * prop arrays in case a preset is not needed
 	 *
 	 * @param string|array $preset Preset name or simple prop array
-	 * @throws \Kirby\Exception\NotFoundException
+	 * @throws NotFoundException
 	 */
 	protected function preset(string|array $preset): array
 	{
@@ -88,7 +88,7 @@ class Email
 	 * Renders the email template(s) and sets the body props
 	 * to the result
 	 *
-	 * @throws \Kirby\Exception\NotFoundException
+	 * @throws NotFoundException
 	 */
 	protected function template(): void
 	{

--- a/src/Cms/Event.php
+++ b/src/Cms/Event.php
@@ -231,7 +231,7 @@ class Event implements Stringable
 	 * Updates a given argument with a new value
 	 *
 	 * @unstable
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function updateArgument(string $name, $value): void
 	{

--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -15,7 +15,7 @@ use Kirby\Toolkit\Str;
  * @license   https://getkirby.com/license
  * @since     3.5.0
  *
- * @extends \Kirby\Cms\Item<\Kirby\Cms\Fieldsets>
+ * @extends Item<Fieldsets>
  */
 class Fieldset extends Item
 {

--- a/src/Cms/Fieldsets.php
+++ b/src/Cms/Fieldsets.php
@@ -15,7 +15,7 @@ use Kirby\Toolkit\Str;
  * @license   https://getkirby.com/license
  * @since     3.5.0
  *
- * @extends \Kirby\Cms\Items<\Kirby\Cms\Fieldset>
+ * @extends Items<Fieldset>
  */
 class Fieldsets extends Items
 {

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -11,6 +11,7 @@ use Kirby\Filesystem\IsFile;
 use Kirby\Panel\File as Panel;
 use Kirby\Toolkit\BlockCollectionAccess;
 use Kirby\Toolkit\Str;
+use Kirby\Uuid\FileUuid;
 
 /**
  * The `$file` object provides a set
@@ -29,8 +30,8 @@ use Kirby\Toolkit\Str;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Files>
- * @method \Kirby\Uuid\FileUuid uuid()
+ * @use HasSiblings<Files>
+ * @method FileUuid uuid()
  */
 class File extends ModelWithContent
 {
@@ -149,7 +150,7 @@ class File extends ModelWithContent
 	 */
 	public function blueprint(): FileBlueprint
 	{
-		/** @var \Kirby\Blueprint\FileBlueprint */
+		/** @var FileBlueprint */
 		return $this->blueprint ??= FileBlueprint::factory(
 			'files/' . $this->template(),
 			'files/default',

--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -20,7 +20,7 @@ use Kirby\Uuid\Uuids;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @mixin \Kirby\Cms\File
+ * @mixin File
  */
 trait FileActions
 {
@@ -35,7 +35,7 @@ trait FileActions
 	 * Renames the file (optionally also the extension).
 	 * The store is used to actually execute this.
 	 *
-	 * @throws \Kirby\Exception\LogicException
+	 * @throws LogicException
 	 */
 	#[BlockCollectionAccess]
 	public function changeName(
@@ -224,8 +224,8 @@ trait FileActions
 	 * way of generating files.
 	 *
 	 * @param bool $move If set to `true`, the source will be deleted
-	 * @throws \Kirby\Exception\InvalidArgumentException
-	 * @throws \Kirby\Exception\LogicException
+	 * @throws InvalidArgumentException
+	 * @throws LogicException
 	 */
 	#[BlockCollectionAccess]
 	public static function create(array $props, bool $move = false): static
@@ -440,7 +440,7 @@ trait FileActions
 	 * source.
 	 *
 	 * @param bool $move If set to `true`, the source will be deleted
-	 * @throws \Kirby\Exception\LogicException
+	 * @throws LogicException
 	 */
 	#[BlockCollectionAccess]
 	public function replace(string $source, bool $move = false): static
@@ -503,7 +503,7 @@ trait FileActions
 	 * Updates the file's data and ensures that
 	 * media files get wiped if `focus` changed
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the input array contains invalid values
+	 * @throws InvalidArgumentException If the input array contains invalid values
 	 */
 	#[BlockCollectionAccess]
 	public function update(

--- a/src/Cms/FileModifications.php
+++ b/src/Cms/FileModifications.php
@@ -95,7 +95,7 @@ trait FileModifications
 	 * Resizes the file with the given width and height
 	 * while keeping the aspect ratio.
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	#[BlockCollectionAccess]
 	public function resize(
@@ -173,7 +173,7 @@ trait FileModifications
 	 * could potentially also be a CDN or any other
 	 * place.
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	#[BlockCollectionAccess]
 	public function thumb(

--- a/src/Cms/FilePermissions.php
+++ b/src/Cms/FilePermissions.php
@@ -8,7 +8,7 @@ namespace Kirby\Cms;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\ModelPermissions<\Kirby\Cms\File>
+ * @extends ModelPermissions<File>
  */
 class FilePermissions extends ModelPermissions
 {
@@ -17,7 +17,7 @@ class FilePermissions extends ModelPermissions
 	/**
 	 * Used to cache once determined permissions in memory
 	 *
-	 * @param \Kirby\Cms\File $model
+	 * @param File $model
 	 * @psalm-suppress MoreSpecificImplementedParamType
 	 */
 	protected static function cacheKey(

--- a/src/Cms/FilePicker.php
+++ b/src/Cms/FilePicker.php
@@ -30,7 +30,7 @@ class FilePicker extends Picker
 	/**
 	 * Search all files for the picker
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function items(): Files|null
 	{

--- a/src/Cms/FileRules.php
+++ b/src/Cms/FileRules.php
@@ -21,8 +21,8 @@ class FileRules
 	/**
 	 * Validates if the filename can be changed
 	 *
-	 * @throws \Kirby\Exception\DuplicateException If a file with this name exists
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to rename the file
+	 * @throws DuplicateException If a file with this name exists
+	 * @throws PermissionException If the user is not allowed to rename the file
 	 */
 	public static function changeName(File $file, string $name): void
 	{
@@ -66,8 +66,8 @@ class FileRules
 	/**
 	 * Validates if the template of the file can be changed
 	 *
-	 * @throws \Kirby\Exception\LogicException If the template of the page cannot be changed at all
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the template
+	 * @throws LogicException If the template of the page cannot be changed at all
+	 * @throws PermissionException If the user is not allowed to change the template
 	 */
 	public static function changeTemplate(File $file, string $template): void
 	{
@@ -100,8 +100,8 @@ class FileRules
 	/**
 	 * Validates if the file can be created
 	 *
-	 * @throws \Kirby\Exception\DuplicateException If a file with the same name exists
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to create the file
+	 * @throws DuplicateException If a file with the same name exists
+	 * @throws PermissionException If the user is not allowed to create the file
 	 */
 	public static function create(File $file, BaseFile $upload): void
 	{
@@ -146,7 +146,7 @@ class FileRules
 	/**
 	 * Validates if the file can be deleted
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to delete the file
+	 * @throws PermissionException If the user is not allowed to delete the file
 	 */
 	public static function delete(File $file): void
 	{
@@ -160,8 +160,8 @@ class FileRules
 	/**
 	 * Validates if the file can be replaced
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to replace the file
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file type of the new file is different
+	 * @throws PermissionException If the user is not allowed to replace the file
+	 * @throws InvalidArgumentException If the file type of the new file is different
 	 */
 	public static function replace(File $file, BaseFile $upload): void
 	{
@@ -190,7 +190,7 @@ class FileRules
 	/**
 	 * Validates if the file can be updated
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to update the file
+	 * @throws PermissionException If the user is not allowed to update the file
 	 */
 	public static function update(File $file, array $content = []): void
 	{
@@ -204,7 +204,7 @@ class FileRules
 	/**
 	 * Validates the file extension
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the extension is missing or forbidden
+	 * @throws InvalidArgumentException If the extension is missing or forbidden
 	 */
 	public static function validExtension(File $file, string $extension): void
 	{
@@ -249,7 +249,7 @@ class FileRules
 	 *
 	 * @param string|false|null $mime If not passed, the MIME type is detected from the file,
 	 *                                if `false`, the MIME type is not validated for performance reasons
-	 * @throws \Kirby\Exception\InvalidArgumentException If the extension, MIME type or filename is missing or forbidden
+	 * @throws InvalidArgumentException If the extension, MIME type or filename is missing or forbidden
 	 */
 	public static function validFile(
 		File $file,
@@ -267,7 +267,7 @@ class FileRules
 	/**
 	 * Validates the filename
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the filename is missing or forbidden
+	 * @throws InvalidArgumentException If the filename is missing or forbidden
 	 */
 	public static function validFilename(File $file, string $filename): void
 	{
@@ -301,7 +301,7 @@ class FileRules
 	/**
 	 * Validates the MIME type
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the MIME type is missing or forbidden
+	 * @throws InvalidArgumentException If the MIME type is missing or forbidden
 	 */
 	public static function validMime(File $file, string|null $mime = null): void
 	{

--- a/src/Cms/Files.php
+++ b/src/Cms/Files.php
@@ -20,8 +20,8 @@ use Throwable;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template TValue of \Kirby\Cms\File
- * @extends \Kirby\Cms\Collection<TValue>
+ * @template TValue of File
+ * @extends Collection<TValue>
  */
 class Files extends Collection
 {
@@ -33,7 +33,7 @@ class Files extends Collection
 	public static array $methods = [];
 
 	/**
-	 * @var \Kirby\Cms\Page|\Kirby\Cms\Site|\Kirby\Cms\User
+	 * @var Page|Site|User
 	 */
 	protected object|null $parent = null;
 
@@ -42,9 +42,9 @@ class Files extends Collection
 	 * an entire second collection to the
 	 * current collection
 	 *
-	 * @param \Kirby\Cms\Files<TValue>|TValue|string $object
+	 * @param Files<TValue>|TValue|string $object
 	 * @return $this
-	 * @throws \Kirby\Exception\InvalidArgumentException When no `File` or `Files` object or an ID of an existing file is passed
+	 * @throws InvalidArgumentException When no `File` or `Files` object or an ID of an existing file is passed
 	 */
 	public function add($object): static
 	{
@@ -98,7 +98,7 @@ class Files extends Collection
 	 * Deletes the files with the given IDs
 	 * if they exist in the collection
 	 *
-	 * @throws \Kirby\Exception\Exception If not all files could be deleted
+	 * @throws Exception If not all files could be deleted
 	 */
 	public function delete(array $ids): void
 	{

--- a/src/Cms/Find.php
+++ b/src/Cms/Find.php
@@ -22,7 +22,7 @@ class Find
 	 * parent path and filename
 	 *
 	 * @param string $path Path to file's parent model
-	 * @throws \Kirby\Exception\NotFoundException if the file cannot be found
+	 * @throws NotFoundException if the file cannot be found
 	 */
 	public static function file(
 		string $path,
@@ -46,7 +46,7 @@ class Find
 	 * Returns the language object for the given code
 	 *
 	 * @param string $code Language code
-	 * @throws \Kirby\Exception\NotFoundException if the language cannot be found
+	 * @throws NotFoundException if the language cannot be found
 	 */
 	public static function language(string $code): Language|null
 	{
@@ -64,7 +64,7 @@ class Find
 	 * Returns the page object for the given id
 	 *
 	 * @param string $id Page's id
-	 * @throws \Kirby\Exception\NotFoundException if the page cannot be found
+	 * @throws NotFoundException if the page cannot be found
 	 */
 	public static function page(string $id): Page|null
 	{
@@ -87,8 +87,8 @@ class Find
 	 * Returns the model's object for the given path
 	 *
 	 * @param string $path Path to parent model
-	 * @throws \Kirby\Exception\InvalidArgumentException if the model type is invalid
-	 * @throws \Kirby\Exception\NotFoundException if the model cannot be found
+	 * @throws InvalidArgumentException if the model type is invalid
+	 * @throws NotFoundException if the model cannot be found
 	 */
 	public static function parent(string $path): ModelWithContent
 	{
@@ -135,7 +135,7 @@ class Find
 	 * Returns the role object for the given name
 	 *
 	 * @param string $name Role name/id
-	 * @throws \Kirby\Exception\NotFoundException if the role cannot be found
+	 * @throws NotFoundException if the role cannot be found
 	 */
 	public static function role(string $name): Role
 	{
@@ -164,7 +164,7 @@ class Find
 	/**
 	 * Returns the site object if the site is accessible
 	 *
-	 * @throws \Kirby\Exception\NotFoundException if the site cannot be accessed
+	 * @throws NotFoundException if the site cannot be accessed
 	 * @since 5.4.0
 	 */
 	public static function site(): Site
@@ -186,7 +186,7 @@ class Find
 	 * id is passed
 	 *
 	 * @param string|null $id User's id
-	 * @throws \Kirby\Exception\NotFoundException if the user for the given id cannot be found
+	 * @throws NotFoundException if the user for the given id cannot be found
 	 */
 	public static function user(string|null $id = null): User
 	{

--- a/src/Cms/HasMethods.php
+++ b/src/Cms/HasMethods.php
@@ -23,7 +23,7 @@ trait HasMethods
 	 * Calls a registered method class with the
 	 * passed arguments
 	 *
-	 * @throws \Kirby\Exception\BadMethodCallException
+	 * @throws BadMethodCallException
 	 */
 	#[BlockCollectionAccess]
 	protected function callMethod(string $method, array $args = []): mixed

--- a/src/Cms/HasSiblings.php
+++ b/src/Cms/HasSiblings.php
@@ -9,7 +9,7 @@ namespace Kirby\Cms;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template TCollection of \Kirby\Cms\Collection
+ * @template TCollection of Collection
  */
 trait HasSiblings
 {

--- a/src/Cms/Helpers.php
+++ b/src/Cms/Helpers.php
@@ -111,10 +111,10 @@ class Helpers
 	 * for all PHP errors and warnings
 	 * @since 3.7.4
 	 *
-	 * @param \Closure $action Any action that may cause an error or warning
-	 * @param \Closure $condition Closure that returns bool to determine if to
-	 *                            suppress an error, receives arguments for
-	 *                            `set_error_handler()`
+	 * @param Closure $action Any action that may cause an error or warning
+	 * @param Closure $condition Closure that returns bool to determine if to
+	 *                           suppress an error, receives arguments for
+	 *                           `set_error_handler()`
 	 * @param mixed $fallback Value to return when error is suppressed
 	 * @return mixed Return value of the `$action` closure,
 	 *               possibly overridden by `$fallback`
@@ -200,7 +200,7 @@ class Helpers
 	 * Determines the size/length of numbers,
 	 * strings, arrays and countable objects
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function size(mixed $value): int
 	{

--- a/src/Cms/Html.php
+++ b/src/Cms/Html.php
@@ -21,7 +21,7 @@ class Html extends \Kirby\Toolkit\Html
 	 * Creates one or multiple CSS link tags
 	 * @since 3.7.0
 	 *
-	 * @param string|array|\Kirby\Plugin\Plugin|\Kirby\Plugin\Assets $url Relative or absolute URLs, an array of URLs or `@auto` for automatic template css loading
+	 * @param string|array|Plugin|Assets $url Relative or absolute URLs, an array of URLs or `@auto` for automatic template css loading
 	 * @param string|array|null $options Pass an array of attributes for the link tag or a media attribute string
 	 */
 	public static function css(

--- a/src/Cms/Item.php
+++ b/src/Cms/Item.php
@@ -18,8 +18,8 @@ use Kirby\Toolkit\Str;
  * @license   https://getkirby.com/license
  * @since     3.5.0
  *
- * @template TCollection of \Kirby\Cms\Items
- * @use \Kirby\Cms\HasSiblings<TCollection>
+ * @template TCollection of Items
+ * @use HasSiblings<TCollection>
  */
 class Item
 {

--- a/src/Cms/Items.php
+++ b/src/Cms/Items.php
@@ -13,8 +13,8 @@ use Kirby\Exception\InvalidArgumentException;
  * @license   https://getkirby.com/license
  * @since     3.5.0
  *
- * @template TValue of \Kirby\Cms\Item
- * @extends \Kirby\Cms\Collection<TValue>
+ * @template TValue of Item
+ * @extends Collection<TValue>
  */
 class Items extends Collection
 {
@@ -30,7 +30,7 @@ class Items extends Collection
 	protected array $options;
 
 	/**
-	 * @var \Kirby\Cms\ModelWithContent
+	 * @var ModelWithContent
 	 */
 	protected object|null $parent = null;
 

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -25,7 +25,7 @@ use Stringable;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Languages>
+ * @use HasSiblings<Languages>
  */
 class Language implements Stringable
 {
@@ -214,7 +214,7 @@ class Language implements Stringable
 	 * Delete the current language and
 	 * all its translation files
 	 *
-	 * @throws \Kirby\Exception\Exception
+	 * @throws Exception
 	 */
 	#[BlockCollectionAccess]
 	public function delete(): bool
@@ -269,7 +269,7 @@ class Language implements Stringable
 	/**
 	 * Converts a "user-facing" language code to a `Language` object
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If the language does not exist
+	 * @throws NotFoundException If the language does not exist
 	 * @unstable
 	 */
 	public static function ensure(self|string|null $code = null): static

--- a/src/Cms/LanguagePermissions.php
+++ b/src/Cms/LanguagePermissions.php
@@ -8,7 +8,7 @@ namespace Kirby\Cms;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\ModelPermissions<\Kirby\Cms\Language>
+ * @extends ModelPermissions<Language>
  */
 class LanguagePermissions extends ModelPermissions
 {

--- a/src/Cms/LanguageRouter.php
+++ b/src/Cms/LanguageRouter.php
@@ -33,7 +33,7 @@ class LanguageRouter
 	 * Fetches all scoped routes for the
 	 * current language from the Kirby instance
 	 *
-	 * @throws \Kirby\Exception\NotFoundException
+	 * @throws NotFoundException
 	 */
 	public function routes(): array
 	{

--- a/src/Cms/LanguageRoutes.php
+++ b/src/Cms/LanguageRoutes.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Filesystem\F;
+use Kirby\Http\Route;
 
 /**
  * Generates multi-language routes for the Kirby router
@@ -46,7 +47,7 @@ class LanguageRoutes
 
 					// jump through to the fallback if nothing
 					// can be found for this language
-					/** @var \Kirby\Http\Route $this */
+					/** @var Route $this */
 					$this->next();
 				}
 			];

--- a/src/Cms/LanguageRules.php
+++ b/src/Cms/LanguageRules.php
@@ -19,8 +19,8 @@ class LanguageRules
 	/**
 	 * Validates if the language can be created
 	 *
-	 * @throws \Kirby\Exception\DuplicateException If the language already exists
-	 * @throws \Kirby\Exception\PermissionException If current user has not sufficient permissions
+	 * @throws DuplicateException If the language already exists
+	 * @throws PermissionException If current user has not sufficient permissions
 	 */
 	public static function create(Language $language): void
 	{
@@ -44,8 +44,8 @@ class LanguageRules
 	/**
 	 * Validates if the language can be deleted
 	 *
-	 * @throws \Kirby\Exception\LogicException If the language cannot be deleted
-	 * @throws \Kirby\Exception\PermissionException If current user has not sufficient permissions
+	 * @throws LogicException If the language cannot be deleted
+	 * @throws PermissionException If current user has not sufficient permissions
 	 */
 	public static function delete(Language $language): void
 	{
@@ -91,7 +91,7 @@ class LanguageRules
 	/**
 	 * Validates if the language code is formatted correctly
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the language code is not valid
+	 * @throws InvalidArgumentException If the language code is not valid
 	 */
 	public static function validLanguageCode(Language $language): void
 	{
@@ -109,7 +109,7 @@ class LanguageRules
 	/**
 	 * Validates if the language name is formatted correctly
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the language name is invalid
+	 * @throws InvalidArgumentException If the language name is invalid
 	 */
 	public static function validLanguageName(Language $language): void
 	{

--- a/src/Cms/Languages.php
+++ b/src/Cms/Languages.php
@@ -11,7 +11,7 @@ use Kirby\Filesystem\F;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\Collection<\Kirby\Cms\Language>
+ * @extends Collection<Language>
  */
 class Languages extends Collection
 {
@@ -24,7 +24,7 @@ class Languages extends Collection
 	 * Creates a new collection with the given language objects
 	 *
 	 * @param null $parent
-	 * @throws \Kirby\Exception\DuplicateException
+	 * @throws DuplicateException
 	 */
 	public function __construct(
 		array $objects = [],

--- a/src/Cms/Layout.php
+++ b/src/Cms/Layout.php
@@ -12,7 +12,7 @@ use Kirby\Content\Content;
  * @license   https://getkirby.com/license
  * @since     3.5.0
  *
- * @extends \Kirby\Cms\Item<\Kirby\Cms\Layouts>
+ * @extends Item<Layouts>
  */
 class Layout extends Item
 {

--- a/src/Cms/LayoutColumn.php
+++ b/src/Cms/LayoutColumn.php
@@ -12,7 +12,7 @@ use Kirby\Toolkit\Str;
  * @license   https://getkirby.com/license
  * @since     3.5.0
  *
- * @extends \Kirby\Cms\Item<\Kirby\Cms\LayoutColumns>
+ * @extends Item<LayoutColumns>
  */
 class LayoutColumn extends Item
 {

--- a/src/Cms/LayoutColumns.php
+++ b/src/Cms/LayoutColumns.php
@@ -9,7 +9,7 @@ namespace Kirby\Cms;
  * @license   https://getkirby.com/license
  * @since     3.5.0
  *
- * @extends \Kirby\Cms\Items<\Kirby\Cms\LayoutColumn>
+ * @extends Items<LayoutColumn>
  */
 class LayoutColumns extends Items
 {

--- a/src/Cms/Layouts.php
+++ b/src/Cms/Layouts.php
@@ -13,7 +13,7 @@ use Throwable;
  * @license   https://getkirby.com/license
  * @since     3.5.0
  *
- * @extends \Kirby\Cms\Items<\Kirby\Cms\Layout>
+ * @extends Items<Layout>
  */
 class Layouts extends Items
 {

--- a/src/Cms/LazyCollection.php
+++ b/src/Cms/LazyCollection.php
@@ -27,7 +27,7 @@ use Kirby\Exception\LogicException;
  * @license   https://getkirby.com/license
  *
  * @template TValue
- * @extends \Kirby\Cms\Collection<TValue>
+ * @extends Collection<TValue>
  */
 abstract class LazyCollection extends Collection
 {
@@ -224,7 +224,7 @@ abstract class LazyCollection extends Collection
 
 	/**
 	 * Returns an iterator for the elements
-	 * @return \Iterator<string, TValue>
+	 * @return Iterator<string, TValue>
 	 */
 	public function getIterator(): Iterator
 	{

--- a/src/Cms/ModelPermissions.php
+++ b/src/Cms/ModelPermissions.php
@@ -11,7 +11,7 @@ use Kirby\Toolkit\A;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template TModel of \Kirby\Cms\ModelWithContent|\Kirby\Cms\Language
+ * @template TModel of ModelWithContent|Language
  */
 abstract class ModelPermissions
 {

--- a/src/Cms/ModelState.php
+++ b/src/Cms/ModelState.php
@@ -16,7 +16,7 @@ class ModelState
 	/**
 	 * Updates the state of the given model.
 	 *
-	 * @template TModel of \Kirby\Cms\ModelWithContent
+	 * @template TModel of ModelWithContent
 	 * @param TModel $current
 	 * @param TModel|bool|null $next
 	 */

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -15,6 +15,7 @@ use Kirby\Content\Version;
 use Kirby\Content\VersionId;
 use Kirby\Content\Versions;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\NotFoundException;
 use Kirby\Form\Fields;
 use Kirby\Form\Form;
 use Kirby\Panel\Model;
@@ -170,7 +171,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	/**
 	 * Returns the content
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the language for the given code does not exist
+	 * @throws InvalidArgumentException If the language for the given code does not exist
 	 */
 	public function content(string|null $languageCode = null): Content
 	{
@@ -642,7 +643,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 * Returns a single translation by language code
 	 * If no code is specified the current translation is returned
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If the language does not exist
+	 * @throws NotFoundException If the language does not exist
 	 */
 	public function translation(
 		string|null $languageCode = null
@@ -670,7 +671,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	/**
 	 * Updates the model data
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the input array contains invalid values
+	 * @throws InvalidArgumentException If the input array contains invalid values
 	 */
 	#[BlockCollectionAccess]
 	public function update(

--- a/src/Cms/NestCollection.php
+++ b/src/Cms/NestCollection.php
@@ -11,7 +11,7 @@ use Kirby\Toolkit\Collection as BaseCollection;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Toolkit\Collection<\Kirby\Cms\NestCollection|\Kirby\Cms\NestObject|\Kirby\Content\Field>
+ * @extends BaseCollection<NestCollection|NestObject|\Kirby\Content\Field>
  */
 class NestCollection extends BaseCollection
 {

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -18,6 +18,7 @@ use Kirby\Toolkit\A;
 use Kirby\Toolkit\BlockCollectionAccess;
 use Kirby\Toolkit\LazyValue;
 use Kirby\Toolkit\Str;
+use Kirby\Uuid\PageUuid;
 use Throwable;
 
 /**
@@ -29,8 +30,8 @@ use Throwable;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Pages>
- * @method \Kirby\Uuid\PageUuid uuid()
+ * @use HasSiblings<Pages>
+ * @method PageUuid uuid()
  */
 class Page extends ModelWithContent
 {
@@ -203,7 +204,7 @@ class Page extends ModelWithContent
 	 */
 	public function blueprint(): PageBlueprint
 	{
-		/** @var \Kirby\Blueprint\PageBlueprint */
+		/** @var PageBlueprint */
 		return $this->blueprint ??= PageBlueprint::factory(
 			'pages/' . $this->intendedTemplate(),
 			'pages/default',
@@ -292,7 +293,7 @@ class Page extends ModelWithContent
 	/**
 	 * Call the page controller
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the controller returns invalid objects for `kirby`, `site`, `pages` or `page`
+	 * @throws InvalidArgumentException If the controller returns invalid objects for `kirby`, `site`, `pages` or `page`
 	 */
 	#[BlockCollectionAccess]
 	public function controller(
@@ -490,7 +491,7 @@ class Page extends ModelWithContent
 	/**
 	 * Compares the current object with the given page object
 	 *
-	 * @param \Kirby\Cms\Page|string $page
+	 * @param Page|string $page
 	 */
 	public function is($page): bool
 	{
@@ -600,7 +601,7 @@ class Page extends ModelWithContent
 	/**
 	 * Checks if the page is a child of the given page
 	 *
-	 * @param \Kirby\Cms\Page|string $parent
+	 * @param Page|string $parent
 	 */
 	public function isChildOf($parent): bool
 	{
@@ -610,7 +611,7 @@ class Page extends ModelWithContent
 	/**
 	 * Checks if the page is a descendant of the given page
 	 *
-	 * @param \Kirby\Cms\Page|string $parent
+	 * @param Page|string $parent
 	 */
 	public function isDescendantOf($parent): bool
 	{
@@ -906,8 +907,8 @@ class Page extends ModelWithContent
 	 * the default template.
 	 *
 	 * @param string $contentType
-	 * @param \Kirby\Content\VersionId|string|null $versionId Optional override for the auto-detected version to render
-	 * @throws \Kirby\Exception\NotFoundException If the default template cannot be found
+	 * @param VersionId|string|null $versionId Optional override for the auto-detected version to render
+	 * @throws NotFoundException If the default template cannot be found
 	 */
 	#[BlockCollectionAccess]
 	public function render(
@@ -1042,7 +1043,7 @@ class Page extends ModelWithContent
 	}
 
 	/**
-	 * @throws \Kirby\Exception\NotFoundException If the content representation cannot be found
+	 * @throws NotFoundException If the content representation cannot be found
 	 */
 	#[BlockCollectionAccess]
 	public function representation(mixed $type): Template

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -11,6 +11,7 @@ use Kirby\Content\VersionId;
 use Kirby\Exception\DuplicateException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
+use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\BlockCollectionAccess;
@@ -25,7 +26,7 @@ use Kirby\Uuid\Uuids;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @mixin \Kirby\Cms\Page
+ * @mixin Page
  */
 trait PageActions
 {
@@ -38,7 +39,7 @@ trait PageActions
 	 * @internal
 	 *
 	 * @return $this|static
-	 * @throws \Kirby\Exception\LogicException If a draft is being sorted or the directory cannot be moved
+	 * @throws LogicException If a draft is being sorted or the directory cannot be moved
 	 */
 	#[BlockCollectionAccess]
 	public function changeNum(int|null $num = null): static
@@ -91,7 +92,7 @@ trait PageActions
 	 * Changes the slug/uid of the page
 	 *
 	 * @return $this|static
-	 * @throws \Kirby\Exception\LogicException If the directory cannot be moved
+	 * @throws LogicException If the directory cannot be moved
 	 */
 	#[BlockCollectionAccess]
 	public function changeSlug(
@@ -170,8 +171,8 @@ trait PageActions
 	/**
 	 * Change the slug for a specific language
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If the language for the given language code cannot be found
-	 * @throws \Kirby\Exception\InvalidArgumentException If the slug for the default language is being changed
+	 * @throws NotFoundException If the language for the given language code cannot be found
+	 * @throws InvalidArgumentException If the slug for the default language is being changed
 	 */
 	protected function changeSlugForLanguage(
 		string $slug,
@@ -224,7 +225,7 @@ trait PageActions
 	 *
 	 * @param string $status "draft", "listed" or "unlisted"
 	 * @param int|null $position Optional sorting number
-	 * @throws \Kirby\Exception\InvalidArgumentException If an invalid status is being passed
+	 * @throws InvalidArgumentException If an invalid status is being passed
 	 */
 	#[BlockCollectionAccess]
 	public function changeStatus(
@@ -333,7 +334,7 @@ trait PageActions
 	 * Changes the page template
 	 *
 	 * @return $this|static
-	 * @throws \Kirby\Exception\LogicException If the textfile cannot be renamed/moved
+	 * @throws LogicException If the textfile cannot be renamed/moved
 	 */
 	#[BlockCollectionAccess]
 	public function changeTemplate(string $template): static
@@ -416,7 +417,7 @@ trait PageActions
 	 * (e.g. permissions) before calling it.
 	 * @internal
 	 *
-	 * @throws \Kirby\Exception\DuplicateException If the page already exists
+	 * @throws DuplicateException If the page already exists
 	 */
 	#[BlockCollectionAccess]
 	public function copy(array $options = []): static
@@ -815,7 +816,7 @@ trait PageActions
 
 	/**
 	 * @return $this|static
-	 * @throws \Kirby\Exception\LogicException If the folder cannot be moved
+	 * @throws LogicException If the folder cannot be moved
 	 */
 	#[BlockCollectionAccess]
 	public function publish(): static
@@ -881,7 +882,7 @@ trait PageActions
 	}
 
 	/**
-	 * @throws \Kirby\Exception\LogicException If the page is not included in the siblings collection
+	 * @throws LogicException If the page is not included in the siblings collection
 	 */
 	protected function resortSiblingsAfterListing(int|null $position = null): bool
 	{
@@ -970,7 +971,7 @@ trait PageActions
 	 * Convert a page from listed or unlisted to draft
 	 *
 	 * @return $this|static
-	 * @throws \Kirby\Exception\LogicException If the folder cannot be moved
+	 * @throws LogicException If the folder cannot be moved
 	 */
 	#[BlockCollectionAccess]
 	public function unpublish(): static

--- a/src/Cms/PagePermissions.php
+++ b/src/Cms/PagePermissions.php
@@ -8,7 +8,7 @@ namespace Kirby\Cms;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\ModelPermissions<\Kirby\Cms\Page>
+ * @extends ModelPermissions<Page>
  */
 class PagePermissions extends ModelPermissions
 {
@@ -17,7 +17,7 @@ class PagePermissions extends ModelPermissions
 	/**
 	 * Used to cache once determined permissions in memory
 	 *
-	 * @param \Kirby\Cms\Page $model
+	 * @param Page $model
 	 * @psalm-suppress MoreSpecificImplementedParamType
 	 */
 	protected static function cacheKey(

--- a/src/Cms/PagePicker.php
+++ b/src/Cms/PagePicker.php
@@ -162,7 +162,7 @@ class PagePicker extends Picker
 	/**
 	 * Search for pages by query string
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function itemsForQuery(): Pages
 	{
@@ -197,8 +197,8 @@ class PagePicker extends Picker
 	 * site root when the requested parent is missing or not
 	 * accessible for the current user.
 	 *
-	 * @throws \Kirby\Exception\PermissionException if neither the requested parent
-	 *                                              nor the site are accessible
+	 * @throws PermissionException if neither the requested parent
+	 *                             nor the site are accessible
 	 */
 	public function parent(): Page|Site
 	{

--- a/src/Cms/PageRules.php
+++ b/src/Cms/PageRules.php
@@ -20,7 +20,7 @@ class PageRules
 	/**
 	 * Validates if the sorting number of the page can be changed
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the given number is invalid
+	 * @throws InvalidArgumentException If the given number is invalid
 	 */
 	public static function changeNum(Page $page, int|null $num = null): void
 	{
@@ -32,8 +32,8 @@ class PageRules
 	/**
 	 * Validates if the slug for the page can be changed
 	 *
-	 * @throws \Kirby\Exception\DuplicateException If a page with this slug already exists
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the slug
+	 * @throws DuplicateException If a page with this slug already exists
+	 * @throws PermissionException If the user is not allowed to change the slug
 	 */
 	public static function changeSlug(Page $page, string $slug): void
 	{
@@ -68,7 +68,7 @@ class PageRules
 	/**
 	 * Validates if the status for the page can be changed
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the given status is invalid
+	 * @throws InvalidArgumentException If the given status is invalid
 	 */
 	public static function changeStatus(
 		Page $page,
@@ -92,7 +92,7 @@ class PageRules
 	/**
 	 * Validates if a page can be converted to a draft
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the status or the page cannot be converted to a draft
+	 * @throws PermissionException If the user is not allowed to change the status or the page cannot be converted to a draft
 	 */
 	public static function changeStatusToDraft(Page $page): void
 	{
@@ -114,8 +114,8 @@ class PageRules
 	/**
 	 * Validates if the status of a page can be changed to listed
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the given position is invalid
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the status or the status for the page cannot be changed by any user
+	 * @throws InvalidArgumentException If the given position is invalid
+	 * @throws PermissionException If the user is not allowed to change the status or the status for the page cannot be changed by any user
 	 */
 	public static function changeStatusToListed(Page $page, int $position): void
 	{
@@ -142,7 +142,7 @@ class PageRules
 	/**
 	 * Validates if the status of a page can be changed to unlisted
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the status
+	 * @throws PermissionException If the user is not allowed to change the status
 	 */
 	public static function changeStatusToUnlisted(Page $page)
 	{
@@ -152,8 +152,8 @@ class PageRules
 	/**
 	 * Validates if the template of the page can be changed
 	 *
-	 * @throws \Kirby\Exception\LogicException If the template of the page cannot be changed at all
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the template
+	 * @throws LogicException If the template of the page cannot be changed at all
+	 * @throws PermissionException If the user is not allowed to change the template
 	 */
 	public static function changeTemplate(Page $page, string $template): void
 	{
@@ -180,8 +180,8 @@ class PageRules
 	/**
 	 * Validates if the title of the page can be changed
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the new title is empty
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the title
+	 * @throws InvalidArgumentException If the new title is empty
+	 * @throws PermissionException If the user is not allowed to change the title
 	 */
 	public static function changeTitle(Page $page, string $title): void
 	{
@@ -198,9 +198,9 @@ class PageRules
 	/**
 	 * Validates if the page can be created
 	 *
-	 * @throws \Kirby\Exception\DuplicateException If the same page or a draft already exists
-	 * @throws \Kirby\Exception\InvalidArgumentException If the slug is invalid
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to create this page
+	 * @throws DuplicateException If the same page or a draft already exists
+	 * @throws InvalidArgumentException If the slug is invalid
+	 * @throws PermissionException If the user is not allowed to create this page
 	 */
 	public static function create(Page $page): void
 	{
@@ -249,8 +249,8 @@ class PageRules
 	/**
 	 * Validates if the page can be deleted
 	 *
-	 * @throws \Kirby\Exception\LogicException If the page has children and should not be force-deleted
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to delete the page
+	 * @throws LogicException If the page has children and should not be force-deleted
+	 * @throws PermissionException If the user is not allowed to delete the page
 	 */
 	public static function delete(Page $page, bool $force = false): void
 	{
@@ -269,7 +269,7 @@ class PageRules
 	/**
 	 * Validates if the page can be duplicated
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to duplicate the page
+	 * @throws PermissionException If the user is not allowed to duplicate the page
 	 */
 	public static function duplicate(
 		Page $page,
@@ -399,7 +399,7 @@ class PageRules
 	/**
 	 * Validates if the page can be updated
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to update the page
+	 * @throws PermissionException If the user is not allowed to update the page
 	 */
 	public static function update(Page $page, array $content = []): void
 	{
@@ -415,7 +415,7 @@ class PageRules
 	 * Ensures that the slug is not empty and doesn't exceed the maximum length
 	 * to make sure that the directory name will be accepted by the filesystem
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the slug is empty or too long
+	 * @throws InvalidArgumentException If the slug is empty or too long
 	 */
 	public static function validateSlugLength(string $slug): void
 	{
@@ -442,7 +442,7 @@ class PageRules
 	 * Ensure that a top-level page path does not start with one of
 	 * the reserved URL paths, e.g. for API or the Panel
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the page ID starts as one of the disallowed paths
+	 * @throws InvalidArgumentException If the page ID starts as one of the disallowed paths
 	 */
 	protected static function validateSlugProtectedPaths(
 		Page $page,
@@ -473,7 +473,7 @@ class PageRules
 	/**
 	 * Ensures that the page title is not empty
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the title is empty
+	 * @throws InvalidArgumentException If the title is empty
 	 */
 	public static function validateTitleLength(string $title): void
 	{

--- a/src/Cms/Pages.php
+++ b/src/Cms/Pages.php
@@ -21,8 +21,8 @@ use Throwable;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template TValue of \Kirby\Cms\Page
- * @extends \Kirby\Cms\Collection<TValue>
+ * @template TValue of Page
+ * @extends Collection<TValue>
  */
 class Pages extends Collection
 {
@@ -44,7 +44,7 @@ class Pages extends Collection
 	public static array $methods = [];
 
 	/**
-	 * @var \Kirby\Cms\Page|\Kirby\Cms\Site|null
+	 * @var Page|Site|null
 	 */
 	protected object|null $parent = null;
 
@@ -53,9 +53,9 @@ class Pages extends Collection
 	 * an entire second collection to the
 	 * current collection
 	 *
-	 * @param \Kirby\Cms\Pages<TValue>|TValue|string $object
+	 * @param Pages<TValue>|TValue|string $object
 	 * @return $this
-	 * @throws \Kirby\Exception\InvalidArgumentException When no `Page` or `Pages` object or an ID of an existing page is passed
+	 * @throws InvalidArgumentException When no `Page` or `Pages` object or an ID of an existing page is passed
 	 */
 	public function add($object): static
 	{
@@ -124,7 +124,7 @@ class Pages extends Collection
 	 * Deletes the pages with the given IDs
 	 * if they exist in the collection
 	 *
-	 * @throws \Kirby\Exception\Exception If not all pages could be deleted
+	 * @throws Exception If not all pages could be deleted
 	 */
 	public function delete(array $ids): void
 	{

--- a/src/Cms/Permissions.php
+++ b/src/Cms/Permissions.php
@@ -96,7 +96,7 @@ class Permissions
 	/**
 	 * Permissions constructor
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function __construct(array|bool|null $settings = [])
 	{

--- a/src/Cms/Roles.php
+++ b/src/Cms/Roles.php
@@ -13,7 +13,7 @@ namespace Kirby\Cms;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\Collection<\Kirby\Cms\Role>
+ * @extends Collection<Role>
  */
 class Roles extends Collection
 {

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -10,6 +10,7 @@ use Kirby\Filesystem\Dir;
 use Kirby\Panel\Site as Panel;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\BlockCollectionAccess;
+use Kirby\Uuid\SiteUuid;
 
 /**
  * The `$site` object is the root element
@@ -20,7 +21,7 @@ use Kirby\Toolkit\BlockCollectionAccess;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @method \Kirby\Uuid\SiteUuid uuid()
+ * @method SiteUuid uuid()
  */
 class Site extends ModelWithContent
 {
@@ -164,7 +165,7 @@ class Site extends ModelWithContent
 	 */
 	public function blueprint(): SiteBlueprint
 	{
-		/** @var \Kirby\Blueprint\SiteBlueprint */
+		/** @var SiteBlueprint */
 		return $this->blueprint ??= SiteBlueprint::factory('site', null, $this);
 	}
 

--- a/src/Cms/SiteActions.php
+++ b/src/Cms/SiteActions.php
@@ -11,7 +11,7 @@ use Kirby\Toolkit\BlockCollectionAccess;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @mixin \Kirby\Cms\Site
+ * @mixin Site
  */
 trait SiteActions
 {

--- a/src/Cms/SitePermissions.php
+++ b/src/Cms/SitePermissions.php
@@ -8,7 +8,7 @@ namespace Kirby\Cms;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\ModelPermissions<\Kirby\Cms\Site>
+ * @extends ModelPermissions<Site>
  */
 class SitePermissions extends ModelPermissions
 {

--- a/src/Cms/SiteRules.php
+++ b/src/Cms/SiteRules.php
@@ -17,8 +17,8 @@ class SiteRules
 	/**
 	 * Validates if the site title can be changed
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the title is empty
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the title
+	 * @throws InvalidArgumentException If the title is empty
+	 * @throws PermissionException If the user is not allowed to change the title
 	 */
 	public static function changeTitle(Site $site, string $title): void
 	{
@@ -38,7 +38,7 @@ class SiteRules
 	/**
 	 * Validates if the site can be updated
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to update the site
+	 * @throws PermissionException If the user is not allowed to update the site
 	 */
 	public static function update(Site $site, array $content = []): void
 	{

--- a/src/Cms/Structure.php
+++ b/src/Cms/Structure.php
@@ -13,7 +13,7 @@ namespace Kirby\Cms;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\Items<\Kirby\Cms\StructureObject>
+ * @extends Items<StructureObject>
  */
 class Structure extends Items
 {

--- a/src/Cms/StructureObject.php
+++ b/src/Cms/StructureObject.php
@@ -17,7 +17,7 @@ use Kirby\Content\Content;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\Item<\Kirby\Cms\Structure>
+ * @extends Item<Structure>
  */
 class StructureObject extends Item
 {

--- a/src/Cms/System.php
+++ b/src/Cms/System.php
@@ -3,6 +3,8 @@
 namespace Kirby\Cms;
 
 use Kirby\Cms\System\UpdateStatus;
+use Kirby\Exception\Exception;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Toolkit\A;
@@ -190,7 +192,7 @@ class System
 	 * Create the most important folders
 	 * if they don't exist yet
 	 *
-	 * @throws \Kirby\Exception\PermissionException
+	 * @throws PermissionException
 	 */
 	public function init(): void
 	{
@@ -308,8 +310,8 @@ class System
 	 * Returns the configured UI modes for the login form
 	 * with their respective options
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the configuration is invalid
-	 *                                                   (only in debug mode)
+	 * @throws InvalidArgumentException If the configuration is invalid
+	 *                                  (only in debug mode)
 	 *
 	 * @deprecated 6.0.0 Use `$kirby->auth()->methods()->enabled()` instead
 	 */
@@ -341,8 +343,8 @@ class System
 	 * and adds it to the .license file in the config
 	 * folder if possible.
 	 *
-	 * @throws \Kirby\Exception\Exception
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws Exception
+	 * @throws InvalidArgumentException
 	 */
 	public function register(
 		string|null $license = null,

--- a/src/Cms/Translations.php
+++ b/src/Cms/Translations.php
@@ -14,7 +14,7 @@ use Kirby\Filesystem\F;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\Collection<\Kirby\Cms\Translation>
+ * @extends Collection<Translation>
  */
 class Translations extends Collection
 {

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -14,6 +14,7 @@ use Kirby\Panel\User as Panel;
 use Kirby\Session\Session;
 use Kirby\Toolkit\BlockCollectionAccess;
 use Kirby\Toolkit\Str;
+use Kirby\Uuid\UserUuid;
 use SensitiveParameter;
 
 /**
@@ -23,8 +24,8 @@ use SensitiveParameter;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @use \Kirby\Cms\HasSiblings<\Kirby\Cms\Users>
- * @method \Kirby\Uuid\UserUuid uuid()
+ * @use HasSiblings<Users>
+ * @method UserUuid uuid()
  */
 class User extends ModelWithContent
 {
@@ -152,7 +153,7 @@ class User extends ModelWithContent
 	public function blueprint(): UserBlueprint
 	{
 		try {
-			/** @var \Kirby\Blueprint\UserBlueprint */
+			/** @var UserBlueprint */
 			return $this->blueprint ??= UserBlueprint::factory(
 				'users/' . $this->role(),
 				'users/default',
@@ -375,7 +376,7 @@ class User extends ModelWithContent
 	/**
 	 * Logs the user in
 	 *
-	 * @param \Kirby\Session\Session|array|null $session Session options or session object to set the user in
+	 * @param Session|array|null $session Session options or session object to set the user in
 	 */
 	#[BlockCollectionAccess]
 	public function login(
@@ -392,7 +393,7 @@ class User extends ModelWithContent
 	/**
 	 * Logs the user in without checking the password
 	 *
-	 * @param \Kirby\Session\Session|array|null $session Session options or session object to set the user in
+	 * @param Session|array|null $session Session options or session object to set the user in
 	 */
 	#[BlockCollectionAccess]
 	public function loginPasswordless(
@@ -430,7 +431,7 @@ class User extends ModelWithContent
 	/**
 	 * Logs the user out
 	 *
-	 * @param \Kirby\Session\Session|array|null $session Session options or session object to unset the user in
+	 * @param Session|array|null $session Session options or session object to unset the user in
 	 */
 	#[BlockCollectionAccess]
 	public function logout(Session|array|null $session = null): void
@@ -706,7 +707,7 @@ class User extends ModelWithContent
 	/**
 	 * Converts session options into a session object
 	 *
-	 * @param \Kirby\Session\Session|array $session Session options or session object to unset the user in
+	 * @param Session|array $session Session options or session object to unset the user in
 	 */
 	protected function sessionFromOptions(Session|array|null $session): Session
 	{
@@ -779,9 +780,9 @@ class User extends ModelWithContent
 	/**
 	 * Compares the given password with the stored one
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If the user has no password
-	 * @throws \Kirby\Exception\InvalidArgumentException If the entered password is not valid
-	 *                                                   or does not match the user password
+	 * @throws NotFoundException If the user has no password
+	 * @throws InvalidArgumentException If the entered password is not valid
+	 *                                  or does not match the user password
 	 */
 	#[BlockCollectionAccess]
 	public function validatePassword(

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -7,6 +7,7 @@ use Kirby\Content\ImmutableMemoryStorage;
 use Kirby\Content\MemoryStorage;
 use Kirby\Data\Data;
 use Kirby\Data\Json;
+use Kirby\Exception\LogicException;
 use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
@@ -23,7 +24,7 @@ use Throwable;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @mixin \Kirby\Cms\User
+ * @mixin User
  */
 trait UserActions
 {
@@ -200,7 +201,7 @@ trait UserActions
 	 * 4. applies the `after` hook
 	 * 5. returns the result
 	 *
-	 * @throws \Kirby\Exception\PermissionException
+	 * @throws PermissionException
 	 */
 	protected function commit(
 		string $action,
@@ -335,7 +336,7 @@ trait UserActions
 	/**
 	 * Deletes the user
 	 *
-	 * @throws \Kirby\Exception\LogicException
+	 * @throws LogicException
 	 */
 	#[BlockCollectionAccess]
 	public function delete(): bool
@@ -525,7 +526,7 @@ trait UserActions
 		string|null $languageCode = null,
 		bool $validate = false
 	): static {
-		/** @var \Kirby\Cms\User $user */
+		/** @var User $user */
 		$user = parent::update($input, $languageCode, $validate);
 
 		// set auth user data only if the current user is this user

--- a/src/Cms/UserPermissions.php
+++ b/src/Cms/UserPermissions.php
@@ -8,14 +8,14 @@ namespace Kirby\Cms;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\ModelPermissions<\Kirby\Cms\User>
+ * @extends ModelPermissions<User>
  */
 class UserPermissions extends ModelPermissions
 {
 	/**
 	 * Used to cache once determined permissions in memory
 	 *
-	 * @param \Kirby\Cms\User $model
+	 * @param User $model
 	 * @psalm-suppress MoreSpecificImplementedParamType
 	 */
 	protected static function cacheKey(
@@ -63,7 +63,7 @@ class UserPermissions extends ModelPermissions
 	}
 
 	/**
-	 * @param \Kirby\Cms\User $model
+	 * @param User $model
 	 * @psalm-suppress MoreSpecificImplementedParamType
 	 */
 	protected static function category(ModelWithContent|Language $model): string

--- a/src/Cms/UserPicker.php
+++ b/src/Cms/UserPicker.php
@@ -30,7 +30,7 @@ class UserPicker extends Picker
 	/**
 	 * Search all users for the picker
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function items(): Users|null
 	{

--- a/src/Cms/UserRules.php
+++ b/src/Cms/UserRules.php
@@ -25,7 +25,7 @@ class UserRules
 	/**
 	 * Validates if the email address can be changed
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the address
+	 * @throws PermissionException If the user is not allowed to change the address
 	 */
 	public static function changeEmail(User $user, string $email): void
 	{
@@ -42,7 +42,7 @@ class UserRules
 	/**
 	 * Validates if the language can be changed
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the language
+	 * @throws PermissionException If the user is not allowed to change the language
 	 */
 	public static function changeLanguage(User $user, string $language): void
 	{
@@ -59,7 +59,7 @@ class UserRules
 	/**
 	 * Validates if the name can be changed
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the name
+	 * @throws PermissionException If the user is not allowed to change the name
 	 */
 	public static function changeName(User $user, string $name): void
 	{
@@ -74,7 +74,7 @@ class UserRules
 	/**
 	 * Validates if the password can be changed
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the password
+	 * @throws PermissionException If the user is not allowed to change the password
 	 */
 	public static function changePassword(
 		User $user,
@@ -94,8 +94,8 @@ class UserRules
 	/**
 	 * Validates if the role can be changed
 	 *
-	 * @throws \Kirby\Exception\LogicException If the user is the last admin
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the role
+	 * @throws LogicException If the user is the last admin
+	 * @throws PermissionException If the user is not allowed to change the role
 	 */
 	public static function changeRole(User $user, string $role): void
 	{
@@ -137,7 +137,7 @@ class UserRules
 	 * Validates if the user secret can be changed
 	 * @since 6.0.0
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the secret
+	 * @throws PermissionException If the user is not allowed to change the secret
 	 */
 	public static function changeSecret(
 		User $user,
@@ -162,7 +162,7 @@ class UserRules
 	 * @since 4.0.0
 	 * @deprecated 6.0.0
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the password
+	 * @throws PermissionException If the user is not allowed to change the password
 	 */
 	public static function changeTotp(
 		User $user,
@@ -190,7 +190,7 @@ class UserRules
 	/**
 	 * Validates if the user can be created
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to create a new user
+	 * @throws PermissionException If the user is not allowed to create a new user
 	 */
 	public static function create(User $user, array $props = []): void
 	{
@@ -247,7 +247,7 @@ class UserRules
 	/**
 	 * Validates if a new avatar can be created
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to create a new avatar
+	 * @throws PermissionException If the user is not allowed to create a new avatar
 	 */
 	public static function createAvatar(User $user, string $source, string $extension): void
 	{
@@ -271,8 +271,8 @@ class UserRules
 	/**
 	 * Validates if the user can be deleted
 	 *
-	 * @throws \Kirby\Exception\LogicException If this is the last user or last admin, which cannot be deleted
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to delete this user
+	 * @throws LogicException If this is the last user or last admin, which cannot be deleted
+	 * @throws PermissionException If the user is not allowed to delete this user
 	 */
 	public static function delete(User $user): void
 	{
@@ -299,7 +299,7 @@ class UserRules
 	/**
 	 * Validates if the avatar for the user can be deleted
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to delete this user's avatar
+	 * @throws PermissionException If the user is not allowed to delete this user's avatar
 	 */
 	public static function deleteAvatar(User $user): void
 	{
@@ -321,7 +321,7 @@ class UserRules
 	/**
 	 * Validates if the avatar can be replaced
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user is not allowed to change the avatar
+	 * @throws PermissionException If the user is not allowed to change the avatar
 	 */
 	public static function replaceAvatar(User $user, string $source, string $extension): void
 	{
@@ -345,7 +345,7 @@ class UserRules
 	/**
 	 * Validates if the user can be updated
 	 *
-	 * @throws \Kirby\Exception\PermissionException If the user it not allowed to update this user
+	 * @throws PermissionException If the user it not allowed to update this user
 	 */
 	public static function update(
 		User $user,
@@ -363,8 +363,8 @@ class UserRules
 	/**
 	 * Validates an email address
 	 *
-	 * @throws \Kirby\Exception\DuplicateException If the email address already exists
-	 * @throws \Kirby\Exception\InvalidArgumentException If the email address is invalid
+	 * @throws DuplicateException If the email address already exists
+	 * @throws InvalidArgumentException If the email address is invalid
 	 */
 	public static function validEmail(
 		User $user,
@@ -414,7 +414,7 @@ class UserRules
 	/**
 	 * Validates a user id
 	 *
-	 * @throws \Kirby\Exception\DuplicateException If the user already exists
+	 * @throws DuplicateException If the user already exists
 	 */
 	public static function validId(User $user, string $id): void
 	{
@@ -434,7 +434,7 @@ class UserRules
 	/**
 	 * Validates a user language code
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the language does not exist
+	 * @throws InvalidArgumentException If the language does not exist
 	 */
 	public static function validLanguage(User $user, string $language): void
 	{
@@ -446,7 +446,7 @@ class UserRules
 	/**
 	 * Validates a password
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the password is too short
+	 * @throws InvalidArgumentException If the password is too short
 	 */
 	public static function validPassword(
 		User $user,
@@ -460,7 +460,7 @@ class UserRules
 	/**
 	 * Validates a user role
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the user role does not exist
+	 * @throws InvalidArgumentException If the user role does not exist
 	 * @deprecated 4.5.0
 	 */
 	public static function validRole(User $user, string $role): void

--- a/src/Cms/Users.php
+++ b/src/Cms/Users.php
@@ -19,8 +19,8 @@ use Kirby\Uuid\HasUuids;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template TValue of \Kirby\Cms\User
- * @extends \Kirby\Cms\LazyCollection<TValue>
+ * @template TValue of User
+ * @extends LazyCollection<TValue>
  */
 class Users extends LazyCollection
 {
@@ -58,9 +58,9 @@ class Users extends LazyCollection
 	 * an entire second collection to the
 	 * current collection
 	 *
-	 * @param \Kirby\Cms\Users<TValue>|TValue|string $object
+	 * @param Users<TValue>|TValue|string $object
 	 * @return $this
-	 * @throws \Kirby\Exception\InvalidArgumentException When no `User` or `Users` object or an ID of an existing user is passed
+	 * @throws InvalidArgumentException When no `User` or `Users` object or an ID of an existing user is passed
 	 */
 	public function add($object): static
 	{

--- a/src/Content/Changes.php
+++ b/src/Content/Changes.php
@@ -54,7 +54,7 @@ class Changes
 	 * Verify that the tracked model still really has changes.
 	 * If not, untrack and remove from collection.
 	 *
-	 * @template T of \Kirby\Cms\Files|\Kirby\Cms\Pages|\Kirby\Cms\Users
+	 * @template T of Files|Pages|Users
 	 * @param T $tracked
 	 * @return T
 	 */

--- a/src/Content/Field.php
+++ b/src/Content/Field.php
@@ -29,7 +29,7 @@ class Field implements Stringable
 	/**
 	 * Creates a new field object
 	 *
-	 * @param \Kirby\Cms\ModelWithContent|null $parent Parent object if available. This will be the page, site, user or file to which the content belongs
+	 * @param ModelWithContent|null $parent Parent object if available. This will be the page, site, user or file to which the content belongs
 	 * @param string $key The field name
 	 */
 	public function __construct(

--- a/src/Content/FieldMethods.php
+++ b/src/Content/FieldMethods.php
@@ -14,6 +14,7 @@ use Kirby\Cms\Html;
 use Kirby\Cms\Layouts;
 use Kirby\Cms\Page;
 use Kirby\Cms\Pages;
+use Kirby\Cms\Site;
 use Kirby\Cms\Structure;
 use Kirby\Cms\Url;
 use Kirby\Cms\User;
@@ -46,7 +47,7 @@ use Throwable;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @mixin \Kirby\Content\Field
+ * @mixin Field
  */
 trait FieldMethods
 {
@@ -295,7 +296,7 @@ trait FieldMethods
 	 */
 	public function permalinksToUrls(): static
 	{
-		/** @var \Kirby\Content\Field $field */
+		/** @var Field $field */
 		$field = clone $this;
 
 		if ($field->isNotEmpty() === true) {
@@ -468,7 +469,7 @@ trait FieldMethods
 	/**
 	 * Converts the field value to a timestamp or a formatted date
 	 *
-	 * @param string|\IntlDateFormatter|null $format PHP date formatting string
+	 * @param string|IntlDateFormatter|null $format PHP date formatting string
 	 * @param string|null $fallback Fallback string for `strtotime`
 	 */
 	public function toDate(
@@ -578,7 +579,7 @@ trait FieldMethods
 		array|null $attr2 = null
 	): string {
 		/**
-		 * @var \Kirby\Cms\Page|\Kirby\Cms\Site $parent
+		 * @var Page|Site $parent
 		 */
 		$parent   = $this->parent();
 		$parent ??= $this->kirby()->site();

--- a/src/Content/ImmutableMemoryStorage.php
+++ b/src/Content/ImmutableMemoryStorage.php
@@ -22,7 +22,7 @@ class ImmutableMemoryStorage extends MemoryStorage
 	/**
 	 * Immutable storage entries cannot be deleted
 	 *
-	 * @throws \Kirby\Exception\LogicException
+	 * @throws LogicException
 	 */
 	public function delete(VersionId $versionId, Language $language): void
 	{
@@ -32,7 +32,7 @@ class ImmutableMemoryStorage extends MemoryStorage
 	/**
 	 * Immutable storage entries cannot be moved
 	 *
-	 * @throws \Kirby\Exception\LogicException
+	 * @throws LogicException
 	 */
 	public function move(
 		VersionId $fromVersionId,
@@ -56,7 +56,7 @@ class ImmutableMemoryStorage extends MemoryStorage
 	/**
 	 * Throws an exception to avoid the mutation of storage data
 	 *
-	 * @throws \Kirby\Exception\LogicException
+	 * @throws LogicException
 	 */
 	protected function preventMutation(string $mutation): void
 	{
@@ -68,7 +68,7 @@ class ImmutableMemoryStorage extends MemoryStorage
 	/**
 	 * Immutable storage entries cannot be touched
 	 *
-	 * @throws \Kirby\Exception\LogicException
+	 * @throws LogicException
 	 */
 	public function touch(VersionId $versionId, Language $language): void
 	{
@@ -78,7 +78,7 @@ class ImmutableMemoryStorage extends MemoryStorage
 	/**
 	 * Immutable storage entries cannot be updated
 	 *
-	 * @throws \Kirby\Exception\LogicException
+	 * @throws LogicException
 	 */
 	public function update(VersionId $versionId, Language $language, array $fields): void
 	{

--- a/src/Content/MemoryStorage.php
+++ b/src/Content/MemoryStorage.php
@@ -5,6 +5,7 @@ namespace Kirby\Content;
 use Kirby\Cache\MemoryCache;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Exception\NotFoundException;
 
 /**
  * @copyright Bastian Allgeier
@@ -82,7 +83,7 @@ class MemoryStorage extends Storage
 	/**
 	 * Updates the modification timestamp of an existing version
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
+	 * @throws NotFoundException If the version does not exist
 	 */
 	public function touch(VersionId $versionId, Language $language): void
 	{

--- a/src/Content/PlainTextStorage.php
+++ b/src/Content/PlainTextStorage.php
@@ -160,7 +160,7 @@ class PlainTextStorage extends Storage
 	/**
 	 * Helper to delete empty _changes directories
 	 *
-	 * @throws \Kirby\Exception\Exception if the directory cannot be deleted
+	 * @throws Exception if the directory cannot be deleted
 	 */
 	protected function deleteEmptyDirectory(string $directory): void
 	{
@@ -323,7 +323,7 @@ class PlainTextStorage extends Storage
 	/**
 	 * Updates the modification timestamp of an existing version
 	 *
-	 * @throws \Kirby\Exception\Exception If the file cannot be touched
+	 * @throws Exception If the file cannot be touched
 	 */
 	public function touch(VersionId $versionId, Language $language): void
 	{
@@ -343,7 +343,7 @@ class PlainTextStorage extends Storage
 	 *
 	 * @param array<string, string> $fields Content fields
 	 *
-	 * @throws \Kirby\Exception\Exception If the content cannot be written
+	 * @throws Exception If the content cannot be written
 	 */
 	protected function write(VersionId $versionId, Language $language, array $fields): void
 	{

--- a/src/Content/Storage.php
+++ b/src/Content/Storage.php
@@ -6,6 +6,8 @@ use Generator;
 use Kirby\Cms\Language;
 use Kirby\Cms\Languages;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Exception\Exception;
+use Kirby\Exception\NotFoundException;
 use Kirby\Toolkit\A;
 
 /**
@@ -29,7 +31,7 @@ abstract class Storage
 	/**
 	 * Returns generator for all existing version-language combinations
 	 *
-	 * @return Generator<\Kirby\Content\VersionId, \Kirby\Cms\Language>
+	 * @return Generator<VersionId, Language>
 	 */
 	public function all(): Generator
 	{
@@ -252,7 +254,7 @@ abstract class Storage
 	/**
 	 * Searches and replaces one or multiple strings
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
+	 * @throws NotFoundException If the version does not exist
 	 */
 	public function replaceStrings(
 		VersionId $versionId,
@@ -282,7 +284,7 @@ abstract class Storage
 	/**
 	 * Updates the modification timestamp of an existing version
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
+	 * @throws NotFoundException If the version does not exist
 	 */
 	abstract public function touch(VersionId $versionId, Language $language): void;
 
@@ -305,7 +307,7 @@ abstract class Storage
 	 *
 	 * @param array<string, string> $fields Content fields
 	 *
-	 * @throws \Kirby\Exception\Exception If the file cannot be written
+	 * @throws Exception If the file cannot be written
 	 */
 	public function update(VersionId $versionId, Language $language, array $fields): void
 	{
@@ -317,7 +319,7 @@ abstract class Storage
 	 *
 	 * @param array<string, string> $fields Content fields
 	 *
-	 * @throws \Kirby\Exception\Exception If the content cannot be written
+	 * @throws Exception If the content cannot be written
 	 */
 	abstract protected function write(VersionId $versionId, Language $language, array $fields): void;
 }

--- a/src/Content/Translations.php
+++ b/src/Content/Translations.php
@@ -11,7 +11,7 @@ use Kirby\Cms\ModelWithContent;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\Collection<\Kirby\Content\Translation>
+ * @extends Collection<Translation>
  */
 class Translations extends Collection
 {

--- a/src/Content/Version.php
+++ b/src/Content/Version.php
@@ -311,7 +311,7 @@ class Version
 	/**
 	 * Moves the version to a new language and/or version
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
+	 * @throws NotFoundException If the version does not exist
 	 */
 	#[BlockCollectionAccess]
 	public function move(
@@ -529,7 +529,7 @@ class Version
 	 *
 	 * @param array<string, mixed> $fields Content fields; null removes a field
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
+	 * @throws NotFoundException If the version does not exist
 	 */
 	#[BlockCollectionAccess]
 	public function replace(
@@ -588,7 +588,7 @@ class Version
 	/**
 	 * Updates the modification timestamp of an existing version
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
+	 * @throws NotFoundException If the version does not exist
 	 */
 	#[BlockCollectionAccess]
 	public function touch(Language|string $language = 'default'): void
@@ -635,7 +635,7 @@ class Version
 	 *
 	 * @param array<string, mixed> $fields Content fields; null removes a field
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
+	 * @throws NotFoundException If the version does not exist
 	 */
 	#[BlockCollectionAccess]
 	public function update(

--- a/src/Content/VersionId.php
+++ b/src/Content/VersionId.php
@@ -37,7 +37,7 @@ class VersionId implements Stringable
 	public static self|null $render = null;
 
 	/**
-	 * @throws \Kirby\Exception\InvalidArgumentException If the version ID is not valid
+	 * @throws InvalidArgumentException If the version ID is not valid
 	 */
 	public function __construct(
 		public string $value

--- a/src/Content/VersionRules.php
+++ b/src/Content/VersionRules.php
@@ -49,7 +49,7 @@ class VersionRules
 	 * Checks if a version/language combination exists and otherwise
 	 * will throw a `NotFoundException`
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If the version does not exist
+	 * @throws NotFoundException If the version does not exist
 	 */
 	public static function ensure(Version $version, Language $language): void
 	{

--- a/src/Content/Versions.php
+++ b/src/Content/Versions.php
@@ -9,7 +9,7 @@ use Kirby\Cms\ModelWithContent;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\Collection<\Kirby\Content\Version>
+ * @extends Collection<Version>
  */
 class Versions extends Collection
 {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -327,7 +327,6 @@ class Database
 			$this->lastError = null;
 
 			if (Str::startsWith($query, 'insert ', true) === true) {
-				/** @var string|false $lastId */
 				$lastId = $this->connection->lastInsertId();
 
 				if ($lastId === false) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -139,7 +139,7 @@ class Database
 	 * Connects to a database
 	 *
 	 * @param array|null $params This can either be a config key or an array of parameters for the connection
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function connect(array|null $params = null): PDO|null
 	{

--- a/src/Database/Db.php
+++ b/src/Database/Db.php
@@ -94,7 +94,7 @@ class Db
 	 * redirected to either a predefined query or
 	 * the respective method of the Database object
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function __callStatic(string $method, $arguments)
 	{

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -200,7 +200,7 @@ class Query
 	 * Sets the name of the table, which should be queried
 	 *
 	 * @return $this
-	 * @throws \Kirby\Exception\InvalidArgumentException if the table does not exist
+	 * @throws InvalidArgumentException if the table does not exist
 	 */
 	public function table(string $table): static
 	{

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -441,7 +441,7 @@ class Query
 	 *
 	 * @param string $type (select, update, insert, delete)
 	 * @return array The final query
-	 * @throws \InvalidArgumentException If the query type is invalid
+	 * @throws InvalidArgumentException If the query type is invalid
 	 */
 	public function build(string $type): array
 	{

--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -171,7 +171,7 @@ abstract class Sql
 	 *                      - `unique`: Whether the index (or if not set the column itself) has a UNIQUE constraint
 	 *                      - `default`: Default value of this column
 	 * @return array Array with `query` and `key` strings, a `unique` boolean and a `bindings` array
-	 * @throws \Kirby\Exception\InvalidArgumentException if no column type is given or the column type is not supported.
+	 * @throws InvalidArgumentException if no column type is given or the column type is not supported.
 	 */
 	public function createColumn(string $name, array $column): array
 	{
@@ -454,7 +454,7 @@ abstract class Sql
 	/**
 	 * Creates a join query
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException if an invalid join type is given
+	 * @throws InvalidArgumentException if an invalid join type is given
 	 */
 	public function join(string $type, string $table, string $on): array
 	{
@@ -675,7 +675,7 @@ abstract class Sql
 	 * Splits a (qualified) identifier into table and column
 	 *
 	 * @param string $table Default table if the identifier is not qualified
-	 * @throws \Kirby\Exception\InvalidArgumentException if an invalid identifier is given
+	 * @throws InvalidArgumentException if an invalid identifier is given
 	 */
 	public function splitIdentifier(string $table, string $identifier): array
 	{
@@ -708,7 +708,7 @@ abstract class Sql
 	/**
 	 * Validates and quotes a table name
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException if an invalid table name is given
+	 * @throws InvalidArgumentException if an invalid table name is given
 	 */
 	public function tableName(string $table): string
 	{
@@ -789,7 +789,7 @@ abstract class Sql
 	/**
 	 * Validates a given column name in a table
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the column is invalid
+	 * @throws InvalidArgumentException If the column is invalid
 	 */
 	public function validateColumn(string $table, string $column): bool
 	{

--- a/src/Email/Email.php
+++ b/src/Email/Email.php
@@ -206,7 +206,7 @@ class Email
 	/**
 	 * Converts single or multiple email addresses to a sanitized format
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	protected function resolveEmail(
 		string|array|null $email = null,

--- a/src/Email/PHPMailer.php
+++ b/src/Email/PHPMailer.php
@@ -17,7 +17,7 @@ class PHPMailer extends Email
 	/**
 	 * Sends email via PHPMailer library
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function send(bool $debug = false): bool
 	{

--- a/src/Filesystem/Asset.php
+++ b/src/Filesystem/Asset.php
@@ -58,7 +58,7 @@ class Asset
 	/**
 	 * Magic caller for asset methods
 	 *
-	 * @throws \Kirby\Exception\BadMethodCallException
+	 * @throws BadMethodCallException
 	 */
 	public function __call(string $method, array $arguments = []): mixed
 	{

--- a/src/Filesystem/Dir.php
+++ b/src/Filesystem/Dir.php
@@ -260,7 +260,7 @@ class Dir
 	 * @param string $dir The path for the new directory
 	 * @param bool $recursive Create all parent directories, which don't exist
 	 * @return bool True: the dir has been created, false: creating failed
-	 * @throws \Exception If a file with the provided path already exists or the parent directory is not writable
+	 * @throws Exception If a file with the provided path already exists or the parent directory is not writable
 	 */
 	public static function make(
 		string $dir,

--- a/src/Filesystem/File.php
+++ b/src/Filesystem/File.php
@@ -6,6 +6,8 @@ use IntlDateFormatter;
 use Kirby\Cms\App;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Exception\LogicException;
+use Kirby\Exception\NotFoundException;
 use Kirby\Http\Response;
 use Kirby\Sane\Sane;
 use Kirby\Toolkit\Escape;
@@ -53,7 +55,7 @@ class File implements Stringable
 	 * @param array|string|null $props Properties or deprecated `$root` string
 	 * @param string|null $url Deprecated argument, use `$props['url']` instead
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException When the model does not use the `Kirby\Filesystem\IsFile` trait
+	 * @throws InvalidArgumentException When the model does not use the `Kirby\Filesystem\IsFile` trait
 	 */
 	public function __construct(
 		array|string|null $props = null,
@@ -273,7 +275,7 @@ class File implements Stringable
 	 * Runs a set of validations on the file object
 	 * (mainly for images).
 	 *
-	 * @throws \Kirby\Exception\Exception
+	 * @throws Exception
 	 */
 	public function match(array $rules): bool
 	{
@@ -478,10 +480,10 @@ class File implements Stringable
 	 *                              `true` for lazy autodetection or
 	 *                              `false` for normal autodetection
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file didn't pass validation
-	 * @throws \Kirby\Exception\LogicException If more than one handler applies
-	 * @throws \Kirby\Exception\NotFoundException If the handler was not found
-	 * @throws \Kirby\Exception\Exception On other errors
+	 * @throws InvalidArgumentException If the file didn't pass validation
+	 * @throws LogicException If more than one handler applies
+	 * @throws NotFoundException If the handler was not found
+	 * @throws Exception On other errors
 	 */
 	public function sanitizeContents(string|bool $typeLazy = false): void
 	{
@@ -492,7 +494,7 @@ class File implements Stringable
 	 * Returns the sha1 hash of the file
 	 * @since 3.6.0
 	 *
-	 * @throws \Kirby\Exception\Exception If the file cannot be read
+	 * @throws Exception If the file cannot be read
 	 */
 	public function sha1(): string
 	{
@@ -574,9 +576,9 @@ class File implements Stringable
 	 *                              `true` for lazy autodetection or
 	 *                              `false` for normal autodetection
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file didn't pass validation
-	 * @throws \Kirby\Exception\NotFoundException If the handler was not found
-	 * @throws \Kirby\Exception\Exception On other errors
+	 * @throws InvalidArgumentException If the file didn't pass validation
+	 * @throws NotFoundException If the handler was not found
+	 * @throws Exception On other errors
 	 */
 	public function validateContents(string|bool $typeLazy = false): void
 	{

--- a/src/Filesystem/IsFile.php
+++ b/src/Filesystem/IsFile.php
@@ -50,7 +50,7 @@ trait IsFile
 	/**
 	 * Magic caller for asset methods
 	 *
-	 * @throws \Kirby\Exception\BadMethodCallException
+	 * @throws BadMethodCallException
 	 */
 	public function __call(string $method, array $arguments = []): mixed
 	{

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -18,7 +18,7 @@ use Kirby\Toolkit\I18n;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  *
- * @use \Kirby\Cms\HasSiblings<\Kirby\Form\Fields>
+ * @use HasSiblings<Fields>
  */
 class Field extends Component
 {
@@ -52,7 +52,7 @@ class Field extends Component
 	protected mixed $value = null;
 
 	/**
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function __construct(
 		string $type,
@@ -180,19 +180,19 @@ class Field extends Component
 			],
 			'computed' => [
 				'after' => function () {
-					/** @var \Kirby\Form\Field $this */
+					/** @var Field $this */
 					if ($this->after !== null) {
 						return $this->model()->toString($this->after);
 					}
 				},
 				'before' => function () {
-					/** @var \Kirby\Form\Field $this */
+					/** @var Field $this */
 					if ($this->before !== null) {
 						return $this->model()->toString($this->before);
 					}
 				},
 				'default' => function () {
-					/** @var \Kirby\Form\Field $this */
+					/** @var Field $this */
 					if (isset($this->default) === false) {
 						return;
 					}
@@ -204,7 +204,7 @@ class Field extends Component
 					return $this->model()->toString($this->default);
 				},
 				'help' => function () {
-					/** @var \Kirby\Form\Field $this */
+					/** @var Field $this */
 					if ($this->help) {
 						$help = $this->model()->toSafeString($this->help);
 						$help = $this->kirby()->kirbytext($help);
@@ -212,13 +212,13 @@ class Field extends Component
 					}
 				},
 				'label' => function () {
-					/** @var \Kirby\Form\Field $this */
+					/** @var Field $this */
 					if ($this->label !== null) {
 						return $this->model()->toString($this->label);
 					}
 				},
 				'placeholder' => function () {
-					/** @var \Kirby\Form\Field $this */
+					/** @var Field $this */
 					if ($this->placeholder !== null) {
 						return $this->model()->toString($this->placeholder);
 					}

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Form\Field;
 
+use Kirby\Cms\Api;
 use Kirby\Cms\App;
 use Kirby\Cms\Block;
 use Kirby\Cms\Blocks as BlocksCollection;
@@ -141,7 +142,7 @@ class BlocksField extends InputField
 					string|null $path = null
 				) use ($field) {
 					/**
-					 * @var \Kirby\Cms\Api $api
+					 * @var Api $api
 					 */
 					$api    = $this;
 					$fields = $field->fields($fieldsetType);

--- a/src/Form/Field/FilePickerField.php
+++ b/src/Form/Field/FilePickerField.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Form\Field;
 
+use Kirby\Api\Api;
 use Kirby\Cms\File;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Form\Mixin;
@@ -15,7 +16,7 @@ use Kirby\Panel\Ui\Item\FileItem;
  * @license   https://getkirby.com/license
  * @since     6.0.0
  *
- * @extends \Kirby\Form\Field\ModelPickerField<\Kirby\Cms\File>
+ * @extends ModelPickerField<File>
  */
 class FilePickerField extends ModelPickerField
 {
@@ -94,7 +95,7 @@ class FilePickerField extends ModelPickerField
 				'action'  => function () use ($field) {
 					// @codeCoverageIgnoreStart
 					/**
-					 * @var \Kirby\Api\Api
+					 * @var Api
 					 */
 					$api = $this;
 
@@ -158,7 +159,7 @@ class FilePickerField extends ModelPickerField
 	}
 
 	/**
-	 * @param \Kirby\Cms\File $model
+	 * @param File $model
 	 */
 	public function store(ModelWithContent|null $model = null): string
 	{
@@ -171,7 +172,7 @@ class FilePickerField extends ModelPickerField
 	}
 
 	/**
-	 * @param \Kirby\Cms\File $model
+	 * @param File $model
 	 */
 	public function toItem(ModelWithContent $model): array
 	{

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -3,6 +3,7 @@
 namespace Kirby\Form\Field;
 
 use Kirby\Blueprint\Blueprint;
+use Kirby\Cms\Api;
 use Kirby\Cms\App;
 use Kirby\Cms\Fieldset;
 use Kirby\Cms\Layout;
@@ -136,7 +137,7 @@ class LayoutField extends BlocksField
 				string|null $path = null
 			) use ($field): array {
 				/**
-				 * @var \Kirby\Cms\Api $api
+				 * @var Api $api
 				 */
 				$api   = $this;
 				$form  = $field->attrsForm();

--- a/src/Form/Field/ModelPickerField.php
+++ b/src/Form/Field/ModelPickerField.php
@@ -16,7 +16,7 @@ use Kirby\Uuid\Uuids;
  * @license   https://getkirby.com/license
  * @since     6.0.0
  *
- * @template TModel of \Kirby\Cms\ModelWithContent
+ * @template TModel of ModelWithContent
  */
 abstract class ModelPickerField extends InputField
 {

--- a/src/Form/Field/PagePickerField.php
+++ b/src/Form/Field/PagePickerField.php
@@ -14,7 +14,7 @@ use Kirby\Panel\Ui\Item\PageItem;
  * @license   https://getkirby.com/license
  * @since     6.0.0
  *
- * @extends \Kirby\Form\Field\ModelPickerField<\Kirby\Cms\Page>
+ * @extends ModelPickerField<Page>
  */
 class PagePickerField extends ModelPickerField
 {
@@ -112,7 +112,7 @@ class PagePickerField extends ModelPickerField
 	}
 
 	/**
-	 * @param \Kirby\Cms\Page $model
+	 * @param Page $model
 	 */
 	public function toItem(ModelWithContent $model): array
 	{

--- a/src/Form/Field/TextareaField.php
+++ b/src/Form/Field/TextareaField.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Form\Field;
 
+use Kirby\Api\Api;
 use Kirby\Cms\File;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Form\Mixin;
@@ -100,7 +101,7 @@ class TextareaField extends InputField
 				'action'  => function () use ($field) {
 					// @codeCoverageIgnoreStart
 					/**
-					 * @var \Kirby\Api\Api
+					 * @var Api
 					 */
 					$api = $this;
 

--- a/src/Form/Field/UserPickerField.php
+++ b/src/Form/Field/UserPickerField.php
@@ -14,7 +14,7 @@ use Kirby\Panel\Ui\Item\UserItem;
  * @license   https://getkirby.com/license
  * @since     6.0.0
  *
- * @extends \Kirby\Form\Field\ModelPickerField<\Kirby\Cms\User>
+ * @extends ModelPickerField<User>
  */
 class UserPickerField extends ModelPickerField
 {
@@ -48,7 +48,7 @@ class UserPickerField extends ModelPickerField
 	}
 
 	/**
-	 * @param \Kirby\Cms\User $model
+	 * @param User $model
 	 */
 	public function toItem(ModelWithContent $model): array
 	{

--- a/src/Form/FieldClass.php
+++ b/src/Form/FieldClass.php
@@ -13,7 +13,7 @@ use Kirby\Form\Field\InputField;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @use \Kirby\Cms\HasSiblings<\Kirby\Form\Fields>
+ * @use \Kirby\Cms\HasSiblings<Fields>
  */
 abstract class FieldClass extends InputField
 {

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -19,7 +19,7 @@ use Kirby\Toolkit\Str;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  *
- * @extends \Kirby\Cms\Collection<\Kirby\Form\Field|\Kirby\Form\Field\BaseField>
+ * @extends Collection<Field|BaseField>
  */
 class Fields extends Collection
 {
@@ -55,7 +55,7 @@ class Fields extends Collection
 	 * This takes care of validation and of setting
 	 * the collection prop on each object correctly.
 	 *
-	 * @param \Kirby\Form\Field|\Kirby\Form\Field\BaseField|array $field
+	 * @param Field|BaseField|array $field
 	 */
 	public function __set(string $name, $field): void
 	{
@@ -105,7 +105,7 @@ class Fields extends Collection
 	 * and handle nested fields correctly
 	 *
 	 * @since 5.0.0
-	 * @throws \Kirby\Exception\NotFoundException
+	 * @throws NotFoundException
 	 */
 	public function field(string $name): Field|BaseField
 	{
@@ -446,7 +446,7 @@ class Fields extends Collection
 	 * exception if there are any
 	 *
 	 * @since 5.0.0
-	 * @throws \Kirby\Exception\FormValidationException
+	 * @throws FormValidationException
 	 */
 	public function validate(): void
 	{

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -5,6 +5,8 @@ namespace Kirby\Form;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Data\Data;
+use Kirby\Exception\FormValidationException;
+use Kirby\Exception\NotFoundException;
 use Kirby\Form\Field\BaseField;
 use Kirby\Toolkit\A;
 
@@ -116,7 +118,7 @@ class Form
 	 * Get the field object by name
 	 * and handle nested fields correctly
 	 *
-	 * @throws \Kirby\Exception\NotFoundException
+	 * @throws NotFoundException
 	 */
 	public function field(string $name): Field|BaseField
 	{
@@ -383,7 +385,7 @@ class Form
 	/**
 	 * Validates the form and throws an exception if there are any errors
 	 *
-	 * @throws \Kirby\Exception\FormValidationException
+	 * @throws FormValidationException
 	 */
 	public function validate(): void
 	{

--- a/src/Form/Validations.php
+++ b/src/Form/Validations.php
@@ -17,8 +17,8 @@ class Validations
 	/**
 	 * Validates if the field value is boolean
 	 *
-	 * @param \Kirby\Form\Field|\Kirby\Form\Field\BaseField $field
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @param Field|BaseField $field
+	 * @throws InvalidArgumentException
 	 */
 	public static function boolean($field, $value): bool
 	{
@@ -36,7 +36,7 @@ class Validations
 	/**
 	 * Validates if the field value is valid date
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function date(Field|BaseField $field, mixed $value): bool
 	{
@@ -54,7 +54,7 @@ class Validations
 	/**
 	 * Validates if the field value is valid email
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function email(Field|BaseField $field, mixed $value): bool
 	{
@@ -72,7 +72,7 @@ class Validations
 	/**
 	 * Validates if the field value is maximum
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function max(Field|BaseField $field, mixed $value): bool
 	{
@@ -93,7 +93,7 @@ class Validations
 	/**
 	 * Validates if the field value is max length
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function maxlength(Field|BaseField $field, mixed $value): bool
 	{
@@ -114,7 +114,7 @@ class Validations
 	/**
 	 * Validates if the field value is minimum
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function min(Field|BaseField $field, mixed $value): bool
 	{
@@ -135,7 +135,7 @@ class Validations
 	/**
 	 * Validates if the field value is min length
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function minlength(Field|BaseField $field, mixed $value): bool
 	{
@@ -156,7 +156,7 @@ class Validations
 	/**
 	 * Validates if the field value matches defined pattern
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function pattern(Field|BaseField $field, mixed $value): bool
 	{
@@ -181,7 +181,7 @@ class Validations
 	/**
 	 * Validates if the field value is required
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function required(Field|BaseField $field, mixed $value): bool
 	{
@@ -201,7 +201,7 @@ class Validations
 	/**
 	 * Validates if the field value is in defined options
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function option(Field|BaseField $field, mixed $value): bool
 	{
@@ -221,7 +221,7 @@ class Validations
 	/**
 	 * Validates if the field values is in defined options
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function options(Field|BaseField $field, mixed $value): bool
 	{
@@ -242,7 +242,7 @@ class Validations
 	/**
 	 * Validates if the field value is valid time
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function time(Field|BaseField $field, mixed $value): bool
 	{
@@ -260,7 +260,7 @@ class Validations
 	/**
 	 * Validates if the field value is valid url
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function url(Field|BaseField $field, mixed $value): bool
 	{

--- a/src/Http/Path.php
+++ b/src/Http/Path.php
@@ -12,7 +12,7 @@ use Kirby\Toolkit\Str;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  *
- * @extends \Kirby\Toolkit\Collection<string>
+ * @extends Collection<string>
  */
 class Path extends Collection
 {

--- a/src/Http/Remote.php
+++ b/src/Http/Remote.php
@@ -46,7 +46,7 @@ class Remote
 	public array $info = [];
 
 	/**
-	 * @throws \Exception when the curl request failed
+	 * @throws Exception when the curl request failed
 	 */
 	public function __construct(
 		string $url,
@@ -123,7 +123,7 @@ class Remote
 	 * Sets up all curl options and sends the request
 	 *
 	 * @return $this
-	 * @throws \Exception when the curl request failed
+	 * @throws Exception when the curl request failed
 	 */
 	public function fetch(): static
 	{
@@ -265,7 +265,7 @@ class Remote
 	/**
 	 * Static method to send a GET request
 	 *
-	 * @throws \Exception when the curl request failed
+	 * @throws Exception when the curl request failed
 	 */
 	public static function get(string $url, array $params = []): static
 	{
@@ -360,7 +360,7 @@ class Remote
 	/**
 	 * Static method to init this class and send a request
 	 *
-	 * @throws \Exception when the curl request failed
+	 * @throws Exception when the curl request failed
 	 */
 	public static function request(string $url, array $params = []): static
 	{

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -51,7 +51,7 @@ class Router
 	 * Creates a new router object and
 	 * registers all the given routes
 	 *
-	 * @param array<string, \Closure> $hooks Optional `beforeEach` and `afterEach` hooks
+	 * @param array<string, Closure> $hooks Optional `beforeEach` and `afterEach` hooks
 	 */
 	public function __construct(array $routes = [], array $hooks = [])
 	{

--- a/src/Http/Visitor.php
+++ b/src/Http/Visitor.php
@@ -51,7 +51,7 @@ class Visitor
 	 * provided or returns the user's
 	 * accepted language otherwise
 	 *
-	 * @return $this|\Kirby\Toolkit\Obj|null
+	 * @return $this|Obj|null
 	 */
 	public function acceptedLanguage(
 		string|null $acceptedLanguage = null
@@ -68,7 +68,7 @@ class Visitor
 	 * Returns an array of all accepted languages
 	 * including their quality and locale
 	 *
-	 * @return \Kirby\Toolkit\Collection<\Kirby\Toolkit\Obj>
+	 * @return Collection<Obj>
 	 */
 	public function acceptedLanguages(): Collection
 	{
@@ -115,7 +115,7 @@ class Visitor
 	 * provided or returns the user's
 	 * accepted mime type otherwise
 	 *
-	 * @return $this|\Kirby\Toolkit\Obj|null
+	 * @return $this|Obj|null
 	 */
 	public function acceptedMimeType(
 		string|null $acceptedMimeType = null

--- a/src/Image/Darkroom.php
+++ b/src/Image/Darkroom.php
@@ -32,7 +32,7 @@ class Darkroom
 	 * Creates a new Darkroom instance
 	 * for the given type/driver
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public static function factory(string $type, array $settings = []): static
 	{

--- a/src/Image/Darkroom/ImageMagick.php
+++ b/src/Image/Darkroom/ImageMagick.php
@@ -110,7 +110,7 @@ class ImageMagick extends Darkroom
 	 * Creates and runs the full imagemagick command
 	 * to process the image
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function process(string $file, array $options = []): array
 	{

--- a/src/Image/Darkroom/Imagick.php
+++ b/src/Image/Darkroom/Imagick.php
@@ -118,7 +118,7 @@ class Imagick extends Darkroom
 	 * Creates and runs the full imagemagick command
 	 * to process the image
 	 *
-	 * @throws \Exception
+	 * @throws Exception
 	 */
 	public function process(string $file, array $options = []): array
 	{

--- a/src/Option/Options.php
+++ b/src/Option/Options.php
@@ -13,7 +13,7 @@ use Kirby\Toolkit\A;
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  *
- * @extends \Kirby\Cms\Collection<\Kirby\Option\Option>
+ * @extends Collection<Option>
  */
 class Options extends Collection
 {

--- a/src/Panel/Access.php
+++ b/src/Panel/Access.php
@@ -21,7 +21,7 @@ class Access
 	 * Check if the given user has access to a given area.
 	 * Use `*` to check for general Panel access.
 	 *
-	 * @throws \Kirby\Exception\PermissionException when has no access
+	 * @throws PermissionException when has no access
 	 */
 	public function area(
 		string|null $area = null,

--- a/src/Panel/Areas.php
+++ b/src/Panel/Areas.php
@@ -11,7 +11,7 @@ use Kirby\Toolkit\A;
  * @license   https://getkirby.com/license
  * @since     6.0.0
  *
- * @extends \Kirby\Cms\Collection<\Kirby\Panel\Area>
+ * @extends Collection<Area>
  */
 class Areas extends Collection
 {

--- a/src/Panel/Assets.php
+++ b/src/Panel/Assets.php
@@ -116,7 +116,7 @@ class Assets
 	/**
 	 * Returns array of favicon icons based on config option
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public function favicons(): array
 	{
@@ -258,7 +258,7 @@ class Assets
 	 * Links all dist files in the media folder
 	 * and returns the link to the requested asset
 	 *
-	 * @throws \Kirby\Exception\Exception If Panel assets could not be moved to the public directory
+	 * @throws Exception If Panel assets could not be moved to the public directory
 	 */
 	public function link(): bool
 	{

--- a/src/Panel/Collector/FilesCollector.php
+++ b/src/Panel/Collector/FilesCollector.php
@@ -13,7 +13,7 @@ use Kirby\Cms\Users;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Panel\Collector\ModelsCollector<\Kirby\Cms\Files>
+ * @extends ModelsCollector<Files>
  */
 class FilesCollector extends ModelsCollector
 {

--- a/src/Panel/Collector/ModelsCollector.php
+++ b/src/Panel/Collector/ModelsCollector.php
@@ -15,7 +15,7 @@ use Kirby\Cms\Users;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @template TModels of \Kirby\Cms\Files|\Kirby\Cms\Pages|\Kirby\Cms\Users
+ * @template TModels of Files|Pages|Users
  */
 abstract class ModelsCollector
 {
@@ -135,7 +135,7 @@ abstract class ModelsCollector
 
 	public function pagination(): Pagination
 	{
-		/** @var \Kirby\Cms\Pagination */
+		/** @var Pagination */
 		return $this->models(paginated: true)->pagination();
 	}
 

--- a/src/Panel/Collector/PagesCollector.php
+++ b/src/Panel/Collector/PagesCollector.php
@@ -13,7 +13,7 @@ use Kirby\Cms\Users;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Panel\Collector\ModelsCollector<\Kirby\Cms\Pages>
+ * @extends ModelsCollector<Pages>
  */
 class PagesCollector extends ModelsCollector
 {

--- a/src/Panel/Collector/UsersCollector.php
+++ b/src/Panel/Collector/UsersCollector.php
@@ -14,7 +14,7 @@ use Kirby\Cms\Users;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Panel\Collector\ModelsCollector<\Kirby\Cms\Users>
+ * @extends ModelsCollector<Users>
  */
 class UsersCollector extends ModelsCollector
 {

--- a/src/Panel/Controller/Dialog/FilePickerDialogController.php
+++ b/src/Panel/Controller/Dialog/FilePickerDialogController.php
@@ -72,7 +72,7 @@ class FilePickerDialogController extends ModelPickerDialogController
 
 	/**
 	 * Returns the item data for a file
-	 * @param \Kirby\Cms\File $model
+	 * @param File $model
 	 */
 	public function item(ModelWithContent $model): array
 	{

--- a/src/Panel/Controller/Dialog/PageCreateDialogController.php
+++ b/src/Panel/Controller/Dialog/PageCreateDialogController.php
@@ -56,12 +56,12 @@ class PageCreateDialogController extends ModelCreateDialogController
 	public array $blueprints;
 
 	/**
-	 * @var \Kirby\Cms\Page
+	 * @var Page
 	 */
 	public ModelWithContent|null $model = null;
 
 	/**
-	 * @var \Kirby\Cms\Page|\Kirby\Cms\Site
+	 * @var Page|Site
 	 */
 	public Page|Site|User $parent;
 

--- a/src/Panel/Controller/Dialog/PagePickerDialogController.php
+++ b/src/Panel/Controller/Dialog/PagePickerDialogController.php
@@ -108,7 +108,7 @@ class PagePickerDialogController extends ModelPickerDialogController
 
 	/**
 	 * Returns the item data for a page
-	 * @param \Kirby\Cms\Page $model
+	 * @param Page $model
 	 */
 	public function item(ModelWithContent $model): array
 	{
@@ -134,8 +134,8 @@ class PagePickerDialogController extends ModelPickerDialogController
 	 * requested parent is missing or not accessible
 	 * for the current user.
 	 *
-	 * @throws \Kirby\Exception\PermissionException if neither
-	 *                                              the requested parent nor the root are accessible
+	 * @throws PermissionException if neither
+	 *                             the requested parent nor the root are accessible
 	 */
 	public function parent(): Page|Site|null
 	{

--- a/src/Panel/Controller/Dialog/UserPickerDialogController.php
+++ b/src/Panel/Controller/Dialog/UserPickerDialogController.php
@@ -73,7 +73,7 @@ class UserPickerDialogController extends ModelPickerDialogController
 
 	/**
 	 * Returns the item data for a user
-	 * @param \Kirby\Cms\User $model
+	 * @param User $model
 	 */
 	public function item(ModelWithContent $model): array
 	{

--- a/src/Panel/Controller/Drawer/UserCredentialDrawerController.php
+++ b/src/Panel/Controller/Drawer/UserCredentialDrawerController.php
@@ -51,7 +51,7 @@ abstract class UserCredentialDrawerController extends UserDrawerController
 	/**
 	 * Ensures the removal is authorized before the credential is deleted
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	protected function authorize(): void
 	{

--- a/src/Panel/Controller/Dropdown/FileSettingsDropdownController.php
+++ b/src/Panel/Controller/Dropdown/FileSettingsDropdownController.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Panel\Controller\Dropdown;
 
+use Kirby\Cms\File;
 use Kirby\Cms\Find;
 use Kirby\Cms\ModelWithContent;
 
@@ -15,7 +16,7 @@ use Kirby\Cms\ModelWithContent;
 class FileSettingsDropdownController extends ModelSettingsDropdownController
 {
 	/**
-	 * @param \Kirby\Cms\File $model
+	 * @param File $model
 	 */
 	public function __construct(
 		protected ModelWithContent $model

--- a/src/Panel/Controller/Dropdown/PageSettingsDropdownController.php
+++ b/src/Panel/Controller/Dropdown/PageSettingsDropdownController.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel\Controller\Dropdown;
 
 use Kirby\Cms\Find;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Page;
 
 /**
  * @copyright Bastian Allgeier
@@ -15,7 +16,7 @@ use Kirby\Cms\ModelWithContent;
 class PageSettingsDropdownController extends ModelSettingsDropdownController
 {
 	/**
-	 * @param \Kirby\Cms\Page $model
+	 * @param Page $model
 	 */
 	public function __construct(
 		protected ModelWithContent $model

--- a/src/Panel/Controller/Dropdown/UserSettingsDropdownController.php
+++ b/src/Panel/Controller/Dropdown/UserSettingsDropdownController.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel\Controller\Dropdown;
 
 use Kirby\Cms\Find;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\User;
 
 /**
  * @copyright Bastian Allgeier
@@ -15,7 +16,7 @@ use Kirby\Cms\ModelWithContent;
 class UserSettingsDropdownController extends ModelSettingsDropdownController
 {
 	/**
-	 * @param \Kirby\Cms\User $model
+	 * @param User $model
 	 */
 	public function __construct(
 		protected ModelWithContent $model

--- a/src/Panel/Controller/Search/FilesSearchController.php
+++ b/src/Panel/Controller/Search/FilesSearchController.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Panel\Controller\Search;
 
+use Kirby\Cms\File;
 use Kirby\Cms\Files;
 use Kirby\Panel\Ui\Item\FileItem;
 
@@ -15,7 +16,7 @@ use Kirby\Panel\Ui\Item\FileItem;
 class FilesSearchController extends ModelsSearchController
 {
 	/**
-	 * @param \Kirby\Cms\File $model
+	 * @param File $model
 	 */
 	public function item($model): FileItem
 	{

--- a/src/Panel/Controller/Search/PagesSearchController.php
+++ b/src/Panel/Controller/Search/PagesSearchController.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Panel\Controller\Search;
 
+use Kirby\Cms\Page;
 use Kirby\Cms\Pages;
 use Kirby\Panel\Ui\Item\PageItem;
 
@@ -15,7 +16,7 @@ use Kirby\Panel\Ui\Item\PageItem;
 class PagesSearchController extends ModelsSearchController
 {
 	/**
-	 * @param \Kirby\Cms\Page $model
+	 * @param Page $model
 	 */
 	public function item($model): PageItem
 	{

--- a/src/Panel/Controller/Search/UsersSearchController.php
+++ b/src/Panel/Controller/Search/UsersSearchController.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Panel\Controller\Search;
 
+use Kirby\Cms\User;
 use Kirby\Cms\Users;
 use Kirby\Panel\Ui\Item\UserItem;
 
@@ -15,7 +16,7 @@ use Kirby\Panel\Ui\Item\UserItem;
 class UsersSearchController extends ModelsSearchController
 {
 	/**
-	 * @param \Kirby\Cms\User $model
+	 * @param User $model
 	 */
 	public function item($model): UserItem
 	{

--- a/src/Panel/Controller/View/FileViewController.php
+++ b/src/Panel/Controller/View/FileViewController.php
@@ -15,7 +15,7 @@ use Kirby\Panel\Ui\FilePreview;
  * @license   https://getkirby.com/license
  * @since     6.0.0
  *
- * @extends \Kirby\Panel\Controller\View\ModelViewController<\Kirby\Cms\File, \Kirby\Panel\File>
+ * @extends ModelViewController<File, \Kirby\Panel\File>
  */
 class FileViewController extends ModelViewController
 {

--- a/src/Panel/Controller/View/ModelViewController.php
+++ b/src/Panel/Controller/View/ModelViewController.php
@@ -18,8 +18,8 @@ use Kirby\Panel\Ui\View;
  * @license   https://getkirby.com/license
  * @since     6.0.0
  *
- * @template TModel of \Kirby\Cms\ModelWithContent
- * @template TPanel of \Kirby\Panel\Model
+ * @template TModel of ModelWithContent
+ * @template TPanel of Model
  */
 abstract class ModelViewController extends ViewController
 {

--- a/src/Panel/Controller/View/PageViewController.php
+++ b/src/Panel/Controller/View/PageViewController.php
@@ -14,7 +14,7 @@ use Kirby\Panel\Ui\Button\ViewButtons;
  * @license   https://getkirby.com/license
  * @since     6.0.0
  *
- * @extends \Kirby\Panel\Controller\View\ModelViewController<\Kirby\Cms\Page, \Kirby\Panel\Page>
+ * @extends ModelViewController<Page, \Kirby\Panel\Page>
  */
 class PageViewController extends ModelViewController
 {

--- a/src/Panel/Controller/View/PreviewViewController.php
+++ b/src/Panel/Controller/View/PreviewViewController.php
@@ -77,7 +77,7 @@ class PreviewViewController extends ViewController
 
 	/**
 	 * Resolves the provided URL to an existing site/page.
-	 * @throws \Kirby\Panel\Redirect When no model can be found for the URL
+	 * @throws Redirect When no model can be found for the URL
 	 */
 	protected function modelFromUri(Uri $url): Site|Page
 	{

--- a/src/Panel/Controller/View/SiteViewController.php
+++ b/src/Panel/Controller/View/SiteViewController.php
@@ -13,7 +13,7 @@ use Kirby\Panel\Ui\Button\ViewButtons;
  * @license   https://getkirby.com/license
  * @since     6.0.0
  *
- * @extends \Kirby\Panel\Controller\View\ModelViewController<\Kirby\Cms\Site, \Kirby\Panel\Site>
+ * @extends ModelViewController<Site, \Kirby\Panel\Site>
  */
 class SiteViewController extends ModelViewController
 {

--- a/src/Panel/Controller/View/UserFileViewController.php
+++ b/src/Panel/Controller/View/UserFileViewController.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Panel\Controller\View;
 
+use Kirby\Cms\User;
+
 /**
  * Controls the view for a user file
  *
@@ -13,7 +15,7 @@ class UserFileViewController extends FileViewController
 {
 	public function breadcrumb(): array
 	{
-		/** @var \Kirby\Cms\User $parent */
+		/** @var User $parent */
 		$parent     = $this->model->parent();
 		$breadcrumb = [];
 

--- a/src/Panel/Controller/View/UserViewController.php
+++ b/src/Panel/Controller/View/UserViewController.php
@@ -14,7 +14,7 @@ use Kirby\Panel\Ui\Button\ViewButtons;
  * @license   https://getkirby.com/license
  * @since     6.0.0
  *
- * @extends \Kirby\Panel\Controller\View\ModelViewController<\Kirby\Cms\User, \Kirby\Panel\User>
+ * @extends ModelViewController<User, \Kirby\Panel\User>
  */
 class UserViewController extends ModelViewController
 {

--- a/src/Panel/File.php
+++ b/src/Panel/File.php
@@ -16,7 +16,7 @@ use Throwable;
  * @license   https://getkirby.com/license
  * @since     3.6.0
  *
- * @extends \Kirby\Panel\Model<\Kirby\Cms\File>
+ * @extends Model<cmsfile>
  */
 class File extends Model
 {

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -17,7 +17,7 @@ use Kirby\Toolkit\A;
  * @license   https://getkirby.com/license
  * @since     3.6.0
  *
- * @template TModel of \Kirby\Cms\ModelWithContent
+ * @template TModel of ModelWithContent
  */
 abstract class Model
 {

--- a/src/Panel/Page.php
+++ b/src/Panel/Page.php
@@ -15,7 +15,7 @@ use Kirby\Panel\Ui\Item\PageItem;
  * @license   https://getkirby.com/license
  * @since     3.6.0
  *
- * @extends \Kirby\Panel\Model<\Kirby\Cms\Page>
+ * @extends Model<\Kirby\Cms\Page>
  */
 class Page extends Model
 {

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -51,7 +51,7 @@ class Panel
 	/**
 	 * Redirect to a Panel url
 	 *
-	 * @throws \Kirby\Panel\Redirect
+	 * @throws Redirect
 	 * @codeCoverageIgnore
 	 */
 	public static function go(string|null $url = null, int $code = 302, int|false $refresh = false): void

--- a/src/Panel/Site.php
+++ b/src/Panel/Site.php
@@ -13,7 +13,7 @@ use Kirby\Panel\Controller\View\SiteViewController;
  * @license   https://getkirby.com/license
  * @since     3.6.0
  *
- * @extends \Kirby\Panel\Model<\Kirby\Cms\Site>
+ * @extends Model<\Kirby\Cms\Site>
  */
 class Site extends Model
 {

--- a/src/Panel/Ui/Item/FileItem.php
+++ b/src/Panel/Ui/Item/FileItem.php
@@ -9,7 +9,7 @@ use Kirby\Cms\File;
  * @license   https://getkirby.com/license
  * @since     5.1.0
  *
- * @extends \Kirby\Panel\Ui\Item\ModelItem<\Kirby\Cms\File, \Kirby\Panel\File>
+ * @extends ModelItem<File, \Kirby\Panel\File>
  */
 class FileItem extends ModelItem
 {

--- a/src/Panel/Ui/Item/ModelItem.php
+++ b/src/Panel/Ui/Item/ModelItem.php
@@ -11,8 +11,8 @@ use Kirby\Panel\Ui\Item;
  * @license   https://getkirby.com/license
  * @since     5.1.0
  *
- * @template TModel of \Kirby\Cms\ModelWithContent
- * @template TPanel of \Kirby\Panel\Model
+ * @template TModel of ModelWithContent
+ * @template TPanel of panel
  */
 class ModelItem extends Item
 {

--- a/src/Panel/Ui/Item/PageItem.php
+++ b/src/Panel/Ui/Item/PageItem.php
@@ -9,7 +9,7 @@ use Kirby\Cms\Page;
  * @license   https://getkirby.com/license
  * @since     5.1.0
  *
- * @extends \Kirby\Panel\Ui\Item\ModelItem<\Kirby\Cms\Page, \Kirby\Panel\Page>
+ * @extends ModelItem<Page, \Kirby\Panel\Page>
  */
 class PageItem extends ModelItem
 {

--- a/src/Panel/Ui/Item/UserItem.php
+++ b/src/Panel/Ui/Item/UserItem.php
@@ -9,7 +9,7 @@ use Kirby\Cms\User;
  * @license   https://getkirby.com/license
  * @since     5.1.0
  *
- * @extends \Kirby\Panel\Ui\Item\ModelItem<\Kirby\Cms\User, \Kirby\Panel\User>
+ * @extends ModelItem<User, \Kirby\Panel\User>
  */
 class UserItem extends ModelItem
 {

--- a/src/Panel/User.php
+++ b/src/Panel/User.php
@@ -17,7 +17,7 @@ use Kirby\Panel\Ui\Item\UserItem;
  * @license   https://getkirby.com/license
  * @since     3.6.0
  *
- * @extends \Kirby\Panel\Model<\Kirby\Cms\User>
+ * @extends Model<\Kirby\Cms\User>
  */
 class User extends Model
 {

--- a/src/Plugin/Assets.php
+++ b/src/Plugin/Assets.php
@@ -19,7 +19,7 @@ use Kirby\Toolkit\Str;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  *
- * @extends \Kirby\Cms\Collection<\Kirby\Plugin\Asset>
+ * @extends Collection<Asset>
  */
 class Assets extends Collection
 {

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -34,7 +34,7 @@ class Plugin
 	 * @param string $name Plugin name within Kirby (`vendor/plugin`)
 	 * @param array $extends Associative array of plugin extensions
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the plugin name has an invalid format
+	 * @throws InvalidArgumentException If the plugin name has an invalid format
 	 */
 	public function __construct(
 		protected string $name,
@@ -311,7 +311,7 @@ class Plugin
 	 * Checks if the name follows the required pattern
 	 * and throws an exception if not
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function validateName(string $name): void
 	{

--- a/src/Query/Arguments.php
+++ b/src/Query/Arguments.php
@@ -13,7 +13,7 @@ use Kirby\Toolkit\Collection;
  * @license   https://opensource.org/licenses/MIT
  *
  * @deprecated 6.0.0 Will be removed in Kirby 7
- * @extends \Kirby\Toolkit\Collection<\Kirby\Query\Argument>
+ * @extends Collection<Argument>
  */
 class Arguments extends Collection
 {

--- a/src/Query/Parser/Parser.php
+++ b/src/Query/Parser/Parser.php
@@ -125,7 +125,7 @@ class Parser
 	/**
 	 * Collect the next token of a type
 	 *
-	 * @throws \Exception when next token is not of specified type
+	 * @throws Exception when next token is not of specified type
 	 */
 	protected function consume(
 		TokenType $type,

--- a/src/Query/Parser/Tokenizer.php
+++ b/src/Query/Parser/Tokenizer.php
@@ -78,7 +78,7 @@ class Tokenizer
 	 *
 	 * @param int $current The current position in the source string
 	 *
-	 * @throws \Exception If an unexpected character is encountered
+	 * @throws Exception If an unexpected character is encountered
 	 */
 	public static function token(string $query, int $current): Token
 	{

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -10,6 +10,7 @@ use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Cms\User;
 use Kirby\Cms\Users;
+use Kirby\Exception\BadMethodCallException;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Image\QrCode;
 use Kirby\Query\Runners\DefaultRunner;
@@ -73,8 +74,8 @@ class Query
 	 * Returns the query result if anything
 	 * can be found, otherwise returns null
 	 *
-	 * @throws \Kirby\Exception\BadMethodCallException If an invalid method is accessed by the query
-	 * @throws \Kirby\Exception\InvalidArgumentException If an invalid query runner is set in the config option
+	 * @throws BadMethodCallException If an invalid method is accessed by the query
+	 * @throws InvalidArgumentException If an invalid query runner is set in the config option
 	 */
 	public function resolve(array|object $data = []): mixed
 	{

--- a/src/Query/Segment.php
+++ b/src/Query/Segment.php
@@ -34,7 +34,7 @@ class Segment
 	 * @param string $name Name of the method/property that was accessed
 	 * @param string $label Type of the name (`method`, `property` or `method/property`)
 	 *
-	 * @throws \Kirby\Exception\BadMethodCallException
+	 * @throws BadMethodCallException
 	 */
 	#[BlockCollectionAccess]
 	public static function error(

--- a/src/Query/Segments.php
+++ b/src/Query/Segments.php
@@ -13,7 +13,7 @@ use Kirby\Toolkit\Collection;
  * @license   https://opensource.org/licenses/MIT
  *
  * @deprecated 6.0.0 Will be removed in Kirby 7
- * @extends \Kirby\Toolkit\Collection<\Kirby\Query\Segment>
+ * @extends Collection<Segment>
  */
 class Segments extends Collection
 {

--- a/src/Sane/DomHandler.php
+++ b/src/Sane/DomHandler.php
@@ -5,6 +5,7 @@ namespace Kirby\Sane;
 use DOMAttr;
 use DOMDocumentType;
 use DOMElement;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\Dom;
 
 /**
@@ -62,7 +63,7 @@ class DomHandler extends Handler
 	 * @param bool $isExternal Whether the string is from an external file
 	 *                         that may be accessed directly
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file couldn't be parsed
+	 * @throws InvalidArgumentException If the file couldn't be parsed
 	 */
 	public static function sanitize(
 		string $string,
@@ -79,8 +80,8 @@ class DomHandler extends Handler
 	 * @param bool $isExternal Whether the string is from an external file
 	 *                         that may be accessed directly
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file couldn't be parsed
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file didn't pass validation
+	 * @throws InvalidArgumentException If the file couldn't be parsed
+	 * @throws InvalidArgumentException If the file didn't pass validation
 	 */
 	public static function validate(
 		string $string,
@@ -165,7 +166,7 @@ class DomHandler extends Handler
 	/**
 	 * Parses the given string into a `Toolkit\Dom` object
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file couldn't be parsed
+	 * @throws InvalidArgumentException If the file couldn't be parsed
 	 */
 	protected static function parse(string $string): Dom
 	{

--- a/src/Sane/Handler.php
+++ b/src/Sane/Handler.php
@@ -3,6 +3,7 @@
 namespace Kirby\Sane;
 
 use Kirby\Exception\Exception;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\F;
 
 /**
@@ -31,8 +32,8 @@ abstract class Handler
 	 * Sanitizes the contents of a file by overwriting
 	 * the file with the sanitized version
 	 *
-	 * @throws \Kirby\Exception\Exception If the file does not exist
-	 * @throws \Kirby\Exception\Exception On other errors
+	 * @throws Exception If the file does not exist
+	 * @throws Exception On other errors
 	 */
 	public static function sanitizeFile(string $file): void
 	{
@@ -47,8 +48,8 @@ abstract class Handler
 	 * @param bool $isExternal Whether the string is from an external file
 	 *                         that may be accessed directly
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file didn't pass validation
-	 * @throws \Kirby\Exception\Exception On other errors
+	 * @throws InvalidArgumentException If the file didn't pass validation
+	 * @throws Exception On other errors
 	 */
 	abstract public static function validate(
 		string $string,
@@ -58,9 +59,9 @@ abstract class Handler
 	/**
 	 * Validates the contents of a file
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file didn't pass validation
-	 * @throws \Kirby\Exception\Exception If the file does not exist
-	 * @throws \Kirby\Exception\Exception On other errors
+	 * @throws InvalidArgumentException If the file didn't pass validation
+	 * @throws Exception If the file does not exist
+	 * @throws Exception On other errors
 	 */
 	public static function validateFile(string $file): void
 	{
@@ -72,7 +73,7 @@ abstract class Handler
 	 * Reads the contents of a file
 	 * for sanitization or validation
 	 *
-	 * @throws \Kirby\Exception\Exception If the file does not exist
+	 * @throws Exception If the file does not exist
 	 */
 	protected static function readFile(string $file): string
 	{

--- a/src/Sane/Sane.php
+++ b/src/Sane/Sane.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Sane;
 
+use Kirby\Exception\Exception;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\F;
@@ -45,7 +47,7 @@ class Sane
 	 *
 	 * @param bool $lazy If set to `true`, `null` is returned for undefined handlers
 	 *
-	 * @throws \Kirby\Exception\NotFoundException If no handler was found and `$lazy` was set to `false`
+	 * @throws NotFoundException If no handler was found and `$lazy` was set to `false`
 	 */
 	public static function handler(
 		string $type,
@@ -100,10 +102,10 @@ class Sane
 	 *                              `true` for lazy autodetection or
 	 *                              `false` for normal autodetection
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file didn't pass validation
-	 * @throws \Kirby\Exception\LogicException If more than one handler applies
-	 * @throws \Kirby\Exception\NotFoundException If the handler was not found
-	 * @throws \Kirby\Exception\Exception On other errors
+	 * @throws InvalidArgumentException If the file didn't pass validation
+	 * @throws LogicException If more than one handler applies
+	 * @throws NotFoundException If the handler was not found
+	 * @throws Exception On other errors
 	 */
 	public static function sanitizeFile(
 		string $file,
@@ -156,9 +158,9 @@ class Sane
 	 * @param bool $isExternal Whether the string is from an external file
 	 *                         that may be accessed directly
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file didn't pass validation
-	 * @throws \Kirby\Exception\NotFoundException If the handler was not found
-	 * @throws \Kirby\Exception\Exception On other errors
+	 * @throws InvalidArgumentException If the file didn't pass validation
+	 * @throws NotFoundException If the handler was not found
+	 * @throws Exception On other errors
 	 */
 	public static function validate(string $string, string $type, bool $isExternal = false): void
 	{
@@ -174,9 +176,9 @@ class Sane
 	 *                              `true` for lazy autodetection or
 	 *                              `false` for normal autodetection
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file didn't pass validation
-	 * @throws \Kirby\Exception\NotFoundException If the handler was not found
-	 * @throws \Kirby\Exception\Exception On other errors
+	 * @throws InvalidArgumentException If the file didn't pass validation
+	 * @throws NotFoundException If the handler was not found
+	 * @throws Exception On other errors
 	 */
 	public static function validateFile(
 		string $file,
@@ -199,7 +201,7 @@ class Sane
 	 * file extension and MIME type
 	 *
 	 * @param bool $lazy If set to `true`, undefined handlers are skipped
-	 * @return array<\Kirby\Sane\Handler>
+	 * @return array<Handler>
 	 */
 	protected static function handlersForFile(
 		string $file,

--- a/src/Sane/Svg.php
+++ b/src/Sane/Svg.php
@@ -482,7 +482,7 @@ class Svg extends Xml
 	/**
 	 * Parses the given string into a `Toolkit\Dom` object
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file couldn't be parsed
+	 * @throws InvalidArgumentException If the file couldn't be parsed
 	 */
 	protected static function parse(string $string): Dom
 	{

--- a/src/Sane/Svgz.php
+++ b/src/Sane/Svgz.php
@@ -19,7 +19,7 @@ class Svgz extends Svg
 	 * @param bool $isExternal Whether the string is from an external file
 	 *                         that may be accessed directly
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file couldn't be parsed or recompressed
+	 * @throws InvalidArgumentException If the file couldn't be parsed or recompressed
 	 */
 	public static function sanitize(
 		string $string,
@@ -42,8 +42,8 @@ class Svgz extends Svg
 	 * @param bool $isExternal Whether the string is from an external file
 	 *                         that may be accessed directly
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file couldn't be parsed
-	 * @throws \Kirby\Exception\InvalidArgumentException If the file didn't pass validation
+	 * @throws InvalidArgumentException If the file couldn't be parsed
+	 * @throws InvalidArgumentException If the file didn't pass validation
 	 */
 	public static function validate(
 		string $string,

--- a/src/Session/FileStore.php
+++ b/src/Session/FileStore.php
@@ -195,7 +195,7 @@ class FileStore extends Store
 	 * Throws an exception for an unexpected file system error
 	 * @since 6.0.0
 	 *
-	 * @throws \Kirby\Exception\Exception
+	 * @throws Exception
 	 * @codeCoverageIgnore
 	 */
 	protected function fail(): never

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -39,7 +39,7 @@ class Session
 	/**
 	 * Creates a new Session instance
 	 *
-	 * @param \Kirby\Session\Sessions $sessions Parent sessions object
+	 * @param Sessions $sessions Parent sessions object
 	 * @param $token Session token or null for a new session
 	 * @param $options Optional additional options:
 	 *                - `mode`: Token transmission mode (cookie or manual); defaults to `cookie`
@@ -146,7 +146,7 @@ class Session
 	}
 
 	/**
-	 * @see \Kirby\Session\Data::clear()
+	 * @see Data::clear()
 	 * @since 6.0.0
 	 */
 	public function clear(): void
@@ -225,7 +225,7 @@ class Session
 	}
 
 	/**
-	 * @see \Kirby\Session\Data::decrement()
+	 * @see Data::decrement()
 	 * @since 6.0.0
 	 */
 	public function decrement(
@@ -334,7 +334,7 @@ class Session
 	}
 
 	/**
-	 * @see \Kirby\Session\Data::get()
+	 * @see Data::get()
 	 * @since 6.0.0
 	 */
 	public function get(string|null $key = null, mixed $default = null): mixed
@@ -343,7 +343,7 @@ class Session
 	}
 
 	/**
-	 * @see \Kirby\Session\Data::increment()
+	 * @see Data::increment()
 	 * @since 6.0.0
 	 */
 	public function increment(
@@ -562,7 +562,7 @@ class Session
 	}
 
 	/**
-	 * @see \Kirby\Session\Data::pull()
+	 * @see Data::pull()
 	 * @since 6.0.0
 	 */
 	public function pull(string $key, mixed $default = null): mixed
@@ -623,7 +623,7 @@ class Session
 	}
 
 	/**
-	 * @see \Kirby\Session\Data::remove()
+	 * @see Data::remove()
 	 * @since 6.0.0
 	 */
 	public function remove(string|array $key): void
@@ -666,7 +666,7 @@ class Session
 	}
 
 	/**
-	 * @see \Kirby\Session\Data::set()
+	 * @see Data::set()
 	 * @since 6.0.0
 	 */
 	public function set(string|array $key, mixed $value = null): void
@@ -686,7 +686,7 @@ class Session
 	 * Throws an exception for an invalid session
 	 * @since 6.0.0
 	 *
-	 * @throws \Kirby\Exception\LogicException
+	 * @throws LogicException
 	 */
 	protected function throwInvalid(): never
 	{

--- a/src/Session/Sessions.php
+++ b/src/Session/Sessions.php
@@ -4,6 +4,7 @@ namespace Kirby\Session;
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\LogicException;
+use Kirby\Exception\NotFoundException;
 use Throwable;
 
 /**
@@ -20,7 +21,7 @@ class Sessions
 	public const TIMEOUT = 1800;
 
 	/**
-	 * @var array<string, \Kirby\Session\Session>
+	 * @var array<string, Session>
 	 */
 	protected array $cache = [];
 	protected Session|null $autoSession = null;
@@ -121,7 +122,7 @@ class Sessions
 	 * Returns the current session based on the
 	 * configured token transmission $mode
 	 *
-	 * @throws \Kirby\Exception\LogicException In `manual` mode
+	 * @throws LogicException In `manual` mode
 	 */
 	public function current(): Session|null
 	{
@@ -249,9 +250,9 @@ class Sessions
 	 * @param $token Session token, either including or without the key
 	 * @param $mode Optional transmission mode override
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the token is malformed
-	 * @throws \Kirby\Exception\NotFoundException If no matching session exists
-	 * @throws \Kirby\Exception\LogicException If the session data is invalid or expired
+	 * @throws InvalidArgumentException If the token is malformed
+	 * @throws NotFoundException If no matching session exists
+	 * @throws LogicException If the session data is invalid or expired
 	 */
 	public function find(string $token, string|null $mode = null): Session
 	{

--- a/src/Session/Token.php
+++ b/src/Session/Token.php
@@ -78,7 +78,7 @@ class Token implements Stringable
 	 *
 	 * @param $token Session token
 	 * @param $key Whether the token string includes the secret key
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	public static function parse(
 		string $token,

--- a/src/Template/Snippet.php
+++ b/src/Template/Snippet.php
@@ -143,7 +143,7 @@ class Snippet extends Tpl
 	 *
 	 * @param string $file Path to the snippet file
 	 * @param array $data Data available inside the snippet
-	 * @param \Kirby\Template\Slots|null Slots available in the snippet
+	 * @param Slots|null Slots available in the snippet
 	 * @return string The rendered content of the given snippet file
 	 */
 	public static function load(
@@ -371,7 +371,7 @@ class Snippet extends Tpl
 	/**
 	 * Returns the data variables that get passed to a snippet
 	 *
-	 * @param \Kirby\Template\Slots|null $slots If null, an empty dummy object is used
+	 * @param Slots|null $slots If null, an empty dummy object is used
 	 */
 	protected static function scope(
 		array $data = [],

--- a/src/Toolkit/A.php
+++ b/src/Toolkit/A.php
@@ -793,7 +793,7 @@ class A
 	 * Returns a number of random elements from an array,
 	 * either in original or shuffled order
 	 *
-	 * @throws \Exception When $count is larger than array length
+	 * @throws Exception When $count is larger than array length
 	 */
 	public static function random(
 		array $array,

--- a/src/Toolkit/Collection.php
+++ b/src/Toolkit/Collection.php
@@ -19,7 +19,7 @@ use Stringable;
  * @license   https://opensource.org/licenses/MIT
  *
  * @template TValue
- * @extends \Kirby\Toolkit\Iterator<string, TValue>
+ * @extends Iterator<string, TValue>
  */
 class Collection extends Iterator implements Stringable
 {
@@ -38,7 +38,7 @@ class Collection extends Iterator implements Stringable
 	protected bool $caseSensitive = false;
 
 	/**
-	 * @var \Kirby\Toolkit\Pagination|null
+	 * @var Pagination|null
 	 */
 	protected $pagination;
 
@@ -537,8 +537,8 @@ class Collection extends Iterator implements Stringable
 	 * Returns a new collection with an element for each group
 	 * and a subcollection in each group
 	 *
-	 * @param string|\Closure $field
-	 * @throws \Exception if $field is not a string nor a callback function
+	 * @param string|Closure $field
+	 * @throws Exception if $field is not a string nor a callback function
 	 */
 	public function group(
 		$field,

--- a/src/Toolkit/Date.php
+++ b/src/Toolkit/Date.php
@@ -55,7 +55,7 @@ class Date extends DateTime implements Stringable
 	 * @param $unit `year`, `month`, `day`, `hour`, `minute` or `second`
 	 * @return $this
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the unit name is invalid
+	 * @throws InvalidArgumentException If the unit name is invalid
 	 */
 	public function ceil(string $unit): static
 	{
@@ -134,7 +134,7 @@ class Date extends DateTime implements Stringable
 	 * @param $unit `year`, `month`, `day`, `hour`, `minute` or `second`
 	 * @return $this
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the unit name is invalid
+	 * @throws InvalidArgumentException If the unit name is invalid
 	 */
 	public function floor(string $unit): static
 	{
@@ -359,7 +359,7 @@ class Date extends DateTime implements Stringable
 	 * @param $size Rounding step starting at `0` of the specified unit
 	 * @return $this
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the unit name or size is invalid
+	 * @throws InvalidArgumentException If the unit name or size is invalid
 	 */
 	public function round(string $unit, int $size = 1): static
 	{
@@ -520,7 +520,7 @@ class Date extends DateTime implements Stringable
 	 * @param $mode `date`, `time` or `datetime`
 	 * @param $timezone Whether the timezone is printed as well
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the mode is invalid
+	 * @throws InvalidArgumentException If the mode is invalid
 	 */
 	public function toString(
 		string $mode = 'datetime',
@@ -558,7 +558,7 @@ class Date extends DateTime implements Stringable
 	/**
 	 * Ensures that the provided string is a valid unit name
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException
+	 * @throws InvalidArgumentException
 	 */
 	protected static function validateUnit(string $unit): void
 	{

--- a/src/Toolkit/Dom.php
+++ b/src/Toolkit/Dom.php
@@ -511,7 +511,7 @@ class Dom
 	 * Executes an XPath query in the document
 	 *
 	 * @param $node Optional context node for relative queries
-	 * @throws \Kirby\Exception\InvalidArgumentException for invalid XPath queries
+	 * @throws InvalidArgumentException for invalid XPath queries
 	 */
 	public function query(
 		string $query,
@@ -570,7 +570,7 @@ class Dom
 	 *                objects for each modification
 	 *                - `urlAttrs`: List of attributes that may contain URLs
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the doctype is not valid
+	 * @throws InvalidArgumentException If the doctype is not valid
 	 */
 	public function sanitize(array $options): array
 	{
@@ -962,7 +962,7 @@ class Dom
 	 *
 	 * @param $options See `Dom::sanitize()`
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException If the doctype is not valid
+	 * @throws InvalidArgumentException If the doctype is not valid
 	 */
 	protected function validateDoctype(
 		DOMDocumentType $doctype,

--- a/src/Toolkit/Iterator.php
+++ b/src/Toolkit/Iterator.php
@@ -33,7 +33,7 @@ class Iterator implements Countable, IteratorAggregate
 
 	/**
 	 * Returns an iterator for the elements
-	 * @return \Iterator<TKey, TValue>
+	 * @return PhpIterator<TKey, TValue>
 	 */
 	public function getIterator(): PhpIterator
 	{

--- a/src/Toolkit/Locale.php
+++ b/src/Toolkit/Locale.php
@@ -53,8 +53,8 @@ class Locale
 	 * @param int|string $category Locale category constant or constant name
 	 * @return array|string Associative array if `LC_ALL` was passed (default), otherwise string
 	 *
-	 * @throws \Kirby\Exception\Exception If the locale cannot be determined
-	 * @throws \Kirby\Exception\InvalidArgumentException If the provided locale category is invalid
+	 * @throws Exception If the locale cannot be determined
+	 * @throws InvalidArgumentException If the provided locale category is invalid
 	 */
 	public static function get(int|string $category = LC_ALL): array|string
 	{

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -385,7 +385,7 @@ class Str
 	/**
 	 * Converts a string to a different encoding
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException when conversion failed
+	 * @throws InvalidArgumentException when conversion failed
 	 */
 	public static function convert(
 		string $string,
@@ -790,7 +790,7 @@ class Str
 	 * Returns the position of a needle in a string
 	 * if it can be found
 	 *
-	 * @throws \Kirby\Exception\InvalidArgumentException for empty $needle
+	 * @throws InvalidArgumentException for empty $needle
 	 */
 	public static function position(
 		string|null $string,

--- a/src/Uuid/BlockUuid.php
+++ b/src/Uuid/BlockUuid.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Uuid;
 
+use Kirby\Cms\Block;
 use Kirby\Cms\Blocks;
 use Kirby\Content\Field;
 
@@ -22,7 +23,7 @@ class BlockUuid extends FieldUuid
 	protected const string FIELD = 'blocks';
 
 	/**
-	 * @var \Kirby\Cms\Block|null
+	 * @var Block|null
 	 */
 	public Identifiable|null $model = null;
 

--- a/src/Uuid/FieldUuid.php
+++ b/src/Uuid/FieldUuid.php
@@ -4,6 +4,7 @@ namespace Kirby\Uuid;
 
 use Generator;
 use Kirby\Cms\Collection;
+use Kirby\Cms\ModelWithContent;
 use Kirby\Content\Field;
 use Kirby\Toolkit\A;
 
@@ -42,7 +43,7 @@ abstract class FieldUuid extends Uuid
 				/**
 				 * $value is an array containing the UUID for the parent,
 				 * the field name and the specific ID
-				 * @var \Kirby\Cms\ModelWithContent|null $parent
+				 * @var ModelWithContent|null $parent
 				 */
 				$parent = Uuid::from($value['parent'])->model();
 
@@ -84,7 +85,7 @@ abstract class FieldUuid extends Uuid
 	 * Generator function that returns collections for all fields globally
 	 * (in any page's, file's, user's or site's content file)
 	 *
-	 * @return \Generator<string, \Kirby\Cms\Collection>
+	 * @return Generator<string, Collection>
 	 */
 	public static function index(): Generator
 	{
@@ -116,7 +117,7 @@ abstract class FieldUuid extends Uuid
 	public function value(): array
 	{
 		/**
-		 * @var \Kirby\Cms\ModelWithContent $model
+		 * @var ModelWithContent $model
 		 */
 		$model  = $this->model();
 		$parent = Uuid::for($model->parent());

--- a/src/Uuid/FileUuid.php
+++ b/src/Uuid/FileUuid.php
@@ -4,6 +4,9 @@ namespace Kirby\Uuid;
 
 use Generator;
 use Kirby\Cms\File;
+use Kirby\Cms\Page;
+use Kirby\Cms\Site;
+use Kirby\Cms\User;
 
 /**
  * UUID for \Kirby\Cms\File
@@ -17,7 +20,7 @@ class FileUuid extends ModelUuid
 	protected const string TYPE = 'file';
 
 	/**
-	 * @var \Kirby\Cms\File|null
+	 * @var File|null
 	 */
 	public Identifiable|null $model = null;
 
@@ -34,7 +37,7 @@ class FileUuid extends ModelUuid
 			if ($value = Uuids::cache()->get($key)) {
 				// value is an array containing
 				// the UUID for the parent and the filename
-				/** @var \Kirby\Cms\Site|\Kirby\Cms\Page|\Kirby\Cms\User $parent */
+				/** @var Site|Page|User $parent */
 				$parent = Uuid::from($value['parent'])->model();
 				return $parent?->file($value['filename']);
 			}
@@ -47,7 +50,7 @@ class FileUuid extends ModelUuid
 	 * Generator for all files in the site
 	 * (of all pages, users and site)
 	 *
-	 * @return \Generator<string, \Kirby\Cms\File>
+	 * @return Generator<string, File>
 	 */
 	public static function index(): Generator
 	{

--- a/src/Uuid/ModelUuid.php
+++ b/src/Uuid/ModelUuid.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Uuid;
 
+use Kirby\Cms\ModelWithContent;
+
 /**
  * Base for UUIDs for models where id string
  * is stored in the content, such as pages and files
@@ -10,12 +12,12 @@ namespace Kirby\Uuid;
  * @license   https://getkirby.com/license
  * @since     3.8.0
  *
- * @method \Kirby\Cms\ModelWithContent|null model(bool $lazy = false)
+ * @method ModelWithContent|null model(bool $lazy = false)
  */
 abstract class ModelUuid extends Uuid
 {
 	/**
-	 * @var \Kirby\Cms\ModelWithContent|null
+	 * @var ModelWithContent|null
 	 */
 	public Identifiable|null $model = null;
 
@@ -60,7 +62,7 @@ abstract class ModelUuid extends Uuid
 	 * Retrieves the ID string (UUID without scheme) for the model
 	 * from the content file, if it is already stored there
 	 *
-	 * @param \Kirby\Cms\ModelWithContent $model
+	 * @param ModelWithContent $model
 	 */
 	public static function retrieveId(Identifiable $model): string|null
 	{

--- a/src/Uuid/PageUuid.php
+++ b/src/Uuid/PageUuid.php
@@ -18,7 +18,7 @@ class PageUuid extends ModelUuid
 	protected const string TYPE = 'page';
 
 	/**
-	 * @var \Kirby\Cms\Page|null
+	 * @var Page|null
 	 */
 	public Identifiable|null $model = null;
 
@@ -56,7 +56,7 @@ class PageUuid extends ModelUuid
 	/**
 	 * Generator for all pages and drafts in the site
 	 *
-	 * @return \Generator<string, \Kirby\Cms\Page>
+	 * @return Generator<string, Page>
 	 */
 	public static function index(Page|null $entry = null): Generator
 	{

--- a/src/Uuid/SiteUuid.php
+++ b/src/Uuid/SiteUuid.php
@@ -18,7 +18,7 @@ class SiteUuid extends Uuid
 	protected const string TYPE = 'site';
 
 	/**
-	 * @var \Kirby\Cms\Site|null
+	 * @var Site|null
 	 */
 	public Identifiable|null $model = null;
 
@@ -34,7 +34,7 @@ class SiteUuid extends Uuid
 	/**
 	 * Generator for the one and only site object
 	 *
-	 * @return \Generator<string, \Kirby\Cms\Site>
+	 * @return Generator<string, Site>
 	 */
 	public static function index(): Generator
 	{

--- a/src/Uuid/StructureUuid.php
+++ b/src/Uuid/StructureUuid.php
@@ -3,6 +3,7 @@
 namespace Kirby\Uuid;
 
 use Kirby\Cms\Structure;
+use Kirby\Cms\StructureObject;
 use Kirby\Content\Field;
 
 /**
@@ -22,7 +23,7 @@ class StructureUuid extends FieldUuid
 	protected const string FIELD = 'structure';
 
 	/**
-	 * @var \Kirby\Cms\StructureObject|null
+	 * @var StructureObject|null
 	 */
 	public Identifiable|null $model = null;
 

--- a/src/Uuid/UserUuid.php
+++ b/src/Uuid/UserUuid.php
@@ -18,7 +18,7 @@ class UserUuid extends Uuid
 	protected const string TYPE = 'user';
 
 	/**
-	 * @var \Kirby\Cms\User|null
+	 * @var User|null
 	 */
 	public Identifiable|null $model = null;
 
@@ -36,7 +36,7 @@ class UserUuid extends Uuid
 	/**
 	 * Generator for all users
 	 *
-	 * @return \Generator<string, \Kirby\Cms\User>
+	 * @return Generator<string, User>
 	 */
 	public static function index(): Generator
 	{

--- a/src/Uuid/Uuid.php
+++ b/src/Uuid/Uuid.php
@@ -258,7 +258,7 @@ abstract class Uuid implements Stringable
 	 * into one iterator
 	 * @internal
 	 *
-	 * @return \Generator<string, \Kirby\Uuid\Identifiable>
+	 * @return Generator<string, Identifiable>
 	 */
 	final public function indexes(): Generator
 	{

--- a/tests/Auth/Method/BasicAuthMethodTest.php
+++ b/tests/Auth/Method/BasicAuthMethodTest.php
@@ -39,7 +39,7 @@ class BasicAuthMethodTest extends TestCase
 				return $this->ssl;
 			}
 
-			public function auth(): \Kirby\Http\Request\Auth|false|null
+			public function auth(): Request\Auth|false|null
 			{
 				return $this->header;
 			}

--- a/tests/Database/DatabaseTest.php
+++ b/tests/Database/DatabaseTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Database;
 
+use Kirby\Database\Sql\Sqlite;
 use Kirby\Exception\InvalidArgumentException;
 use PDO;
 use PDOException;
@@ -255,7 +256,7 @@ class DatabaseTest extends TestCase
 		$database->execute('CREATE TABLE "kirby_users" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE)');
 
 		$this->assertSame('kirby_', $database->prefix());
-		$this->assertInstanceOf(\Kirby\Database\Sql\Sqlite::class, $database->sql());
+		$this->assertInstanceOf(Sqlite::class, $database->sql());
 		$this->assertSame(
 			'SELECT * FROM "kirby_users"',
 			$database->table('users')->build('select')['query']

--- a/tests/Filesystem/DirTest.php
+++ b/tests/Filesystem/DirTest.php
@@ -29,7 +29,7 @@ class DirRemoveRecursiveThrows extends Dir
 {
 	protected static function removeRecursive(string $dir): void
 	{
-		throw new \Exception('test: cleanup failure');
+		throw new Exception('test: cleanup failure');
 	}
 }
 

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -19,7 +19,7 @@ class InvalidFileModel
 	public string $foo = 'bar';
 }
 
-#[CoversClass(\Kirby\Filesystem\File::class)]
+#[CoversClass(File::class)]
 class FileTest extends TestCase
 {
 	public const string FIXTURES = __DIR__ . '/fixtures/files';

--- a/tests/Form/Field/StructureFieldTest.php
+++ b/tests/Form/Field/StructureFieldTest.php
@@ -402,7 +402,7 @@ class StructureFieldTest extends TestCase
 		]);
 
 		/**
-		 * @var \Kirby\Form\Field\StructureField $field
+		 * @var StructureField $field
 		 */
 		$field = $this->field('structure', [
 			'name'   => 'mothers',
@@ -465,7 +465,7 @@ class StructureFieldTest extends TestCase
 		$this->assertEquals($expected, $motherForm->toStoredValues()); // cannot use strict assertion (array order)
 
 		/**
-		 * @var \Kirby\Form\Field\StructureField $childrenField
+		 * @var StructureField $childrenField
 		 */
 		$childrenField = $motherForm->field('children');
 		$this->assertSame('structure', $childrenField->type());
@@ -481,7 +481,7 @@ class StructureFieldTest extends TestCase
 		$this->assertSame('Test', $childrenForm->toStoredValues()['name']);
 
 		/**
-		 * @var \Kirby\Form\Field\StructureField $childrenNameField
+		 * @var StructureField $childrenNameField
 		 */
 		$childrenNameField = $childrenField->form()->fields()->name();
 		$this->assertSame('text', $childrenNameField->type());

--- a/tests/Http/RouterTest.php
+++ b/tests/Http/RouterTest.php
@@ -156,7 +156,7 @@ class RouterTest extends TestCase
 						return 'a';
 					}
 
-					/** @var \Kirby\Http\Route $this */
+					/** @var Route $this */
 					$this->next();
 				}
 			],
@@ -167,7 +167,7 @@ class RouterTest extends TestCase
 						return 'b';
 					}
 
-					/** @var \Kirby\Http\Route $this */
+					/** @var Route $this */
 					$this->next();
 				}
 			],
@@ -178,7 +178,7 @@ class RouterTest extends TestCase
 						return 'c';
 					}
 
-					/** @var \Kirby\Http\Route $this */
+					/** @var Route $this */
 					$this->next();
 				}
 			]
@@ -219,7 +219,7 @@ class RouterTest extends TestCase
 				[
 					'pattern' => 'a',
 					'action'  => function () {
-						/** @var \Kirby\Http\Route $this */
+						/** @var Route $this */
 						$this->next();
 					}
 				],

--- a/tests/Parsley/Schema/BlocksTest.php
+++ b/tests/Parsley/Schema/BlocksTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 #[CoversClass(Blocks::class)]
 class BlocksTest extends TestCase
 {
-	/** @var \Kirby\Parsley\Schema\Blocks */
+	/** @var Blocks */
 	protected Schema $schema;
 
 	protected function setUp(): void

--- a/tests/Parsley/Schema/PlainTest.php
+++ b/tests/Parsley/Schema/PlainTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(Plain::class)]
 class PlainTest extends TestCase
 {
-	/** @var \Kirby\Parsley\Schema\Plain */
+	/** @var Plain */
 	protected Schema $schema;
 
 	protected function setUp(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Not sure if I like it yet myself.
But wanted to try it, sleep over it and hear your opinions too.

Currently, we use fully-qualified class names in docblocks all the time. They get quite bulky.
Psalm, IDEs (and with some tweaks our automatic docs too) do however understand short class names when a `use` statement is in place (or same namespace, basically same as when we write it as PHP code.

PHP CS Fixer also has a rule to enforce it.