### PR TITLE
refact: Resolve `HtmlString` objects in the right places

### DIFF
--- a/panel/src/panel/panel.ts
+++ b/panel/src/panel/panel.ts
@@ -7,7 +7,7 @@ import Drag from "./drag";
 import Drawer, { type DrawerState } from "./drawer";
 import Dropdown, { type DropdownState } from "./dropdown.js";
 import Events from "./events";
-import html from "./html";
+import html, { HtmlString } from "./html";
 import Language, { type LanguageState } from "./language";
 import { type Listener } from "./listeners";
 import Menu, { type MenuState } from "./menu";
@@ -231,7 +231,8 @@ export default class Panel {
 	}
 
 	static create(app: App, plugins: Prettify<PanelPlugins> = {}): Panel {
-		const panel = reactive(new Panel(app, window.panelState, plugins));
+		const state = HtmlString.resolve(window.panelState);
+		const panel = reactive(new Panel(app, state, plugins));
 
 		// Register as the single source of truth for all Vue components
 		window.panel = app.config.globalProperties.$panel = panel;

--- a/panel/src/panel/request.test.ts
+++ b/panel/src/panel/request.test.ts
@@ -4,6 +4,7 @@ import JsonRequestError from "@/errors/JsonRequestError";
 import OfflineError from "@/errors/OfflineError";
 import RedirectError from "@/errors/RedirectError";
 import RequestError from "@/errors/RequestError";
+import { HtmlString } from "./html";
 import {
 	body,
 	globals,
@@ -133,6 +134,27 @@ describe("panel.request", () => {
 			expect(response.status).toBe(200);
 			expect(response.json).toStrictEqual({ message: "ok" });
 			expect(response.text).toStrictEqual(JSON.stringify({ message: "ok" }));
+		});
+
+		it("should rewrap <key> payloads into HtmlString instances", async () => {
+			const { response } = await responder(
+				req,
+				jsonResponse({
+					dialog: {
+						props: {
+							"<help>": "<b>trusted</b>",
+							text: "plain"
+						}
+					}
+				})
+			);
+
+			const props = (response.json.dialog as Record<string, unknown>)
+				.props as { help: HtmlString; text: string };
+
+			expect(props.help).toBeInstanceOf(HtmlString);
+			expect(props.help.toString()).toBe("<b>trusted</b>");
+			expect(props.text).toBe("plain");
 		});
 
 		it("should throw JsonRequestError for invalid JSON", async () => {

--- a/panel/src/panel/request.ts
+++ b/panel/src/panel/request.ts
@@ -8,6 +8,7 @@ import JsonRequestError from "@/errors/JsonRequestError.js";
 import OfflineError from "@/errors/OfflineError.js";
 import RedirectError from "@/errors/RedirectError.js";
 import RequestError from "@/errors/RequestError.js";
+import { HtmlString } from "@/panel/html";
 import { isAbortError } from "@/helpers/error";
 import { toLowerKeys } from "@/helpers/object";
 import { buildUrl, isSameOrigin, makeAbsolute } from "@/helpers/url";
@@ -179,7 +180,10 @@ export async function responder(
 
 	try {
 		response.text = await raw.text();
-		response.json = JSON.parse(response.text);
+
+		// rewrap any `<key>` payloads into HtmlString instances, so that
+		// the backend can flag trusted HTML through the same JSON shape
+		response.json = HtmlString.resolve(JSON.parse(response.text));
 	} catch (error) {
 		if (isAbortError(error) === true) {
 			throw error;

--- a/panel/src/panel/state.test.ts
+++ b/panel/src/panel/state.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { HtmlString } from "./html";
 import State from "./state";
 
 describe("panel.state", () => {
@@ -60,24 +59,6 @@ describe("panel.state", () => {
 			state.set({ message: null });
 
 			expect(state.message).toStrictEqual("default");
-		});
-
-		it("rewraps <key> payloads into HtmlString instances", () => {
-			const state = State("test", {
-				title: null as string | null,
-				body: null as string | HtmlString | null
-			});
-
-			state.set({
-				title: "untrusted <script>",
-				"<body>": "<p>trusted</p>"
-			} as never);
-
-			expect(state.title).toStrictEqual("untrusted <script>");
-			expect(state.body).toBeInstanceOf(HtmlString);
-			expect((state.body as HtmlString).toString()).toStrictEqual(
-				"<p>trusted</p>"
-			);
 		});
 
 		it("throws when state is not a plain object", () => {

--- a/panel/src/panel/state.ts
+++ b/panel/src/panel/state.ts
@@ -1,5 +1,4 @@
 import { reactive } from "vue";
-import { HtmlString } from "./html";
 import { isObject } from "@/helpers/object";
 
 /**
@@ -60,11 +59,6 @@ export default function State<T extends Record<string, unknown>>(
 			if (isObject(state) === false) {
 				throw new Error(`Invalid ${this.key()} state`);
 			}
-
-			// rewrap any `<key>` payloads into HtmlString instances
-			// (including nested objects and arrays), so that the
-			// backend can flag trusted HTML through the same JSON shape
-			state = HtmlString.resolve(state);
 
 			const defaults = this.defaults();
 

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -24,6 +24,7 @@ use Kirby\Http\Route;
 use Kirby\Http\Router;
 use Kirby\Session\Session;
 use Kirby\Toolkit\Collection as BaseCollection;
+use Kirby\Toolkit\HtmlString;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Pagination;
 use Throwable;
@@ -592,6 +593,7 @@ class Api
 
 		// pretty print json data
 		$pretty = (bool)($requestData['query']['pretty'] ?? false) === true;
+		$code   = 200;
 
 		if (($result['status'] ?? 'ok') === 'error') {
 			$code = $result['code'] ?? 400;
@@ -600,11 +602,15 @@ class Api
 			if ($code < 400 || $code > 599) {
 				$code = 500;
 			}
-
-			return Response::json($result, $code, $pretty);
 		}
 
-		return Response::json($result, 200, $pretty);
+		// mark trusted HTML for the Panel, but never for the public
+		// API, where the marked keys would be a breaking change
+		if ((bool)$this->requestHeaders('x-panel') === true) {
+			$result = HtmlString::resolve($result);
+		}
+
+		return Response::json($result, $code, $pretty);
 	}
 
 	/**

--- a/src/Panel/Response/JsonResponse.php
+++ b/src/Panel/Response/JsonResponse.php
@@ -10,6 +10,7 @@ use Kirby\Http\Response;
 use Kirby\Panel\Area;
 use Kirby\Panel\Redirect;
 use Kirby\Panel\Ui\Component;
+use Kirby\Toolkit\HtmlString;
 use Throwable;
 
 /**
@@ -44,7 +45,7 @@ class JsonResponse extends Response
 	 */
 	public function body(): string
 	{
-		return Json::encode([static::$key => $this->data()], $this->pretty());
+		return Json::encode($this->payload(), $this->pretty());
 	}
 
 	/**
@@ -170,6 +171,15 @@ class JsonResponse extends Response
 	}
 
 	/**
+	 * Returns the full body data with all trusted HTML
+	 * marked for the frontend.
+	 */
+	protected function payload(): array
+	{
+		return HtmlString::resolve($this->wrap());
+	}
+
+	/**
 	 * Should the JSON in the body be pretty-printed?
 	 */
 	public function pretty(): bool
@@ -196,5 +206,13 @@ class JsonResponse extends Response
 	public function type(): string
 	{
 		return 'application/json';
+	}
+
+	/**
+	 * Wraps the data in the response key namespace
+	 */
+	protected function wrap(): array
+	{
+		return [static::$key => $this->data()];
 	}
 }

--- a/src/Panel/Response/RequestResponse.php
+++ b/src/Panel/Response/RequestResponse.php
@@ -2,8 +2,6 @@
 
 namespace Kirby\Panel\Response;
 
-use Kirby\Data\Json;
-
 /**
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
@@ -12,20 +10,19 @@ use Kirby\Data\Json;
 class RequestResponse extends JsonResponse
 {
 	/**
-	 * Returns the data as JSON
-	 * Request responses are not wrapped in a custom namespace
-	 */
-	public function body(): string
-	{
-		return Json::encode($this->data(), $this->pretty());
-	}
-
-	/**
 	 * Returns the full data array
 	 * without additional information
 	 */
 	public function data(): array
 	{
 		return $this->data;
+	}
+
+	/**
+	 * Request responses are not wrapped in a key namespace
+	 */
+	protected function wrap(): array
+	{
+		return $this->data();
 	}
 }

--- a/src/Panel/Response/ViewDocumentResponse.php
+++ b/src/Panel/Response/ViewDocumentResponse.php
@@ -60,7 +60,7 @@ class ViewDocumentResponse extends ViewResponse
 			'assets'     => $this->assets->external(),
 			'icons'      => $this->assets->icons(),
 			'nonce'      => $this->kirby->nonce(),
-			'state'      => $this->data(),
+			'state'      => $this->payload(),
 			'panelUrl'   => $this->url(),
 		]);
 	}

--- a/src/Panel/Response/ViewResponse.php
+++ b/src/Panel/Response/ViewResponse.php
@@ -3,7 +3,6 @@
 namespace Kirby\Panel\Response;
 
 use Kirby\Cms\App;
-use Kirby\Data\Json;
 use Kirby\Http\Response;
 use Kirby\Panel\Redirect;
 use Kirby\Panel\State;
@@ -32,15 +31,6 @@ class ViewResponse extends JsonResponse
 			code: $code,
 			pretty: $pretty
 		);
-	}
-
-	/**
-	 * Returns the data as JSON
-	 * Request responses are not wrapped in a custom namespace
-	 */
-	public function body(): string
-	{
-		return Json::encode($this->data(), $this->pretty());
 	}
 
 	/**
@@ -126,5 +116,13 @@ class ViewResponse extends JsonResponse
 	public function view(): array
 	{
 		return $this->view;
+	}
+
+	/**
+	 * View responses are not wrapped in a key namespace
+	 */
+	protected function wrap(): array
+	{
+		return $this->data();
 	}
 }

--- a/src/Panel/State.php
+++ b/src/Panel/State.php
@@ -8,7 +8,6 @@ use Kirby\Cms\Language;
 use Kirby\Cms\User;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Date;
-use Kirby\Toolkit\HtmlString;
 use Kirby\Toolkit\Str;
 
 /**
@@ -274,20 +273,17 @@ class State
 		if ($globals === false) {
 			// filter data, if only globals headers or
 			// query parameters are requested
-			$data = $this->filter($data);
-			return HtmlString::resolve($data);
+			return $this->filter($data);
 		}
 
 		// load globals for the full document response
 		$globals = $this->globals();
 
 		// resolve and merge globals and shared data
-		$data = array_merge_recursive(
+		return array_merge_recursive(
 			A::apply($globals),
 			A::apply($data)
 		);
-
-		return HtmlString::resolve($data);
 	}
 
 	public function translation(): array

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -16,6 +16,7 @@ use Kirby\Filesystem\Dir;
 use Kirby\Http\Response as HttpResponse;
 use Kirby\TestCase;
 use Kirby\Toolkit\Collection;
+use Kirby\Toolkit\HtmlString;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Obj;
 use stdClass;
@@ -992,6 +993,55 @@ class ApiTest extends TestCase
 
 		$this->assertInstanceOf(HttpResponse::class, $result);
 		$this->assertSame(json_encode(['a' => 'A']), $result->body());
+	}
+
+	public function testRenderArrayWithHtmlString(): void
+	{
+		$api = new Api([
+			'routes' => [
+				[
+					'pattern' => 'test',
+					'method'  => 'POST',
+					'action'  => fn () => [
+						'text' => new HtmlString('<b>trusted</b>'),
+						'info' => 'plain'
+					]
+				]
+			]
+		]);
+
+		$result = $api->render('test', 'POST', [
+			'headers' => ['x-panel' => 'true']
+		]);
+
+		$this->assertSame(
+			json_encode(['<text>' => '<b>trusted</b>', 'info' => 'plain']),
+			$result->body()
+		);
+	}
+
+	public function testRenderArrayWithHtmlStringOutsideThePanel(): void
+	{
+		$api = new Api([
+			'routes' => [
+				[
+					'pattern' => 'test',
+					'method'  => 'POST',
+					'action'  => fn () => [
+						'text' => new HtmlString('<b>trusted</b>'),
+						'info' => 'plain'
+					]
+				]
+			]
+		]);
+
+		$result = $api->render('test', 'POST');
+
+		// without the Panel header, keys must stay untouched
+		$this->assertSame(
+			json_encode(['text' => '<b>trusted</b>', 'info' => 'plain']),
+			$result->body()
+		);
 	}
 
 	public function testRenderTrue(): void

--- a/tests/Panel/Response/JsonResponseTest.php
+++ b/tests/Panel/Response/JsonResponseTest.php
@@ -10,6 +10,7 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Panel\Redirect;
 use Kirby\Panel\TestCase;
 use Kirby\Panel\Ui\Button;
+use Kirby\Toolkit\HtmlString;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(JsonResponse::class)]
@@ -53,6 +54,19 @@ class JsonResponseTest extends TestCase
 		];
 
 		$this->assertSame(Json::encode(['response' => $expected], true), $response->body());
+	}
+
+	public function testBodyWithHtmlString(): void
+	{
+		$response = new JsonResponse([
+			'help' => new HtmlString('<b>trusted</b>'),
+			'text' => 'plain'
+		]);
+
+		$body = Json::decode($response->body());
+
+		$this->assertSame('<b>trusted</b>', $body['response']['<help>']);
+		$this->assertSame('plain', $body['response']['text']);
 	}
 
 	public function testData(): void
@@ -194,6 +208,15 @@ class JsonResponseTest extends TestCase
 	{
 		$response = new JsonResponse();
 		$this->assertSame('response', $response->key());
+	}
+
+	public function testPayload(): void
+	{
+		$response = new JsonResponse(['foo' => 'bar']);
+		$payload  = Json::decode($response->body());
+
+		$this->assertSame(['response'], array_keys($payload));
+		$this->assertSame('bar', $payload['response']['foo']);
 	}
 
 	public function testPretty(): void


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

Doing it in `State` would miss dialog requests etc., now on the backend resolving in every `JsonResponse` and also the API (if requests comes from the Panel). And on the frontend, we do it centrally in the `request` module.


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion