### PR TITLE
perf: `items` helper for batching requests

### DIFF
--- a/panel/src/components/Forms/Previews/ModelsFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/ModelsFieldPreview.vue
@@ -75,17 +75,18 @@ export default {
 			// get all missing items from API
 			// and replace in tags array
 			if (missing.length > 0) {
-				const data = await this.$panel.get(this.$options.endpoint, {
-					query: {
-						items: missing.join(",")
-					}
-				});
+				const loaded = await this.$helper.items(
+					this.$options.endpoint,
+					missing
+				);
 
-				for (let index = 0; index < missing.length; index++) {
-					const id = missing[index];
-					const tag = data.items[index];
+				for (const [index, id] of missing.entries()) {
 					const key = this.tags.findIndex((tag) => tag.id === id);
-					this.tags[key] = { ...tag, id };
+
+					// the value might have changed while the request was in flight
+					if (key !== -1) {
+						this.tags[key] = { ...loaded[index], id };
+					}
 				}
 			}
 		},

--- a/panel/src/components/Layout/Frame/ImageFrame.vue
+++ b/panel/src/components/Layout/Frame/ImageFrame.vue
@@ -11,6 +11,8 @@
 			:src="src ?? resolvedSrc"
 			:srcset="srcset ?? resolvedSrcset"
 			:sizes="sizes"
+			decoding="async"
+			loading="lazy"
 			@dragstart.prevent
 		/>
 	</k-frame>
@@ -81,20 +83,17 @@ export default {
 
 			// if internal file, load data for file UUID from request endpoint
 			if (this.file) {
-				const data = await this.$panel.get("items/files", {
-					query: {
-						items: this.file,
-						layout: "auto",
-						image: JSON.stringify({
-							ratio: this.ratio,
-							cover: this.cover
-						})
-					}
+				const item = await this.$helper.items("items/files", this.file, {
+					layout: "auto",
+					image: JSON.stringify({
+						ratio: this.ratio,
+						cover: this.cover
+					})
 				});
 
-				alt = data.items[0]?.alt;
-				src = data.items[0]?.image.src;
-				srcset = data.items[0]?.image.srcset;
+				alt = item?.alt;
+				src = item?.image?.src;
+				srcset = item?.image?.srcset;
 			}
 
 			this.resolvedAlt = alt;

--- a/panel/src/components/Layout/Frame/ImageFrame.vue
+++ b/panel/src/components/Layout/Frame/ImageFrame.vue
@@ -11,8 +11,8 @@
 			:src="src ?? resolvedSrc"
 			:srcset="srcset ?? resolvedSrcset"
 			:sizes="sizes"
+			:loading="lazy === true ? 'lazy' : 'eager'"
 			decoding="async"
-			loading="lazy"
 			@dragstart.prevent
 		/>
 	</k-frame>
@@ -33,6 +33,15 @@ export const props = {
 		 * @since 6.0.0
 		 */
 		file: String,
+		/**
+		 * Whether the image is only loaded once it comes into view.
+		 * Disable for images that are visible right away.
+		 * @since 6.0.0
+		 */
+		lazy: {
+			type: Boolean,
+			default: true
+		},
 		/**
 		 * For responsive images, pass the `sizes` attribute
 		 */

--- a/panel/src/components/Layout/Frame/ImageFrame.vue
+++ b/panel/src/components/Layout/Frame/ImageFrame.vue
@@ -86,19 +86,25 @@ export default {
 	},
 	methods: {
 		async fetch() {
+			const file = this.file;
 			let alt,
 				src,
 				srcset = null;
 
 			// if internal file, load data for file UUID from request endpoint
-			if (this.file) {
-				const item = await this.$helper.items("items/files", this.file, {
+			if (file) {
+				const item = await this.$helper.items("items/files", file, {
 					layout: "auto",
 					image: JSON.stringify({
 						ratio: this.ratio,
 						cover: this.cover
 					})
 				});
+
+				// the file might have changed while the request was in flight
+				if (this.file !== file) {
+					return;
+				}
 
 				alt = item?.alt;
 				src = item?.image?.src;

--- a/panel/src/components/Layout/Frame/VideoFrame.vue
+++ b/panel/src/components/Layout/Frame/VideoFrame.vue
@@ -74,11 +74,17 @@ export default {
 	},
 	methods: {
 		async fetch() {
+			const file = this.file;
 			let url = null;
 
 			// if internal file, load data for file UUID from request endpoint
-			if (this.file) {
-				url = (await this.$helper.items("items/files", this.file))?.url;
+			if (file) {
+				url = (await this.$helper.items("items/files", file))?.url;
+
+				// the file might have changed while the request was in flight
+				if (this.file !== file) {
+					return;
+				}
 			}
 
 			this.resolvedUrl = url;

--- a/panel/src/components/Layout/Frame/VideoFrame.vue
+++ b/panel/src/components/Layout/Frame/VideoFrame.vue
@@ -78,11 +78,7 @@ export default {
 
 			// if internal file, load data for file UUID from request endpoint
 			if (this.file) {
-				const data = await await this.$panel.get("items/files", {
-					query: { items: this.file }
-				});
-
-				url = data.items[0]?.url;
+				url = (await this.$helper.items("items/files", this.file))?.url;
 			}
 
 			this.resolvedUrl = url;

--- a/panel/src/components/Views/Files/ImageFilePreview.vue
+++ b/panel/src/components/Views/Files/ImageFilePreview.vue
@@ -9,7 +9,7 @@
 				:value="focus"
 				@input="setFocus($event)"
 			>
-				<img alt="" v-bind="image" @dragstart.prevent />
+				<img alt="" v-bind="image" decoding="async" @dragstart.prevent />
 			</k-coords-input>
 		</k-file-preview-frame>
 

--- a/panel/src/helpers/index.ts
+++ b/panel/src/helpers/index.ts
@@ -9,6 +9,7 @@ import file from "./file.js";
 import focus from "./focus";
 import isComponent from "./isComponent";
 import isUploadEvent from "./isUploadEvent";
+import items from "./items";
 import keyboard from "./keyboard";
 import link from "./link";
 import object from "./object";
@@ -35,6 +36,7 @@ export const helper = {
 	debounce,
 	field,
 	file,
+	items,
 	keyboard,
 	link,
 	object,

--- a/panel/src/helpers/items.test.ts
+++ b/panel/src/helpers/items.test.ts
@@ -9,7 +9,7 @@ function mockPanel(
 			responder(options.query)
 	);
 
-	window.panel = { get } as unknown as typeof window.panel;
+	window.panel = { get, error: vi.fn() } as unknown as typeof window.panel;
 
 	return get;
 }
@@ -105,6 +105,18 @@ describe("$helper.items()", () => {
 		]);
 
 		expect(results).toStrictEqual([undefined, undefined]);
+	});
+
+	it("should hand the error of a failed batch to the Panel", async () => {
+		const error = new Error("nope");
+
+		mockPanel(() => {
+			throw error;
+		});
+
+		await items("items/files", "a");
+
+		expect(window.panel.error).toHaveBeenCalledWith(error);
 	});
 
 	it("should resolve a list of ids in order", async () => {

--- a/panel/src/helpers/items.test.ts
+++ b/panel/src/helpers/items.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import items from "./items";
+
+function mockPanel(
+	responder: (query: Record<string, unknown>) => Record<string, unknown>
+) {
+	const get = vi.fn(
+		async (_endpoint: string, options: { query: Record<string, unknown> }) =>
+			responder(options.query)
+	);
+
+	window.panel = { get } as unknown as typeof window.panel;
+
+	return get;
+}
+
+function echo(query: Record<string, unknown>) {
+	const ids = String(query.items).split(",");
+	return { items: ids.map((id) => (id === "missing" ? null : { id })) };
+}
+
+afterEach(() => {
+	window.panel = undefined as unknown as typeof window.panel;
+});
+
+describe("$helper.items()", () => {
+	it("should collect lookups from the same tick into one request", async () => {
+		const get = mockPanel(echo);
+
+		const results = await Promise.all([
+			items("items/files", "a"),
+			items("items/files", "b"),
+			items("items/files", "c")
+		]);
+
+		expect(get).toHaveBeenCalledTimes(1);
+		expect(get.mock.calls[0][1].query.items).toBe("a,b,c");
+		expect(results).toStrictEqual([{ id: "a" }, { id: "b" }, { id: "c" }]);
+	});
+
+	it("should keep lookups with different options apart", async () => {
+		const get = mockPanel(echo);
+
+		await Promise.all([
+			items("items/files", "a", { layout: "cards" }),
+			items("items/files", "b", { layout: "list" }),
+			items("items/files", "c", { layout: "cards" })
+		]);
+
+		expect(get).toHaveBeenCalledTimes(2);
+
+		const batched = get.mock.calls.map((call) => call[1].query.items).sort();
+		expect(batched).toStrictEqual(["a,c", "b"]);
+	});
+
+	it("should keep lookups for different endpoints apart", async () => {
+		const get = mockPanel(echo);
+
+		await Promise.all([items("items/files", "a"), items("items/pages", "b")]);
+
+		expect(get).toHaveBeenCalledTimes(2);
+	});
+
+	it("should start a new batch for lookups after the flush", async () => {
+		const get = mockPanel(echo);
+
+		await items("items/files", "a");
+		await items("items/files", "b");
+
+		expect(get).toHaveBeenCalledTimes(2);
+	});
+
+	it("should pass the query along to the endpoint", async () => {
+		const get = mockPanel(echo);
+
+		await items("items/files", "a", { layout: "auto", image: "{}" });
+
+		expect(get.mock.calls[0][1].query).toStrictEqual({
+			layout: "auto",
+			image: "{}",
+			items: "a"
+		});
+	});
+
+	it("should resolve to undefined for an unknown id", async () => {
+		mockPanel(echo);
+
+		const [found, missing] = await Promise.all([
+			items("items/files", "a"),
+			items("items/files", "missing")
+		]);
+
+		expect(found).toStrictEqual({ id: "a" });
+		expect(missing).toBeUndefined();
+	});
+
+	it("should resolve every lookup of a failed batch to undefined", async () => {
+		mockPanel(() => {
+			throw new Error("nope");
+		});
+
+		const results = await Promise.all([
+			items("items/files", "a"),
+			items("items/files", "b")
+		]);
+
+		expect(results).toStrictEqual([undefined, undefined]);
+	});
+
+	it("should resolve a list of ids in order", async () => {
+		const get = mockPanel(echo);
+
+		const results = await items("items/files", ["a", "missing", "c"]);
+
+		expect(get).toHaveBeenCalledTimes(1);
+		expect(get.mock.calls[0][1].query.items).toBe("a,missing,c");
+		expect(results).toStrictEqual([{ id: "a" }, undefined, { id: "c" }]);
+	});
+
+	it("should not request anything for an empty list", async () => {
+		const get = mockPanel(echo);
+
+		expect(await items("items/files", [])).toStrictEqual([]);
+		expect(get).not.toHaveBeenCalled();
+	});
+
+	it("should only send an id once, no matter how many callers wait", async () => {
+		const get = mockPanel(echo);
+
+		const results = await Promise.all([
+			items("items/files", "a"),
+			items("items/files", ["a", "b"]),
+			items("items/files", "b")
+		]);
+
+		expect(get).toHaveBeenCalledTimes(1);
+		expect(get.mock.calls[0][1].query.items).toBe("a,b");
+		expect(results).toStrictEqual([
+			{ id: "a" },
+			[{ id: "a" }, { id: "b" }],
+			{ id: "b" }
+		]);
+	});
+
+	it("should split a batch that exceeds the request limit", async () => {
+		const get = mockPanel(echo);
+
+		const ids = Array.from({ length: 250 }, (_, index) => "id-" + index);
+		const results = await items("items/files", ids);
+
+		expect(get).toHaveBeenCalledTimes(3);
+
+		const chunks = get.mock.calls.map(
+			(call) => String(call[1].query.items).split(",").length
+		);
+		expect(chunks).toStrictEqual([100, 100, 50]);
+		expect(results).toStrictEqual(ids.map((id) => ({ id })));
+	});
+
+	it("should share a batch when the query only differs in key order", async () => {
+		const get = mockPanel(echo);
+
+		const results = await Promise.all([
+			items("items/files", "a", { image: "{}", layout: "cards" }),
+			items("items/files", "b", { layout: "cards", image: "{}" })
+		]);
+
+		expect(get).toHaveBeenCalledTimes(1);
+		expect(results).toStrictEqual([{ id: "a" }, { id: "b" }]);
+	});
+
+	it("should join a lookup that is already in flight", async () => {
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		const get = vi.fn(async () => await promise);
+
+		window.panel = { get } as unknown as typeof window.panel;
+
+		const first = items("items/files", "a");
+
+		// let the batch flush, so that the request is on its way
+		await Promise.resolve();
+
+		const second = items("items/files", "a");
+
+		resolve({ items: [{ id: "a" }] });
+
+		expect(await first).toStrictEqual({ id: "a" });
+		expect(await second).toStrictEqual({ id: "a" });
+		expect(get).toHaveBeenCalledTimes(1);
+	});
+
+	it("should not keep the item once the request resolved", async () => {
+		const get = mockPanel(echo);
+
+		await items("items/files", "a");
+		await items("items/files", "a");
+
+		expect(get).toHaveBeenCalledTimes(2);
+	});
+
+	it("should only resolve the ids of a failed chunk to undefined", async () => {
+		const get = mockPanel((query) => {
+			const ids = String(query.items).split(",");
+
+			if (ids.includes("id-100") === true) {
+				throw new Error("nope");
+			}
+
+			return echo(query);
+		});
+
+		const ids = Array.from({ length: 150 }, (_, index) => "id-" + index);
+		const results = await items("items/files", ids);
+
+		expect(get).toHaveBeenCalledTimes(2);
+		expect(results[99]).toStrictEqual({ id: "id-99" });
+		expect(results[100]).toBeUndefined();
+	});
+});

--- a/panel/src/helpers/items.test.ts
+++ b/panel/src/helpers/items.test.ts
@@ -136,6 +136,20 @@ describe("$helper.items()", () => {
 		expect(get).not.toHaveBeenCalled();
 	});
 
+	it("should never send a blank id, as it would shift the response", async () => {
+		const get = mockPanel(echo);
+
+		const results = await items("items/files", ["a", "", "  ", "b"]);
+
+		expect(get.mock.calls[0][1].query.items).toBe("a,b");
+		expect(results).toStrictEqual([
+			{ id: "a" },
+			undefined,
+			undefined,
+			{ id: "b" }
+		]);
+	});
+
 	it("should only send an id once, no matter how many callers wait", async () => {
 		const get = mockPanel(echo);
 

--- a/panel/src/helpers/items.test.ts
+++ b/panel/src/helpers/items.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
 });
 
 describe("$helper.items()", () => {
-	it("should collect lookups from the same tick into one request", async () => {
+	it("should collect calls from the same tick into one request", async () => {
 		const get = mockPanel(echo);
 
 		const results = await Promise.all([
@@ -38,7 +38,7 @@ describe("$helper.items()", () => {
 		expect(results).toStrictEqual([{ id: "a" }, { id: "b" }, { id: "c" }]);
 	});
 
-	it("should keep lookups with different options apart", async () => {
+	it("should keep calls with different options apart", async () => {
 		const get = mockPanel(echo);
 
 		await Promise.all([
@@ -53,7 +53,7 @@ describe("$helper.items()", () => {
 		expect(batched).toStrictEqual(["a,c", "b"]);
 	});
 
-	it("should keep lookups for different endpoints apart", async () => {
+	it("should keep calls for different endpoints apart", async () => {
 		const get = mockPanel(echo);
 
 		await Promise.all([items("items/files", "a"), items("items/pages", "b")]);
@@ -61,13 +61,30 @@ describe("$helper.items()", () => {
 		expect(get).toHaveBeenCalledTimes(2);
 	});
 
-	it("should start a new batch for lookups after the flush", async () => {
+	it("should start a new queue after the previous request resolved", async () => {
 		const get = mockPanel(echo);
 
 		await items("items/files", "a");
 		await items("items/files", "b");
 
 		expect(get).toHaveBeenCalledTimes(2);
+	});
+
+	it("should send a new request for an id queued while one is in flight", async () => {
+		const get = mockPanel(echo);
+
+		const first = items("items/files", "a");
+
+		// let the queue send, so that the request is on its way
+		await Promise.resolve();
+
+		const second = items("items/files", "b");
+
+		expect(await first).toStrictEqual({ id: "a" });
+		expect(await second).toStrictEqual({ id: "b" });
+		expect(get).toHaveBeenCalledTimes(2);
+		expect(get.mock.calls[0][1].query.items).toBe("a");
+		expect(get.mock.calls[1][1].query.items).toBe("b");
 	});
 
 	it("should pass the query along to the endpoint", async () => {
@@ -94,7 +111,7 @@ describe("$helper.items()", () => {
 		expect(missing).toBeUndefined();
 	});
 
-	it("should resolve every lookup of a failed batch to undefined", async () => {
+	it("should resolve every id of a failed batch to undefined", async () => {
 		mockPanel(() => {
 			throw new Error("nope");
 		});
@@ -195,7 +212,7 @@ describe("$helper.items()", () => {
 		expect(results).toStrictEqual([{ id: "a" }, { id: "b" }]);
 	});
 
-	it("should join a lookup that is already in flight", async () => {
+	it("should join a call that is already in flight", async () => {
 		const { promise, resolve } = Promise.withResolvers<unknown>();
 		const get = vi.fn(async () => await promise);
 
@@ -203,7 +220,7 @@ describe("$helper.items()", () => {
 
 		const first = items("items/files", "a");
 
-		// let the batch flush, so that the request is on its way
+		// let the queue send, so that the request is on its way
 		await Promise.resolve();
 
 		const second = items("items/files", "a");

--- a/panel/src/helpers/items.ts
+++ b/panel/src/helpers/items.ts
@@ -1,0 +1,178 @@
+/**
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ * @since     6.0.0
+ */
+
+type Item = Record<string, unknown>;
+type Query = Record<string, unknown>;
+type Batch = {
+	endpoint: string;
+	ids: string[];
+	key: string;
+	query: Query;
+	resolvers: Map<string, (item: Item | undefined) => void>;
+};
+
+/**
+ * Max number of ids per request.
+ * The ids travel in the query string,
+ * so a large batch needs to be split
+ * before the url gets too long.
+ */
+const LIMIT = 100;
+
+/**
+ * Pending batches, keyed by endpoint and options.
+ * Calls can only share a request when they ask
+ * the backend for the same representation.
+ */
+const batches = new Map<string, Batch>();
+
+/**
+ * Lookups that are already on their way,
+ * keyed by representation and id. They are
+ * dropped as soon as the request resolved,
+ * so that no item is kept around.
+ */
+const pending = new Map<string, Promise<Item | undefined>>();
+
+/**
+ * Sends the collected batch and hands
+ * each caller the item for its own id
+ */
+async function flush(key: string): Promise<void> {
+	const batch = batches.get(key);
+
+	if (batch === undefined) {
+		return;
+	}
+
+	// drop the batch right away, so that new calls added while this
+	// request is in flight will start their own new batch
+	batches.delete(key);
+
+	const chunks = [];
+
+	for (let index = 0; index < batch.ids.length; index += LIMIT) {
+		chunks.push(request(batch, batch.ids.slice(index, index + LIMIT)));
+	}
+
+	await Promise.all(chunks);
+}
+
+/**
+ * Adds a single id to its batch and returns the promise
+ * that resolves once the batch has been flushed
+ */
+function item(
+	endpoint: string,
+	id: string,
+	query: Query
+): Promise<Item | undefined> {
+	const key = endpoint + "/" + normalize(query);
+	const lookup = key + "/" + id;
+	const existing = pending.get(lookup);
+
+	// join a request for the same item that is already on its way,
+	// no matter if it is still collecting or already in flight
+	if (existing !== undefined) {
+		return existing;
+	}
+
+	let batch = batches.get(key);
+
+	if (batch === undefined) {
+		batch = { endpoint, ids: [], key, query, resolvers: new Map() };
+		batches.set(key, batch);
+
+		// flush once the current tick has queued all its lookups
+		queueMicrotask(() => flush(key));
+	}
+
+	const { promise, resolve } = Promise.withResolvers<Item | undefined>();
+
+	batch.ids.push(id);
+	batch.resolvers.set(id, resolve);
+	pending.set(lookup, promise);
+
+	return promise;
+}
+
+/**
+ * Sorts the query, so that the same options
+ * share a batch, no matter in which order
+ * the caller passed them
+ */
+function normalize(query: Query): string {
+	const sorted: Query = {};
+
+	for (const name of Object.keys(query).sort()) {
+		sorted[name] = query[name];
+	}
+
+	return JSON.stringify(sorted);
+}
+
+/**
+ * Requests a single chunk of ids from the endpoint
+ */
+async function request(batch: Batch, ids: string[]): Promise<void> {
+	try {
+		const response = (await window.panel.get(batch.endpoint, {
+			query: {
+				...batch.query,
+				items: ids.join(",")
+			}
+		})) as { items?: (Item | null)[] };
+
+		for (const [index, id] of ids.entries()) {
+			settle(batch, id, response.items?.[index] ?? undefined);
+		}
+	} catch {
+		// a failed lookup resolves to nothing, just like an unknown id
+		for (const id of ids) {
+			settle(batch, id, undefined);
+		}
+	}
+}
+
+/**
+ * Hands the item to the caller and clears the lookup,
+ * so that the next call starts a fresh request
+ */
+function settle(batch: Batch, id: string, item: Item | undefined): void {
+	pending.delete(batch.key + "/" + id);
+	batch.resolvers.get(id)?.(item);
+}
+
+/**
+ * Request props for items by model id. Calls from the same tick
+ * share a request and a lookup that is already on its way is
+ * joined instead of being requested again.
+ *
+ * @example
+ * const item = await items("items/files", "file://abc");
+ * const list = await items("items/pages", ["page://a", "page://b"]);
+ */
+export default function items(
+	endpoint: string,
+	id: string,
+	query?: Query
+): Promise<Item | undefined>;
+export default function items(
+	endpoint: string,
+	ids: string[],
+	query?: Query
+): Promise<(Item | undefined)[]>;
+export default function items(
+	endpoint: string,
+	ids: string | string[],
+	query: Query = {}
+): Promise<Item | undefined> | Promise<(Item | undefined)[]> {
+	if (Array.isArray(ids) === true) {
+		return Promise.all(ids.map((id) => item(endpoint, id, query)));
+	}
+
+	return item(endpoint, ids, query);
+}

--- a/panel/src/helpers/items.ts
+++ b/panel/src/helpers/items.ts
@@ -1,16 +1,17 @@
 /**
- * Item props request from the same tick are collected
+ * Item props requested in the same tick are collected
  * into a batch and sent as one request:
  *
- * 1. items() calls queueItem() for each id
- * 2. queueItem() adds the id to the queue for its endpoint
+ * 1. items() calls item() for each id
+ * 2. item() adds the id to the batch for its endpoint
  *    and options
- * 3. Queue waits via queueMicrotask() for the end of tick
- * 4. sendQueue() takes the queued ids and splits them
- *    into chunks (if needed)
- * 5. sendChunk() gets called for each chunk, sends
+ * 3. Batch.add() waits via queueMicrotask() for the
+ *    end of the tick
+ * 4. Batch.send() takes the collected ids and splits
+ *    them into chunks (if needed)
+ * 5. Batch.sendChunk() gets called for each chunk, sends
  *    request to endpoint
- * 6. resolveItem() gets called for each id individually,
+ * 6. Batch.resolve() gets called for each id individually,
  *    hands over item props to the initial caller
  *
  * @copyright Bastian Allgeier
@@ -24,147 +25,161 @@ type Item = Record<string, unknown>;
 type Query = Record<string, unknown>;
 
 /**
+ * One batch per endpoint and options
+ */
+const batches = new Map<string, Batch>();
+
+/**
+ * Max number of ids per request: ids are added to the
+ * query string, we must ensure the URL does not get too long
+ */
+const LIMIT = 100;
+
+/**
  * Collects ids by endpoint and options,
  * in the two states they can be in:
  * ids waiting to be sent and items waiting to come back.
  */
-type Queue = {
+class Batch {
 	endpoint: string;
-	ids: string[];
-	items: Map<string, PromiseWithResolvers<Item | undefined>>;
+	ids: string[] = [];
+	items = new Map<string, PromiseWithResolvers<Item | undefined>>();
 	key: string;
 	query: Query;
-};
 
-/**
- * One queue per endpoint and options
- */
-const queues = new Map<string, Queue>();
-
-/**
- * Returns the queue for an endpoint and its options
- * and creates it, if it does not exist yet
- */
-function getQueue(endpoint: string, query: Query): Queue {
-	// sort query, so that same options share a queue, no matter the order
-	const key = endpoint + "/" + JSON.stringify(query, Object.keys(query).sort());
-	let queue = queues.get(key);
-
-	if (queue === undefined) {
-		queue = { endpoint, ids: [], items: new Map(), key, query };
-		queues.set(key, queue);
+	constructor(endpoint: string, key: string, query: Query) {
+		this.endpoint = endpoint;
+		this.key = key;
+		this.query = query;
 	}
 
-	return queue;
+	/**
+	 * Adds a single id to the batch and returns
+	 * the item props once the promise resolves
+	 */
+	add(id: string): Promise<Item | undefined> {
+		// check if a response for the same item is already pending;
+		// so that it can join the request and not create its redundant own
+		const existing = this.items.get(id);
+
+		if (existing !== undefined) {
+			return existing.promise;
+		}
+
+		// create and track the promise in the batch:
+		// we return the promise here, but resolve it with the
+		// props data later in `resolve()`
+		const pending = Promise.withResolvers<Item | undefined>();
+
+		this.items.set(id, pending);
+		this.ids.push(id);
+
+		// for a fresh batch start the timer to send the request
+		// once the current tick has passed;
+		// in the meantime more ids can join the batch
+		if (this.ids.length === 1) {
+			queueMicrotask(() => this.send());
+		}
+
+		return pending.promise;
+	}
+
+	/**
+	 * Returns the batch for an endpoint and its options
+	 * and creates it, if it does not exist yet
+	 */
+	static for(endpoint: string, query: Query): Batch {
+		// sort query, so that same options share a batch, no matter the order
+		const key =
+			endpoint + "/" + JSON.stringify(query, Object.keys(query).sort());
+		let batch = batches.get(key);
+
+		if (batch === undefined) {
+			batch = new Batch(endpoint, key, query);
+			batches.set(key, batch);
+		}
+
+		return batch;
+	}
+
+	/**
+	 * Hands the item to the caller and drops it from the batch,
+	 * so that the next call starts a fresh request
+	 */
+	resolve(id: string, item: Item | undefined): void {
+		this.items.get(id)?.resolve(item);
+		this.items.delete(id);
+
+		if (this.ids.length === 0 && this.items.size === 0) {
+			batches.delete(this.key);
+		}
+	}
+
+	/**
+	 * Sends the collected ids as one or more requests/chunks and
+	 * hands each caller the item for its own id
+	 */
+	async send(): Promise<void> {
+		// take the collected ids right away, so that new calls added while
+		// this request is in flight will collect a batch of their own
+		const ids = this.ids;
+		this.ids = [];
+
+		const requests = [];
+
+		for (let index = 0; index < ids.length; index += LIMIT) {
+			requests.push(this.sendChunk(ids.slice(index, index + LIMIT)));
+		}
+
+		await Promise.all(requests);
+	}
+
+	/**
+	 * Sends one chunk of ids to the endpoint. The batch supplies
+	 * the endpoint, the options and the waiting callers.
+	 */
+	async sendChunk(chunk: string[]): Promise<void> {
+		try {
+			const response = (await window.panel.get(this.endpoint, {
+				query: {
+					...this.query,
+					items: chunk.join(",")
+				}
+			})) as { items?: (Item | null)[] };
+
+			for (const [index, id] of chunk.entries()) {
+				this.resolve(id, response.items?.[index] ?? undefined);
+			}
+		} catch (error) {
+			// hand the error to the Panel, so that an expired session,
+			// a redirect or a lost connection is still acted upon
+			window.panel.error(error);
+
+			// a failed request resolves to nothing, just like an unknown id
+			for (const id of chunk) {
+				this.resolve(id, undefined);
+			}
+		}
+	}
 }
 
 /**
- * Adds a single id to its matching queue and
+ * Adds a single id to its matching batch and
  * returns the item props once the promise resolves
  */
-function queueItem(
+function item(
 	endpoint: string,
 	id: string,
 	query: Query
 ): Promise<Item | undefined> {
 	// the backend drops blank ids when it splits the query string,
-	// which would shift the response for every id after them
+	// which would shift the response for every id after them;
+	// checked before the batch, so that a blank id never creates one
 	if (id?.trim() === "" || id === null || id === undefined) {
 		return Promise.resolve(undefined);
 	}
 
-	// get the right queue for the item and check
-	// if a response for the same item is already pending;
-	// so that it can join the request and not create its redundant own
-	const queue = getQueue(endpoint, query);
-	const existing = queue.items.get(id);
-
-	if (existing !== undefined) {
-		return existing.promise;
-	}
-
-	// create and track the promise in the queue:
-	// we return the promise here, but resolve it with the
-	// props data later in `resolveItem()`
-	const item = Promise.withResolvers<Item | undefined>();
-
-	queue.items.set(id, item);
-	queue.ids.push(id);
-
-	// for a newly created queue start the timer to send
-	// the request once the current tick has passed;
-	// in the meantime more ids can join the queue
-	if (queue.ids.length === 1) {
-		queueMicrotask(() => sendQueue(queue));
-	}
-
-	return item.promise;
-}
-
-/**
- * Hands the item to the caller and drops it from the queue,
- * so that the next call starts a fresh request
- */
-function resolveItem(queue: Queue, id: string, item: Item | undefined): void {
-	queue.items.get(id)?.resolve(item);
-	queue.items.delete(id);
-
-	if (queue.ids.length === 0 && queue.items.size === 0) {
-		queues.delete(queue.key);
-	}
-}
-
-/**
- * Sends one chunk of ids to the endpoint. The queue supplies
- * the endpoint, the options and the waiting callers.
- */
-async function sendChunk(queue: Queue, chunk: string[]): Promise<void> {
-	try {
-		const response = (await window.panel.get(queue.endpoint, {
-			query: {
-				...queue.query,
-				items: chunk.join(",")
-			}
-		})) as { items?: (Item | null)[] };
-
-		for (const [index, id] of chunk.entries()) {
-			resolveItem(queue, id, response.items?.[index] ?? undefined);
-		}
-	} catch (error) {
-		// hand the error to the Panel, so that an expired session,
-		// a redirect or a lost connection is still acted upon
-		window.panel.error(error);
-
-		// a failed request resolves to nothing, just like an unknown id
-		for (const id of chunk) {
-			resolveItem(queue, id, undefined);
-		}
-	}
-}
-
-/**
- * Sends the queued ids as one or more requests/chunks and
- * hands each caller the item for its own id
- */
-async function sendQueue(queue: Queue): Promise<void> {
-	// take the queued ids right away, so that new calls added while
-	// this request is in flight will collect their own new batch
-	const batch = queue.ids;
-	queue.ids = [];
-
-	const requests = [];
-
-	// max number of ids per request:
-	// ids are added to the query string,
-	// we must ensure the URL does not get too long
-	const limit = 100;
-
-	for (let index = 0; index < batch.length; index += limit) {
-		const chunk = batch.slice(index, index + limit);
-		requests.push(sendChunk(queue, chunk));
-	}
-
-	await Promise.all(requests);
+	return Batch.for(endpoint, query).add(id);
 }
 
 /**
@@ -192,8 +207,8 @@ export default function items(
 	query: Query = {}
 ): Promise<Item | undefined> | Promise<(Item | undefined)[]> {
 	if (Array.isArray(ids) === true) {
-		return Promise.all(ids.map((id) => queueItem(endpoint, id, query)));
+		return Promise.all(ids.map((id) => item(endpoint, id, query)));
 	}
 
-	return queueItem(endpoint, ids, query);
+	return item(endpoint, ids, query);
 }

--- a/panel/src/helpers/items.ts
+++ b/panel/src/helpers/items.ts
@@ -129,7 +129,11 @@ async function request(batch: Batch, ids: string[]): Promise<void> {
 		for (const [index, id] of ids.entries()) {
 			settle(batch, id, response.items?.[index] ?? undefined);
 		}
-	} catch {
+	} catch (error) {
+		// hand the error to the Panel, so that an expired session,
+		// a redirect or a lost connection is still acted upon
+		window.panel.error(error);
+
 		// a failed lookup resolves to nothing, just like an unknown id
 		for (const id of ids) {
 			settle(batch, id, undefined);

--- a/panel/src/helpers/items.ts
+++ b/panel/src/helpers/items.ts
@@ -1,71 +1,68 @@
 /**
+ * Item props request from the same tick are collected
+ * into a batch and sent as one request:
+ *
+ * 1. items() calls queueItem() for each id
+ * 2. queueItem() adds the id to the queue for its endpoint
+ *    and options
+ * 3. Queue waits via queueMicrotask() for the end of tick
+ * 4. sendQueue() takes the queued ids and splits them
+ *    into chunks (if needed)
+ * 5. sendChunk() gets called for each chunk, sends
+ *    request to endpoint
+ * 6. resolveItem() gets called for each id individually,
+ *    hands over item props to the initial caller
+ *
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
  * @since     6.0.0
  */
 
+/** Item props from the response */
 type Item = Record<string, unknown>;
+/** Request options passed on to the endpoint */
 type Query = Record<string, unknown>;
-type Batch = {
+
+/**
+ * Collects ids by endpoint and options,
+ * in the two states they can be in:
+ * ids waiting to be sent and items waiting to come back.
+ */
+type Queue = {
 	endpoint: string;
 	ids: string[];
+	items: Map<string, PromiseWithResolvers<Item | undefined>>;
 	key: string;
 	query: Query;
-	resolvers: Map<string, (item: Item | undefined) => void>;
 };
 
 /**
- * Max number of ids per request. The ids travel in the query
- * string, so a large batch needs to be split before the url gets
- * too long. A plain count is a rough stand-in for the actual
- * length, which is fine as long as ids stay reasonably short.
+ * One queue per endpoint and options
  */
-const LIMIT = 100;
+const queues = new Map<string, Queue>();
 
 /**
- * Pending batches, keyed by endpoint and options.
- * Calls can only share a request when they ask
- * the backend for the same representation.
+ * Returns the queue for an endpoint and its options
+ * and creates it, if it does not exist yet
  */
-const batches = new Map<string, Batch>();
+function getQueue(endpoint: string, query: Query): Queue {
+	// sort query, so that same options share a queue, no matter the order
+	const key = endpoint + "/" + JSON.stringify(query, Object.keys(query).sort());
+	let queue = queues.get(key);
 
-/**
- * Lookups that are already on their way,
- * keyed by representation and id. They are
- * dropped as soon as the request resolved,
- * so that no item is kept around.
- */
-const pending = new Map<string, Promise<Item | undefined>>();
-
-/**
- * Sends the collected batch and hands
- * each caller the item for its own id
- */
-async function flush(key: string): Promise<void> {
-	const batch = batches.get(key);
-
-	if (batch === undefined) {
-		return;
+	if (queue === undefined) {
+		queue = { endpoint, ids: [], items: new Map(), key, query };
+		queues.set(key, queue);
 	}
 
-	// drop the batch right away, so that new calls added while this
-	// request is in flight will start their own new batch
-	batches.delete(key);
-
-	const chunks = [];
-
-	for (let index = 0; index < batch.ids.length; index += LIMIT) {
-		chunks.push(request(batch, batch.ids.slice(index, index + LIMIT)));
-	}
-
-	await Promise.all(chunks);
+	return queue;
 }
 
 /**
- * Adds a single id to its batch and returns the promise
- * that resolves once the batch has been flushed
+ * Adds a single id to its matching queue and
+ * returns the item props once the promise resolves
  */
-function item(
+function queueItem(
 	endpoint: string,
 	id: string,
 	query: Query
@@ -76,90 +73,104 @@ function item(
 		return Promise.resolve(undefined);
 	}
 
-	const key = endpoint + "/" + normalize(query);
-	const lookup = key + "/" + id;
-	const existing = pending.get(lookup);
+	// get the right queue for the item and check
+	// if a response for the same item is already pending;
+	// so that it can join the request and not create its redundant own
+	const queue = getQueue(endpoint, query);
+	const existing = queue.items.get(id);
 
-	// join a request for the same item that is already on its way,
-	// no matter if it is still collecting or already in flight
 	if (existing !== undefined) {
-		return existing;
+		return existing.promise;
 	}
 
-	let batch = batches.get(key);
+	// create and track the promise in the queue:
+	// we return the promise here, but resolve it with the
+	// props data later in `resolveItem()`
+	const item = Promise.withResolvers<Item | undefined>();
 
-	if (batch === undefined) {
-		batch = { endpoint, ids: [], key, query, resolvers: new Map() };
-		batches.set(key, batch);
+	queue.items.set(id, item);
+	queue.ids.push(id);
 
-		// flush once the current tick has queued all its lookups
-		queueMicrotask(() => flush(key));
+	// for a newly created queue start the timer to send
+	// the request once the current tick has passed;
+	// in the meantime more ids can join the queue
+	if (queue.ids.length === 1) {
+		queueMicrotask(() => sendQueue(queue));
 	}
 
-	const { promise, resolve } = Promise.withResolvers<Item | undefined>();
-
-	batch.ids.push(id);
-	batch.resolvers.set(id, resolve);
-	pending.set(lookup, promise);
-
-	return promise;
+	return item.promise;
 }
 
 /**
- * Sorts the query, so that the same options
- * share a batch, no matter in which order
- * the caller passed them
+ * Hands the item to the caller and drops it from the queue,
+ * so that the next call starts a fresh request
  */
-function normalize(query: Query): string {
-	const sorted: Query = {};
+function resolveItem(queue: Queue, id: string, item: Item | undefined): void {
+	queue.items.get(id)?.resolve(item);
+	queue.items.delete(id);
 
-	for (const name of Object.keys(query).sort()) {
-		sorted[name] = query[name];
+	if (queue.ids.length === 0 && queue.items.size === 0) {
+		queues.delete(queue.key);
 	}
-
-	return JSON.stringify(sorted);
 }
 
 /**
- * Requests a single chunk of ids from the endpoint
+ * Sends one chunk of ids to the endpoint. The queue supplies
+ * the endpoint, the options and the waiting callers.
  */
-async function request(batch: Batch, ids: string[]): Promise<void> {
+async function sendChunk(queue: Queue, chunk: string[]): Promise<void> {
 	try {
-		const response = (await window.panel.get(batch.endpoint, {
+		const response = (await window.panel.get(queue.endpoint, {
 			query: {
-				...batch.query,
-				items: ids.join(",")
+				...queue.query,
+				items: chunk.join(",")
 			}
 		})) as { items?: (Item | null)[] };
 
-		for (const [index, id] of ids.entries()) {
-			settle(batch, id, response.items?.[index] ?? undefined);
+		for (const [index, id] of chunk.entries()) {
+			resolveItem(queue, id, response.items?.[index] ?? undefined);
 		}
 	} catch (error) {
 		// hand the error to the Panel, so that an expired session,
 		// a redirect or a lost connection is still acted upon
 		window.panel.error(error);
 
-		// a failed lookup resolves to nothing, just like an unknown id
-		for (const id of ids) {
-			settle(batch, id, undefined);
+		// a failed request resolves to nothing, just like an unknown id
+		for (const id of chunk) {
+			resolveItem(queue, id, undefined);
 		}
 	}
 }
 
 /**
- * Hands the item to the caller and clears the lookup,
- * so that the next call starts a fresh request
+ * Sends the queued ids as one or more requests/chunks and
+ * hands each caller the item for its own id
  */
-function settle(batch: Batch, id: string, item: Item | undefined): void {
-	pending.delete(batch.key + "/" + id);
-	batch.resolvers.get(id)?.(item);
+async function sendQueue(queue: Queue): Promise<void> {
+	// take the queued ids right away, so that new calls added while
+	// this request is in flight will collect their own new batch
+	const batch = queue.ids;
+	queue.ids = [];
+
+	const requests = [];
+
+	// max number of ids per request:
+	// ids are added to the query string,
+	// we must ensure the URL does not get too long
+	const limit = 100;
+
+	for (let index = 0; index < batch.length; index += limit) {
+		const chunk = batch.slice(index, index + limit);
+		requests.push(sendChunk(queue, chunk));
+	}
+
+	await Promise.all(requests);
 }
 
 /**
  * Request props for items by model id. Calls from the same tick
- * share a request and a lookup that is already on its way is
- * joined instead of being requested again.
+ * share a request and a call for an item that is already on its
+ * way is joined instead of being requested again.
  *
  * @example
  * const item = await items("items/files", "file://abc");
@@ -181,8 +192,8 @@ export default function items(
 	query: Query = {}
 ): Promise<Item | undefined> | Promise<(Item | undefined)[]> {
 	if (Array.isArray(ids) === true) {
-		return Promise.all(ids.map((id) => item(endpoint, id, query)));
+		return Promise.all(ids.map((id) => queueItem(endpoint, id, query)));
 	}
 
-	return item(endpoint, ids, query);
+	return queueItem(endpoint, ids, query);
 }

--- a/panel/src/helpers/items.ts
+++ b/panel/src/helpers/items.ts
@@ -15,10 +15,10 @@ type Batch = {
 };
 
 /**
- * Max number of ids per request.
- * The ids travel in the query string,
- * so a large batch needs to be split
- * before the url gets too long.
+ * Max number of ids per request. The ids travel in the query
+ * string, so a large batch needs to be split before the url gets
+ * too long. A plain count is a rough stand-in for the actual
+ * length, which is fine as long as ids stay reasonably short.
  */
 const LIMIT = 100;
 

--- a/panel/src/helpers/items.ts
+++ b/panel/src/helpers/items.ts
@@ -70,6 +70,12 @@ function item(
 	id: string,
 	query: Query
 ): Promise<Item | undefined> {
+	// the backend drops blank ids when it splits the query string,
+	// which would shift the response for every id after them
+	if (id?.trim() === "" || id === null || id === undefined) {
+		return Promise.resolve(undefined);
+	}
+
 	const key = endpoint + "/" + normalize(query);
 	const lookup = key + "/" + id;
 	const existing = pending.get(lookup);

--- a/panel/src/helpers/link.test.ts
+++ b/panel/src/helpers/link.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { length } from "./object";
 import {
 	detect,
@@ -6,7 +6,6 @@ import {
 	getPageUUID,
 	isFileUUID,
 	isPageUUID,
-	preview,
 	types
 } from "./link";
 
@@ -65,116 +64,6 @@ describe("$helper.link", () => {
 			expect(isPageUUID("/@/page/324hjk24")).toBeTruthy();
 			expect(isPageUUID("/en/@/page/324hjk24")).toBeTruthy();
 			expect(isPageUUID("site://")).toBeTruthy();
-		});
-	});
-
-	describe("preview()", () => {
-		beforeEach(() => {
-			window.panel = {
-				t: (value: string) => value,
-				api: {
-					files: { get: vi.fn() },
-					pages: { get: vi.fn() }
-				}
-			} as unknown as typeof window.panel;
-		});
-
-		it("should return null when there is no link", async () => {
-			expect(await preview({ type: "url", link: "" })).toBeNull();
-		});
-
-		it("should return a label-only preview for a plain link", async () => {
-			expect(
-				await preview({ type: "url", link: "https://getkirby.com" })
-			).toEqual({
-				label: "https://getkirby.com"
-			});
-		});
-
-		it("should return a page preview", async () => {
-			vi.mocked(window.panel.api.pages.get).mockResolvedValue({
-				title: "About",
-				panelImage: "IMG"
-			});
-
-			const result = await preview({ type: "page", link: "page://2" }, [
-				"title",
-				"panelImage"
-			]);
-
-			expect(result).toEqual({ label: "About", image: "IMG" });
-			expect(window.panel.api.pages.get).toHaveBeenCalledWith("page://2", {
-				select: "title,panelImage"
-			});
-		});
-
-		it("should request default page preview fields", async () => {
-			vi.mocked(window.panel.api.pages.get).mockResolvedValue({
-				title: "Page"
-			});
-
-			await preview({ type: "page", link: "page://324hjk24" });
-
-			expect(window.panel.api.pages.get).toHaveBeenCalledWith(
-				"page://324hjk24",
-				{ select: "title,panelImage" }
-			);
-		});
-
-		it("should return the site label for site://", async () => {
-			const result = await preview({ type: "page", link: "site://" });
-
-			expect(result).toEqual({ label: "view.site" });
-			expect(window.panel.api.pages.get).not.toHaveBeenCalled();
-		});
-
-		it("should return null when the page api throws", async () => {
-			vi.mocked(window.panel.api.pages.get).mockRejectedValue(
-				new Error("nope")
-			);
-			expect(await preview({ type: "page", link: "page://2" })).toBeNull();
-		});
-
-		it("should return a file preview", async () => {
-			vi.mocked(window.panel.api.files.get).mockResolvedValue({
-				filename: "image.png",
-				panelImage: "IMG"
-			});
-
-			const result = await preview({ type: "file", link: "file://1" }, [
-				"filename",
-				"panelImage"
-			]);
-
-			expect(result).toEqual({ label: "image.png", image: "IMG" });
-			expect(window.panel.api.files.get).toHaveBeenCalledWith(
-				null,
-				"file://1",
-				{
-					select: "filename,panelImage"
-				}
-			);
-		});
-
-		it("should request default file preview fields", async () => {
-			vi.mocked(window.panel.api.files.get).mockResolvedValue({
-				filename: "image.jpg"
-			});
-
-			await preview({ type: "file", link: "file://324hjk24" });
-
-			expect(window.panel.api.files.get).toHaveBeenCalledWith(
-				null,
-				"file://324hjk24",
-				{ select: "filename,panelImage" }
-			);
-		});
-
-		it("should return null when the file api throws", async () => {
-			vi.mocked(window.panel.api.files.get).mockRejectedValue(
-				new Error("nope")
-			);
-			expect(await preview({ type: "file", link: "file://1" })).toBeNull();
 		});
 	});
 

--- a/panel/src/helpers/link.ts
+++ b/panel/src/helpers/link.ts
@@ -15,9 +15,6 @@ type LinkType = {
 	value: (value: string) => string;
 };
 
-// TODO: better type once we have Vue components as types
-type LinkPreview = { label: string; image?: unknown } | null;
-
 /**
  * Detects the type of a link
  * @param _types - Custom types, otherwise default types are used
@@ -79,70 +76,6 @@ export function isPageUUID(value: string): boolean {
 		value.startsWith("page://") === true ||
 		value.match(/^\/(.*\/)?@\/page\//) !== null
 	);
-}
-
-/**
- * Returns preview data for the link
- */
-export async function preview(
-	{ type, link }: { type: string; link: string },
-	fields?: string[]
-): Promise<LinkPreview> {
-	if (type === "page" && link) {
-		return await previewForPage(link, fields);
-	}
-
-	if (type === "file" && link) {
-		return await previewForFile(link, fields);
-	}
-
-	if (link) {
-		return {
-			label: link
-		};
-	}
-
-	return null;
-}
-
-async function previewForFile(
-	id: string,
-	fields = ["filename", "panelImage"]
-): Promise<LinkPreview> {
-	try {
-		const file = (await window.panel.api.files.get(null, id, {
-			select: fields.join(",")
-		})) as { filename: string; panelImage: unknown };
-
-		return {
-			label: file.filename,
-			image: file.panelImage
-		};
-	} catch {
-		return null;
-	}
-}
-
-async function previewForPage(
-	id: string,
-	fields = ["title", "panelImage"]
-): Promise<LinkPreview> {
-	if (id === "site://") {
-		return { label: window.panel.t("view.site") };
-	}
-
-	try {
-		const page = (await window.panel.api.pages.get(id, {
-			select: fields.join(",")
-		})) as { title: string; panelImage: unknown };
-
-		return {
-			label: page.title,
-			image: page.panelImage
-		};
-	} catch {
-		return null;
-	}
 }
 
 export function types(keys: string[] = []): Record<string, LinkType> {


### PR DESCRIPTION
## Review

- [x] **Design & concept**: Judge the approach, the API and the naming. Implementation details matter less.
- [x] **Deep read**: Please follow the logic. Ask me anything, I'll explain.

The helper juggles microtask batching, in-flight de-duplication and chunking, so the concurrency semantics deserve a careful look. Two questions I'd especially like an opinion on:

1. **No cache.** A lookup is dropped the moment its request resolves, so two `await`s in a row are two requests. That leans towards avoiding stale content in the Panel, but it means batching only helps within a tick. Is that the right trade?
2. **`queueMicrotask` as the batch window.** Callers only share a request if they line up in the same microtask. That covers components created in the same render pass, but anything behind an `await` starts its own batch. A `setTimeout(0)` window would batch more aggressively at the cost of a frame.


**Timing:** No rush. Happy to hold this for the 2024-baseline PR (see below).

## Description

So far, every model item preview fetches its own data/sends its own request. A gallery block with 20 images fires 20 requests at `items/files`, one per `<k-image-frame>`, because each component resolves its own file UUID.

This PR adds `$helper.items()` which puts a batches requests. Calls in the same microtask are collected, de-duplicated and sent as a single request. Each caller still gets its own promise resolving to its own item.

Batches are keyed by endpoint and query, because two callers can only share a response if they ask the backend for the same representation. `<k-image-frame>` passes `layout` and `image`, so its lookups stay separate from a bare models field preview.

A few more details:

- Asking for an id that is already on its way returns the existing promise instead of queueing a second lookup.
- Max 100 IDs are chunked. The IDs travel in the query string, so a large batch is split before the url gets too long.
- Stale responses are discarded: `<k-image-frame>`, `<k-video-frame>` and the models field preview all re-check that their value hasn't changed before writing a resolved item.

**Out of scope:** `Promise.withResolvers` needs Firefox 121, and our build target still lists `firefox120`. That's a one-version gap that moving to 2024 baseline closes. Will add its own PR for that.

### Benchmarks

Request count, which is what this PR actually changes, no timing claims:

| Case | Before | After |
| --- | --- | --- |
| Gallery block, 20 images | 20 requests | 1 request |

Pages field previews already batched their own IDs. But now also multiple pages field previews (e.g. across rows) could batch their calls.

To reproduce: open a page with a gallery block and watch the network tab filtered to `items/files`. Before this PR there is one request per image, after it there is one for all of them, even though each still renders as its own component.

## Changelog

### 🏎️ Performance

- Panel requests for model item preview data are now batched. Components that ask for a file or page in the same tick share a single request instead of firing one each.

### ✨ Enhancements

- New `this.$helper.items()` to request model item preview data by id. Requests made in the same tick are batched automatically.
- `<k-image-frame>` now loads images lazily and decodes them asynchronously. Set `:lazy="false"` for images that are visible right away.

### 🚨 Breaking changes

- `$helper.link.preview()` has been removed. Use `<k-pages-field-preview>` or `<k-files-field-preview>` to render a model preview, or `$helper.items("items/pages", id)` / `$helper.items("items/files", id)` if you need the raw data.

## Docs

### `$helper.items()`

Requests preview data for one or more models by id. Calls made in the same tick share a single request, so components can ask for what they need without coordinating.

```js
// a single item
const file = await this.$helper.items("items/files", "file://abc");

// a list of items, resolved in the order you asked for them
const pages = await this.$helper.items("items/pages", [
	"page://a",
	"page://b"
]);
```

Pass a query as the third argument:

```js
const file = await this.$helper.items("items/files", "file://abc", {
	layout: "auto",
	image: JSON.stringify({ ratio: "16/9", cover: true })
});
```

### `<k-image-frame :lazy="false">`

Images in a frame are lazy-loaded by default, so long lists only fetch what is on screen. Turn it off for images that are visible immediately, e.g. an avatar in the header:

```html
<k-image-frame :lazy="false" :src="avatar" :cover="true" />
```

## For review team

- [x] Add changes & docs to release notes draft in Notion
