### PR TITLE
perf: Cache `content.diff`

### DIFF
--- a/panel/src/panel/content.test.ts
+++ b/panel/src/panel/content.test.ts
@@ -320,6 +320,36 @@ describe("panel.content", () => {
 				content.merge({ title: "New" }, { api: "/pages/other" })
 			).toThrow("The content in another view cannot be merged");
 		});
+
+		it("keeps the identity of the changes object", () => {
+			const panel = createPanel();
+			const content = Content(panel);
+			const before = content.version("changes");
+			content.merge({ title: "New Title" });
+			expect(content.version("changes")).toBe(before);
+		});
+
+		it("does not touch the latest version after a discard", async () => {
+			const panel = createPanel({
+				latest: { title: "Published" },
+				changes: { title: "Draft" }
+			});
+			const content = Content(panel);
+			await content.discard();
+			content.merge({ title: "Typed after discarding" });
+			expect(content.version("latest")).toStrictEqual({ title: "Published" });
+		});
+
+		it("does not touch the latest version after a publish", async () => {
+			const panel = createPanel({
+				latest: { title: "Published" },
+				changes: { title: "Draft" }
+			});
+			const content = Content(panel);
+			await content.publish();
+			content.merge({ title: "Typed after publishing" });
+			expect(content.version("latest")).toStrictEqual({ title: "Draft" });
+		});
 	});
 
 	describe("publish()", () => {

--- a/panel/src/panel/content.ts
+++ b/panel/src/panel/content.ts
@@ -119,6 +119,7 @@ export default function Content(panel: Panel) {
 			try {
 				await this.request("discard", {}, env);
 
+				// update the props for the current view
 				this.versions().changes = { ...this.version("latest") };
 
 				this.emit("discard", {}, env);
@@ -279,6 +280,7 @@ export default function Content(panel: Panel) {
 				// close the dialog if it is still open
 				this.dialog?.close();
 
+				// update the props for the current view
 				this.versions().latest = { ...this.version("changes") };
 
 				this.emit("publish", { values }, env);

--- a/panel/src/panel/content.ts
+++ b/panel/src/panel/content.ts
@@ -1,4 +1,4 @@
-import { reactive } from "vue";
+import { computed, reactive } from "vue";
 import RequestError from "@/errors/RequestError";
 import { isAbortError } from "@/helpers/error";
 import { isObject, length } from "@/helpers/object";
@@ -33,6 +33,36 @@ const isLockRequestError = (
  * @since     5.0.0
  */
 export default function Content(panel: Panel) {
+	/**
+	 * Cached diff between the latest and the changes version
+	 */
+	const diff = computed(() => {
+		const versions = panel.view.props.versions as Record<
+			VersionId,
+			Record<string, unknown>
+		>;
+		const diff: Record<string, unknown> = {};
+
+		for (const field in versions.changes) {
+			const changed = JSON.stringify(versions.changes[field]);
+			const original = JSON.stringify(versions.latest[field]);
+
+			if (changed !== original) {
+				diff[field] = versions.changes[field];
+			}
+		}
+
+		// find all fields that have been present in the original content
+		// but have been removed from the current content
+		for (const field in versions.latest) {
+			if (versions.changes[field] === undefined) {
+				diff[field] = null;
+			}
+		}
+
+		return diff;
+	});
+
 	const content = reactive({
 		/**
 		 * Cancel any scheduled or ongoing save requests
@@ -57,27 +87,7 @@ export default function Content(panel: Panel) {
 				throw new Error("Cannot get changes for another view");
 			}
 
-			const versions = this.versions();
-			const diff: Record<string, unknown> = {};
-
-			for (const field in versions.changes) {
-				const changed = JSON.stringify(versions.changes[field]);
-				const original = JSON.stringify(versions.latest[field]);
-
-				if (changed !== original) {
-					diff[field] = versions.changes[field];
-				}
-			}
-
-			// find all fields that have been present in the original content
-			// but have been removed from the current content
-			for (const field in versions.latest) {
-				if (versions.changes[field] === undefined) {
-					diff[field] = null;
-				}
-			}
-
-			return diff;
+			return diff.value;
 		},
 
 		/**
@@ -109,8 +119,7 @@ export default function Content(panel: Panel) {
 			try {
 				await this.request("discard", {}, env);
 
-				// update the props for the current view
-				this.versions().changes = this.version("latest");
+				this.versions().changes = { ...this.version("latest") };
 
 				this.emit("discard", {}, env);
 			} catch (error) {
@@ -237,10 +246,7 @@ export default function Content(panel: Panel) {
 				values = {};
 			}
 
-			return (this.versions().changes = {
-				...this.version("changes"),
-				...values
-			});
+			return Object.assign(this.versions().changes, values);
 		},
 
 		/**
@@ -273,8 +279,7 @@ export default function Content(panel: Panel) {
 				// close the dialog if it is still open
 				this.dialog?.close();
 
-				// update the props for the current view
-				this.versions().latest = this.version("changes");
+				this.versions().latest = { ...this.version("changes") };
 
 				this.emit("publish", { values }, env);
 			} catch (error) {


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

- Adding a computed cache for `diff` in `panel.content` instead of computing it 3 times per keystroke
- Also merging more resourcefully in `panel.content.merge()`