### PR TITLE
fix: `unescapeHTML()` unescapes entities twice

### DIFF
--- a/panel/src/helpers/string.ts
+++ b/panel/src/helpers/string.ts
@@ -6,14 +6,16 @@ import type WriterMark from "@/components/Forms/Writer/Mark";
 import type WriterNode from "@/components/Forms/Writer/Node";
 
 const escapingMap: Record<string, string> = {
-	"&": "&amp;",
 	"<": "&lt;",
 	">": "&gt;",
 	'"': "&quot;",
 	"'": "&#039;",
 	"/": "&#x2F;",
 	"`": "&#x60;",
-	"=": "&#x3D;"
+	"=": "&#x3D;",
+	// `&` has to stay last: `unescapeHTML()` walks this map in order
+	// and would otherwise turn `&amp;lt;` into `&lt;` and then into `<`
+	"&": "&amp;"
 };
 
 /**

--- a/panel/src/helpers/string.unescapeHTML.test.ts
+++ b/panel/src/helpers/string.unescapeHTML.test.ts
@@ -10,4 +10,15 @@ describe("$helper.string.unescapeHTML", () => {
 			'<div class="button">This text includes `&<>"\'/=` characters</div>'
 		);
 	});
+
+	it("should not unescape an escaped entity twice", () => {
+		expect(string.unescapeHTML("&amp;lt;b&amp;gt;")).toBe("&lt;b&gt;");
+		expect(string.unescapeHTML("a &amp;amp; b")).toBe("a &amp; b");
+	});
+
+	it("should reverse escapeHTML", () => {
+		for (const value of ["&lt;b&gt;", "a &amp; b", '<a href="#">x</a>']) {
+			expect(string.unescapeHTML(string.escapeHTML(value))).toBe(value);
+		}
+	});
 });


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- `$helper.string.unescapeHTML()` does not unescape entities twice anymore


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion