### PR TITLE
lab: Integrate `v-safe-html` in Vue components

### DIFF
--- a/config/sections/info.php
+++ b/config/sections/info.php
@@ -1,5 +1,6 @@
 <?php
 
+use Kirby\Toolkit\HtmlString;
 use Kirby\Toolkit\I18n;
 
 return [
@@ -22,7 +23,7 @@ return [
 			if ($this->text) {
 				$text = $this->model()->toSafeString($this->text);
 				$text = $this->kirby()->kirbytext($text);
-				return $text;
+				return new HtmlString($text);
 			}
 		},
 	],

--- a/panel/eslint.config.js
+++ b/panel/eslint.config.js
@@ -89,7 +89,7 @@ export default [
 		rules: {
 			"vuejs-accessibility/heading-has-content": [
 				"error",
-				{ accessibleDirectives: ["safe-html"], accessibleChildren: ["span"] }
+				{ accessibleDirectives: ["safe-html"] }
 			],
 			"vue/attributes-order": "error",
 			"vue/no-v-html": "error",

--- a/panel/eslint.config.js
+++ b/panel/eslint.config.js
@@ -87,6 +87,10 @@ export default [
 	},
 	{
 		rules: {
+			"vuejs-accessibility/heading-has-content": [
+				"error",
+				{ accessibleDirectives: ["safe-html"], accessibleChildren: ["span"] }
+			],
 			"vue/attributes-order": "error",
 			"vue/component-definition-name-casing": "off",
 			"vue/html-closing-bracket-newline": [

--- a/panel/eslint.config.js
+++ b/panel/eslint.config.js
@@ -92,6 +92,7 @@ export default [
 				{ accessibleDirectives: ["safe-html"], accessibleChildren: ["span"] }
 			],
 			"vue/attributes-order": "error",
+			"vue/no-v-html": "error",
 			"vue/component-definition-name-casing": "off",
 			"vue/html-closing-bracket-newline": [
 				"error",

--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -30,7 +30,7 @@
 				"eslint": "^10.7.0",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-vue": "^10.9.2",
-				"eslint-plugin-vuejs-accessibility": "^2.5.0",
+				"eslint-plugin-vuejs-accessibility": "^2.6.0",
 				"glob": "^13.0.6",
 				"globals": "^17.7.0",
 				"happy-dom": "^20.10.6",
@@ -2083,9 +2083,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-vuejs-accessibility": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.5.0.tgz",
-			"integrity": "sha512-oZ2fL4tS91Cm/ezH3BueNP+FtpbbeS627OSqqgp9/lsN//glmoPcLBT6D53xwGocLtyBybaT99tX4ThBh8+ytA==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.6.0.tgz",
+			"integrity": "sha512-QtJO3UdLH+aydue/im7aBsYKO99ouJ6hm4wEHL1Xm/BwDfYTAmXEPhTImNwlOHp2bbid7rNY7IrHz+IZzGApYA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/panel/package.json
+++ b/panel/package.json
@@ -40,7 +40,7 @@
 		"eslint": "^10.7.0",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-vue": "^10.9.2",
-		"eslint-plugin-vuejs-accessibility": "^2.5.0",
+		"eslint-plugin-vuejs-accessibility": "^2.6.0",
 		"glob": "^13.0.6",
 		"globals": "^17.7.0",
 		"happy-dom": "^20.10.6",

--- a/panel/src/components/Collection/Collection.vue
+++ b/panel/src/components/Collection/Collection.vue
@@ -40,7 +40,7 @@
 		</component>
 
 		<footer v-if="help || hasPagination" class="k-collection-footer">
-			<k-text class="k-help k-collection-help" :html="help" />
+			<k-text class="k-help k-collection-help" :text="help" />
 			<!--
 				Emitted when the pagination changes
 				@event paginate

--- a/panel/src/components/Collection/Item.test.ts
+++ b/panel/src/components/Collection/Item.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "@test/unit";
 import { mount as vueMount } from "@vue/test-utils";
+import html from "@/panel/html";
 import Item from "./Item.vue";
 
 function mount(props = {}, attrs = {}) {
@@ -85,8 +86,15 @@ describe("Item.vue", () => {
 	});
 
 	describe("text prop", () => {
-		it("renders the text as HTML", () => {
+		it("escapes a plain string", () => {
 			const wrapper = mount({ text: "<b>Hello</b>" });
+			expect(wrapper.find(".k-item-title span").html()).toBe(
+				"<span>&lt;b&gt;Hello&lt;/b&gt;</span>"
+			);
+		});
+
+		it("renders trusted HTML as-is", () => {
+			const wrapper = mount({ text: html("<b>Hello</b>") });
 			expect(wrapper.find(".k-item-title span").html()).toBe(
 				"<span><b>Hello</b></span>"
 			);
@@ -177,15 +185,24 @@ describe("Item.vue", () => {
 			);
 		});
 
-		it("strips tags", () => {
+		it("keeps markup a plain string renders as visible text", () => {
 			const wrapper = mount({ text: "<b>Hello</b>" });
-			expect(wrapper.find(".k-item-title").attributes("title")).toBe("Hello");
+			expect(wrapper.find(".k-item-title").attributes("title")).toBe(
+				"<b>Hello</b>"
+			);
 		});
 
-		it("unescapes entities", () => {
-			const wrapper = mount({ text: "Tom &amp; Jerry" });
+		it("strips authored tags from trusted HTML", () => {
+			const wrapper = mount({ text: html("<b>Tom &amp; Jerry</b>") });
 			expect(wrapper.find(".k-item-title").attributes("title")).toBe(
 				"Tom & Jerry"
+			);
+		});
+
+		it("keeps escaped tags, which render as visible text", () => {
+			const wrapper = mount({ text: html("Using &lt;div&gt; tags") });
+			expect(wrapper.find(".k-item-title").attributes("title")).toBe(
+				"Using <div> tags"
 			);
 		});
 

--- a/panel/src/components/Collection/Item.vue
+++ b/panel/src/components/Collection/Item.vue
@@ -33,14 +33,16 @@
 						:target="target"
 						:to="link"
 					>
-						<!-- eslint-disable-next-line vue/no-v-html -->
-						<span v-html="text ?? '&nbsp;'" />
+						<span v-safe-html="text ?? '\u00a0'" />
 					</k-link>
-					<!-- eslint-disable-next-line vue/no-v-html -->
-					<span v-else v-html="text ?? '&nbsp;'" />
+					<span v-else v-safe-html="text ?? '\u00a0'" />
 				</h3>
-				<!-- eslint-disable-next-line vue/no-v-html -->
-				<p v-if="info" :title="title(info)" class="k-item-info" v-html="info" />
+				<p
+					v-if="info"
+					v-safe-html="info"
+					:title="title(info)"
+					class="k-item-info"
+				/>
 			</div>
 
 			<div
@@ -81,6 +83,7 @@
 <script>
 import { props as ItemImageProps } from "./ItemImage.vue";
 import { layout } from "@/mixins/props.js";
+import { HtmlString } from "@/panel/html";
 /**
  * A collection item that can be displayed in various layouts
  *
@@ -182,9 +185,16 @@ export default {
 			this.$emit("option", event);
 		},
 		title(text) {
-			return this.$helper.string
-				.stripHTML(this.$helper.string.unescapeHTML(text))
-				.trim();
+			// only trusted HTML carries tags and entities to undo,
+			// a plain string is already the text we want. Tags go
+			// first, so escaped ones survive as visible characters.
+			if (text instanceof HtmlString) {
+				return this.$helper.string
+					.unescapeHTML(this.$helper.string.stripHTML(text))
+					.trim();
+			}
+
+			return String(text ?? "").trim();
 		}
 	}
 };

--- a/panel/src/components/Dialogs/Elements/Text.vue
+++ b/panel/src/components/Dialogs/Elements/Text.vue
@@ -1,5 +1,5 @@
 <template>
-	<k-text v-if="text" :html="text" />
+	<k-text v-if="text" :text="text" />
 	<k-box v-else theme="info">{{ empty }}</k-box>
 </template>
 

--- a/panel/src/components/Dialogs/LicenseDialog.vue
+++ b/panel/src/components/Dialogs/LicenseDialog.vue
@@ -45,12 +45,12 @@
 				<k-definition v-if="license.info" :term="$t('status')">
 					<p :data-theme="license.theme">
 						<k-icon :type="license.icon" />
-						<k-text :html="license.info" />
+						<k-text :text="license.info" />
 					</p>
 				</k-definition>
 			</k-definitions>
 
-			<k-text class="k-help" :html="licenseHubText" />
+			<k-text class="k-help" :text="licenseHubText" />
 		</k-stack>
 	</k-dialog>
 </template>

--- a/panel/src/components/Dialogs/LicenseDialog.vue
+++ b/panel/src/components/Dialogs/LicenseDialog.vue
@@ -80,9 +80,11 @@ export default {
 	emits: ["cancel", "submit"],
 	computed: {
 		licenseHubText() {
-			return this.$t("license.manage.hub", {
-				url: "https://hub.getkirby.com/"
-			});
+			return this.$panel.html(
+				this.$t("license.manage.hub", {
+					url: "https://hub.getkirby.com/"
+				})
+			);
 		}
 	}
 };

--- a/panel/src/components/Drawers/Elements/Text.vue
+++ b/panel/src/components/Drawers/Elements/Text.vue
@@ -1,5 +1,5 @@
 <template>
-	<k-text v-if="text" :html="text" />
+	<k-text v-if="text" :text="text" />
 	<k-box v-else theme="info">{{ empty }}</k-box>
 </template>
 

--- a/panel/src/components/Drawers/UserTotpDrawer.vue
+++ b/panel/src/components/Drawers/UserTotpDrawer.vue
@@ -22,8 +22,8 @@
 							text: qr,
 							help: $panel.html(
 								$t('login.totp.enable.qr.help', {
-									secret: value.secret,
-									uri
+									secret: $esc(value.secret),
+									uri: $esc(uri)
 								})
 							),
 							theme: 'passive',

--- a/panel/src/components/Drawers/UserTotpDrawer.vue
+++ b/panel/src/components/Drawers/UserTotpDrawer.vue
@@ -20,10 +20,12 @@
 							label: $t('login.totp.enable.qr.label'),
 							type: 'info',
 							text: qr,
-							help: $t('login.totp.enable.qr.help', {
-								secret: value.secret,
-								uri
-							}),
+							help: $panel.html(
+								$t('login.totp.enable.qr.help', {
+									secret: value.secret,
+									uri
+								})
+							),
 							theme: 'passive',
 							class: 'k-totp-qrcode'
 						},

--- a/panel/src/components/Forms/Field.vue
+++ b/panel/src/components/Forms/Field.vue
@@ -44,7 +44,7 @@
 		<slot name="footer">
 			<footer v-if="help || $slots.help" class="k-field-footer">
 				<slot name="help">
-					<k-text v-if="help" class="k-help k-field-help" :html="help" />
+					<k-text v-if="help" class="k-help k-field-help" :text="help" />
 				</slot>
 			</footer>
 		</slot>

--- a/panel/src/components/Forms/Field/ColorField.vue
+++ b/panel/src/components/Forms/Field/ColorField.vue
@@ -44,8 +44,7 @@
 			</template>
 
 			<template v-if="currentOption?.text" #after>
-				<!-- eslint-disable-next-line vue/no-v-html -->
-				<span v-html="currentOption.text" />
+				<span v-safe-html="currentOption.text" />
 			</template>
 
 			<template v-if="mode === 'picker' && !disabled" #icon>

--- a/panel/src/components/Forms/Field/HeadlineField.vue
+++ b/panel/src/components/Forms/Field/HeadlineField.vue
@@ -4,7 +4,7 @@
 			{{ label }}
 		</k-headline>
 		<footer v-if="help" class="k-field-footer">
-			<k-text class="k-help k-field-help" :html="help" />
+			<k-text class="k-help k-field-help" :text="help" />
 		</footer>
 	</div>
 </template>

--- a/panel/src/components/Forms/Field/InfoField.vue
+++ b/panel/src/components/Forms/Field/InfoField.vue
@@ -3,11 +3,11 @@
 		<k-headline v-if="label">{{ label }}</k-headline>
 
 		<k-box :icon="icon" :theme="theme">
-			<k-text :html="text" />
+			<k-text :text="text" />
 		</k-box>
 
 		<footer v-if="help" class="k-field-footer">
-			<k-text class="k-help k-field-help" :html="help" />
+			<k-text class="k-help k-field-help" :text="help" />
 		</footer>
 	</div>
 </template>

--- a/panel/src/components/Forms/FormControls.vue
+++ b/panel/src/components/Forms/FormControls.vue
@@ -130,10 +130,12 @@ export default {
 						text: this.$t("form.discard")
 					},
 					text: isCurrentUser
-						? this.$t("form.discard.confirm")
-						: this.$t("form.discard.confirm.editor", {
-								editor: this.$helper.string.stripHTML(this.editor)
-							})
+						? this.$panel.html(this.$t("form.discard.confirm"))
+						: this.$panel.html(
+								this.$t("form.discard.confirm.editor", {
+									editor: this.$helper.string.stripHTML(this.editor)
+								})
+							)
 				},
 				on: {
 					submit: () => {

--- a/panel/src/components/Forms/Input/ChoiceInput.vue
+++ b/panel/src/components/Forms/Input/ChoiceInput.vue
@@ -25,10 +25,8 @@
 		<k-icon v-if="icon" :type="icon" class="k-choice-input-icon" />
 
 		<span v-if="label || info" class="k-choice-input-label">
-			<!-- eslint-disable-next-line vue/no-v-html -->
-			<span class="k-choice-input-label-text" v-html="label" />
-			<!-- eslint-disable-next-line vue/no-v-html -->
-			<span v-if="info" class="k-choice-input-label-info" v-html="info" />
+			<span v-safe-html="label" class="k-choice-input-label-text" />
+			<span v-if="info" v-safe-html="info" class="k-choice-input-label-info" />
 		</span>
 	</label>
 </template>

--- a/panel/src/components/Forms/Input/PicklistInput.test.ts
+++ b/panel/src/components/Forms/Input/PicklistInput.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "@test/unit";
 import { mount as vueMount } from "@vue/test-utils";
 import PicklistInput from "./PicklistInput.vue";
 import string from "@/helpers/string";
+import html, { HtmlString } from "@/panel/html";
 
 function mount(props = {}, attrs = {}) {
 	return vueMount(PicklistInput, { props, attrs, shallow: true });
@@ -78,7 +79,7 @@ describe("PicklistInput.vue", () => {
 	// methods
 	describe("highlight()", () => {
 		// the method only needs `query` and the string helpers
-		function highlight(text: unknown, query = ""): string {
+		function highlight(text: unknown, query = ""): HtmlString {
 			return PicklistInput.methods!.highlight.call(
 				{ query, $helper: { string } },
 				text
@@ -101,16 +102,39 @@ describe("PicklistInput.vue", () => {
 			expect(String(highlight("Kirby"))).toBe("Kirby");
 		});
 
-		it("strips tags so a match cannot land inside one", () => {
-			expect(String(highlight("<b>Kirby</b>", "b"))).toBe("Kir<b>b</b>y");
-		});
-
-		it("does not double-escape entities", () => {
-			expect(String(highlight("Tom &amp; Jerry"))).toBe("Tom &amp; Jerry");
-		});
-
 		it("treats the query literally, not as a pattern", () => {
 			expect(String(highlight("a.b", "."))).toBe("a<b>.</b>b");
+		});
+
+		it("returns trusted HTML so the match markup survives rendering", () => {
+			const result = highlight(html("Kirby"), "ir");
+
+			expect(result).toBeInstanceOf(HtmlString);
+			expect(result.toString()).toBe("K<b>ir</b>by");
+		});
+
+		it("escapes untrusted text before adding the match markup", () => {
+			const result = highlight("<script>x</script>", "script");
+
+			expect(result.toString()).not.toContain("<script>");
+			expect(result.toString()).toContain("<b>script</b>");
+		});
+
+		it("neutralises untrusted markup that stripHTML would miss", () => {
+			// an unclosed tag never matches stripHTML's `<…>` regex,
+			// so escaping — not stripping — is what makes this safe
+			const result = highlight("<img src=x onerror=alert(1)");
+
+			expect(result.toString()).not.toContain("<img");
+			expect(result.toString()).toContain("&lt;img");
+		});
+
+		it("strips tags from trusted HTML so a match cannot land inside one", () => {
+			expect(String(highlight(html("<b>Kirby</b>"), "b"))).toBe("Kir<b>b</b>y");
+		});
+
+		it("does not double-escape entities in trusted HTML", () => {
+			expect(String(highlight(html("Tom &amp; Jerry")))).toBe("Tom &amp; Jerry");
 		});
 	});
 });

--- a/panel/src/components/Forms/Input/PicklistInput.vue
+++ b/panel/src/components/Forms/Input/PicklistInput.vue
@@ -70,6 +70,7 @@
 <script>
 import Input, { props as InputProps } from "@/mixins/input.js";
 import { autofocus, disabled, options, required } from "@/mixins/props.js";
+import html, { HtmlString } from "@/panel/html";
 
 export const picklist = {
 	mixins: [autofocus, disabled, options, required],
@@ -278,17 +279,21 @@ export default {
 				this.$refs.options?.focus();
 			}
 		},
-		highlight(string) {
-			// make sure that no HTML exists before in the string
-			// to avoid XSS when displaying via `v-html`
-			string = this.$helper.string.stripHTML(string);
+		highlight(text) {
+			// trusted HTML gets its tags dropped, so that a match can
+			// never land inside one; untrusted text has to be escaped,
+			// as the result is rendered as HTML either way
+			const string =
+				text instanceof HtmlString
+					? this.$helper.string.stripHTML(text)
+					: this.$helper.string.escapeHTML(text);
 
 			if (this.query.length > 0) {
 				const regex = new RegExp(`(${RegExp.escape(this.query)})`, "ig");
-				return string.replace(regex, "<b>$1</b>");
+				return html(string.replace(regex, "<b>$1</b>"));
 			}
 
-			return string;
+			return html(string);
 		},
 		input(values) {
 			/**

--- a/panel/src/components/Forms/Input/TogglesInput.vue
+++ b/panel/src/components/Forms/Input/TogglesInput.vue
@@ -26,13 +26,11 @@
 					/>
 					<label :for="id + '-' + index" :title="option.text">
 						<k-icon v-if="option.icon" :type="option.icon" />
-						<!-- eslint-disable vue/no-v-html -->
 						<span
 							v-if="labels || !option.icon"
+							v-safe-html="option.text"
 							class="k-toggles-text"
-							v-html="option.text"
 						/>
-						<!-- eslint-enable vue/no-v-html -->
 					</label>
 				</li>
 			</ul>

--- a/panel/src/components/Forms/Previews/HtmlFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/HtmlFieldPreview.vue
@@ -4,7 +4,7 @@
 		:style="$attrs.style"
 	>
 		{{ column.before }}
-		<k-text :html="html" />
+		<k-text :text="html" />
 		{{ column.after }}
 	</div>
 </template>

--- a/panel/src/components/Forms/Previews/ModelsFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/ModelsFieldPreview.vue
@@ -1,6 +1,5 @@
 <template>
 	<k-tags-field-preview
-		:html="html"
 		:removable="removable"
 		:value="tags"
 		class="k-models-field-preview"
@@ -18,9 +17,11 @@ import FieldPreview from "@/mixins/forms/fieldPreview.js";
 export default {
 	mixins: [FieldPreview],
 	props: {
+		/**
+		 * @deprecated 6.0.0 Model items already carry trusted HTML
+		 */
 		html: {
-			type: Boolean,
-			default: true
+			type: Boolean
 		},
 		removable: Boolean,
 		value: {
@@ -40,6 +41,13 @@ export default {
 			handler() {
 				this.collect();
 			}
+		}
+	},
+	created() {
+		if (this.html === true) {
+			window.panel.deprecated(
+				"`k-models-field-preview`: the `html` prop has been deprecated. Model items already carry trusted HTML."
+			);
 		}
 	},
 	methods: {

--- a/panel/src/components/Forms/Previews/TagFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/TagFieldPreview.vue
@@ -10,13 +10,14 @@
 		:style="$attrs.style"
 	>
 		<li>
-			<k-tag :html="html" :text="value" theme="light" @click.stop />
+			<k-tag :text="content" theme="light" @click.stop />
 		</li>
 	</ul>
 </template>
 
 <script>
 import FieldPreview from "@/mixins/forms/fieldPreview.js";
+import html from "@/panel/html";
 
 /**
  * @copyright Bastian Allgeier
@@ -28,11 +29,25 @@ export default {
 		/**
 		 * If set to `true`, the `text` is rendered as HTML code,
 		 * otherwise as plain text
+		 * @deprecated 6.0.0 Trusted HTML in the value is rendered as-is
 		 */
 		html: {
 			type: Boolean
 		},
 		value: String
+	},
+	computed: {
+		content() {
+			// the deprecated `html` flag rendered the value raw
+			return this.html === true ? html(this.value) : this.value;
+		}
+	},
+	created() {
+		if (this.html === true) {
+			window.panel.deprecated(
+				"`k-tag-field-preview`: the `html` prop has been deprecated. Trusted HTML in the value is rendered as-is."
+			);
+		}
 	}
 };
 </script>

--- a/panel/src/components/Forms/Previews/TagsFieldPreview.vue
+++ b/panel/src/components/Forms/Previews/TagsFieldPreview.vue
@@ -9,7 +9,6 @@
 		>
 			<k-tag
 				:element="!removable ? 'div' : undefined"
-				:html="html"
 				:image="tag.image"
 				:link="!removable ? tag.link : undefined"
 				:text="tag.text"
@@ -23,6 +22,7 @@
 
 <script>
 import FieldPreview from "@/mixins/forms/fieldPreview.js";
+import html from "@/panel/html";
 
 /**
  * @copyright Bastian Allgeier
@@ -34,6 +34,7 @@ export default {
 		/**
 		 * If set to `true`, the `text` is rendered as HTML code,
 		 * otherwise as plain text
+		 * @deprecated 6.0.0 Trusted HTML in the value is rendered as-is
 		 */
 		html: {
 			type: Boolean
@@ -63,12 +64,25 @@ export default {
 
 				for (const option of options) {
 					if (option.value === tag.value) {
+						// an option's text is already trusted HTML
 						tag.text = option.text;
 					}
 				}
 
+				// the deprecated `html` flag rendered every tag raw
+				if (this.html === true) {
+					tag.text = html(tag.text);
+				}
+
 				return tag;
 			});
+		}
+	},
+	created() {
+		if (this.html === true) {
+			window.panel.deprecated(
+				"`k-tags-field-preview`: the `html` prop has been deprecated. Trusted HTML in the value is rendered as-is."
+			);
 		}
 	}
 };

--- a/panel/src/components/Lab/Docs/Description.vue
+++ b/panel/src/components/Lab/Docs/Description.vue
@@ -5,7 +5,7 @@
 		</header>
 
 		<k-box theme="text">
-			<k-text :html="description" />
+			<k-text :text="description" />
 		</k-box>
 	</section>
 </template>

--- a/panel/src/components/Lab/Docs/DocBlock.vue
+++ b/panel/src/components/Lab/Docs/DocBlock.vue
@@ -5,7 +5,7 @@
 		</header>
 
 		<k-box theme="text">
-			<k-text :html="docBlock" />
+			<k-text :text="docBlock" />
 		</k-box>
 	</section>
 </template>

--- a/panel/src/components/Lab/Docs/Events.vue
+++ b/panel/src/components/Lab/Docs/Events.vue
@@ -22,7 +22,7 @@
 						</td>
 						<td>
 							<k-lab-docs-warning title="Deprecated" :text="event.deprecated" />
-							<k-text :html="event.description" />
+							<k-text :text="event.description" />
 						</td>
 						<td v-if="hasProperties">
 							<k-lab-docs-params :params="event.properties" />

--- a/panel/src/components/Lab/Docs/Methods.vue
+++ b/panel/src/components/Lab/Docs/Methods.vue
@@ -27,7 +27,7 @@
 								title="Deprecated"
 								:text="method.deprecated"
 							/>
-							<k-text :html="method.description" />
+							<k-text :text="method.description" />
 						</td>
 						<td>
 							<k-lab-docs-params :params="method.params" />

--- a/panel/src/components/Lab/Docs/Props.vue
+++ b/panel/src/components/Lab/Docs/Props.vue
@@ -35,7 +35,7 @@
 
 							<k-text
 								v-if="prop.description?.length"
-								:html="prop.description"
+								:text="prop.description"
 							/>
 
 							<k-text

--- a/panel/src/components/Lab/Docs/Slots.vue
+++ b/panel/src/components/Lab/Docs/Slots.vue
@@ -22,7 +22,7 @@
 						</td>
 						<td>
 							<k-lab-docs-warning title="Deprecated" :text="slot.deprecated" />
-							<k-text :html="slot.description" />
+							<k-text :text="slot.description" />
 						</td>
 						<td v-if="hasBindings">
 							<k-lab-docs-params :params="slot.bindings" />

--- a/panel/src/components/Lab/DocsParams.vue
+++ b/panel/src/components/Lab/DocsParams.vue
@@ -4,8 +4,10 @@
 			<k-text>
 				<code>{{ param.name }}</code>
 				<k-lab-docs-types :types="[param.type]" />
-				<!-- eslint-disable-next-line vue/no-v-html -->
-				<span v-if="param.description.length" v-html="param.description" />
+				<span
+					v-if="param.description.length"
+					v-safe-html="param.description"
+				/>
 			</k-text>
 		</li>
 	</ul>

--- a/panel/src/components/Lab/DocsWarning.vue
+++ b/panel/src/components/Lab/DocsWarning.vue
@@ -5,11 +5,13 @@
 		theme="warning"
 		class="k-lab-docs-warning"
 	>
-		<k-text :html="'<strong>' + title + ':</strong> ' + text" />
+		<k-text :text="content" />
 	</k-box>
 </template>
 
 <script>
+import html from "@/panel/html";
+
 /**
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
@@ -22,6 +24,13 @@ export default {
 		},
 		title: String,
 		text: String
+	},
+	computed: {
+		content() {
+			// both parts were already rendered raw before and the
+			// text is kirbytext output, so they stay trusted
+			return html("<strong>" + this.title + ":</strong> " + this.text);
+		}
 	}
 };
 </script>

--- a/panel/src/components/Lab/IndexView.vue
+++ b/panel/src/components/Lab/IndexView.vue
@@ -26,7 +26,7 @@
 			]"
 		/>
 
-		<k-box v-if="info" icon="question" theme="info" :text="info" :html="true" />
+		<k-box v-if="info" icon="question" theme="info" :text="info" />
 
 		<k-section
 			v-for="category in filteredCategories"

--- a/panel/src/components/Layout/Box.test.ts
+++ b/panel/src/components/Layout/Box.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "@test/unit";
+import { beforeEach, describe, expect, it, vi } from "@test/unit";
 import { mount } from "@vue/test-utils";
 import Box from "./Box.vue";
 
@@ -32,6 +32,24 @@ describe("Box.vue", () => {
 		it("sets type attribute to button", () => {
 			const wrapper = mount(Box, { props: { button: true } });
 			expect(wrapper.attributes("type")).toBe("button");
+		});
+	});
+
+	describe("html prop", () => {
+		beforeEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it("does not warn when the deprecated prop is unused", () => {
+			mount(Box);
+			expect(window.panel.deprecated).not.toHaveBeenCalled();
+		});
+
+		it("warns that the prop is deprecated", () => {
+			mount(Box, { props: { html: true } });
+			expect(window.panel.deprecated).toHaveBeenCalledWith(
+				expect.stringContaining("`html` prop has been deprecated")
+			);
 		});
 	});
 

--- a/panel/src/components/Layout/Box.vue
+++ b/panel/src/components/Layout/Box.vue
@@ -11,18 +11,16 @@
 		<!--
 			@slot Box content, replaces content from `text` prop
 			@binding {string} text
-			@binding {boolean} html
 		-->
-		<slot v-bind="{ html, text }">
-			<k-text v-if="html" :text="text" />
-			<k-text v-else>
-				{{ text }}
-			</k-text>
+		<slot v-bind="{ text: content }">
+			<k-text :text="content" />
 		</slot>
 	</component>
 </template>
 
 <script>
+import html from "@/panel/html";
+
 /**
  * The `<k-box>` component is a multi-purpose box with text.
  * You can use it as a foundation for empty state displays
@@ -63,22 +61,36 @@ export default {
 			type: String
 		},
 		/**
-		 * Text to display inside the box
+		 * Text to display inside the box.
+		 * A plain string is escaped, trusted HTML is rendered as-is.
 		 */
 		text: String,
 		/**
 		 * If set to `true`, the `text` is rendered as HTML code, otherwise as plain text
+		 * @deprecated 6.0.0 Pass trusted HTML as `text` instead
 		 */
 		html: {
 			type: Boolean
 		}
 	},
 	computed: {
+		content() {
+			// the deprecated `html` flag rendered the text raw,
+			// so it stays trusted
+			return this.html === true ? html(this.text) : this.text;
+		},
 		element() {
 			return this.button ? "button" : "div";
 		},
 		type() {
 			return this.button ? "button" : null;
+		}
+	},
+	created() {
+		if (this.html === true) {
+			window.panel.deprecated(
+				"`k-box`: the `html` prop has been deprecated. Pass trusted HTML as `text` instead."
+			);
 		}
 	}
 };

--- a/panel/src/components/Layout/Box.vue
+++ b/panel/src/components/Layout/Box.vue
@@ -14,7 +14,7 @@
 			@binding {boolean} html
 		-->
 		<slot v-bind="{ html, text }">
-			<k-text v-if="html" :html="text" />
+			<k-text v-if="html" :text="text" />
 			<k-text v-else>
 				{{ text }}
 			</k-text>

--- a/panel/src/components/Navigation/Tag.vue
+++ b/panel/src/components/Navigation/Tag.vue
@@ -20,9 +20,7 @@
 		</slot>
 
 		<template v-if="text">
-			<!-- eslint-disable-next-line vue/no-v-html -->
-			<span v-if="html" class="k-tag-text" v-html="text" />
-			<span v-else class="k-tag-text">{{ text }}</span>
+			<span v-safe-html="content" class="k-tag-text" />
 		</template>
 		<template v-else-if="$slots.default">
 			<span class="k-tag-text">
@@ -41,6 +39,8 @@
 </template>
 
 <script>
+import html from "@/panel/html";
+
 export const props = {
 	props: {
 		/**
@@ -50,6 +50,7 @@ export const props = {
 		/**
 		 * If set to `true`, the `text` is rendered as HTML code,
 		 * otherwise as plain text
+		 * @deprecated 6.0.0 Pass trusted HTML as `text` instead
 		 */
 		html: {
 			type: Boolean
@@ -100,12 +101,18 @@ export default {
 		 */
 		link: String,
 		/**
-		 * Text to display in the bubble
+		 * Text to display in the bubble.
+		 * A plain string is escaped, trusted HTML is rendered as-is.
 		 */
 		text: String
 	},
 	emits: ["remove"],
 	computed: {
+		content() {
+			// the deprecated `html` flag rendered the text raw,
+			// so it stays trusted
+			return this.html === true ? html(this.text) : this.text;
+		},
 		isRemovable() {
 			return this.removable && !this.disabled;
 		},
@@ -113,6 +120,13 @@ export default {
 			// removable tags need to be focusable, no matter which
 			// element they render as, to be removed by keyboard
 			return this.isRemovable === true ? 0 : null;
+		}
+	},
+	created() {
+		if (this.html === true) {
+			window.panel.deprecated(
+				"`k-tag`: the `html` prop has been deprecated. Pass trusted HTML as `text` instead."
+			);
 		}
 	},
 	methods: {

--- a/panel/src/components/Navigation/Tags.vue
+++ b/panel/src/components/Navigation/Tags.vue
@@ -30,8 +30,7 @@
 				@dblclick="edit(itemIndex, item, $event)"
 				@remove="remove(itemIndex, item)"
 			>
-				<!-- eslint-disable-next-line vue/no-v-html -->
-				<span v-html="item.text" />
+				<span v-safe-html="item.text" />
 			</k-tag>
 			<template #footer>
 				<!-- @slot Place stuff here in the non-draggable footer -->
@@ -229,17 +228,12 @@ export default {
 			// try to find a matching option
 			const option = this.option(tag);
 
-			// always prefer options as source
-			// as they can be trusted without escaping
 			if (option) {
 				return option;
 			}
 
 			return {
-				// always escape HTML in text for tags that
-				// can't be matched with any defined option
-				// to avoid XSS when displaying via `v-html`
-				text: this.$helper.string.escapeHTML(tag.text ?? tag.value),
+				text: tag.text ?? tag.value,
 				...tag
 			};
 		}

--- a/panel/src/components/Sections/FieldsSection.vue
+++ b/panel/src/components/Sections/FieldsSection.vue
@@ -8,7 +8,6 @@
 		<k-box
 			v-if="issue"
 			:text="issue.message"
-			:html="false"
 			icon="alert"
 			theme="negative"
 		/>

--- a/panel/src/components/Sections/InfoSection.vue
+++ b/panel/src/components/Sections/InfoSection.vue
@@ -4,7 +4,7 @@
 		:class="['k-info-section', $attrs.class]"
 		:style="$attrs.style"
 	>
-		<k-box :html="true" :icon="icon" :text="text" :theme="theme" />
+		<k-box :icon="icon" :text="text" :theme="theme" />
 	</k-section>
 </template>
 

--- a/panel/src/components/Sections/Sections.vue
+++ b/panel/src/components/Sections/Sections.vue
@@ -1,10 +1,5 @@
 <template>
-	<k-box
-		v-if="tab.columns.length === 0 && empty"
-		:html="true"
-		:text="empty"
-		theme="info"
-	/>
+	<k-box v-if="tab.columns.length === 0 && empty" :text="empty" theme="info" />
 
 	<k-grid v-else class="k-sections" variant="columns">
 		<k-column

--- a/panel/src/components/Text/Text.test.ts
+++ b/panel/src/components/Text/Text.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "@test/unit";
 import { mount as vueMount } from "@vue/test-utils";
 import Text from "./Text.vue";
+import html from "@/panel/html";
 
 function mount(props = {}, attrs = {}) {
 	return vueMount(Text, { props, attrs }).find(".k-text");
@@ -36,6 +37,33 @@ describe("Text.vue", () => {
 		it("does not render slot when html is provided", () => {
 			const wrapper = vueMount(Text, {
 				props: { html: "<b>Hello</b>" },
+				slots: { default: "Slot content" }
+			});
+			expect(wrapper.text()).not.toContain("Slot content");
+		});
+
+		it("warns that the prop is deprecated", () => {
+			mount({ html: "<b>Hello</b>" });
+			expect(window.panel.deprecated).toHaveBeenCalledWith(
+				expect.stringContaining("`html` prop has been deprecated")
+			);
+		});
+	});
+
+	describe("text prop", () => {
+		it("escapes a plain string", () => {
+			const wrapper = mount({ text: "<b>Hello</b>" });
+			expect(wrapper.html()).toContain("&lt;b&gt;Hello&lt;/b&gt;");
+		});
+
+		it("renders trusted HTML as-is", () => {
+			const wrapper = mount({ text: html("<b>Hello</b>") });
+			expect(wrapper.html()).toContain("<b>Hello</b>");
+		});
+
+		it("does not render slot when text is provided", () => {
+			const wrapper = vueMount(Text, {
+				props: { text: "Hello" },
 				slots: { default: "Slot content" }
 			});
 			expect(wrapper.text()).not.toContain("Slot content");

--- a/panel/src/components/Text/Text.vue
+++ b/panel/src/components/Text/Text.vue
@@ -1,6 +1,5 @@
 <template>
-	<!-- eslint-disable-next-line vue/no-v-html -->
-	<div v-if="html" v-bind="attrs" v-html="html"></div>
+	<div v-if="content" v-safe-html="content" v-bind="attrs" />
 	<div v-else v-bind="attrs">
 		<!-- @slot Text content -->
 		<slot />
@@ -8,6 +7,8 @@
 </template>
 
 <script>
+import html from "@/panel/html";
+
 /**
  * A container for all multi-line text with additional formats.
  *
@@ -27,15 +28,21 @@ export default {
 		 */
 		align: String,
 		/**
-		 * HTML content to render instead
-		 * of the default slot
+		 * HTML content to render instead of the default slot
+		 * @deprecated 6.0.0 Use `text` instead
 		 */
 		html: String,
 		/**
 		 * Font size of the text
 		 * @values tiny, small, medium, large, huge
 		 */
-		size: String
+		size: String,
+		/**
+		 * Content to render instead of the default slot.
+		 * A plain string is escaped, trusted HTML is rendered as-is.
+		 * @since 6.0.0
+		 */
+		text: String
 	},
 	computed: {
 		attrs() {
@@ -44,6 +51,18 @@ export default {
 				"data-align": this.align,
 				"data-size": this.size
 			};
+		},
+		content() {
+			// the deprecated `html` prop was always rendered raw,
+			// so it stays trusted
+			return this.html !== undefined ? html(this.html) : this.text;
+		}
+	},
+	created() {
+		if (this.html !== undefined) {
+			window.panel.deprecated(
+				"`k-text`: the `html` prop has been deprecated. Use `text` instead."
+			);
 		}
 	}
 };

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -48,7 +48,7 @@
 			:content="content"
 			:empty="
 				$panel.config.debug
-					? $t('file.blueprint', { blueprint: $esc(blueprint) })
+					? $panel.html($t('file.blueprint', { blueprint: $esc(blueprint) }))
 					: null
 			"
 			:lock="lock"

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -41,7 +41,7 @@
 			:content="content"
 			:empty="
 				$panel.config.debug
-					? $t('page.blueprint', { blueprint: $esc(blueprint) })
+					? $panel.html($t('page.blueprint', { blueprint: $esc(blueprint) }))
 					: null
 			"
 			:lock="lock"

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -43,7 +43,7 @@
 		<k-sections
 			:blueprint="blueprint"
 			:content="content"
-			:empty="$panel.config.debug ? $t('site.blueprint') : null"
+			:empty="$panel.config.debug ? $panel.html($t('site.blueprint')) : null"
 			:lock="lock"
 			:tab="tab"
 			parent="site"

--- a/panel/src/components/Views/Preview/PreviewForm.vue
+++ b/panel/src/components/Views/Preview/PreviewForm.vue
@@ -26,7 +26,7 @@
 				:content="content"
 				:empty="
 					$panel.config.debug
-						? $t('page.blueprint', { blueprint: $esc(blueprint) })
+						? $panel.html($t('page.blueprint', { blueprint: $esc(blueprint) }))
 						: null
 				"
 				:lock="lock"

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -66,7 +66,7 @@
 			:content="content"
 			:empty="
 				$panel.config.debug
-					? $t('user.blueprint', { blueprint: $esc(blueprint) })
+					? $panel.html($t('user.blueprint', { blueprint: $esc(blueprint) }))
 					: null
 			"
 			:lock="lock"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -469,9 +469,11 @@
 				// if we don't have a result, use the fallback if given
 				$result ??= $fallback;
 
-				// callback on result if given
+				// callback on result if given, with the raw result
+				// on top, so that values that look the same once
+				// cast to a string can still be told apart
 				if ($callback !== null) {
-					$callback = $callback((string)$result, $query, $data);
+					$callback = $callback((string)$result, $query, $data, $result);
 
 					if ($result !== null || $callback !== '') {
 						// the empty string came just from string casting,

--- a/src/Cms/LicenseStatus.php
+++ b/src/Cms/LicenseStatus.php
@@ -103,12 +103,13 @@ enum LicenseStatus: string
 	/**
 	 * The info text is shown in the license dialog
 	 * in the status row. The core translations carry
-	 * authored markup, the date is formatted by us.
+	 * authored markup.
 	 */
 	public function info(string|null $end = null): HtmlString
 	{
-		return new HtmlString(
-			I18n::template('license.status.' . $this->value . '.info', ['date' => $end])
+		return HtmlString::translate(
+			'license.status.' . $this->value . '.info',
+			['date' => $end]
 		);
 	}
 

--- a/src/Cms/LicenseStatus.php
+++ b/src/Cms/LicenseStatus.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Toolkit\HtmlString;
 use Kirby\Toolkit\I18n;
 
 /**
@@ -101,11 +102,14 @@ enum LicenseStatus: string
 
 	/**
 	 * The info text is shown in the license dialog
-	 * in the status row.
+	 * in the status row. The core translations carry
+	 * authored markup, the date is formatted by us.
 	 */
-	public function info(string|null $end = null): string
+	public function info(string|null $end = null): HtmlString
 	{
-		return I18n::template('license.status.' . $this->value . '.info', ['date' => $end]);
+		return new HtmlString(
+			I18n::template('license.status.' . $this->value . '.info', ['date' => $end])
+		);
 	}
 
 	/**

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -20,6 +20,7 @@ use Kirby\Form\Fields;
 use Kirby\Form\Form;
 use Kirby\Panel\Model as PanelModel;
 use Kirby\Toolkit\BlockCollectionAccess;
+use Kirby\Toolkit\HtmlString;
 use Kirby\Toolkit\Str;
 use Kirby\Uuid\Identifiable;
 use Kirby\Uuid\Uuid;
@@ -579,6 +580,27 @@ abstract class ModelWithContent extends Model implements Identifiable
 			'content'      => $this->content()->toArray(),
 			'translations' => $this->translations()->toArray()
 		];
+	}
+
+	/**
+	 * String template builder with automatic HTML escaping,
+	 * marking the result as trusted HTML for the Panel.
+	 * Use this over `toSafeString()` whenever the result is
+	 * rendered as HTML rather than used as plain text.
+	 * @since 6.0.0
+	 *
+	 * @param $template Template string or `null` to use the model ID
+	 * @param $fallback Fallback for tokens in the template that cannot be replaced
+	 *                 (`null` to keep the original token)
+	 */
+	public function toSafeHtmlString(
+		string|null $template = null,
+		array $data = [],
+		string|null $fallback = ''
+	): HtmlString {
+		return new HtmlString(
+			$this->toSafeString($template, $data, $fallback)
+		);
 	}
 
 	/**

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -8,6 +8,7 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Form\Field\BaseField;
 use Kirby\Toolkit\BlockCollectionAccess;
 use Kirby\Toolkit\Component;
+use Kirby\Toolkit\HtmlString;
 use Kirby\Toolkit\I18n;
 
 /**
@@ -208,7 +209,7 @@ class Field extends Component
 					if ($this->help) {
 						$help = $this->model()->toSafeString($this->help);
 						$help = $this->kirby()->kirbytext($help);
-						return $help;
+						return new HtmlString($help);
 					}
 				},
 				'label' => function () {

--- a/src/Form/Field/ColorField.php
+++ b/src/Form/Field/ColorField.php
@@ -98,12 +98,13 @@ class ColorField extends OptionField
 
 		if (
 			is_numeric($options[0]['value']) ||
-			$options[0]['value'] === $options[0]['text']
+			$options[0]['value'] === (string)$options[0]['text']
 		) {
 			// simple array of values
-			// or value=text (from Options class)
+			// or value=text (from Options class).
+			// the text is trusted HTML, the value must stay a plain string
 			$options = A::map($options, fn ($option) => [
-				'value' => $option['text']
+				'value' => (string)$option['text']
 			]);
 
 		} else {

--- a/src/Form/Field/ToggleField.php
+++ b/src/Form/Field/ToggleField.php
@@ -5,6 +5,7 @@ namespace Kirby\Form\Field;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Form\Mixin;
 use Kirby\Toolkit\A;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Toggle Field
@@ -86,7 +87,7 @@ class ToggleField extends InputField
 		];
 	}
 
-	public function text(): array|string|null
+	public function text(): array|HtmlString|null
 	{
 		$text = $this->text;
 
@@ -94,11 +95,17 @@ class ToggleField extends InputField
 			return null;
 		}
 
-		if (is_string($text) === true || A::isAssociative($text) === true) {
-			return $this->stringTemplateI18n($text);
+		if (
+			is_string($text) === true ||
+			A::isAssociative($text) === true
+		) {
+			return new HtmlString($this->stringTemplateI18n($text));
 		}
 
-		return A::map($text, fn ($value) => $this->stringTemplateI18n($value));
+		return A::map(
+			$text,
+			fn ($value) => new HtmlString($this->stringTemplateI18n($value))
+		);
 	}
 
 	public function toFormValue(): bool

--- a/src/Form/Mixin/Help.php
+++ b/src/Form/Mixin/Help.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Form\Mixin;
 
+use Kirby\Toolkit\HtmlString;
+
 /**
  * Provides the `help` prop for optional help text below the field
  *
@@ -15,12 +17,12 @@ trait Help
 	 */
 	protected array|string|null $help;
 
-	public function help(): string|null
+	public function help(): HtmlString|null
 	{
 		if ($this->help !== null && $this->help !== [] && $this->help !== '') {
 			$help = $this->stringTemplateI18n($this->help);
 			$help = $this->kirby()->kirbytext($help);
-			return $help;
+			return new HtmlString($help);
 		}
 
 		return null;

--- a/src/Form/Mixin/Text.php
+++ b/src/Form/Mixin/Text.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Form\Mixin;
 
+use Kirby\Toolkit\HtmlString;
+
 /**
  * Provides the `text` prop for displayable text content
  *
@@ -15,12 +17,12 @@ trait Text
 	 */
 	protected array|string|null $text;
 
-	public function text(): string|null
+	public function text(): HtmlString|null
 	{
 		if ($this->text !== null && $this->text !== [] && $this->text !== '') {
 			$text = $this->stringTemplateI18n($this->text);
 			$text = $this->kirby()->kirbytext($text);
-			return $text;
+			return new HtmlString($text);
 		}
 
 		return null;

--- a/src/Option/Option.php
+++ b/src/Option/Option.php
@@ -43,8 +43,9 @@ class Option
 			$props = ['value' => $props];
 		}
 
-		// Normalize info to be an array
-		// (trusted HTML is already resolved and passes through)
+		// Normalize info to be an array, unless it is trusted HTML:
+		// that is already resolved and `I18n::translate()` would
+		// cast it back to an untrusted string
 		if (isset($props['info']) === true) {
 			$props['info'] = match (true) {
 				is_array($props['info']),
@@ -55,8 +56,9 @@ class Option
 			};
 		}
 
-		// Normalize text to be an array
-		// (trusted HTML is already resolved and passes through)
+		// Normalize text to be an array, unless it is trusted HTML:
+		// that is already resolved and `I18n::translate()` would
+		// cast it back to an untrusted string
 		if (isset($props['text']) === true) {
 			$props['text'] = match (true) {
 				is_array($props['text']),

--- a/src/Option/Option.php
+++ b/src/Option/Option.php
@@ -4,6 +4,7 @@ namespace Kirby\Option;
 
 use Kirby\Cms\ModelWithContent;
 use Kirby\Toolkit\HasI18n;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Option for select fields, radio fields, etc.
@@ -15,7 +16,7 @@ class Option
 {
 	use HasI18n;
 
-	public string|array $text;
+	public HtmlString|string|array $text;
 
 	/**
 	 * @param bool $resolve Deprecated, will be removed in v6
@@ -24,8 +25,8 @@ class Option
 		public string|int|float|null $value,
 		public bool $disabled = false,
 		public string|null $icon = null,
-		public string|array|null $info = null,
-		string|array|null $text = null,
+		public HtmlString|string|array|null $info = null,
+		HtmlString|string|array|null $text = null,
 		public bool $resolve = true
 	) {
 		$this->text = $text ?? ['en' => $this->value];
@@ -43,9 +44,11 @@ class Option
 		}
 
 		// Normalize info to be an array
+		// (trusted HTML is already resolved and passes through)
 		if (isset($props['info']) === true) {
 			$props['info'] = match (true) {
-				is_array($props['info']) => $props['info'],
+				is_array($props['info']),
+				$props['info'] instanceof HtmlString => $props['info'],
 				$props['info'] === null,
 				$props['info'] === false => null,
 				default                  => ['en' => $props['info']]
@@ -53,9 +56,11 @@ class Option
 		}
 
 		// Normalize text to be an array
+		// (trusted HTML is already resolved and passes through)
 		if (isset($props['text']) === true) {
 			$props['text'] = match (true) {
-				is_array($props['text']) => $props['text'],
+				is_array($props['text']),
+				$props['text'] instanceof HtmlString => $props['text'],
 				$props['text'] === null,
 				$props['text'] === false => null,
 				default                  => ['en' => $props['text']]
@@ -79,7 +84,7 @@ class Option
 	): array {
 		$info = $this->i18n($this->info);
 		$text = $this->i18n($this->text);
-		$method = $safeMode === true ? 'toSafeString' : 'toString';
+		$method = $safeMode === true ? 'toSafeHtmlString' : 'toString';
 
 		return [
 			'disabled' => $this->disabled,

--- a/src/Option/OptionsApi.php
+++ b/src/Option/OptionsApi.php
@@ -133,7 +133,7 @@ class OptionsApi extends OptionsProvider
 				$item = new Field(null, $key, $item);
 			}
 
-			$safeMethod = $safeMode === true ? 'toSafeString' : 'toString';
+			$safeMethod = $safeMode === true ? 'toSafeHtmlString' : 'toString';
 
 			$options[] = [
 				// value is always a raw string

--- a/src/Option/OptionsQuery.php
+++ b/src/Option/OptionsQuery.php
@@ -187,7 +187,7 @@ class OptionsQuery extends OptionsProvider
 
 			// text is only a raw string when using {< >}
 			// or when the safe mode is explicitly disabled (select field)
-			$safeMethod = $safeMode === true ? 'toSafeString' : 'toString';
+			$safeMethod = $safeMode === true ? 'toSafeHtmlString' : 'toString';
 			$text = $model->$safeMethod($this->text ?? $text, $data);
 
 			// additional data

--- a/src/Panel/Controller/Dialog/FileDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/FileDeleteDialogController.php
@@ -5,6 +5,7 @@ namespace Kirby\Panel\Controller\Dialog;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
 use Kirby\Toolkit\Escape;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Controls the Panel dialog for deleting a file
@@ -20,9 +21,11 @@ class FileDeleteDialogController extends FileDialogController
 	public function load(): Dialog
 	{
 		return new RemoveDialog(
-			text: $this->i18n('file.delete.confirm', [
-				'filename' => Escape::html($this->file->filename())
-			])
+			text: new HtmlString(
+				$this->i18n('file.delete.confirm', [
+					'filename' => Escape::html($this->file->filename())
+				])
+			)
 		);
 	}
 

--- a/src/Panel/Controller/Dialog/FileDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/FileDeleteDialogController.php
@@ -4,8 +4,6 @@ namespace Kirby\Panel\Controller\Dialog;
 
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
-use Kirby\Toolkit\Escape;
-use Kirby\Toolkit\HtmlString;
 
 /**
  * Controls the Panel dialog for deleting a file
@@ -21,11 +19,9 @@ class FileDeleteDialogController extends FileDialogController
 	public function load(): Dialog
 	{
 		return new RemoveDialog(
-			text: new HtmlString(
-				$this->i18n('file.delete.confirm', [
-					'filename' => Escape::html($this->file->filename())
-				])
-			)
+			text: $this->i18nHtml('file.delete.confirm', [
+				'filename' => $this->file->filename()
+			])
 		);
 	}
 

--- a/src/Panel/Controller/Dialog/LanguageDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/LanguageDeleteDialogController.php
@@ -8,6 +8,7 @@ use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
 use Kirby\Toolkit\Escape;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Dialog controller for deleting a language
@@ -33,9 +34,11 @@ class LanguageDeleteDialogController extends DialogController
 	public function load(): Dialog
 	{
 		return new RemoveDialog(
-			text: $this->i18n('language.delete.confirm', [
-				'name' => Escape::html($this->language->name())
-			])
+			text: new HtmlString(
+				$this->i18n('language.delete.confirm', [
+					'name' => Escape::html($this->language->name())
+				])
+			)
 		);
 	}
 

--- a/src/Panel/Controller/Dialog/LanguageDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/LanguageDeleteDialogController.php
@@ -7,8 +7,6 @@ use Kirby\Cms\Language;
 use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
-use Kirby\Toolkit\Escape;
-use Kirby\Toolkit\HtmlString;
 
 /**
  * Dialog controller for deleting a language
@@ -34,11 +32,9 @@ class LanguageDeleteDialogController extends DialogController
 	public function load(): Dialog
 	{
 		return new RemoveDialog(
-			text: new HtmlString(
-				$this->i18n('language.delete.confirm', [
-					'name' => Escape::html($this->language->name())
-				])
-			)
+			text: $this->i18nHtml('language.delete.confirm', [
+				'name' => $this->language->name()
+			])
 		);
 	}
 

--- a/src/Panel/Controller/Dialog/LanguageVariableDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/LanguageVariableDeleteDialogController.php
@@ -9,6 +9,7 @@ use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
 use Kirby\Toolkit\Escape;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Dialog controller for deleting a language variable
@@ -40,9 +41,11 @@ class LanguageVariableDeleteDialogController extends DialogController
 	public function load(): Dialog
 	{
 		return new RemoveDialog(
-			text: $this->i18n('language.variable.delete.confirm', [
-				'key' => Escape::html($this->variable->key())
-			])
+			text: new HtmlString(
+				$this->i18n('language.variable.delete.confirm', [
+					'key' => Escape::html($this->variable->key())
+				])
+			)
 		);
 	}
 

--- a/src/Panel/Controller/Dialog/LanguageVariableDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/LanguageVariableDeleteDialogController.php
@@ -8,8 +8,6 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
-use Kirby\Toolkit\Escape;
-use Kirby\Toolkit\HtmlString;
 
 /**
  * Dialog controller for deleting a language variable
@@ -41,11 +39,9 @@ class LanguageVariableDeleteDialogController extends DialogController
 	public function load(): Dialog
 	{
 		return new RemoveDialog(
-			text: new HtmlString(
-				$this->i18n('language.variable.delete.confirm', [
-					'key' => Escape::html($this->variable->key())
-				])
-			)
+			text: $this->i18nHtml('language.variable.delete.confirm', [
+				'key' => $this->variable->key()
+			])
 		);
 	}
 

--- a/src/Panel/Controller/Dialog/LanguageVariableFormDialogController.php
+++ b/src/Panel/Controller/Dialog/LanguageVariableFormDialogController.php
@@ -9,6 +9,7 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Dialog controller for creating a new language variable
@@ -73,7 +74,9 @@ class LanguageVariableFormDialogController extends DialogController
 			'entries' => [
 				'field'     => ['type' => 'text'],
 				'label'     => $this->i18n('language.variable.entries'),
-				'help'      => $this->i18n('language.variable.entries.help'),
+				'help'      => new HtmlString(
+					$this->i18n('language.variable.entries.help')
+				),
 				'type'      => 'entries',
 				'min'       => 1,
 				'when'      => ['multiple' => true],

--- a/src/Panel/Controller/Dialog/LanguageVariableFormDialogController.php
+++ b/src/Panel/Controller/Dialog/LanguageVariableFormDialogController.php
@@ -9,7 +9,6 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\HtmlString;
 
 /**
  * Dialog controller for creating a new language variable
@@ -74,9 +73,7 @@ class LanguageVariableFormDialogController extends DialogController
 			'entries' => [
 				'field'     => ['type' => 'text'],
 				'label'     => $this->i18n('language.variable.entries'),
-				'help'      => new HtmlString(
-					$this->i18n('language.variable.entries.help')
-				),
+				'help'      => $this->i18nHtml('language.variable.entries.help'),
 				'type'      => 'entries',
 				'min'       => 1,
 				'when'      => ['multiple' => true],

--- a/src/Panel/Controller/Dialog/PageDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/PageDeleteDialogController.php
@@ -6,8 +6,6 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
-use Kirby\Toolkit\Escape;
-use Kirby\Toolkit\HtmlString;
 
 /**
  * Controls the Panel dialog for deleting a page
@@ -22,11 +20,9 @@ class PageDeleteDialogController extends PageDialogController
 {
 	public function load(): Dialog
 	{
-		$text = new HtmlString(
-			$this->i18n('page.delete.confirm', [
-				'title' => Escape::html($this->page->title()->value())
-			])
-		);
+		$text = $this->i18nHtml('page.delete.confirm', [
+			'title' => $this->page->title()->value()
+		]);
 
 		if ($this->page->childrenAndDrafts()->count() === 0) {
 			return new RemoveDialog(text: $text);
@@ -37,9 +33,7 @@ class PageDeleteDialogController extends PageDialogController
 				'info' => [
 					'type'  => 'info',
 					'theme' => 'negative',
-					'text'  => new HtmlString(
-						$this->i18n('page.delete.confirm.subpages')
-					)
+					'text'  => $this->i18nHtml('page.delete.confirm.subpages')
 				],
 				'check' => [
 					'label'   => $this->i18n('page.delete.confirm.title'),

--- a/src/Panel/Controller/Dialog/PageDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/PageDeleteDialogController.php
@@ -37,7 +37,9 @@ class PageDeleteDialogController extends PageDialogController
 				'info' => [
 					'type'  => 'info',
 					'theme' => 'negative',
-					'text'  => $this->i18n('page.delete.confirm.subpages')
+					'text'  => new HtmlString(
+						$this->i18n('page.delete.confirm.subpages')
+					)
 				],
 				'check' => [
 					'label'   => $this->i18n('page.delete.confirm.title'),

--- a/src/Panel/Controller/Dialog/PageDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/PageDeleteDialogController.php
@@ -7,6 +7,7 @@ use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
 use Kirby\Toolkit\Escape;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Controls the Panel dialog for deleting a page
@@ -21,9 +22,11 @@ class PageDeleteDialogController extends PageDialogController
 {
 	public function load(): Dialog
 	{
-		$text = $this->i18n('page.delete.confirm', [
-			'title' => Escape::html($this->page->title()->value())
-		]);
+		$text = new HtmlString(
+			$this->i18n('page.delete.confirm', [
+				'title' => Escape::html($this->page->title()->value())
+			])
+		);
 
 		if ($this->page->childrenAndDrafts()->count() === 0) {
 			return new RemoveDialog(text: $text);

--- a/src/Panel/Controller/Dialog/SystemLicenseActivateDialogController.php
+++ b/src/Panel/Controller/Dialog/SystemLicenseActivateDialogController.php
@@ -7,7 +7,6 @@ use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
-use Kirby\Toolkit\Escape;
 use Kirby\Toolkit\HtmlString;
 
 /**
@@ -32,11 +31,9 @@ class SystemLicenseActivateDialogController extends DialogController
 				'theme' => 'white',
 				'type'  => 'info',
 				'icon'  => 'info',
-				'text'  => new HtmlString(
-					$this->i18n('license.activate.domain', [
-						'host' => Escape::html($system->indexUrl())
-					])
-				),
+				'text'  => $this->i18nHtml('license.activate.domain', [
+					'host' => $system->indexUrl()
+				]),
 			],
 			'type' => [
 				'label'    =>  $this->i18n('license.activate.label'),
@@ -60,11 +57,9 @@ class SystemLicenseActivateDialogController extends DialogController
 			'warning' => [
 				'type'  => 'info',
 				'theme' => 'warning',
-				'text'  => new HtmlString(
-					$this->i18n('license.activate.' . ($local ? 'local' : 'public'), [
-						'host' => Escape::html($system->indexUrl())
-					])
-				),
+				'text'  => $this->i18nHtml('license.activate.' . ($local ? 'local' : 'public'), [
+					'host' => $system->indexUrl()
+				]),
 				'when'  => ['type' => $local ? 'regular' : 'free'],
 			],
 			'acknowledge' => [
@@ -73,11 +68,9 @@ class SystemLicenseActivateDialogController extends DialogController
 				'type'     => 'toggle',
 				'text'     =>  $this->i18n('license.activate.acknowledge.text'),
 				'required' => true,
-				'help'     => new HtmlString(
-					$this->i18n('license.activate.acknowledge.help', [
-						'url' => 'https://getkirby.com/license/free-licenses'
-					])
-				),
+				'help'     => $this->i18nHtml('license.activate.acknowledge.help', [
+					'url' => 'https://getkirby.com/license/free-licenses'
+				]),
 			],
 			'license' => [
 				'when'        => ['type' => 'regular'],

--- a/src/Panel/Controller/Dialog/SystemLicenseActivateDialogController.php
+++ b/src/Panel/Controller/Dialog/SystemLicenseActivateDialogController.php
@@ -7,6 +7,7 @@ use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Dialog to activate/register the site with a license
@@ -67,9 +68,11 @@ class SystemLicenseActivateDialogController extends DialogController
 				'type'     => 'toggle',
 				'text'     =>  $this->i18n('license.activate.acknowledge.text'),
 				'required' => true,
-				'help'     => $this->i18n('license.activate.acknowledge.help', [
-					'url' => 'https://getkirby.com/license/free-licenses'
-				]),
+				'help'     => new HtmlString(
+					$this->i18n('license.activate.acknowledge.help', [
+						'url' => 'https://getkirby.com/license/free-licenses'
+					])
+				),
 			],
 			'license' => [
 				'when'        => ['type' => 'regular'],
@@ -78,7 +81,8 @@ class SystemLicenseActivateDialogController extends DialogController
 				'required'    => true,
 				'counter'     => false,
 				'placeholder' => 'K-',
-				'help'        => $this->i18n('license.code.help') . ' ' . '<a href="https://getkirby.com/buy" target="_blank">' . $this->i18n('license.buy') . ' &rarr;</a>'
+				// the link is appended by us, the translation is plain
+				'help'        => new HtmlString($this->i18n('license.code.help') . ' ' . '<a href="https://getkirby.com/buy" target="_blank">' . $this->i18n('license.buy') . ' &rarr;</a>')
 			],
 			'email' => Field::email([
 				'when'     => ['type' => 'regular'],

--- a/src/Panel/Controller/Dialog/SystemLicenseActivateDialogController.php
+++ b/src/Panel/Controller/Dialog/SystemLicenseActivateDialogController.php
@@ -7,6 +7,7 @@ use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
+use Kirby\Toolkit\Escape;
 use Kirby\Toolkit\HtmlString;
 
 /**
@@ -31,9 +32,11 @@ class SystemLicenseActivateDialogController extends DialogController
 				'theme' => 'white',
 				'type'  => 'info',
 				'icon'  => 'info',
-				'text'  => $this->i18n('license.activate.domain', [
-					'host' => $system->indexUrl()
-				]),
+				'text'  => new HtmlString(
+					$this->i18n('license.activate.domain', [
+						'host' => Escape::html($system->indexUrl())
+					])
+				),
 			],
 			'type' => [
 				'label'    =>  $this->i18n('license.activate.label'),
@@ -57,9 +60,11 @@ class SystemLicenseActivateDialogController extends DialogController
 			'warning' => [
 				'type'  => 'info',
 				'theme' => 'warning',
-				'text'  =>  $this->i18n('license.activate.' . ($local ? 'local' : 'public'), [
-					'host' => $system->indexUrl()
-				]),
+				'text'  => new HtmlString(
+					$this->i18n('license.activate.' . ($local ? 'local' : 'public'), [
+						'host' => Escape::html($system->indexUrl())
+					])
+				),
 				'when'  => ['type' => $local ? 'regular' : 'free'],
 			],
 			'acknowledge' => [

--- a/src/Panel/Controller/Dialog/SystemLicenseRemoveDialogController.php
+++ b/src/Panel/Controller/Dialog/SystemLicenseRemoveDialogController.php
@@ -5,6 +5,7 @@ namespace Kirby\Panel\Controller\Dialog;
 use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Dialog to remove the site's license
@@ -20,7 +21,7 @@ class SystemLicenseRemoveDialogController extends DialogController
 	public function load(): Dialog
 	{
 		return new RemoveDialog(
-			text: $this->i18n('license.remove.text'),
+			text: new HtmlString($this->i18n('license.remove.text')),
 			size: 'medium',
 			submitButton: [
 				'icon'  => 'trash',

--- a/src/Panel/Controller/Dialog/SystemLicenseRemoveDialogController.php
+++ b/src/Panel/Controller/Dialog/SystemLicenseRemoveDialogController.php
@@ -5,7 +5,6 @@ namespace Kirby\Panel\Controller\Dialog;
 use Kirby\Panel\Controller\DialogController;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
-use Kirby\Toolkit\HtmlString;
 
 /**
  * Dialog to remove the site's license
@@ -21,7 +20,7 @@ class SystemLicenseRemoveDialogController extends DialogController
 	public function load(): Dialog
 	{
 		return new RemoveDialog(
-			text: new HtmlString($this->i18n('license.remove.text')),
+			text: $this->i18nHtml('license.remove.text'),
 			size: 'medium',
 			submitButton: [
 				'icon'  => 'trash',

--- a/src/Panel/Controller/Dialog/UserChangePasswordDialogController.php
+++ b/src/Panel/Controller/Dialog/UserChangePasswordDialogController.php
@@ -7,6 +7,8 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Panel\Field;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\FormDialog;
+use Kirby\Toolkit\Escape;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Controls the Panel dialog for changing the password of a user
@@ -47,7 +49,9 @@ class UserChangePasswordDialogController extends UserDialogController
 			'password' => Field::password([
 				'label'        => $this->i18n('user.changePassword.new'),
 				'autocomplete' => 'new-password',
-				'help'         => $this->i18n('account') . ': ' . $this->user->email() . ($hint ? '<br>' . $hint : ''),
+				'help'         => new HtmlString(
+					$this->i18n('account') . ': ' . Escape::html($this->user->email()) . ($hint ? '<br>' . $hint : '')
+				),
 				'minlength'    => $policy->minlength()
 			]),
 			'passwordConfirmation' => Field::password([

--- a/src/Panel/Controller/Dialog/UserDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/UserDeleteDialogController.php
@@ -4,8 +4,6 @@ namespace Kirby\Panel\Controller\Dialog;
 
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
-use Kirby\Toolkit\Escape;
-use Kirby\Toolkit\HtmlString;
 
 /**
  * Controls the Panel dialog for deleting a user
@@ -23,11 +21,9 @@ class UserDeleteDialogController extends UserDialogController
 		$i18nPrefix = $this->user->isLoggedIn() ? 'account' : 'user';
 
 		return new RemoveDialog(
-			text: new HtmlString(
-				$this->i18n($i18nPrefix . '.delete.confirm', [
-					'email' => Escape::html($this->user->email())
-				])
-			)
+			text: $this->i18nHtml($i18nPrefix . '.delete.confirm', [
+				'email' => $this->user->email()
+			])
 		);
 	}
 

--- a/src/Panel/Controller/Dialog/UserDeleteDialogController.php
+++ b/src/Panel/Controller/Dialog/UserDeleteDialogController.php
@@ -5,6 +5,7 @@ namespace Kirby\Panel\Controller\Dialog;
 use Kirby\Panel\Ui\Dialog;
 use Kirby\Panel\Ui\Dialog\RemoveDialog;
 use Kirby\Toolkit\Escape;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Controls the Panel dialog for deleting a user
@@ -22,9 +23,11 @@ class UserDeleteDialogController extends UserDialogController
 		$i18nPrefix = $this->user->isLoggedIn() ? 'account' : 'user';
 
 		return new RemoveDialog(
-			text: $this->i18n($i18nPrefix . '.delete.confirm', [
-				'email' => Escape::html($this->user->email())
-			])
+			text: new HtmlString(
+				$this->i18n($i18nPrefix . '.delete.confirm', [
+					'email' => Escape::html($this->user->email())
+				])
+			)
 		);
 	}
 

--- a/src/Panel/Controller/View/SystemViewController.php
+++ b/src/Panel/Controller/View/SystemViewController.php
@@ -12,6 +12,7 @@ use Kirby\Panel\Ui\Stat;
 use Kirby\Panel\Ui\Stats;
 use Kirby\Panel\Ui\View;
 use Kirby\Plugin\Plugin;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Controls the system view
@@ -123,7 +124,10 @@ class SystemViewController extends ViewController
 					// @codeCoverageIgnoreStart
 					$security[] = [
 						'id'   => 'extension-' . $extension,
-						'text' => $this->i18n('installation.issues.extension', ['extension' => $extension])
+						// the translation contains authored markup
+						'text' => new HtmlString(
+							$this->i18n('installation.issues.extension', ['extension' => $extension])
+						)
 					];
 					// @codeCoverageIgnoreEnd
 				}

--- a/src/Panel/Controller/View/SystemViewController.php
+++ b/src/Panel/Controller/View/SystemViewController.php
@@ -124,7 +124,6 @@ class SystemViewController extends ViewController
 					// @codeCoverageIgnoreStart
 					$security[] = [
 						'id'   => 'extension-' . $extension,
-						// the translation contains authored markup
 						'text' => new HtmlString(
 							$this->i18n('installation.issues.extension', ['extension' => $extension])
 						)

--- a/src/Panel/Controller/View/SystemViewController.php
+++ b/src/Panel/Controller/View/SystemViewController.php
@@ -12,7 +12,6 @@ use Kirby\Panel\Ui\Stat;
 use Kirby\Panel\Ui\Stats;
 use Kirby\Panel\Ui\View;
 use Kirby\Plugin\Plugin;
-use Kirby\Toolkit\HtmlString;
 
 /**
  * Controls the system view
@@ -124,9 +123,9 @@ class SystemViewController extends ViewController
 					// @codeCoverageIgnoreStart
 					$security[] = [
 						'id'   => 'extension-' . $extension,
-						'text' => new HtmlString(
-							$this->i18n('installation.issues.extension', ['extension' => $extension])
-						)
+						'text' => $this->i18nHtml('installation.issues.extension', [
+							'extension' => $extension
+						])
 					];
 					// @codeCoverageIgnoreEnd
 				}

--- a/src/Panel/Lab/Doc.php
+++ b/src/Panel/Lab/Doc.php
@@ -9,6 +9,7 @@ use Kirby\Panel\Lab\Doc\Method;
 use Kirby\Panel\Lab\Doc\Prop;
 use Kirby\Panel\Lab\Doc\Slot;
 use Kirby\Toolkit\A;
+use Kirby\Toolkit\HtmlString;
 use Kirby\Toolkit\Str;
 use Throwable;
 
@@ -29,9 +30,9 @@ class Doc
 	public function __construct(
 		public string $name,
 		public string $source,
-		public string|null $description = null,
-		public string|null $deprecated = null,
-		public string|null $docBlock = null,
+		public string|HtmlString|null $description = null,
+		public string|HtmlString|null $deprecated = null,
+		public string|HtmlString|null $docBlock = null,
 		public array $events = [],
 		public array $examples = [],
 		public bool $isUnstable = false,
@@ -126,14 +127,14 @@ class Doc
 	/**
 	 * Helper to resolve KirbyText
 	 */
-	public static function kt(string $text, bool $inline = false): string
+	public static function kt(string $text, bool $inline = false): HtmlString
 	{
-		return App::instance()->kirbytext($text, [
+		return new HtmlString(App::instance()->kirbytext($text, [
 			'markdown' => [
 				'breaks' => false,
 				'inline' => $inline,
 			]
-		]);
+		]));
 	}
 
 	/**

--- a/src/Panel/Lab/Doc/Argument.php
+++ b/src/Panel/Lab/Doc/Argument.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel\Lab\Doc;
 
 use Kirby\Panel\Lab\Doc;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Documentation for a single argument for an event, slot or method
@@ -19,7 +20,7 @@ class Argument
 	public function __construct(
 		public string $name,
 		public string|null $type = null,
-		public string|null $description = null,
+		public string|HtmlString|null $description = null,
 	) {
 		$this->description = Doc::kt($this->description ?? '', true);
 	}

--- a/src/Panel/Lab/Doc/Event.php
+++ b/src/Panel/Lab/Doc/Event.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel\Lab\Doc;
 
 use Kirby\Panel\Lab\Doc;
 use Kirby\Toolkit\A;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Documentation for a single Vue emittable event
@@ -19,8 +20,8 @@ class Event
 {
 	public function __construct(
 		public string $name,
-		public string|null $description = null,
-		public string|null $deprecated = null,
+		public string|HtmlString|null $description = null,
+		public string|HtmlString|null $deprecated = null,
 		public string|null $since = null,
 		public array $properties = [],
 	) {

--- a/src/Panel/Lab/Doc/Method.php
+++ b/src/Panel/Lab/Doc/Method.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel\Lab\Doc;
 
 use Kirby\Panel\Lab\Doc;
 use Kirby\Toolkit\A;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Documentation for a single Vue component method
@@ -19,8 +20,8 @@ class Method
 {
 	public function __construct(
 		public string $name,
-		public string|null $description = null,
-		public string|null $deprecated = null,
+		public string|HtmlString|null $description = null,
+		public string|HtmlString|null $deprecated = null,
 		public string|null $since = null,
 		public string|null $returns = null,
 		public array $params = [],

--- a/src/Panel/Lab/Doc/Prop.php
+++ b/src/Panel/Lab/Doc/Prop.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel\Lab\Doc;
 
 use Kirby\Panel\Lab\Doc;
 use Kirby\Toolkit\A;
+use Kirby\Toolkit\HtmlString;
 use Kirby\Toolkit\Str;
 
 /**
@@ -21,9 +22,9 @@ class Prop
 	public function __construct(
 		public string $name,
 		public string|null $type = null,
-		public string|null $description = null,
+		public string|HtmlString|null $description = null,
 		public string|null $default = null,
-		public string|null $deprecated = null,
+		public string|HtmlString|null $deprecated = null,
 		public string|null $example = null,
 		public bool $required = false,
 		public string|null $since = null,

--- a/src/Panel/Lab/Doc/Slot.php
+++ b/src/Panel/Lab/Doc/Slot.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel\Lab\Doc;
 
 use Kirby\Panel\Lab\Doc;
 use Kirby\Toolkit\A;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Documentation for a single Vue slot
@@ -19,8 +20,8 @@ class Slot
 {
 	public function __construct(
 		public string $name,
-		public string|null $description = null,
-		public string|null $deprecated = null,
+		public string|HtmlString|null $description = null,
+		public string|HtmlString|null $deprecated = null,
 		public string|null $since = null,
 		public array $bindings = [],
 	) {

--- a/src/Panel/Ui/Dialog/FormDialog.php
+++ b/src/Panel/Ui/Dialog/FormDialog.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel\Ui\Dialog;
 
 use Kirby\Panel\Ui\Dialog;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Dialog that contains a set of fields
@@ -21,7 +22,7 @@ class FormDialog extends TextDialog
 		public array $fields = [],
 		string|null $size = 'medium',
 		string|array|bool|null $submitButton = null,
-		string|null $text = null,
+		string|HtmlString|null $text = null,
 		public array $value = [],
 		...$attrs
 	) {

--- a/src/Panel/Ui/Dialog/RemoveDialog.php
+++ b/src/Panel/Ui/Dialog/RemoveDialog.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Panel\Ui\Dialog;
 
+use Kirby\Toolkit\HtmlString;
+
 /**
  * Dialog that removes something
  *
@@ -18,7 +20,7 @@ class RemoveDialog extends TextDialog
 		string|array|bool|null $cancelButton = null,
 		string|null $size = 'medium',
 		string|array|bool|null $submitButton = null,
-		string|null $text = null,
+		string|HtmlString|null $text = null,
 		...$attrs
 	) {
 		parent::__construct(...[

--- a/src/Panel/Ui/Dialog/TextDialog.php
+++ b/src/Panel/Ui/Dialog/TextDialog.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel\Ui\Dialog;
 
 use Kirby\Panel\Ui\Dialog;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Dialog that displays some text
@@ -20,7 +21,7 @@ class TextDialog extends Dialog
 		string|array|bool|null $cancelButton = null,
 		string|null $size = 'medium',
 		string|array|bool|null $submitButton = null,
-		public string|null $text = null,
+		public string|HtmlString|null $text = null,
 		...$attrs
 	) {
 		parent::__construct(...[

--- a/src/Panel/Ui/Drawer/TextDrawer.php
+++ b/src/Panel/Ui/Drawer/TextDrawer.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel\Ui\Drawer;
 
 use Kirby\Panel\Ui\Drawer;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * Drawer that displays some text
@@ -23,7 +24,7 @@ class TextDrawer extends Drawer
 		array|null $options = null,
 		string|null $style = null,
 		string|null $title = null,
-		public string|null $text = null,
+		public string|HtmlString|null $text = null,
 		...$attrs
 	) {
 		parent::__construct(...[

--- a/src/Panel/Ui/Item.php
+++ b/src/Panel/Ui/Item.php
@@ -2,6 +2,8 @@
 
 namespace Kirby\Panel\Ui;
 
+use Kirby\Toolkit\HtmlString;
+
 /**
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
@@ -12,9 +14,9 @@ class Item extends Component
 	protected string $layout;
 
 	public function __construct(
-		public string $text,
+		public string|HtmlString $text,
 		public string|array|false|null $image = [],
-		public string|null $info = null,
+		public string|HtmlString|null $info = null,
 		string|null $layout = null,
 	) {
 		parent::__construct(component: 'k-item');
@@ -22,7 +24,7 @@ class Item extends Component
 		$this->layout = $layout ?? 'list';
 	}
 
-	protected function info(): string|null
+	protected function info(): string|HtmlString|null
 	{
 		return $this->info;
 	}
@@ -42,7 +44,7 @@ class Item extends Component
 		];
 	}
 
-	protected function text(): string
+	protected function text(): string|HtmlString
 	{
 		return $this->text;
 	}

--- a/src/Panel/Ui/Item/LanguageItem.php
+++ b/src/Panel/Ui/Item/LanguageItem.php
@@ -4,7 +4,6 @@ namespace Kirby\Panel\Ui\Item;
 
 use Kirby\Cms\Language;
 use Kirby\Panel\Ui\Item;
-use Kirby\Toolkit\Escape;
 
 /**
  * @copyright Bastian Allgeier
@@ -17,8 +16,8 @@ class LanguageItem extends Item
 		protected Language $language
 	) {
 		parent::__construct(
-			info: Escape::html($language->code()),
-			text: Escape::html($language->name()),
+			info: $language->code(),
+			text: $language->name(),
 			image: [
 				'back'  => 'black',
 				'color' => 'gray',

--- a/src/Panel/Ui/Item/ModelItem.php
+++ b/src/Panel/Ui/Item/ModelItem.php
@@ -5,6 +5,7 @@ namespace Kirby\Panel\Ui\Item;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Panel\Model as Panel;
 use Kirby\Panel\Ui\Item;
+use Kirby\Toolkit\HtmlString;
 
 /**
  * @copyright Bastian Allgeier
@@ -44,9 +45,9 @@ class ModelItem extends Item
 		$this->panel = $model->panel();
 	}
 
-	protected function info(): string|null
+	protected function info(): HtmlString|null
 	{
-		return $this->model->toSafeString($this->info ?? false);
+		return $this->model->toSafeHtmlString($this->info ?? false);
 	}
 
 	protected function image(): array|null
@@ -75,8 +76,8 @@ class ModelItem extends Item
 		];
 	}
 
-	protected function text(): string
+	protected function text(): HtmlString
 	{
-		return $this->model->toSafeString($this->text);
+		return $this->model->toSafeHtmlString($this->text);
 	}
 }

--- a/src/Toolkit/HasI18n.php
+++ b/src/Toolkit/HasI18n.php
@@ -38,4 +38,29 @@ trait HasI18n
 
 		return I18n::template($key, $key, $data);
 	}
+
+	/**
+	 * Translates a key or template string and marks the result as
+	 * trusted HTML, escaping every filled-in placeholder.
+	 *
+	 * @since 6.0.0
+	 */
+	protected static function i18nHtml(
+		Closure|string|array|HtmlString|null $key,
+		array $data = []
+	): HtmlString|null {
+		if ($key instanceof Closure) {
+			$key = $key();
+		}
+
+		if ($key === null) {
+			return null;
+		}
+
+		if ($key instanceof HtmlString) {
+			return $key;
+		}
+
+		return HtmlString::translate($key, $data);
+	}
 }

--- a/src/Toolkit/HasI18n.php
+++ b/src/Toolkit/HasI18n.php
@@ -14,18 +14,22 @@ trait HasI18n
 {
 	/**
 	 * Translates a key or template string
-	 * @return ($key is string|array ? string : string|null)
+	 * @return ($key is string|array ? string : string|HtmlString|null)
 	 */
 	protected static function i18n(
-		Closure|string|array|null $key,
+		Closure|string|array|HtmlString|null $key,
 		array|null $data = null
-	): string|null {
+	): string|HtmlString|null {
 		if ($key instanceof Closure) {
 			$key = $key();
 		}
 
 		if ($key === null) {
 			return null;
+		}
+
+		if ($key instanceof HtmlString) {
+			return $key;
 		}
 
 		if ($data === null) {

--- a/src/Toolkit/HtmlString.php
+++ b/src/Toolkit/HtmlString.php
@@ -129,8 +129,6 @@ class HtmlString implements JsonSerializable, Stringable
 	 * Translates a key or template string and marks the result as
 	 * trusted HTML. Every filled-in placeholder is escaped, unless
 	 * its value is already trusted HTML.
-	 *
-	 * @since 6.0.0
 	 */
 	public static function translate(
 		string|array $key,

--- a/src/Toolkit/HtmlString.php
+++ b/src/Toolkit/HtmlString.php
@@ -32,6 +32,24 @@ class HtmlString implements JsonSerializable, Stringable
 	}
 
 	/**
+	 * Escapes a filled-in placeholder for `translate()`. The raw
+	 * value decides, as a plain string can look exactly like
+	 * trusted HTML once the template has cast it.
+	 */
+	protected static function escape(
+		string $result,
+		string $query,
+		array $data,
+		mixed $value
+	): string {
+		if ($value instanceof HtmlString) {
+			return $result;
+		}
+
+		return Escape::html($result);
+	}
+
+	/**
 	 * Checks whether a key has already been marked, so that
 	 * `resolve()` can run more than once over the same data
 	 * without turning `<key>` into `<<key>>`
@@ -105,6 +123,27 @@ class HtmlString implements JsonSerializable, Stringable
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Translates a key or template string and marks the result as
+	 * trusted HTML. Every filled-in placeholder is escaped, unless
+	 * its value is already trusted HTML.
+	 *
+	 * @since 6.0.0
+	 */
+	public static function translate(
+		string|array $key,
+		array $data = [],
+		string|array|null $fallback = null,
+		string|null $locale = null
+	): static {
+		$template = I18n::translate($key, $fallback ?? $key, $locale);
+
+		return new static(Str::template($template, $data, [
+			'callback' => static::escape(...),
+			'fallback' => '-'
+		]));
 	}
 
 	public function value(): string

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1064,7 +1064,8 @@ class Str
 	 *                    Supports query syntax.
 	 * @param array $options An options array that contains:
 	 *                       - fallback: if a token does not have any matches
-	 *                       - callback: to be able to handle each matching result (escaping is applied after the callback)
+	 *                       - callback: to be able to handle each matching result (escaping is applied after the callback);
+	 *                                   receives the result as a string, the query, the data and the raw result
 	 *
 	 * @return string The filled-in and partially escaped string
 	 */
@@ -1084,9 +1085,9 @@ class Str
 		$string = static::template($string, $data, [
 			'start'    => '{{',
 			'end'      => '}}',
-			'callback' => function ($result, $query, $data) use ($callback) {
+			'callback' => function ($result, $query, $data, $value) use ($callback) {
 				if ($callback !== null) {
-					$result = $callback($result, $query, $data);
+					$result = $callback($result, $query, $data, $value);
 				}
 
 				return Escape::html($result);
@@ -1427,7 +1428,8 @@ class Str
 	 *                    Supports query syntax.
 	 * @param array $options An options array that contains:
 	 *                       - fallback: if a token does not have any matches
-	 *                       - callback: to be able to handle each matching result
+	 *                       - callback: to be able to handle each matching result;
+	 *                                   receives the result as a string, the query, the data and the raw result
 	 *                       - start: start placeholder
 	 *                       - end: end placeholder
 	 * @return string The filled-in string
@@ -1463,9 +1465,11 @@ class Str
 				// if we don't have a result, use the fallback if given
 				$result ??= $fallback;
 
-				// callback on result if given
+				// callback on result if given, with the raw result
+				// on top, so that values that look the same once
+				// cast to a string can still be told apart
 				if ($callback !== null) {
-					$callback = $callback((string)$result, $query, $data);
+					$callback = $callback((string)$result, $query, $data, $result);
 
 					if ($result !== null || $callback !== '') {
 						// the empty string came just from string casting,

--- a/src/Toolkit/Str.php
+++ b/src/Toolkit/Str.php
@@ -1065,7 +1065,7 @@ class Str
 	 * @param array $options An options array that contains:
 	 *                       - fallback: if a token does not have any matches
 	 *                       - callback: to be able to handle each matching result (escaping is applied after the callback);
-	 *                                   receives the result as a string, the query, the data and the raw result
+	 *                       receives the result as a string, the query, the data and the raw result
 	 *
 	 * @return string The filled-in and partially escaped string
 	 */
@@ -1429,7 +1429,7 @@ class Str
 	 * @param array $options An options array that contains:
 	 *                       - fallback: if a token does not have any matches
 	 *                       - callback: to be able to handle each matching result;
-	 *                                   receives the result as a string, the query, the data and the raw result
+	 *                       receives the result as a string, the query, the data and the raw result
 	 *                       - start: start placeholder
 	 *                       - end: end placeholder
 	 * @return string The filled-in string

--- a/tests/Blueprint/Sections/FilesSectionTest.php
+++ b/tests/Blueprint/Sections/FilesSectionTest.php
@@ -477,8 +477,8 @@ class FilesSectionTest extends TestCase
 		]);
 
 		$this->assertSame('en: {{ file.page.title }}', $section->info());
-		$this->assertSame('en: test', $section->data()[0]['info']);
-		$this->assertSame('en: test', $section->data()[1]['info']);
+		$this->assertSame('en: test', (string)$section->data()[0]['info']);
+		$this->assertSame('en: test', (string)$section->data()[1]['info']);
 	}
 
 	public function testTranslatedText(): void
@@ -501,8 +501,8 @@ class FilesSectionTest extends TestCase
 		]);
 
 		$this->assertSame('en: {{ file.filename }}', $section->text());
-		$this->assertSame('en: a.jpg', $section->data()[0]['text']);
-		$this->assertSame('en: b.jpg', $section->data()[1]['text']);
+		$this->assertSame('en: a.jpg', (string)$section->data()[0]['text']);
+		$this->assertSame('en: b.jpg', (string)$section->data()[1]['text']);
 	}
 
 	public function testSearchDefault(): void
@@ -711,7 +711,7 @@ class FilesSectionTest extends TestCase
 		$data = $section->data();
 		$item = $data[0];
 
-		$this->assertSame('', $item['info']);
+		$this->assertSame('', (string)$item['info']);
 		$this->assertSame([
 			'text' => 'mount-bike.jpg',
 			'href' => '/pages/test/files/mount-bike.jpg'

--- a/tests/Blueprint/Sections/InfoSectionTest.php
+++ b/tests/Blueprint/Sections/InfoSectionTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Blueprint;
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use Kirby\Toolkit\HtmlString;
 
 class InfoSectionTest extends TestCase
 {
@@ -63,7 +64,7 @@ class InfoSectionTest extends TestCase
 			'text'     => 'Test'
 		]);
 
-		$this->assertSame('<p>Test</p>', $section->text());
+		$this->assertSame('<p>Test</p>', (string)$section->text());
 
 		// translated text
 		$section = new Section('info', [
@@ -75,7 +76,7 @@ class InfoSectionTest extends TestCase
 			]
 		]);
 
-		$this->assertSame('<p>Information</p>', $section->text());
+		$this->assertSame('<p>Information</p>', (string)$section->text());
 	}
 
 	public function testTheme(): void
@@ -103,10 +104,10 @@ class InfoSectionTest extends TestCase
 		$expected = [
 			'icon'  => 'heart',
 			'label' => 'Test Headline',
-			'text'  => '<p>Test Text</p>',
+			'text'  => new HtmlString('<p>Test Text</p>'),
 			'theme' => 'notice'
 		];
 
-		$this->assertSame($expected, $section->toArray());
+		$this->assertEquals($expected, $section->toArray()); // @phpstan-ignore-line
 	}
 }

--- a/tests/Blueprint/Sections/PagesSectionTest.php
+++ b/tests/Blueprint/Sections/PagesSectionTest.php
@@ -335,9 +335,9 @@ class PagesSectionTest extends TestCase
 			'name'  => 'test',
 			'model' => $page
 		]);
-		$this->assertSame('Z', $section->data()[0]['text']);
-		$this->assertSame('Ä', $section->data()[1]['text']);
-		$this->assertSame('B', $section->data()[2]['text']);
+		$this->assertSame('Z', (string)$section->data()[0]['text']);
+		$this->assertSame('Ä', (string)$section->data()[1]['text']);
+		$this->assertSame('B', (string)$section->data()[2]['text']);
 
 		// sort by field
 		$section = new Section('pages', [
@@ -345,9 +345,9 @@ class PagesSectionTest extends TestCase
 			'model'  => $page,
 			'sortBy' => 'title'
 		]);
-		$this->assertSame('B', $section->data()[0]['text']);
-		$this->assertSame('Z', $section->data()[1]['text']);
-		$this->assertSame('Ä', $section->data()[2]['text']);
+		$this->assertSame('B', (string)$section->data()[0]['text']);
+		$this->assertSame('Z', (string)$section->data()[1]['text']);
+		$this->assertSame('Ä', (string)$section->data()[2]['text']);
 
 		// custom sorting direction
 		$section = new Section('pages', [
@@ -355,9 +355,9 @@ class PagesSectionTest extends TestCase
 			'model'  => $page,
 			'sortBy' => 'title desc'
 		]);
-		$this->assertSame('Ä', $section->data()[0]['text']);
-		$this->assertSame('Z', $section->data()[1]['text']);
-		$this->assertSame('B', $section->data()[2]['text']);
+		$this->assertSame('Ä', (string)$section->data()[0]['text']);
+		$this->assertSame('Z', (string)$section->data()[1]['text']);
+		$this->assertSame('B', (string)$section->data()[2]['text']);
 
 		// custom flag
 		$section = new Section('pages', [
@@ -365,9 +365,9 @@ class PagesSectionTest extends TestCase
 			'model'  => $page,
 			'sortBy' => 'title SORT_LOCALE_STRING'
 		]);
-		$this->assertSame('Ä', $section->data()[0]['text']);
-		$this->assertSame('B', $section->data()[1]['text']);
-		$this->assertSame('Z', $section->data()[2]['text']);
+		$this->assertSame('Ä', (string)$section->data()[0]['text']);
+		$this->assertSame('B', (string)$section->data()[1]['text']);
+		$this->assertSame('Z', (string)$section->data()[2]['text']);
 
 		// flag & sorting direction
 		$section = new Section('pages', [
@@ -375,9 +375,9 @@ class PagesSectionTest extends TestCase
 			'model'  => $page,
 			'sortBy' => 'title desc SORT_LOCALE_STRING'
 		]);
-		$this->assertSame('Z', $section->data()[0]['text']);
-		$this->assertSame('B', $section->data()[1]['text']);
-		$this->assertSame('Ä', $section->data()[2]['text']);
+		$this->assertSame('Z', (string)$section->data()[0]['text']);
+		$this->assertSame('B', (string)$section->data()[1]['text']);
+		$this->assertSame('Ä', (string)$section->data()[2]['text']);
 
 		Locale::set($locale);
 	}
@@ -457,9 +457,9 @@ class PagesSectionTest extends TestCase
 			'flip'  => true
 		]);
 
-		$this->assertSame('B', $section->data()[0]['text']);
-		$this->assertSame('A', $section->data()[1]['text']);
-		$this->assertSame('C', $section->data()[2]['text']);
+		$this->assertSame('B', (string)$section->data()[0]['text']);
+		$this->assertSame('A', (string)$section->data()[1]['text']);
+		$this->assertSame('C', (string)$section->data()[2]['text']);
 	}
 
 	public static function sortableStatusProvider(): array
@@ -624,9 +624,9 @@ class PagesSectionTest extends TestCase
 		]);
 
 		$this->assertSame('en: {{ page.slug }}', $section->info());
-		$this->assertSame('en: subpage-1', $section->data()[0]['info']);
-		$this->assertSame('en: subpage-2', $section->data()[1]['info']);
-		$this->assertSame('en: subpage-3', $section->data()[2]['info']);
+		$this->assertSame('en: subpage-1', (string)$section->data()[0]['info']);
+		$this->assertSame('en: subpage-2', (string)$section->data()[1]['info']);
+		$this->assertSame('en: subpage-3', (string)$section->data()[2]['info']);
 	}
 
 	public function testTranslatedText(): void
@@ -650,9 +650,9 @@ class PagesSectionTest extends TestCase
 		]);
 
 		$this->assertSame('en: {{ page.title }}', $section->text());
-		$this->assertSame('en: C', $section->data()[0]['text']);
-		$this->assertSame('en: A', $section->data()[1]['text']);
-		$this->assertSame('en: B', $section->data()[2]['text']);
+		$this->assertSame('en: C', (string)$section->data()[0]['text']);
+		$this->assertSame('en: A', (string)$section->data()[1]['text']);
+		$this->assertSame('en: B', (string)$section->data()[2]['text']);
 	}
 
 	public function testUnreadable(): void
@@ -746,8 +746,8 @@ class PagesSectionTest extends TestCase
 		]);
 
 		$this->assertCount(2, $section->data());
-		$this->assertSame('Bike', $section->data()[0]['text']);
-		$this->assertSame('Mount Bike', $section->data()[1]['text']);
+		$this->assertSame('Bike', (string)$section->data()[0]['text']);
+		$this->assertSame('Mount Bike', (string)$section->data()[1]['text']);
 
 		$_GET = [];
 	}
@@ -772,8 +772,8 @@ class PagesSectionTest extends TestCase
 		]);
 
 		$this->assertCount(2, $section->data());
-		$this->assertSame('Mount Bike', $section->data()[0]['text']);
-		$this->assertSame('Mountain', $section->data()[1]['text']);
+		$this->assertSame('Mount Bike', (string)$section->data()[0]['text']);
+		$this->assertSame('Mountain', (string)$section->data()[1]['text']);
 
 		$_GET = [];
 	}
@@ -799,7 +799,7 @@ class PagesSectionTest extends TestCase
 		]);
 
 		$this->assertCount(1, $section->data());
-		$this->assertSame('Mountain', $section->data()[0]['text']);
+		$this->assertSame('Mountain', (string)$section->data()[0]['text']);
 
 		$_GET = [];
 	}
@@ -825,8 +825,8 @@ class PagesSectionTest extends TestCase
 		]);
 
 		$this->assertCount(2, $section->data());
-		$this->assertSame('Bike', $section->data()[0]['text']);
-		$this->assertSame('Mount Bike', $section->data()[1]['text']);
+		$this->assertSame('Bike', (string)$section->data()[0]['text']);
+		$this->assertSame('Mount Bike', (string)$section->data()[1]['text']);
 
 		$_GET = [];
 	}
@@ -852,8 +852,8 @@ class PagesSectionTest extends TestCase
 		]);
 
 		$this->assertCount(2, $section->data());
-		$this->assertSame('Bike', $section->data()[0]['text']);
-		$this->assertSame('Mount Bike', $section->data()[1]['text']);
+		$this->assertSame('Bike', (string)$section->data()[0]['text']);
+		$this->assertSame('Mount Bike', (string)$section->data()[1]['text']);
 
 		$_GET = [];
 	}
@@ -878,7 +878,7 @@ class PagesSectionTest extends TestCase
 		$data = $section->data();
 		$item = $data[0];
 
-		$this->assertSame('', $item['info']);
+		$this->assertSame('', (string)$item['info']);
 		$this->assertSame([
 			'text' => 'test',
 			'href' => '/pages/test+test'

--- a/tests/Cms/Model/ModelWithContentTest.php
+++ b/tests/Cms/Model/ModelWithContentTest.php
@@ -10,6 +10,7 @@ use Kirby\Content\VersionId;
 use Kirby\Content\Versions;
 use Kirby\Exception\NotFoundException;
 use Kirby\Panel\Page as PanelPage;
+use Kirby\Toolkit\HtmlString;
 use Kirby\Uuid\PageUuid;
 use Kirby\Uuid\SiteUuid;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -405,6 +406,16 @@ class ModelWithContentTest extends TestCase
 			'site' => $site
 		]);
 		$this->assertIsSite($site, $model->site());
+	}
+
+	public function testToSafeHtmlString(): void
+	{
+		$model  = new Page(['slug' => 'foo', 'content' => ['title' => 'value &']]);
+		$result = $model->toSafeHtmlString('Hello {{ model.title }} {{ model.slug }}');
+
+		// same escaping as toSafeString, but marked as trusted HTML
+		$this->assertInstanceOf(HtmlString::class, $result);
+		$this->assertSame('Hello value &amp; foo', (string)$result);
 	}
 
 	public function testToSafeString(): void

--- a/tests/Form/Field/ColorFieldTest.php
+++ b/tests/Form/Field/ColorFieldTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Form\Field;
 
 use Kirby\Cms\App;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Toolkit\HtmlString;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(ColorField::class)]
@@ -121,10 +122,10 @@ class ColorFieldTest extends TestCase
 			],
 		]);
 
-		$this->assertSame([
-			['value' => '#aaa', 'text' => 'Color a'],
-			['value' => '#bbb', 'text' => 'Color b'],
-			['value' => '#ccc', 'text' => 'Color c']
+		$this->assertEquals([
+			['value' => '#aaa', 'text' => new HtmlString('Color a')],
+			['value' => '#bbb', 'text' => new HtmlString('Color b')],
+			['value' => '#ccc', 'text' => new HtmlString('Color c')]
 		], $field->options());
 	}
 
@@ -162,10 +163,10 @@ class ColorFieldTest extends TestCase
 			'options' => ['type' => 'query', 'query' => 'kirby.option("foo")'],
 		]);
 
-		$this->assertSame([
-			['value' => '#aaa', 'text' => 'Color a'],
-			['value' => '#bbb', 'text' => 'Color b'],
-			['value' => '#ccc', 'text' => 'Color c']
+		$this->assertEquals([
+			['value' => '#aaa', 'text' => new HtmlString('Color a')],
+			['value' => '#bbb', 'text' => new HtmlString('Color b')],
+			['value' => '#ccc', 'text' => new HtmlString('Color c')]
 		], $field->options());
 	}
 

--- a/tests/Form/Field/InfoFieldTest.php
+++ b/tests/Form/Field/InfoFieldTest.php
@@ -45,7 +45,7 @@ class InfoFieldTest extends TestCase
 			'text' => 'test'
 		]);
 
-		$this->assertSame('<p>test</p>', $field->text());
+		$this->assertSame('<p>test</p>', (string)$field->text());
 
 		// translated text
 		$field = $this->field('info', [
@@ -55,7 +55,7 @@ class InfoFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertSame('<p>en</p>', $field->text());
+		$this->assertSame('<p>en</p>', (string)$field->text());
 
 		// text template
 		$field = $this->field('info', [
@@ -68,7 +68,7 @@ class InfoFieldTest extends TestCase
 			])
 		]);
 
-		$this->assertSame('<p>Test</p>', $field->text());
+		$this->assertSame('<p>Test</p>', (string)$field->text());
 	}
 
 	public function testTheme(): void

--- a/tests/Form/Field/Mixins/PickerMixinTest.php
+++ b/tests/Form/Field/Mixins/PickerMixinTest.php
@@ -65,7 +65,7 @@ class PickerMixinTest extends TestCase
 		$this->assertIsArray($item);
 		$this->assertArrayHasKey('image', $item);
 		$this->assertSame('test', $item['id']);
-		$this->assertSame('Test Title', $item['text']);
+		$this->assertSame('Test Title', (string)$item['text']);
 	}
 
 	public function testToItems(): void

--- a/tests/Form/Field/TagsFieldTest.php
+++ b/tests/Form/Field/TagsFieldTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Form\Field;
 
+use Kirby\Toolkit\HtmlString;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(TagsField::class)]
@@ -114,28 +115,28 @@ class TagsFieldTest extends TestCase
 				'disabled' => false,
 				'icon' => null,
 				'info' => null,
-				'text' => 'design',
+				'text' => new HtmlString('design'),
 				'value' => 'design'
 			],
 			[
 				'disabled' => false,
 				'icon' => null,
 				'info' => null,
-				'text' => 'photography',
+				'text' => new HtmlString('photography'),
 				'value' => 'photography'
 			],
 			[
 				'disabled' => false,
 				'icon' => null,
 				'info' => null,
-				'text' => '&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;',
+				'text' => new HtmlString('&lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;'),
 				'value' => '<script>alert("XSS")</script>'
 			],
 			[
 				'disabled' => false,
 				'icon' => null,
 				'info' => null,
-				'text' => 'architecture',
+				'text' => new HtmlString('architecture'),
 				'value' => 'architecture'
 			]
 		];
@@ -148,7 +149,7 @@ class TagsFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertSame($expected, $field->options());
+		$this->assertEquals($expected, $field->options());
 
 		$field = $this->field('tags', [
 			'model'   => $app->file('a/b.jpg'),
@@ -158,7 +159,7 @@ class TagsFieldTest extends TestCase
 			],
 		]);
 
-		$this->assertSame($expected, $field->options());
+		$this->assertEquals($expected, $field->options());
 	}
 
 	public function testProps(): void

--- a/tests/Form/Field/ToggleFieldTest.php
+++ b/tests/Form/Field/ToggleFieldTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Form\Field;
 
+use Kirby\Toolkit\HtmlString;
 use Kirby\Toolkit\I18n;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -120,7 +121,8 @@ class ToggleFieldTest extends TestCase
 			'text' => 'Yay {{ page.slug }}'
 		]);
 
-		$this->assertSame('Yay test', $field->text());
+		$this->assertInstanceOf(HtmlString::class, $field->text());
+		$this->assertSame('Yay test', (string)$field->text());
 	}
 
 	public function testTextWithTranslation(): void
@@ -135,12 +137,12 @@ class ToggleFieldTest extends TestCase
 		I18n::$locale = 'en';
 
 		$field = $this->field('toggle', $props);
-		$this->assertSame('Yay test', $field->text());
+		$this->assertSame('Yay test', (string)$field->text());
 
 		I18n::$locale = 'de';
 
 		$field = $this->field('toggle', $props);
-		$this->assertSame('Ja test', $field->text());
+		$this->assertSame('Ja test', (string)$field->text());
 	}
 
 	public function testTextToggle(): void
@@ -152,7 +154,10 @@ class ToggleFieldTest extends TestCase
 			]
 		]);
 
-		$this->assertSame(['Yes test', 'No test'], $field->text());
+		$text = $field->text();
+
+		$this->assertInstanceOf(HtmlString::class, $text[0]);
+		$this->assertSame(['Yes test', 'No test'], array_map(strval(...), $text));
 	}
 
 	public function testTextToggleWithTranslation(): void
@@ -167,11 +172,17 @@ class ToggleFieldTest extends TestCase
 		I18n::$locale = 'en';
 
 		$field = $this->field('toggle', $props);
-		$this->assertSame(['Yes test', 'No test'], $field->text());
+		$this->assertSame(
+			['Yes test', 'No test'],
+			array_map(strval(...), $field->text())
+		);
 
 		I18n::$locale = 'de';
 
 		$field = $this->field('toggle', $props);
-		$this->assertSame(['Ja test', 'Nein test'], $field->text());
+		$this->assertSame(
+			['Ja test', 'Nein test'],
+			array_map(strval(...), $field->text())
+		);
 	}
 }

--- a/tests/Form/FieldClassTest.php
+++ b/tests/Form/FieldClassTest.php
@@ -7,6 +7,7 @@ use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\Exception\NotFoundException;
 use Kirby\TestCase;
+use Kirby\Toolkit\HtmlString;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 class TestField extends FieldClass
@@ -440,11 +441,11 @@ class FieldClassTest extends TestCase
 
 		// regular help
 		$field = new TestField(help: 'Test');
-		$this->assertSame('<p>Test</p>', $field->help());
+		$this->assertSame('<p>Test</p>', (string)$field->help());
 
 		// translated help
 		$field = new TestField(help: ['en' => 'Test']);
-		$this->assertSame('<p>Test</p>', $field->help());
+		$this->assertSame('<p>Test</p>', (string)$field->help());
 
 		// help from string template
 		$field = new TestField(
@@ -458,7 +459,7 @@ class FieldClassTest extends TestCase
 			]
 		]));
 
-		$this->assertSame('<p>A field for Test title</p>', $field->help());
+		$this->assertSame('<p>A field for Test title</p>', (string)$field->help());
 	}
 
 	public function testIcon(): void
@@ -574,13 +575,13 @@ class FieldClassTest extends TestCase
 
 		$array = $field->toArray();
 
-		$this->assertSame([
+		$this->assertEquals([ // @phpstan-ignore-line
 			'after'       => $after,
 			'autofocus'   => true,
 			'before'      => $before,
 			'default'     => $default,
 			'disabled'    => false,
-			'help'        => '<p>Help value</p>',
+			'help'        => new HtmlString('<p>Help value</p>'),
 			'hidden'      => false,
 			'icon'        => $icon,
 			'label'       => $label,

--- a/tests/Form/FieldOptionsTest.php
+++ b/tests/Form/FieldOptionsTest.php
@@ -87,7 +87,7 @@ class FieldOptionsTest extends TestCase
 			'text'  => '{{ item.slogan }}'
 		]);
 		$this->assertInstanceOf(Options::class, $options->resolve($model));
-		$this->assertSame('We are &lt;b&gt;great&lt;/b&gt;', $options->render($model)[0]['text']);
+		$this->assertSame('We are &lt;b&gt;great&lt;/b&gt;', (string)$options->render($model)[0]['text']);
 
 		// without safe mode
 		$options = FieldOptions::factory(
@@ -100,7 +100,7 @@ class FieldOptionsTest extends TestCase
 			false
 		);
 		$this->assertInstanceOf(Options::class, $options->resolve($model));
-		$this->assertSame('We are <b>great</b>', $options->render($model)[0]['text']);
+		$this->assertSame('We are <b>great</b>', (string)$options->render($model)[0]['text']);
 
 		$options = FieldOptions::factory([
 			'type'  => 'query',

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -489,8 +489,8 @@ class FieldTest extends TestCase
 			'help' => 'test'
 		]);
 
-		$this->assertSame('<p>test</p>', $field->help());
-		$this->assertSame('<p>test</p>', $field->help);
+		$this->assertSame('<p>test</p>', (string)$field->help());
+		$this->assertSame('<p>test</p>', (string)$field->help);
 
 		// translated
 		$field = new Field('test', [
@@ -501,8 +501,8 @@ class FieldTest extends TestCase
 			]
 		]);
 
-		$this->assertSame('<p>en</p>', $field->help());
-		$this->assertSame('<p>en</p>', $field->help);
+		$this->assertSame('<p>en</p>', (string)$field->help());
+		$this->assertSame('<p>en</p>', (string)$field->help);
 	}
 
 	public function testIcon(): void

--- a/tests/Option/OptionTest.php
+++ b/tests/Option/OptionTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Option;
 
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use Kirby\Toolkit\HtmlString;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(Option::class)]
@@ -79,13 +80,13 @@ class OptionTest extends TestCase
 		$expected = [
 			'disabled' => false,
 			'icon'     => null,
-			'info'     => 'test',
-			'text'     => 'Test Option',
+			'info'     => new HtmlString('test'),
+			'text'     => new HtmlString('Test Option'),
 			'value'    => 'test',
 		];
 
 		$model = new Page(['slug' => 'test']);
-		$this->assertSame($expected, $option->render($model));
+		$this->assertEquals($expected, $option->render($model)); // @phpstan-ignore-line
 	}
 
 	public function testRenderWithoutSafeMode(): void
@@ -119,5 +120,20 @@ class OptionTest extends TestCase
 
 		$this->assertSame('{{ page.slug }}', $result['text']);
 		$this->assertSame('{{ page.slug }}', $result['info']);
+	}
+
+	public function testRenderPreResolvedHtmlString(): void
+	{
+		// OptionsApi/OptionsQuery mark their escaped output as trusted
+		// HTML — the mark has to survive factory() and i18n()
+		$option = Option::factory([
+			'value' => 'test',
+			'text'  => new HtmlString('Tom &amp; Jerry'),
+		], resolve: false);
+
+		$result = $option->render(new Page(['slug' => 'test']));
+
+		$this->assertInstanceOf(HtmlString::class, $result['text']);
+		$this->assertSame('Tom &amp; Jerry', (string)$result['text']);
 	}
 }

--- a/tests/Option/OptionsApiTest.php
+++ b/tests/Option/OptionsApiTest.php
@@ -83,9 +83,9 @@ class OptionsApiTest extends TestCase
 		$options = new OptionsApi(static::FIXTURES . '/data.json');
 		$result  = $options->render($model);
 
-		$this->assertSame('A', $result[0]['text']);
+		$this->assertSame('A', (string)$result[0]['text']);
 		$this->assertSame('a', $result[0]['value']);
-		$this->assertSame('B', $result[1]['text']);
+		$this->assertSame('B', (string)$result[1]['text']);
 		$this->assertSame('b', $result[1]['value']);
 	}
 
@@ -95,9 +95,9 @@ class OptionsApiTest extends TestCase
 		$options = new OptionsApi(static::FIXTURES . '/data-simple.json');
 		$result  = $options->render($model);
 
-		$this->assertSame('A', $result[0]['text']);
+		$this->assertSame('A', (string)$result[0]['text']);
 		$this->assertSame('a', $result[0]['value']);
-		$this->assertSame('B', $result[1]['text']);
+		$this->assertSame('B', (string)$result[1]['text']);
 		$this->assertSame('b', $result[1]['value']);
 	}
 
@@ -111,9 +111,9 @@ class OptionsApiTest extends TestCase
 		);
 		$result  = $options->render($model);
 
-		$this->assertSame('Company A', $result[0]['text']);
+		$this->assertSame('Company A', (string)$result[0]['text']);
 		$this->assertSame('info@company-a.com', $result[0]['value']);
-		$this->assertSame('Company B', $result[1]['text']);
+		$this->assertSame('Company B', (string)$result[1]['text']);
 		$this->assertSame('info@company-b.com', $result[1]['value']);
 	}
 
@@ -126,9 +126,9 @@ class OptionsApiTest extends TestCase
 		);
 		$result  = $options->render($model);
 
-		$this->assertSame('A', $result[0]['text']);
+		$this->assertSame('A', (string)$result[0]['text']);
 		$this->assertSame('a', $result[0]['value']);
-		$this->assertSame('B', $result[1]['text']);
+		$this->assertSame('B', (string)$result[1]['text']);
 		$this->assertSame('b', $result[1]['value']);
 	}
 
@@ -143,9 +143,9 @@ class OptionsApiTest extends TestCase
 		);
 		$result  = $options->render($model);
 
-		$this->assertSame('Company A', $result[0]['text']);
+		$this->assertSame('Company A', (string)$result[0]['text']);
 		$this->assertSame('info@company-a.com', $result[0]['value']);
-		$this->assertSame('Company B', $result[1]['text']);
+		$this->assertSame('Company B', (string)$result[1]['text']);
 		$this->assertSame('info@company-b.com', $result[1]['value']);
 	}
 
@@ -161,18 +161,18 @@ class OptionsApiTest extends TestCase
 		);
 		$result = $options->render($model);
 
-		$this->assertSame('We are &lt;b&gt;great&lt;/b&gt;', $result[0]['text']);
+		$this->assertSame('We are &lt;b&gt;great&lt;/b&gt;', (string)$result[0]['text']);
 		$this->assertSame('We are <b>great</b>', $result[0]['value']);
-		$this->assertSame('We are &lt;b&gt;better&lt;/b&gt;', $result[1]['text']);
+		$this->assertSame('We are &lt;b&gt;better&lt;/b&gt;', (string)$result[1]['text']);
 		$this->assertSame('We are <b>better</b>', $result[1]['value']);
 
 		// with simple array
 		$options = new OptionsApi(static::FIXTURES . '/data-simple-html.json');
 		$result = $options->render($model);
 
-		$this->assertSame('We are &lt;b&gt;great&lt;/b&gt;', $result[0]['text']);
+		$this->assertSame('We are &lt;b&gt;great&lt;/b&gt;', (string)$result[0]['text']);
 		$this->assertSame('a', $result[0]['value']);
-		$this->assertSame('We are &lt;b&gt;better&lt;/b&gt;', $result[1]['text']);
+		$this->assertSame('We are &lt;b&gt;better&lt;/b&gt;', (string)$result[1]['text']);
 		$this->assertSame('b', $result[1]['value']);
 
 		// with query
@@ -184,9 +184,9 @@ class OptionsApiTest extends TestCase
 		);
 		$result = $options->render($model);
 
-		$this->assertSame('We are &lt;b&gt;great&lt;/b&gt;', $result[0]['text']);
+		$this->assertSame('We are &lt;b&gt;great&lt;/b&gt;', (string)$result[0]['text']);
 		$this->assertSame('We are <b>great</b>', $result[0]['value']);
-		$this->assertSame('We are &lt;b&gt;better&lt;/b&gt;', $result[1]['text']);
+		$this->assertSame('We are &lt;b&gt;better&lt;/b&gt;', (string)$result[1]['text']);
 		$this->assertSame('We are <b>better</b>', $result[1]['value']);
 
 		// text unescaped using {< >}
@@ -196,9 +196,9 @@ class OptionsApiTest extends TestCase
 			value: '{{ item.slogan }}'
 		);
 		$result = $options->render($model);
-		$this->assertSame('We are <b>great</b>', $result[0]['text']);
+		$this->assertSame('We are <b>great</b>', (string)$result[0]['text']);
 		$this->assertSame('We are <b>great</b>', $result[0]['value']);
-		$this->assertSame('We are <b>better</b>', $result[1]['text']);
+		$this->assertSame('We are <b>better</b>', (string)$result[1]['text']);
 		$this->assertSame('We are <b>better</b>', $result[1]['value']);
 
 		// text unescaped using {< >} (simple array)
@@ -208,9 +208,9 @@ class OptionsApiTest extends TestCase
 			value: '{{ item.value }}'
 		);
 		$result = $options->render($model);
-		$this->assertSame('We are <b>great</b>', $result[0]['text']);
+		$this->assertSame('We are <b>great</b>', (string)$result[0]['text']);
 		$this->assertSame('We are <b>great</b>', $result[0]['value']);
-		$this->assertSame('We are <b>better</b>', $result[1]['text']);
+		$this->assertSame('We are <b>better</b>', (string)$result[1]['text']);
 		$this->assertSame('We are <b>better</b>', $result[1]['value']);
 
 		// test unescaped with disabled safe mode
@@ -220,9 +220,9 @@ class OptionsApiTest extends TestCase
 			value: '{{ item.slogan }}'
 		);
 		$result = $options->resolve($model, false)->render($model);
-		$this->assertSame('We are <b>great</b>', $result[0]['text']);
+		$this->assertSame('We are <b>great</b>', (string)$result[0]['text']);
 		$this->assertSame('We are <b>great</b>', $result[0]['value']);
-		$this->assertSame('We are <b>better</b>', $result[1]['text']);
+		$this->assertSame('We are <b>better</b>', (string)$result[1]['text']);
 		$this->assertSame('We are <b>better</b>', $result[1]['value']);
 	}
 
@@ -240,7 +240,7 @@ class OptionsApiTest extends TestCase
 		);
 		$result = $options->render($model);
 
-		$this->assertSame('{{ page.slug }}', $result[0]['text']);
+		$this->assertSame('{{ page.slug }}', (string)$result[0]['text']);
 	}
 
 	public function testResolveApplyFieldMethods(): void
@@ -253,9 +253,9 @@ class OptionsApiTest extends TestCase
 		);
 		$result  = $options->render($model);
 
-		$this->assertSame('Company A', $result[0]['text']);
+		$this->assertSame('Company A', (string)$result[0]['text']);
 		$this->assertSame('company-a', $result[0]['value']);
-		$this->assertSame('Company B', $result[1]['text']);
+		$this->assertSame('Company B', (string)$result[1]['text']);
 		$this->assertSame('company-b', $result[1]['value']);
 	}
 
@@ -270,7 +270,7 @@ class OptionsApiTest extends TestCase
 		);
 		$result  = $options->render($model);
 
-		$this->assertSame('Company A', $result[0]['text']);
+		$this->assertSame('Company A', (string)$result[0]['text']);
 		$this->assertSame('company-a', $result[0]['value']);
 	}
 }

--- a/tests/Option/OptionsQueryTest.php
+++ b/tests/Option/OptionsQueryTest.php
@@ -99,7 +99,7 @@ class OptionsQueryTest extends TestCase
 		// since we didn't define a text query template,
 		// the default `{{ arrayItem.value }}` is used
 		// but our array doesn't have a a value key
-		$this->assertSame('', $options[0]['text']);
+		$this->assertSame('', (string)$options[0]['text']);
 
 		// with shorter alias
 		$options = (new OptionsQuery(
@@ -120,7 +120,7 @@ class OptionsQueryTest extends TestCase
 		$this->assertSame('tag1', $options[0]['value']);
 		$this->assertSame('tag2', $options[1]['value']);
 		$this->assertSame('tag3', $options[2]['value']);
-		$this->assertSame('tag3', $options[2]['text']);
+		$this->assertSame('tag3', (string)$options[2]['text']);
 
 		// associative array uses the array key as value by default
 		$options = (new OptionsQuery(
@@ -128,9 +128,9 @@ class OptionsQueryTest extends TestCase
 		))->render($model);
 
 		$this->assertSame('myValue', $options[0]['value']);
-		$this->assertSame('My text', $options[0]['text']);
+		$this->assertSame('My text', (string)$options[0]['text']);
 		$this->assertSame('otherValue', $options[1]['value']);
-		$this->assertSame('Other text', $options[1]['text']);
+		$this->assertSame('Other text', (string)$options[1]['text']);
 	}
 
 	public function testResolveForStructure(): void
@@ -182,9 +182,9 @@ class OptionsQueryTest extends TestCase
 			value: '{{ block.headline }}',
 		))->render($model);
 
-		$this->assertSame('image', $options[0]['text']);
+		$this->assertSame('image', (string)$options[0]['text']);
 		$this->assertSame('foo', $options[0]['value']);
-		$this->assertSame('test', $options[1]['text']);
+		$this->assertSame('test', (string)$options[1]['text']);
 		$this->assertSame('bar', $options[1]['value']);
 	}
 
@@ -207,10 +207,10 @@ class OptionsQueryTest extends TestCase
 		$options = $options->render($app->site());
 
 
-		$this->assertSame('a', $options[0]['text']);
+		$this->assertSame('a', (string)$options[0]['text']);
 		$this->assertSame('a', $options[0]['value']);
