### PR TITLE
fix: Prevent retaining $app

### DIFF
--- a/src/Cms/AppErrors.php
+++ b/src/Cms/AppErrors.php
@@ -8,6 +8,7 @@ use Kirby\Http\Response;
 use Kirby\Http\Url;
 use Kirby\Toolkit\I18n;
 use Throwable;
+use WeakReference;
 use Whoops\Handler\CallbackHandler;
 use Whoops\Handler\Handler;
 use Whoops\Handler\HandlerInterface;
@@ -124,13 +125,19 @@ trait AppErrors
 				}
 			}
 		} else {
-			$handler = new CallbackHandler(function ($exception, $inspector, $run) {
-				$fatal = $this->option('fatal');
+			// the app must only be referenced weakly,
+			// see `::getAdditionalWhoopsHandler()`
+			$app = WeakReference::create($this);
+
+			$handler = new CallbackHandler(static function ($exception, $inspector, $run) use ($app) {
+				/** @var \Kirby\Cms\App $kirby */
+				$kirby = $app->get() ?? App::instance();
+				$fatal = $kirby->option('fatal');
 
 				if ($fatal instanceof Closure) {
-					echo $fatal($this, $exception);
+					echo $fatal($kirby, $exception);
 				} else {
-					include $this->root('kirby') . '/views/fatal.php';
+					include $kirby->root('kirby') . '/views/fatal.php';
 				}
 
 				return Handler::QUIT;
@@ -149,7 +156,11 @@ trait AppErrors
 	 */
 	protected function handleJsonErrors(): void
 	{
-		$handler = new CallbackHandler(function ($exception, $inspector, $run) {
+		// the app must only be referenced weakly,
+		// see `getAdditionalWhoopsHandler()`
+		$app = WeakReference::create($this);
+
+		$handler = new CallbackHandler(static function ($exception, $inspector, $run) use ($app) {
 			if ($exception instanceof Exception) {
 				$httpCode = $exception->getHttpCode();
 				$code     = $exception->getCode();
@@ -164,19 +175,21 @@ trait AppErrors
 				$details  = null;
 			}
 
-			$editor = $this->option('editor', false);
+			/** @var \Kirby\Cms\App $kirby */
+			$kirby  = $app->get() ?? App::instance();
+			$editor = $kirby->option('editor', false);
 
-			if ($this->option('debug') === true) {
+			if ($kirby->option('debug') === true) {
 				echo Response::json([
 					'status'    => 'error',
 					'exception' => $exception::class,
 					'code'      => $code,
 					'message'   => $exception->getMessage(),
 					'details'   => $details,
-					'file'      => $this->disguiseFilePath($file = $exception->getFile()),
+					'file'      => $kirby->disguiseFilePath($file = $exception->getFile()),
 					'line'      => $line = $exception->getLine(),
 					'editor'    => Url::editor($editor, $file, $line),
-					'trace'     => $this->trace($exception, $editor),
+					'trace'     => $kirby->trace($exception, $editor),
 				], $httpCode);
 			} else {
 				echo Response::json([
@@ -230,11 +243,19 @@ trait AppErrors
 	 */
 	protected function getAdditionalWhoopsHandler(): CallbackHandler
 	{
-		return new CallbackHandler(function ($exception, $inspector, $run) {
+		// Whoops keeps every `Run` instance alive for the rest of the process
+		// via `register_shutdown_function()`. A handler closure that captured
+		// `$this` strongly would pin $app, potentially incl. site tree forever.
+		// Referencing the app weakly allows it to be garbage collected.
+		$app = WeakReference::create($this);
+
+		return new CallbackHandler(static function ($exception, $inspector, $run) use ($app) {
+			/** @var \Kirby\Cms\App $kirby */
+			$kirby    = $app->get() ?? App::instance();
 			$isLogged = true;
 
 			// allow hook to modify whether the exception should be logged
-			$isLogged = $this->apply(
+			$isLogged = $kirby->apply(
 				'system.exception',
 				compact('exception', 'isLogged'),
 				'isLogged'

--- a/src/Cms/AppTranslations.php
+++ b/src/Cms/AppTranslations.php
@@ -20,13 +20,16 @@ trait AppTranslations
 	 */
 	protected function i18n(): void
 	{
-		I18n::$load = function ($locale): array {
-			$data = $this->translation($locale)->data();
+		// These closures are stored statically on `I18n` and therefore outlive
+		// the app that installed them. They must not capture `$this`.
+		I18n::$load = static function ($locale): array {
+			$kirby = App::instance();
+			$data  = $kirby->translation($locale)->data();
 
 			// inject translations from the current language
 			if (
-				$this->multilang() === true &&
-				$language = $this->languages()->find($locale)
+				$kirby->multilang() === true &&
+				$language = $kirby->languages()->find($locale)
 			) {
 				$data = [...$data, ...$language->translations()];
 			}
@@ -36,18 +39,22 @@ trait AppTranslations
 		};
 
 		// the actual locale is set using $app->setCurrentTranslation()
-		I18n::$locale = function (): string {
-			if ($this->multilang() === true) {
-				return $this->defaultLanguage()->code();
+		I18n::$locale = static function (): string {
+			$kirby = App::instance();
+
+			if ($kirby->multilang() === true) {
+				return $kirby->defaultLanguage()->code();
 			}
 
 			return 'en';
 		};
 
-		I18n::$fallback = function (): array {
-			if ($this->multilang() === true) {
+		I18n::$fallback = static function (): array {
+			$kirby = App::instance();
+
+			if ($kirby->multilang() === true) {
 				// first try to fall back to the configured default language
-				$defaultCode = $this->defaultLanguage()->code();
+				$defaultCode = $kirby->defaultLanguage()->code();
 				$fallback    = [$defaultCode];
 
 				// if the default language is specified with a country code

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -15,6 +15,7 @@ use Kirby\Cache\FileCache;
 use Kirby\Cache\MemCached;
 use Kirby\Cache\MemoryCache;
 use Kirby\Cache\RedisCache;
+use Kirby\Filesystem\F;
 use Kirby\Form\Field\BlocksField;
 use Kirby\Form\Field\ButtonsField;
 use Kirby\Form\Field\CheckboxesField;
@@ -239,7 +240,7 @@ class Core
 	 */
 	public function components(): array
 	{
-		return $this->cache['components'] ??= include $this->root . '/components.php';
+		return $this->cache['components'] ??= F::load($this->root . '/components.php');
 	}
 
 	/**
@@ -377,7 +378,7 @@ class Core
 	 */
 	public function kirbyTags(): array
 	{
-		return $this->cache['kirbytags'] ??= include $this->root . '/tags.php';
+		return $this->cache['kirbytags'] ??= F::load($this->root . '/tags.php');
 	}
 
 	/**
@@ -439,7 +440,7 @@ class Core
 	 */
 	public function routes(): array
 	{
-		return $this->cache['routes'] ??= (include $this->root . '/routes.php')($this->kirby);
+		return $this->cache['routes'] ??= F::load($this->root . '/routes.php')($this->kirby);
 	}
 
 	/**

--- a/tests/Cms/App/AppErrorsTest.php
+++ b/tests/Cms/App/AppErrorsTest.php
@@ -6,6 +6,7 @@ use Kirby\Exception\Exception;
 use Kirby\Filesystem\F;
 use PHPUnit\Framework\Attributes\CoversClass;
 use ReflectionMethod;
+use WeakReference;
 use Whoops\Handler\CallbackHandler;
 use Whoops\Handler\PlainTextHandler;
 
@@ -181,6 +182,40 @@ class AppErrorsTest extends TestCase
 		$this->assertCount(2, $handlers);
 		$this->assertInstanceOf('Whoops\Handler\PrettyPageHandler', $handlers[0]);
 		$this->assertInstanceOf('Whoops\Handler\CallbackHandler', $handlers[1]);
+	}
+
+	public function testHandleErrorsDoesNotRetainReplacedApp(): void
+	{
+		$whoopsMethod = new ReflectionMethod(App::class, 'whoops');
+		$testMethod   = new ReflectionMethod(App::class, 'handleErrors');
+
+		$app       = new App(['options' => ['whoops' => true]]);
+		$reference = WeakReference::create($app);
+
+		// keep the `Run` instance around, exactly like the shutdown
+		// function does in production, and install the handlers
+		$whoops = $whoopsMethod->invoke($app);
+		$testMethod->invoke($app);
+		unset($app);
+
+		// replacing the app is what a long-running server, the Kirby CLI
+		// and this test suite do over and over again; it also releases the
+		// static closures from `AppTranslations::i18n()`, which always keep
+		// the most recent app alive on purpose
+		$next = new App(['options' => ['whoops' => true]]);
+		$testMethod->invoke($next);
+
+		gc_collect_cycles();
+
+		// Whoops registers every `Run` instance via `register_shutdown_function()`
+		// and never releases it again, not even on `unregister()`. A handler that
+		// referenced its app strongly would therefore keep it – and its entire
+		// page tree – alive for the rest of the process.
+		$this->assertNull($reference->get());
+
+		// the handlers had to stay installed for the assertion above,
+		// so unregister them now to not leak them into other tests
+		$whoops->unregister();
 	}
 
 	public function testHandleErrorsGlobalSetting(): void

--- a/tests/Cms/App/AppTranslationsTest.php
+++ b/tests/Cms/App/AppTranslationsTest.php
@@ -7,6 +7,7 @@ use Kirby\Filesystem\F;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Locale;
 use Kirby\Toolkit\Str;
+use WeakReference;
 
 class AppTranslationsTest extends TestCase
 {
@@ -90,6 +91,41 @@ class AppTranslationsTest extends TestCase
 		}
 
 		$this->assertCount($i, $translations);
+	}
+
+	public function testTranslationsAlwaysReferToCurrentInstance(): void
+	{
+		$props = ['roots' => ['index' => '/dev/null']];
+
+		$main = new App([
+			...$props,
+			'translations' => ['en' => ['test.probe' => 'from main app']]
+		]);
+
+		I18n::$translations = [];
+		$this->assertSame('from main app', I18n::translate('test.probe'));
+
+		// an app that explicitly does not become the current instance
+		// must not take over the global translation loader either
+		$side      = new App([
+			...$props,
+			'translations' => ['en' => ['test.probe' => 'from side app']]
+		], false);
+		$reference = WeakReference::create($side);
+
+		I18n::$translations = [];
+		$this->assertSame($main, App::instance());
+		$this->assertSame('from main app', I18n::translate('test.probe'));
+
+		// and it must not be kept alive by the loader closures either,
+		// which would otherwise pin its whole page tree for the process
+		unset($side);
+		gc_collect_cycles();
+
+		$this->assertNull($reference->get());
+
+		I18n::$translations = [];
+		$this->assertSame('from main app', I18n::translate('test.probe'));
 	}
 
 	public function testTranslationFromCurrentLanguage(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Three smaller improvements/fixe around parts of our code that kept `$app` from being garbage collected:

1. Whoops registers every `Run` instance via `register_shutdown_function()`, which PHP can never undo. `::unregister()` only restores the error and exception handlers, but doesn't free it. Our Whoops handler closures used `$this`, so every app ever constructed stayed alive for the rest of the process,  potentially with its complete site tree. With this PR, the closures now reference the app weakly and are marked `static`, so the capture cannot silently come back. Measured on a 5,260 page tree, memory no longer grows by ~16 MB per app.

2. `AppTranslations::i18n()` stored closures on `I18n` that captured `$this`. Because those closures outlive the app that installed them, an app created with `setInstance: false` silently took over the global translation loader from the app that is actually the current instance. And kept serving its translations even after being discarded, while being held alive by the closures it had installed. The closures now resolve `App::instance()` on each call, which is the only app that global translation helpers can sensibly refer to.

3. `Core::kirbyTags()` used a bare `include` inside a method, which makes PHP bind every closure in the included file to `$this`, even when `config/tags.php` never uses it. The tag closures are stored in the static `KirbyTag::$types` registry and so pinned the `Core` instance, and with it the app, for the whole process. We use now `F::load()` that includes the file from a static method, which leaves the closures unbound. 

Added also `F::load()` to  `components.php` and `routes.php` for consistency but it's not directly needed.