### PR TITLE
fix: Resolve arrays of `HtmlString` entries

### DIFF
--- a/panel/src/panel/html.test.ts
+++ b/panel/src/panel/html.test.ts
@@ -66,6 +66,19 @@ describe("HtmlString class", () => {
 			expect(result.options[1].text).toBe("Plain");
 		});
 
+		it("rewraps every entry of a marked list", () => {
+			const result = HtmlString.resolve({
+				"<issues>": ["<b>a</b>", "<b>b</b>"]
+			}) as unknown as { issues: HtmlString[] };
+
+			expect(Array.isArray(result.issues)).toBe(true);
+			expect(result.issues).toHaveLength(2);
+			expect(result.issues[0]).toBeInstanceOf(HtmlString);
+			expect(result.issues[0].toString()).toBe("<b>a</b>");
+			expect(result.issues[1]).toBeInstanceOf(HtmlString);
+			expect(result.issues[1].toString()).toBe("<b>b</b>");
+		});
+
 		it("does not touch plain objects/arrays", () => {
 			const input = { a: 1, b: [{ c: 2 }] };
 			const result = HtmlString.resolve(input);

--- a/panel/src/panel/html.ts
+++ b/panel/src/panel/html.ts
@@ -9,10 +9,10 @@ import { isObject } from "@/helpers/object";
  * `v-safe-html` without further escaping.
  *
  * The backend signals safety by emitting JSON with the parent key wrapped
- * in `<…>`, e.g. `"<help>": "<b>html</b>"`. `HtmlString.resolve()` walks
- * incoming state, finds those keys, rewraps their values, and strips the
- * brackets. `Kirby\Toolkit\HtmlString::resolve()` does the inverse on the
- * PHP side.
+ * in `<…>`, e.g. `"<help>": "<b>html</b>"`. A marked key can also hold a
+ * list, in which case every entry is trusted: `"<issues>": ["<b>a</b>"]`.
+ * `HtmlString.resolve()` walks incoming state, finds those keys, rewraps
+ * their values, and strips the brackets.
  *
  * Since the class extends `String`, instances behave like strings in
  * almost every context (template interpolation, attribute binding,
@@ -31,7 +31,7 @@ export class HtmlString extends String {
 	/**
 	 * Recursively walks `data` and rewraps any value whose parent key
 	 * matches `<key>` into an `HtmlString`, stripping the brackets. Plain
-	 * keys are kept as-is. Arrays are walked element by element.Class
+	 * keys are kept as-is. Arrays are walked element by element. Class
 	 * instances (e.g. component  instances passed as props) are passed
 	 * through untouched.
 	 *
@@ -56,16 +56,13 @@ export class HtmlString extends String {
 				) {
 					const key = rawKey.slice(1, -1);
 
-					if (Object.prototype.hasOwnProperty.call(result, key) === true) {
+					if (Object.hasOwn(result, key) === true) {
 						console.warn(
-							`HtmlString.fromJSON: both "${key}" and "${rawKey}" present — the bracketed version wins`
+							`HtmlString.resolve: both "${key}" and "${rawKey}" present, using "${rawKey}"`
 						);
 					}
 
-					result[key] =
-						typeof value === "string"
-							? new HtmlString(value)
-							: HtmlString.resolve(value);
+					result[key] = HtmlString.wrap(value);
 					continue;
 				}
 
@@ -76,6 +73,25 @@ export class HtmlString extends String {
 		}
 
 		return data;
+	}
+
+	/**
+	 * Turns the value of a marked `<key>` into trusted HTML:
+	 * a string becomes an `HtmlString`, a list becomes a list
+	 * of `HtmlString` values
+	 */
+	protected static wrap(value: unknown): unknown {
+		if (typeof value === "string") {
+			return new HtmlString(value);
+		}
+
+		if (Array.isArray(value) === true) {
+			return value.map((item) => HtmlString.wrap(item));
+		}
+
+		// an object cannot be trusted as a whole, but it may
+		// carry marked keys of its own further down
+		return HtmlString.resolve(value);
 	}
 }
 

--- a/src/Toolkit/HtmlString.php
+++ b/src/Toolkit/HtmlString.php
@@ -31,23 +31,68 @@ class HtmlString implements JsonSerializable, Stringable
 		return $this->value;
 	}
 
+	/**
+	 * Checks whether a key has already been marked, so that
+	 * `resolve()` can run more than once over the same data
+	 * without turning `<key>` into `<<key>>`
+	 */
+	protected static function isMarked(int|string $key): bool
+	{
+		$key = (string)$key;
+
+		return
+			strlen($key) > 2 &&
+			str_starts_with($key, '<') === true &&
+			str_ends_with($key, '>') === true;
+	}
+
+	/**
+	 * Checks whether the value is trusted HTML: an `HtmlString`
+	 * or a list of them. A single plain entry disqualifies the
+	 * whole list, so that untrusted values can never be marked
+	 * as trusted. An empty array is not a list of trusted HTML,
+	 * otherwise every empty array would get its key renamed.
+	 */
+	protected static function isTrusted(mixed $value): bool
+	{
+		if ($value instanceof HtmlString) {
+			return true;
+		}
+
+		if (
+			is_array($value) === false ||
+			$value === [] ||
+			array_is_list($value) === false
+		) {
+			return false;
+		}
+
+		return A::every($value, fn ($item) => $item instanceof HtmlString);
+	}
+
 	public function jsonSerialize(): string
 	{
 		return $this->value;
 	}
 
 	/**
-	 * Walks an array recursively and renames any key
-	 * whose value is an `HtmlString` from `key` to `<key>`,
-	 * so the JS side can detect and rewrap the value.
+	 * Walks an array recursively and renames any key whose
+	 * value is an `HtmlString` (or a list of them) from
+	 * `key` to `<key>`, so the JS side can detect and rewrap
+	 * the value.
 	 */
 	public static function resolve(array $data): array
 	{
 		$result = [];
 
 		foreach ($data as $key => $value) {
-			if ($value instanceof HtmlString) {
-				$result['<' . $key . '>'] = $value;
+			if (static::isTrusted($value) === true) {
+				// an already marked key is kept as it is
+				if (static::isMarked($key) === false) {
+					$key = '<' . $key . '>';
+				}
+
+				$result[$key] = $value;
 				continue;
 			}
 

--- a/tests/Toolkit/HtmlStringTest.php
+++ b/tests/Toolkit/HtmlStringTest.php
@@ -79,6 +79,46 @@ class HtmlStringTest extends TestCase
 		$this->assertArrayNotHasKey('<text>', $resolved['options'][1]);
 	}
 
+	public function testResolveMarksListOfHtmlStrings(): void
+	{
+		$resolved = HtmlString::resolve([
+			'issues' => [new HtmlString('<b>a</b>'), new HtmlString('<b>b</b>')]
+		]);
+
+		$this->assertArrayHasKey('<issues>', $resolved);
+		$this->assertArrayNotHasKey('issues', $resolved);
+		$this->assertSame(
+			'{"<issues>":["<b>a</b>","<b>b</b>"]}',
+			Json::encode($resolved)
+		);
+	}
+
+	public function testResolveDoesNotMarkMixedList(): void
+	{
+		$resolved = HtmlString::resolve([
+			'issues' => [new HtmlString('<b>a</b>'), 'plain']
+		]);
+
+		// a single plain string must never end up marked as trusted
+		$this->assertArrayNotHasKey('<issues>', $resolved);
+	}
+
+	public function testResolveIsIdempotent(): void
+	{
+		$data = [
+			'help'   => new HtmlString('<b>trusted</b>'),
+			'issues' => [new HtmlString('<b>a</b>')],
+			'text'   => 'plain'
+		];
+
+		$once  = HtmlString::resolve($data);
+		$twice = HtmlString::resolve($once);
+
+		// a second pass must not turn `<key>` into `<<key>>`
+		$this->assertSame(array_keys($once), array_keys($twice));
+		$this->assertSame(Json::encode($once), Json::encode($twice));
+	}
+
 	public function testResolveLeavesPlainArraysUnchanged(): void
 	{
 		$data = ['a' => 1, 'b' => ['c' => 2]];


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Support backend -> frontend HtmlString pipeline for arrays of marked html strings:

```php
[
	'issues' => [new HtmlString('<b>a</b>'), new HtmlString('<b>b</b>')]
]
```


Didn't add any changelog as the classes are introduced in v6 anyways, so treating it as if this was the state from the beginning.