-		$this->assertSame('b', $options[1]['text']);
-		$this->assertSame('c', $options[2]['text']);
+		$this->assertSame('b', (string)$options[1]['text']);
+		$this->assertSame('c', (string)$options[2]['text']);
 	}
 
 	public function testResolveForFile(): void
@@ -230,8 +230,8 @@ class OptionsQueryTest extends TestCase
 		$options = $options->render($app->site());
 
 
-		$this->assertSame('a.jpg', $options[0]['text']);
-		$this->assertSame('b.pdf', $options[1]['text']);
+		$this->assertSame('a.jpg', (string)$options[0]['text']);
+		$this->assertSame('b.pdf', (string)$options[1]['text']);
 	}
 
 	public function testResolveForUser(): void
@@ -249,7 +249,7 @@ class OptionsQueryTest extends TestCase
 
 
 		$this->assertSame('homer@simpson.com', $options[0]['value']);
-		$this->assertSame('homer', $options[0]['text']);
+		$this->assertSame('homer', (string)$options[0]['text']);
 	}
 
 	public function testResolveForOptions(): void
@@ -258,9 +258,9 @@ class OptionsQueryTest extends TestCase
 		$options = new OptionsQuery('page.myOptions');
 		$options = $options->render($model);
 
-		$this->assertSame('foo', $options[0]['text']);
+		$this->assertSame('foo', (string)$options[0]['text']);
 		$this->assertSame('foo', $options[0]['value']);
-		$this->assertSame('bar', $options[1]['text']);
+		$this->assertSame('bar', (string)$options[1]['text']);
 		$this->assertSame('bar', $options[1]['value']);
 	}
 
@@ -284,7 +284,7 @@ class OptionsQueryTest extends TestCase
 
 		$options = (new OptionsQuery('site.children'))->render($app->site());
 
-		$this->assertSame('{{ page.slug }}', $options[0]['text']);
+		$this->assertSame('{{ page.slug }}', (string)$options[0]['text']);
 	}
 
 	public function testResolveInvalid(): void
@@ -314,9 +314,9 @@ class OptionsQueryTest extends TestCase
 			value: '{{ item.slogan }}',
 		))->render($model);
 
-		$this->assertSame('We are &lt;b&gt;great&lt;/b&gt;', $options[0]['text']);
+		$this->assertSame('We are &lt;b&gt;great&lt;/b&gt;', (string)$options[0]['text']);
 		$this->assertSame('We are <b>great</b>', $options[0]['value']);
-		$this->assertSame('We are &lt;b&gt;better&lt;/b&gt;', $options[1]['text']);
+		$this->assertSame('We are &lt;b&gt;better&lt;/b&gt;', (string)$options[1]['text']);
 		$this->assertSame('We are <b>better</b>', $options[1]['value']);
 
 		// text unescaped via {< >}
@@ -325,9 +325,9 @@ class OptionsQueryTest extends TestCase
 			text: '{< item.slogan >}',
 			value: '{{ item.slogan }}'
 		))->render($model);
-		$this->assertSame('We are <b>great</b>', $options[0]['text']);
+		$this->assertSame('We are <b>great</b>', (string)$options[0]['text']);
 		$this->assertSame('We are <b>great</b>', $options[0]['value']);
-		$this->assertSame('We are <b>better</b>', $options[1]['text']);
+		$this->assertSame('We are <b>better</b>', (string)$options[1]['text']);
 		$this->assertSame('We are <b>better</b>', $options[1]['value']);
 
 		// test unescaped with disabled safe mode
@@ -336,9 +336,9 @@ class OptionsQueryTest extends TestCase
 			text: '{{ item.slogan }}',
 			value: '{{ item.slogan }}'
 		))->resolve($model, false)->render($model);
-		$this->assertSame('We are <b>great</b>', $options[0]['text']);
+		$this->assertSame('We are <b>great</b>', (string)$options[0]['text']);
 		$this->assertSame('We are <b>great</b>', $options[0]['value']);
-		$this->assertSame('We are <b>better</b>', $options[1]['text']);
+		$this->assertSame('We are <b>better</b>', (string)$options[1]['text']);
 		$this->assertSame('We are <b>better</b>', $options[1]['value']);
 	}
 }

--- a/tests/Option/OptionsTest.php
+++ b/tests/Option/OptionsTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Option;
 
 use Kirby\Cms\Page;
 use Kirby\TestCase;
+use Kirby\Toolkit\HtmlString;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(Options::class)]
@@ -89,8 +90,8 @@ class OptionsTest extends TestCase
 
 		$result = $options->render($model);
 
-		$this->assertSame('test', $result[0]['text']);
-		$this->assertSame('test', $result[1]['text']);
+		$this->assertSame('test', (string)$result[0]['text']);
+		$this->assertSame('test', (string)$result[1]['text']);
 
 		// disabled resolving
 		$options = Options::factory([
@@ -100,8 +101,8 @@ class OptionsTest extends TestCase
 
 		$result = $options->render($model);
 
-		$this->assertSame('{{ page.slug }}', $result[0]['text']);
-		$this->assertSame('{{ page.slug }}', $result[1]['text']);
+		$this->assertSame('{{ page.slug }}', (string)$result[0]['text']);
+		$this->assertSame('{{ page.slug }}', (string)$result[1]['text']);
 	}
 
 	public function testRender(): void
@@ -113,19 +114,19 @@ class OptionsTest extends TestCase
 			new Option('b')
 		]);
 
-		$this->assertSame([
+		$this->assertEquals([ // @phpstan-ignore-line
 			[
 				'disabled' => false,
 				'icon'     => null,
 				'info'     => null,
-				'text'     => 'a',
+				'text'     => new HtmlString('a'),
 				'value'    => 'a',
 			],
 			[
 				'disabled' => false,
 				'icon'     => null,
 				'info'     => null,
-				'text'     => 'b',
+				'text'     => new HtmlString('b'),
 				'value'    => 'b',
 			]
 		], $options->render($model));

--- a/tests/Panel/Controller/Dialog/ChangesDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/ChangesDialogControllerTest.php
@@ -86,7 +86,7 @@ class ChangesDialogControllerTest extends TestCase
 		$files      = $controller->files();
 
 		$this->assertCount(1, $files);
-		$this->assertSame('test.jpg', $files[0]['text']);
+		$this->assertSame('test.jpg', (string)$files[0]['text']);
 		$this->assertSame('/pages/test/files/test.jpg', $files[0]['link']);
 	}
 
@@ -150,7 +150,7 @@ class ChangesDialogControllerTest extends TestCase
 		$this->app->impersonate('editor@getkirby.com');
 		$files = (new ChangesDialogController())->files();
 		$this->assertCount(1, $files);
-		$this->assertSame('public.jpg', $files[0]['text']);
+		$this->assertSame('public.jpg', (string)$files[0]['text']);
 	}
 
 	public function testFilesWithoutChanges(): void
@@ -169,7 +169,7 @@ class ChangesDialogControllerTest extends TestCase
 		$controller = new ChangesDialogController();
 		$item       = $controller->item($page);
 
-		$this->assertSame('test', $item['text']);
+		$this->assertSame('test', (string)$item['text']);
 		$this->assertSame('/pages/test', $item['link']);
 	}
 
@@ -186,7 +186,7 @@ class ChangesDialogControllerTest extends TestCase
 
 		$this->assertCount(1, $items);
 
-		$this->assertSame('test', $items[0]['text']);
+		$this->assertSame('test', (string)$items[0]['text']);
 		$this->assertSame('/pages/test', $items[0]['link']);
 	}
 
@@ -215,7 +215,7 @@ class ChangesDialogControllerTest extends TestCase
 		$pages      = $controller->pages();
 
 		$this->assertCount(1, $pages);
-		$this->assertSame('test', $pages[0]['text']);
+		$this->assertSame('test', (string)$pages[0]['text']);
 		$this->assertSame('/pages/test', $pages[0]['link']);
 	}
 
@@ -273,7 +273,7 @@ class ChangesDialogControllerTest extends TestCase
 		$this->app->impersonate('editor@getkirby.com');
 		$pages = (new ChangesDialogController())->pages();
 		$this->assertCount(1, $pages);
-		$this->assertSame('public', $pages[0]['text']);
+		$this->assertSame('public', (string)$pages[0]['text']);
 	}
 
 	public function testPagesWithoutChanges(): void
@@ -293,7 +293,7 @@ class ChangesDialogControllerTest extends TestCase
 		$users      = $controller->users();
 
 		$this->assertCount(1, $users);
-		$this->assertSame('test@getkirby.com', $users[0]['text']);
+		$this->assertSame('test@getkirby.com', (string)$users[0]['text']);
 		$this->assertSame('/users/test', $users[0]['link']);
 	}
 
@@ -346,7 +346,7 @@ class ChangesDialogControllerTest extends TestCase
 		$this->app->impersonate('editor@getkirby.com');
 		$users = (new ChangesDialogController())->users();
 		$this->assertCount(1, $users);
-		$this->assertSame('editor@getkirby.com', $users[0]['text']);
+		$this->assertSame('editor@getkirby.com', (string)$users[0]['text']);
 	}
 
 	public function testUsersWithoutChanges(): void

--- a/tests/Panel/Controller/Dialog/FileDeleteDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/FileDeleteDialogControllerTest.php
@@ -23,7 +23,7 @@ class FileDeleteDialogControllerTest extends FileDialogControllerTestCase
 		$this->assertInstanceOf(RemoveDialog::class, $dialog);
 
 		$props = $dialog->props();
-		$this->assertSame('Do you really want to delete <br><strong>a.jpg</strong>?', $props['text']);
+		$this->assertSame('Do you really want to delete <br><strong>a.jpg</strong>?', (string)$props['text']);
 	}
 
 	protected function assertSubmit(

--- a/tests/Panel/Controller/Dialog/FilePickerDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/FilePickerDialogControllerTest.php
@@ -74,7 +74,7 @@ class FilePickerDialogControllerTest extends TestCase
 
 		$item = $controller->item($this->app->file('test.jpg'));
 		$this->assertArrayHasKey('image', $item);
-		$this->assertSame('', $item['info']);
+		$this->assertSame('', (string)$item['info']);
 		$this->assertSame('list', $item['layout']);
 		$this->assertSame('test.jpg', $item['id']);
 		$this->assertSame('/site/files/test.jpg', $item['link']);

--- a/tests/Panel/Controller/Dialog/LanguageDeleteDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/LanguageDeleteDialogControllerTest.php
@@ -50,7 +50,7 @@ class LanguageDeleteDialogControllerTest extends TestCase
 
 
 		$props = $dialog->props();
-		$this->assertSame('Do you really want to delete the language <strong>Deutsch</strong> including all translations? This cannot be undone!', $props['text']);
+		$this->assertSame('Do you really want to delete the language <strong>Deutsch</strong> including all translations? This cannot be undone!', (string)$props['text']);
 	}
 	public function testSubmit(): void
 	{

--- a/tests/Panel/Controller/Dialog/LanguageVariableDeleteDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/LanguageVariableDeleteDialogControllerTest.php
@@ -59,7 +59,7 @@ class LanguageVariableDeleteDialogControllerTest extends TestCase
 		$this->assertSame('k-remove-dialog', $dialog->component);
 
 		$props = $dialog->props();
-		$this->assertSame('Do you really want to delete the variable for foo?', $props['text']);
+		$this->assertSame('Do you really want to delete the variable for foo?', (string)$props['text']);
 	}
 
 	public function testSubmit(): void

--- a/tests/Panel/Controller/Dialog/PageDeleteDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/PageDeleteDialogControllerTest.php
@@ -50,7 +50,7 @@ class PageDeleteDialogControllerTest extends TestCase
 		$this->assertInstanceOf(RemoveDialog::class, $dialog);
 
 		$props = $dialog->props();
-		$this->assertSame('Do you really want to delete <strong>test</strong>?', $props['text']);
+		$this->assertSame('Do you really want to delete <strong>test</strong>?', (string)$props['text']);
 	}
 
 	public function testLoadWithChildren(): void
@@ -63,7 +63,7 @@ class PageDeleteDialogControllerTest extends TestCase
 		$props = $dialog->props();
 		$this->assertSame('info', $props['fields']['info']['type']);
 		$this->assertSame('text', $props['fields']['check']['type']);
-		$this->assertSame('Do you really want to delete <strong>test-with-children</strong>?', $props['text']);
+		$this->assertSame('Do you really want to delete <strong>test-with-children</strong>?', (string)$props['text']);
 		$this->assertSame('Delete', $props['submitButton']['text']);
 		$this->assertSame('negative', $props['submitButton']['theme']);
 		$this->assertSame('medium', $props['size']);

--- a/tests/Panel/Controller/Dialog/PagePickerDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/PagePickerDialogControllerTest.php
@@ -96,7 +96,7 @@ class PagePickerDialogControllerTest extends TestCase
 
 		$item = $controller->item($this->app->page('alpha'));
 		$this->assertArrayHasKey('image', $item);
-		$this->assertSame('', $item['info']);
+		$this->assertSame('', (string)$item['info']);
 		$this->assertSame('list', $item['layout']);
 		$this->assertSame('alpha', $item['id']);
 		$this->assertSame('/pages/alpha', $item['link']);

--- a/tests/Panel/Controller/Dialog/SystemLicenseDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/SystemLicenseDialogControllerTest.php
@@ -42,7 +42,7 @@ class SystemLicenseDialogControllerTest extends TestCase
 		$this->assertTrue($controller->isRenewable());
 
 		$license = $controller->license();
-		$this->assertSame('No valid license', $license['info']);
+		$this->assertSame('No valid license', (string)$license['info']);
 	}
 
 	public function testLicenseNonRenewable(): void
@@ -55,6 +55,9 @@ class SystemLicenseDialogControllerTest extends TestCase
 		$this->assertFalse($controller->isRenewable());
 
 		$license = $controller->license();
-		$this->assertSame('Includes new major versions until 2999-01-01', $license['info']);
+		$this->assertSame(
+			'Includes new major versions until 2999-01-01',
+			(string)$license['info']
+		);
 	}
 }

--- a/tests/Panel/Controller/Dialog/SystemLicenseRemoveDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/SystemLicenseRemoveDialogControllerTest.php
@@ -19,7 +19,7 @@ class SystemLicenseRemoveDialogControllerTest extends TestCase
 		$this->assertInstanceOf(RemoveDialog::class, $dialog);
 
 		$props = $dialog->props();
-		$this->assertSame(I18n::translate('license.remove.text'), $props['text']);
+		$this->assertSame(I18n::translate('license.remove.text'), (string)$props['text']);
 		$this->assertSame('medium', $props['size']);
 		$this->assertSame('trash', $props['submitButton']['icon']);
 		$this->assertSame(I18n::translate('remove'), $props['submitButton']['text']);

--- a/tests/Panel/Controller/Dialog/UserDeleteDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/UserDeleteDialogControllerTest.php
@@ -57,7 +57,7 @@ class UserDeleteDialogControllerTest extends TestCase
 		$this->assertInstanceOf(RemoveDialog::class, $dialog);
 
 		$props = $dialog->props();
-		$this->assertSame('Do you really want to delete <br><strong>test@getkirby.com</strong>?', $props['text']);
+		$this->assertSame('Do you really want to delete <br><strong>test@getkirby.com</strong>?', (string)$props['text']);
 	}
 
 	public function testSubmit(): void

--- a/tests/Panel/Controller/Dialog/UserPickerDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/UserPickerDialogControllerTest.php
@@ -82,7 +82,7 @@ class UserPickerDialogControllerTest extends TestCase
 
 		$item = $controller->item($this->app->user('test'));
 		$this->assertArrayHasKey('image', $item);
-		$this->assertSame('', $item['info']);
+		$this->assertSame('', (string)$item['info']);
 		$this->assertSame('list', $item['layout']);
 		$this->assertSame('test', $item['id']);
 		$this->assertSame('/users/test', $item['link']);

--- a/tests/Panel/Controller/Request/UserItemsRequestControllerTest.php
+++ b/tests/Panel/Controller/Request/UserItemsRequestControllerTest.php
@@ -52,9 +52,9 @@ class UserItemsRequestControllerTest extends TestCase
 
 		$controller = new UserItemsRequestController();
 		$data       = $controller->load();
-		$this->assertSame('homer@getkirby.com', $data['items'][0]['text']);
+		$this->assertSame('homer@getkirby.com', (string)$data['items'][0]['text']);
 		$this->assertNull($data['items'][1]);
-		$this->assertSame('bart@getkirby.com', $data['items'][2]['text']);
+		$this->assertSame('bart@getkirby.com', (string)$data['items'][2]['text']);
 	}
 
 	public function testLoadNotListable(): void
@@ -93,6 +93,6 @@ class UserItemsRequestControllerTest extends TestCase
 		$controller = new UserItemsRequestController();
 		$data       = $controller->load();
 		$this->assertNull($data['items'][0]);
-		$this->assertSame('bart@getkirby.com', $data['items'][1]['text']);
+		$this->assertSame('bart@getkirby.com', (string)$data['items'][1]['text']);
 	}
 }

--- a/tests/Panel/Controller/View/UsersViewControllerTest.php
+++ b/tests/Panel/Controller/View/UsersViewControllerTest.php
@@ -136,7 +136,7 @@ class UsersViewControllerTest extends TestCase
 		$controller = new UsersViewController();
 		$users      = $controller->users();
 		$this->assertCount(1, $users['data']);
-		$this->assertSame('test@getkirby.com', $users['data'][0]['text']);
+		$this->assertSame('test@getkirby.com', (string)$users['data'][0]['text']);
 		$this->assertSame([
 			'page'      => 1,
 			'firstPage' => 1,

--- a/tests/Panel/FileTest.php
+++ b/tests/Panel/FileTest.php
@@ -230,7 +230,7 @@ class FileTest extends TestCase
 		$option = $panel->dropdownOption();
 
 		$this->assertSame('image', $option['icon']);
-		$this->assertSame('test.jpg', $option['text']);
+		$this->assertSame('test.jpg', (string)$option['text']);
 		$this->assertSame('/pages/test/files/test.jpg', $option['link']);
 	}
 
@@ -648,7 +648,7 @@ class FileTest extends TestCase
 		$this->assertSame('test/test.jpg', $data['id']);
 		$this->assertSame('image', $data['image']['icon']);
 		$this->assertSame('/pages/test/files/test.jpg', $data['link']);
-		$this->assertSame('test.jpg', $data['text']);
+		$this->assertSame('test.jpg', (string)$data['text']);
 	}
 
 	public function testPickerDataWithParams(): void
@@ -675,7 +675,7 @@ class FileTest extends TestCase
 
 		$this->assertSame('test/test.jpg', $data['id']);
 		$this->assertSame('1/1', $data['image']['ratio']);
-		$this->assertSame('From foo to the bar', $data['text']);
+		$this->assertSame('From foo to the bar', (string)$data['text']);
 	}
 
 	public function testPickerDataSameModel(): void

--- a/tests/Panel/ModelTest.php
+++ b/tests/Panel/ModelTest.php
@@ -12,6 +12,7 @@ use Kirby\Filesystem\F;
 use Kirby\Panel\Controller\View\ModelViewController;
 use Kirby\Panel\Controller\View\PageViewController;
 use Kirby\TestCase;
+use Kirby\Toolkit\HtmlString;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 class CustomPanelModel extends Model
@@ -416,27 +417,27 @@ class ModelTest extends TestCase
 		$panel = $this->panel();
 		$data = $panel->pickerData();
 
-		$this->assertSame([
+		$this->assertEquals([ // @phpstan-ignore-line
 			'image' => [
 				'back' => 'pattern',
 				'color' => 'gray-500',
 				'cover' => false,
 				'icon' => 'page',
 			],
-			'info' => '',
+			'info'   => new HtmlString(''),
 			'layout' => 'list',
-			'text' => '',
-			'id' => null,
-			'link' => '/site',
+			'text'   => new HtmlString(''),
+			'id'     => null,
+			'link'   => '/site',
 			'permissions' => [
-				'access' => false,
+				'access'      => false,
 				'changeTitle' => false,
-				'preview' => false,
-				'update' => false,
+				'preview'     => false,
+				'update'      => false,
 			],
-			'uuid' => 'site://',
+			'uuid'     => 'site://',
 			'sortable' => true,
-			'url' => '/custom',
+			'url'      => '/custom',
 		], $data);
 	}
 

--- a/tests/Panel/PageTest.php
+++ b/tests/Panel/PageTest.php
@@ -177,7 +177,7 @@ class PageTest extends TestCase
 		$option = $panel->dropdownOption();
 
 		$this->assertSame('page', $option['icon']);
-		$this->assertSame('Test page', $option['text']);
+		$this->assertSame('Test page', (string)$option['text']);
 		$this->assertSame('/pages/test', $option['link']);
 	}
 
@@ -392,7 +392,7 @@ class PageTest extends TestCase
 		$this->assertSame('(link: page://test-page text: Test Title)', $data['dragText']);
 		$this->assertSame('test', $data['id']);
 		$this->assertSame('/pages/test', $data['link']);
-		$this->assertSame('Test Title', $data['text']);
+		$this->assertSame('Test Title', (string)$data['text']);
 	}
 
 	public function testPosition(): void

--- a/tests/Panel/Ui/Item/FileItemTest.php
+++ b/tests/Panel/Ui/Item/FileItemTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel\Ui\Item;
 
 use Kirby\Cms\File;
 use Kirby\Cms\TestCase;
+use Kirby\Toolkit\HtmlString;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(FileItem::class)]
@@ -31,9 +32,9 @@ class FileItemTest extends TestCase
 
 		$expected = [
 			'image'    => $this->model->panel()->image(),
-			'info'     => '',
+			'info'     => new HtmlString(''),
 			'layout'   => 'list',
-			'text'     => 'test.jpg',
+			'text'     => new HtmlString('test.jpg'),
 			'id'       => 'test.jpg',
 			'link'     => '/site/files/test.jpg',
 			'permissions' => [
@@ -50,6 +51,6 @@ class FileItemTest extends TestCase
 			'url'       => $this->model->url(),
 		];
 
-		$this->assertSame($expected, $item->props());
+		$this->assertEquals($expected, $item->props()); // -ignore-line
 	}
 }

--- a/tests/Panel/Ui/Item/LanguageItemTest.php
+++ b/tests/Panel/Ui/Item/LanguageItemTest.php
@@ -44,8 +44,8 @@ class LanguageItemTest extends TestCase
 		$item = new LanguageItem($this->language);
 		$props = $item->props();
 		$this->assertSame('en', $props['id']);
-		$this->assertSame('English', $props['text']);
-		$this->assertSame('en', $props['info']);
+		$this->assertSame('English', (string)$props['text']);
+		$this->assertSame('en', (string)$props['info']);
 		$this->assertSame('black', $props['image']['back']);
 		$this->assertSame(false, $props['default']);
 		$this->assertSame(true, $props['deletable']);

--- a/tests/Panel/Ui/Item/ModelItemTest.php
+++ b/tests/Panel/Ui/Item/ModelItemTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel\Ui\Item;
 
 use Kirby\Cms\Page;
 use Kirby\Cms\TestCase;
+use Kirby\Toolkit\HtmlString;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(ModelItem::class)]
@@ -54,7 +55,7 @@ class ModelItemTest extends TestCase
 			info: 'Test'
 		);
 
-		$this->assertSame('Test', $item->props()['info']);
+		$this->assertSame('Test', (string)$item->props()['info']);
 	}
 
 	public function testInfoDynamic(): void
@@ -64,7 +65,7 @@ class ModelItemTest extends TestCase
 			info: '{{ page.title }}'
 		);
 
-		$this->assertSame('test', $item->props()['info']);
+		$this->assertSame('test', (string)$item->props()['info']);
 	}
 
 	public function testProps(): void
@@ -78,16 +79,16 @@ class ModelItemTest extends TestCase
 				'cover' => false,
 				'icon'  => 'page',
 			],
-			'info'        => '',
+			'info'        => new HtmlString(''),
 			'layout'      => 'list',
-			'text'        => 'test',
+			'text'        => new HtmlString('test'),
 			'id'          => 'test',
 			'link'        => '/pages/test',
 			'permissions' => $this->model->permissions()->toArray(),
 			'uuid'        => $this->model->uuid()?->toString()
 		];
 
-		$this->assertSame($expected, $item->props());
+		$this->assertEquals($expected, $item->props()); // -ignore-line
 	}
 
 	public function testText(): void
@@ -97,7 +98,7 @@ class ModelItemTest extends TestCase
 			text: 'Test'
 		);
 
-		$this->assertSame('Test', $item->props()['text']);
+		$this->assertSame('Test', (string)$item->props()['text']);
 	}
 
 	public function testTextDynamic(): void
@@ -107,7 +108,7 @@ class ModelItemTest extends TestCase
 			info: '{{ page.title }}'
 		);
 
-		$this->assertSame('test', $item->props()['text']);
+		$this->assertSame('test', (string)$item->props()['text']);
 	}
 
 }

--- a/tests/Panel/Ui/Item/PageItemTest.php
+++ b/tests/Panel/Ui/Item/PageItemTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel\Ui\Item;
 
 use Kirby\Cms\Page;
 use Kirby\Cms\TestCase;
+use Kirby\Toolkit\HtmlString;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(PageItem::class)]
@@ -36,9 +37,9 @@ class PageItemTest extends TestCase
 				'cover' => false,
 				'icon'  => 'page',
 			],
-			'info'     => '',
+			'info'     => new HtmlString(''),
 			'layout'   => 'list',
-			'text'     => 'test',
+			'text'     => new HtmlString('test'),
 			'id'       => 'test',
 			'link'     => '/pages/test',
 			'permissions' => [
@@ -56,6 +57,6 @@ class PageItemTest extends TestCase
 			'url'      => '/test',
 		];
 
-		$this->assertSame($expected, $item->props());
+		$this->assertEquals($expected, $item->props()); // -ignore-line
 	}
 }

--- a/tests/Panel/Ui/Item/UserItemTest.php
+++ b/tests/Panel/Ui/Item/UserItemTest.php
@@ -4,6 +4,7 @@ namespace Kirby\Panel\Ui\Item;
 
 use Kirby\Cms\TestCase;
 use Kirby\Cms\User;
+use Kirby\Toolkit\HtmlString;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(UserItem::class)]
@@ -37,9 +38,9 @@ class UserItemTest extends TestCase
 				'icon'  => 'user',
 				'ratio' => '1/1'
 			],
-			'info'        => 'Nobody',
+			'info'        => new HtmlString('Nobody'),
 			'layout'      => 'list',
-			'text'        => 'test@getkirby.com',
+			'text'        => new HtmlString('test@getkirby.com'),
 			'id'          => 'test',
 			'link'        => '/users/test',
 			'permissions' => [
@@ -57,6 +58,6 @@ class UserItemTest extends TestCase
 			'uuid'         => 'user://test',
 		];
 
-		$this->assertSame($expected, $item->props());
+		$this->assertEquals($expected, $item->props()); // -ignore-line
 	}
 }

--- a/tests/Panel/UserTest.php
+++ b/tests/Panel/UserTest.php
@@ -64,7 +64,7 @@ class UserTest extends TestCase
 
 		$option = (new User($model))->dropdownOption();
 		$this->assertSame('user', $option['icon']);
-		$this->assertSame('test@getkirby.com', $option['text']);
+		$this->assertSame('test@getkirby.com', (string)$option['text']);
 		$this->assertSame('/users/test', $option['link']);
 	}
 
@@ -329,7 +329,7 @@ class UserTest extends TestCase
 
 		$this->assertSame('test@getkirby.com', $data['email']);
 		$this->assertTrue(Str::startsWith($data['link'], '/users/'));
-		$this->assertSame('test@getkirby.com', $data['text']);
+		$this->assertSame('test@getkirby.com', (string)$data['text']);
 	}
 
 	public function testTranslation(): void

--- a/tests/Toolkit/HasI18nTest.php
+++ b/tests/Toolkit/HasI18nTest.php
@@ -33,4 +33,39 @@ class HasI18nTest extends TestCase
 		$this->assertSame('My translation', $class->translate('my.key'));
 		$this->assertSame('All 3 things', $class->translate('my.count', ['count' => 3]));
 	}
+
+	public function testI18nHtml(): void
+	{
+		$class = new class () {
+			use HasI18n;
+
+			public function translate($key, $data = [])
+			{
+				return $this->i18nHtml($key, $data);
+			}
+		};
+
+		I18n::$translations['en'] = [
+			'my.key'  => 'My <b>translation</b>',
+			'my.name' => 'Hello {name}'
+		];
+
+		$this->assertNull($class->translate(null));
+
+		$trusted = new HtmlString('<b>Trusted</b>');
+		$this->assertSame($trusted, $class->translate($trusted));
+
+		$this->assertSame(
+			'My <b>translation</b>',
+			(string)$class->translate('my.key')
+		);
+		$this->assertSame(
+			'My <b>translation</b>',
+			(string)$class->translate(fn () => 'my.key')
+		);
+		$this->assertSame(
+			'Hello &lt;script&gt;',
+			(string)$class->translate('my.name', ['name' => '<script>'])
+		);
+	}
 }

--- a/tests/Toolkit/HtmlStringTest.php
+++ b/tests/Toolkit/HtmlStringTest.php
@@ -9,6 +9,19 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(HtmlString::class)]
 class HtmlStringTest extends TestCase
 {
+	protected function setUp(): void
+	{
+		I18n::$locale       = 'en';
+		I18n::$load         = null;
+		I18n::$fallback     = 'en';
+		I18n::$translations = [];
+	}
+
+	protected function tearDown(): void
+	{
+		I18n::$translations = [];
+	}
+
 	public function testJsonSerialize(): void
 	{
 		$html = new HtmlString('<b>safe</b>');
@@ -137,6 +150,113 @@ class HtmlStringTest extends TestCase
 	{
 		$html = new HtmlString('<b>safe</b>');
 		$this->assertSame('<b>safe</b>', (string)$html);
+	}
+
+	public function testTranslate(): void
+	{
+		I18n::$translations = [
+			'en' => ['confirm' => 'Delete <b>the page</b>?']
+		];
+
+		$result = HtmlString::translate('confirm');
+
+		$this->assertInstanceOf(HtmlString::class, $result);
+		$this->assertSame('Delete <b>the page</b>?', (string)$result);
+	}
+
+	public function testTranslateEscapesValues(): void
+	{
+		I18n::$translations = [
+			'en' => ['greeting' => 'Hello <b>{name}</b>']
+		];
+
+		$result = HtmlString::translate('greeting', [
+			'name' => '<script>alert(1)</script>'
+		]);
+
+		$this->assertSame(
+			'Hello <b>&lt;script&gt;alert(1)&lt;/script&gt;</b>',
+			(string)$result
+		);
+	}
+
+	public function testTranslateEscapesQueryResults(): void
+	{
+		I18n::$translations = [
+			'en' => ['greeting' => 'Hello {user.name}']
+		];
+
+		// the value is only reachable through the query,
+		// so it has to be escaped after it was resolved
+		$result = HtmlString::translate('greeting', [
+			'user' => ['name' => '<script>alert(1)</script>']
+		]);
+
+		$this->assertSame(
+			'Hello &lt;script&gt;alert(1)&lt;/script&gt;',
+			(string)$result
+		);
+	}
+
+	public function testTranslateKeepsTrustedValues(): void
+	{
+		I18n::$translations = [
+			'en' => ['greeting' => 'Hello {name}']
+		];
+
+		$result = HtmlString::translate('greeting', [
+			'name' => new HtmlString('<b>Peter</b>')
+		]);
+
+		$this->assertSame('Hello <b>Peter</b>', (string)$result);
+	}
+
+	public function testTranslateWithArrayOfTranslations(): void
+	{
+		$result = HtmlString::translate(
+			['en' => 'Hello <b>{name}</b>'],
+			['name' => 'Peter']
+		);
+
+		$this->assertSame('Hello <b>Peter</b>', (string)$result);
+	}
+
+	public function testTranslateWithFallback(): void
+	{
+		$result = HtmlString::translate(
+			'does.not.exist',
+			[],
+			'<b>Fallback</b>'
+		);
+
+		$this->assertSame('<b>Fallback</b>', (string)$result);
+	}
+
+	public function testTranslateWithMissingKey(): void
+	{
+		// the key itself is the last resort, just like in `I18n::template()`
+		$this->assertSame(
+			'does.not.exist',
+			(string)HtmlString::translate('does.not.exist')
+		);
+	}
+
+	public function testTranslateWithMissingValue(): void
+	{
+		I18n::$translations = [
+			'en' => ['greeting' => 'Hello {name}']
+		];
+
+		$this->assertSame('Hello -', (string)HtmlString::translate('greeting'));
+	}
+
+	public function testTranslateWithTemplateString(): void
+	{
+		$result = HtmlString::translate('Hello <b>{name}</b>', [
+			'name' => '<script>'
+		]);
+
+		$this->assertSame('Hello <b>&lt;script&gt;</b>', (string)$result);
 	}
 
 	public function testValue(): void

--- a/tests/Toolkit/StrTest.php
+++ b/tests/Toolkit/StrTest.php
@@ -11,6 +11,7 @@ use Kirby\TestCase;
 use Kirby\Tests\MockTime;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use Stringable;
 use TypeError;
 
 #[CoversClass(Str::class)]
@@ -949,6 +950,26 @@ class StrTest extends TestCase
 				}
 			]
 		));
+
+		// callback receives the raw result on top of the string
+		$object = new class () implements Stringable {
+			public function __toString(): string
+			{
+				return 'object';
+			}
+		};
+
+		Str::safeTemplate(
+			'{{ object }}',
+			['object' => $object],
+			[
+				'callback' => function ($result, $query, $data, $value) use ($object) {
+					$this->assertSame('object', $result);
+					$this->assertSame($object, $value);
+					return $result;
+				}
+			]
+		);
 
 		// callback with fallback
 		$this->assertSame('This is a FALLBACK with <HTML>', Str::safeTemplate(


### PR DESCRIPTION
## Review

- [ ] Design & concept
- [x] Deep read (already mostly done by Lukas)
- [x] Security check

**Timing:**## Description

Follow-up to #8175 (`HtmlString`), #8176 (`v-safe-html`), #8347 (`HtmlString::resolve()` in responses) and #8348 (standalone strings). This PR migrates the remaining `v-html` sites in the Panel to `v-safe-html` and marks the corresponding backend strings as trusted `HtmlString`.

## Changelog

### Enhancements

- New `$model->toSafeHtmlString()` method, similar to `toSafeString()`, but the  result is marked as trusted HTML for the Panel.
- `k-text` has a new `text` prop. A plain string is escaped, trusted HTML is rendered as-is.

### ☠️ Deprecated

- `k-text`: the `html` prop has been deprecated, use `text` instead. `<k-text :html="foo" />` becomes
  `<k-text :text="$h(foo)" />` (or just `:text="foo"` if the value should be escaped).
- `k-box`: the `html` prop has been deprecated. Pass trusted HTML as `text` instead:
  `<k-box :html="true" :text="foo" />` becomes `<k-box :text="$h(foo)" />`.
- `k-tag`: the `html` prop has been deprecated. Pass trusted HTML as `text` instead.
- `k-tag-field-preview`, `k-tags-field-preview` and `k-models-field-preview`: the `html` props have
  been deprecated. Values and option texts already carry trusted HTML where appropriate.

### 🚨 Breaking changes

**Changed PHP return types** (all of these returned `string` before and now return `Kirby\Toolkit\HtmlString`; cast with `(string)` if you need the raw string, and use `==`/`assertEquals()` instead of `===`/`assertSame()` when comparing arrays that contain them):

- `Kirby\Cms\LicenseStatus::info()`: `string` → `HtmlString`
- `Kirby\Form\Mixin\Help::help()`: `string|null` → `HtmlString|null`
- `Kirby\Form\Mixin\Text::text()`: `string|null` → `HtmlString|null`
- `Kirby\Form\Field\ToggleField::text()`: `array|string|null` → `array|HtmlString|null`
  (the array variant now contains `HtmlString` entries)
- `Kirby\Panel\Ui\Item::text()`: `string` → `string|HtmlString`
- `Kirby\Panel\Ui\Item::info()`: `string|null` → `string|HtmlString|null`
- `Kirby\Panel\Ui\Item\ModelItem::text()`: `string` → `HtmlString`
- `Kirby\Panel\Ui\Item\ModelItem::info()`: `string|null` → `HtmlString|null`
- `Kirby\Panel\Lab\Doc::kt()`: `string` → `HtmlString`
- `Kirby\Toolkit\HasI18n::i18n()`: `string|null` → `string|HtmlString|null`
  (the `$key` parameter accepts `HtmlString` as well and passes it through unchanged)
- The `text` prop of the `info` section now resolves to `HtmlString`

**Changed array values.** The following arrays now carry `HtmlString` objects where they carried strings before. Relevant if you read them in PHP, compare them with `===` or run them through `is_string()`:

- `Option::render()`, `OptionsApi::resolve()` and `OptionsQuery::resolve()` → `text`, `info` (safe mode only; `safeMode: false`, e.g. the select field, is unchanged)
- `Item::props()` → `text`, `info`
- `FieldClass::toArray()` / `Field::toArray()` → `help`, `text`
- `Section::toArray()` for the `info` section → `text`

Because `HtmlString` values are marked on JSON serialization, these fields appear as `<text>`, `<info>` and `<help>` in Panel JSON responses and are rewrapped in the frontend.

**Panel components**

- `k-box`: the `html` slot binding has been removed. `<slot v-bind="{ text, html }">` is now `<slot v-bind="{ text }">`, where `text` is the resolved (possibly trusted) content.
- `k-item`: `text` and `info` are escaped unless they are trusted HTML. Plugins that passed pre-escaped or raw HTML strings will now see the markup as visible characters. Wrap the value in `$h()` (frontend) or `HtmlString` / `$model->toSafeHtmlString()` (backend).
- `k-tags` / `k-picklist-input`: an option `text` is only rendered as HTML if it is trusted HTML; plain strings are escaped, and the search highlighting escapes untrusted text before adding its `<b>` marker.
- `k-models-field-preview`: the `html` prop no longer defaults to `true`. Model items already carry trusted HTML, so the raw rendering is preserved without the flag.

### 🧹 Housekeeping

- `vue/no-v-html` is now enforced in the CI

## Docs

**`$model->toSafeHtmlString()`**

Same signature as `toSafeString()`, but the result is marked as trusted HTML so the Panel renders it as HTML instead of escaping it: 

```php
$page->toSafeHtmlString('<strong>{{ page.title }}</strong>');
```

Rule of thumb: `toSafeHtmlString()` whenever the value ends up in a Panel prop that is rendered as HTML (item `text`/`info`, option `text`, field `help`, dialog `text`); `toSafeString()` for everything that stays plain text.

**Passing trusted HTML from a plugin**

Backend:

```php
use Kirby\Toolkit\HtmlString;

return new RemoveDialog(
    text: new HtmlString(
        I18n::template('my.plugin.confirm', [
            'name' => Escape::html($page->title()->value())
        ])
    )
);
```

Frontend:

```js
// escaped
<k-text :text="value" />

// rendered as HTML
<k-text :text="$h(value)" />

// rendered i18n string as HTML that auto-escapes passed data
<k-text :text="$th('my.plugin.hint', { name: name }))" />
```

**Migrating `html: true`**

```html
<!-- before -->
<k-box :html="true" :text="text" />
<k-tag :html="true" :text="text" />
<k-text :html="text" />

<!-- after -->
<k-box :text="$h(text)" />
<k-tag :text="$h(text)" />
<k-text :text="$h(text)" />
```

If the value doesn't actually need to be HTML, drop the wrapper entirely and let it be escaped.

## For review team

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
