### PR TITLE
refact: Migrate standalone strings to `v-safe-html`

### DIFF
--- a/panel/src/components/Forms/Blocks/BlockPasteboard.vue
+++ b/panel/src/components/Forms/Blocks/BlockPasteboard.vue
@@ -11,11 +11,7 @@
 		@submit="$emit('submit')"
 	>
 		<label
-			v-safe-html="
-				$panel.html(
-					$t('field.blocks.fieldsets.paste', { shortcut: $esc(shortcut) })
-				)
-			"
+			v-safe-html="$th('field.blocks.fieldsets.paste', { shortcut })"
 			for="pasteboard"
 		/>
 		<textarea id="pasteboard" @paste.prevent="paste" />

--- a/panel/src/components/Forms/Blocks/BlockPasteboard.vue
+++ b/panel/src/components/Forms/Blocks/BlockPasteboard.vue
@@ -10,12 +10,14 @@
 		@cancel="$emit('cancel')"
 		@submit="$emit('submit')"
 	>
-		<!-- eslint-disable vue/no-v-html -->
 		<label
+			v-safe-html="
+				$panel.html(
+					$t('field.blocks.fieldsets.paste', { shortcut: $esc(shortcut) })
+				)
+			"
 			for="pasteboard"
-			v-html="$t('field.blocks.fieldsets.paste', { shortcut })"
 		/>
-		<!-- eslint-enable -->
 		<textarea id="pasteboard" @paste.prevent="paste" />
 	</k-dialog>
 </template>

--- a/panel/src/components/Forms/Blocks/BlockSelector.vue
+++ b/panel/src/components/Forms/Blocks/BlockSelector.vue
@@ -32,12 +32,12 @@
 				/>
 			</k-navigate>
 		</details>
-		<!-- eslint-disable vue/no-v-html -->
 		<p
+			v-safe-html="
+				$panel.html($t('field.blocks.fieldsets.paste', { shortcut: $esc(shortcut) }))
+			"
 			class="k-clipboard-hint"
-			v-html="$t('field.blocks.fieldsets.paste', { shortcut })"
 		/>
-		<!-- eslint-enable -->
 	</k-dialog>
 </template>
 

--- a/panel/src/components/Forms/Blocks/BlockSelector.vue
+++ b/panel/src/components/Forms/Blocks/BlockSelector.vue
@@ -33,9 +33,7 @@
 			</k-navigate>
 		</details>
 		<p
-			v-safe-html="
-				$panel.html($t('field.blocks.fieldsets.paste', { shortcut: $esc(shortcut) }))
-			"
+			v-safe-html="$th('field.blocks.fieldsets.paste', { shortcut })"
 			class="k-clipboard-hint"
 		/>
 	</k-dialog>

--- a/panel/src/components/Views/Installation/InstallationView.vue
+++ b/panel/src/components/Views/Installation/InstallationView.vue
@@ -58,8 +58,6 @@
 </template>
 
 <script>
-import html from "@/panel/html";
-
 /**
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
@@ -120,24 +118,18 @@ export default {
 			const issues = [];
 
 			if (this.isInstallable === false) {
-				issues.push(html(this.$t("installation.disabled")));
+				issues.push(this.$th("installation.disabled"));
 			}
 
 			for (const extension in this.requirements.extensions) {
 				if (this.requirements.extensions[extension] === false) {
-					issues.push(
-						html(
-							this.$t("installation.issues.extension", {
-								extension: this.$esc(extension)
-							})
-						)
-					);
+					issues.push(this.$th("installation.issues.extension", { extension }));
 				}
 			}
 
 			for (const type of ["accounts", "content", "media", "sessions"]) {
 				if (this.requirements[type] === false) {
-					issues.push(html(this.$t("installation.issues." + type)));
+					issues.push(this.$th("installation.issues." + type));
 				}
 			}
 

--- a/panel/src/components/Views/Installation/InstallationView.vue
+++ b/panel/src/components/Views/Installation/InstallationView.vue
@@ -40,8 +40,7 @@
 
 				<k-checklist theme="negative" class="k-installation-issues">
 					<li v-for="issue in issues" :key="issue">
-						<!-- eslint-disable-next-line vue/no-v-html -->
-						<span v-html="issue" />
+						<span v-safe-html="issue" />
 					</li>
 				</k-checklist>
 			</k-stack>
@@ -59,6 +58,8 @@
 </template>
 
 <script>
+import html from "@/panel/html";
+
 /**
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
@@ -119,18 +120,24 @@ export default {
 			const issues = [];
 
 			if (this.isInstallable === false) {
-				issues.push(this.$t("installation.disabled"));
+				issues.push(html(this.$t("installation.disabled")));
 			}
 
 			for (const extension in this.requirements.extensions) {
 				if (this.requirements.extensions[extension] === false) {
-					issues.push(this.$t("installation.issues.extension", { extension }));
+					issues.push(
+						html(
+							this.$t("installation.issues.extension", {
+								extension: this.$esc(extension)
+							})
+						)
+					);
 				}
 			}
 
 			for (const type of ["accounts", "content", "media", "sessions"]) {
 				if (this.requirements[type] === false) {
-					issues.push(this.$t("installation.issues." + type));
+					issues.push(html(this.$t("installation.issues." + type)));
 				}
 			}
 

--- a/panel/src/helpers/string.ts
+++ b/panel/src/helpers/string.ts
@@ -375,7 +375,7 @@ export function template(
 	}
 
 	const resolve = (parts: string[], data: StringTemplateValues = {}) => {
-		const part = escapeHTML(parts.shift());
+		const part = parts.shift() as string;
 		const value = data[part] ?? "…";
 
 		if (value === "…" || parts.length === 0) {

--- a/panel/src/panel/html.test.ts
+++ b/panel/src/panel/html.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import html, { HtmlString } from "./html";
+import html, { escape, HtmlString } from "./html";
 
 describe("HtmlString class", () => {
 	describe("instance", () => {
@@ -165,7 +165,38 @@ describe("HtmlString class", () => {
 	});
 });
 
-describe("$html()", () => {
+describe("escape()", () => {
+	it("escapes plain string values", () => {
+		expect(escape({ name: "<script>" })).toEqual({
+			name: "&lt;script&gt;"
+		});
+	});
+
+	it("escapes nested values", () => {
+		expect(escape({ user: { name: "<script>" } })).toEqual({
+			user: { name: "&lt;script&gt;" }
+		});
+	});
+
+	it("passes trusted values through unescaped", () => {
+		expect(escape({ name: new HtmlString("<b>Peter</b>") })).toEqual({
+			name: "<b>Peter</b>"
+		});
+	});
+
+	it("keeps null and undefined as null", () => {
+		expect(escape({ a: null, b: undefined })).toEqual({ a: null, b: null });
+	});
+
+	it("escapes non-string primitives", () => {
+		expect(escape({ count: 42, flag: true })).toEqual({
+			count: "42",
+			flag: "true"
+		});
+	});
+});
+
+describe("html()", () => {
 	it("wraps a plain string in HtmlString", () => {
 		const result = html("<b>x</b>");
 		expect(result).toBeInstanceOf(HtmlString);

--- a/panel/src/panel/html.ts
+++ b/panel/src/panel/html.ts
@@ -1,23 +1,14 @@
+import { escapeHTML, StringTemplateValues } from "@/helpers/string";
 import { isObject } from "@/helpers/object";
+
+export type HtmlData = {
+	[key: string]:
+		StringTemplateValues[string] | HtmlString | HtmlData | undefined;
+};
 
 /**
  * Wraps and marks a string as trusted, pre-escaped HTML.
- *
- * A plain string flowing through Panel state is treated as untrusted and
- * should get escaped at the render site. An `HtmlString` instance can be
- *  passed through unchanged, so it can be rendered via `v-html`/
- * `v-safe-html` without further escaping.
- *
- * The backend signals safety by emitting JSON with the parent key wrapped
- * in `<…>`, e.g. `"<help>": "<b>html</b>"`. A marked key can also hold a
- * list, in which case every entry is trusted: `"<issues>": ["<b>a</b>"]`.
- * `HtmlString.resolve()` walks incoming state, finds those keys, rewraps
- * their values, and strips the brackets.
- *
- * Since the class extends `String`, instances behave like strings in
- * almost every context (template interpolation, attribute binding,
- * concatenation, `JSON.stringify`), and `instanceof` survives Vue's
- * `reactive()` proxy and prop type validation.
+ * Used by `v-safe-html` to render as actual HTML.
  *
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
@@ -29,13 +20,8 @@ export class HtmlString extends String {
 	}
 
 	/**
-	 * Recursively walks `data` and rewraps any value whose parent key
-	 * matches `<key>` into an `HtmlString`, stripping the brackets. Plain
-	 * keys are kept as-is. Arrays are walked element by element. Class
-	 * instances (e.g. component  instances passed as props) are passed
-	 * through untouched.
-	 *
-	 * Returns a new object/array; does not mutate the input.
+	 * Recursively walks `data` and rewraps any value
+	 * whose parent key matches `<key>` into an `HtmlString`.
 	 */
 	static resolve<T>(data: T): T {
 		if (Array.isArray(data) === true) {
@@ -76,9 +62,7 @@ export class HtmlString extends String {
 	}
 
 	/**
-	 * Turns the value of a marked `<key>` into trusted HTML:
-	 * a string becomes an `HtmlString`, a list becomes a list
-	 * of `HtmlString` values
+	 * Turns the value of a marked `<key>` into trusted HTML
 	 */
 	protected static wrap(value: unknown): unknown {
 		if (typeof value === "string") {
@@ -93,6 +77,31 @@ export class HtmlString extends String {
 		// carry marked keys of its own further down
 		return HtmlString.resolve(value);
 	}
+}
+
+/**
+ * Escapes all values that get interpolated into a trusted string.
+ *
+ * @since 6.0.0
+ */
+export function escape(values: HtmlData): StringTemplateValues {
+	const escaped: StringTemplateValues = {};
+
+	for (const key in values) {
+		const value = values[key];
+
+		if (value instanceof HtmlString) {
+			escaped[key] = String(value);
+		} else if (isObject(value) === true) {
+			escaped[key] = escape(value as HtmlData);
+		} else if (value === null || value === undefined) {
+			escaped[key] = null;
+		} else {
+			escaped[key] = escapeHTML(value);
+		}
+	}
+
+	return escaped;
 }
 
 /**

--- a/panel/src/panel/legacy.ts
+++ b/panel/src/panel/legacy.ts
@@ -26,9 +26,11 @@ export default {
 		);
 		app.config.globalProperties.$events = panel.events;
 		app.config.globalProperties.$go = panel.view.open.bind(panel.view);
+		app.config.globalProperties.$h = panel.html;
 		app.config.globalProperties.$html = panel.html;
 		app.config.globalProperties.$reload = panel.reload;
 		app.config.globalProperties.$t = panel.$t = panel.t;
+		app.config.globalProperties.$th = panel.th;
 		app.config.globalProperties.$url = panel.url;
 	}
 };

--- a/panel/src/panel/panel.ts
+++ b/panel/src/panel/panel.ts
@@ -170,6 +170,7 @@ export default class Panel {
 	redirect: typeof redirect;
 	reload: ReturnType<typeof View>["reload"];
 	t: ReturnType<typeof Translation>["translate"];
+	th: ReturnType<typeof Translation>["translateHtml"];
 
 	// deprecated: assigned by the legacy plugin, not the core
 	$t!: ReturnType<typeof Translation>["translate"];
@@ -218,6 +219,7 @@ export default class Panel {
 
 		// translator
 		this.t = this.translation.translate.bind(this.translation);
+		this.th = this.translation.translateHtml.bind(this.translation);
 
 		// register all plugins
 		this.plugins = Plugins(this.app, plugins);

--- a/panel/src/panel/translation.test.ts
+++ b/panel/src/panel/translation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import dayjs from "@/libraries/dayjs";
+import html, { HtmlString } from "./html";
 import Translation from "./translation";
 
 describe("panel.translation", () => {
@@ -116,6 +117,89 @@ describe("panel.translation", () => {
 		it("returns undefined for non-string keys", () => {
 			const translation = Translation();
 			expect(translation.translate(123)).toBeUndefined();
+		});
+	});
+
+	describe("translateHtml()", () => {
+		it("marks the translation as trusted HTML", () => {
+			const translation = Translation();
+			translation.set({ data: { confirm: "Delete <b>the page</b>?" } });
+
+			const result = translation.translateHtml("confirm");
+
+			expect(result).toBeInstanceOf(HtmlString);
+			expect(result.toString()).toStrictEqual("Delete <b>the page</b>?");
+		});
+
+		it("escapes interpolated values", () => {
+			const translation = Translation();
+			translation.set({ data: { greeting: "Hello <b>{{ name }}</b>" } });
+
+			expect(
+				translation.translateHtml("greeting", { name: "<script>" }).toString()
+			).toStrictEqual("Hello <b>&lt;script&gt;</b>");
+		});
+
+		it("escapes nested values", () => {
+			const translation = Translation();
+			translation.set({ data: { greeting: "Hello {{ user.name }}" } });
+
+			expect(
+				translation
+					.translateHtml("greeting", { user: { name: "<script>" } })
+					.toString()
+			).toStrictEqual("Hello &lt;script&gt;");
+		});
+
+		it("passes trusted values through unescaped", () => {
+			const translation = Translation();
+			translation.set({ data: { greeting: "Hello {{ name }}" } });
+
+			expect(
+				translation
+					.translateHtml("greeting", { name: html("<b>Peter</b>") })
+					.toString()
+			).toStrictEqual("Hello <b>Peter</b>");
+		});
+
+		it("keeps the placeholder fallback for empty values", () => {
+			const translation = Translation();
+			translation.set({ data: { greeting: "Hello {{ name }}" } });
+
+			expect(
+				translation.translateHtml("greeting", { name: null }).toString()
+			).toStrictEqual("Hello …");
+		});
+
+		it("uses the key as fallback when key does not exist", () => {
+			const translation = Translation();
+			expect(translation.translateHtml("missing.key").toString()).toStrictEqual(
+				"missing.key"
+			);
+		});
+
+		it("accepts fallback as second argument", () => {
+			const translation = Translation();
+			expect(
+				translation.translateHtml("missing.key", "<b>Fallback</b>").toString()
+			).toStrictEqual("<b>Fallback</b>");
+		});
+
+		it("accepts fallback as third argument alongside data", () => {
+			const translation = Translation();
+			expect(
+				translation
+					.translateHtml("missing.key", { name: "Peter" }, "Fallback")
+					.toString()
+			).toStrictEqual("Fallback");
+		});
+
+		it("returns an empty HtmlString for non-string keys", () => {
+			const translation = Translation();
+			const result = translation.translateHtml(123 as unknown as string);
+
+			expect(result).toBeInstanceOf(HtmlString);
+			expect(result.toString()).toStrictEqual("");
 		});
 	});
 });

--- a/panel/src/panel/translation.ts
+++ b/panel/src/panel/translation.ts
@@ -1,6 +1,7 @@
 import { reactive } from "vue";
 import dayjs from "@/libraries/dayjs";
 import { StringTemplateValues, template } from "@/helpers/string";
+import html, { escape, HtmlData, HtmlString } from "./html";
 import State from "./state";
 
 export type TranslationState = {
@@ -72,6 +73,37 @@ export default function Translation() {
 		return template(value, data);
 	}
 
+	/**
+	 * Same as `translate()`, but marks the result as trusted HTML
+	 * and escapes every filled placeholder.
+	 *
+	 * @example
+	 * th("page.delete.confirm", { title: page.title })
+	 * th("<b>{title}</b>", { title: "<script>" }) // "<b>&lt;script&gt;</b>"
+	 * th("key", { link: html("<a href='#'>Link</a>") }) // passed through
+	 *
+	 * @since 6.0.0
+	 */
+	function translateHtml(key: string, fallback: string): HtmlString;
+	function translateHtml(
+		key: string,
+		data?: HtmlData,
+		fallback?: string
+	): HtmlString;
+	function translateHtml(
+		this: { data: Data },
+		key: string,
+		data?: HtmlData | string,
+		fallback?: string
+	): HtmlString {
+		if (typeof data === "string") {
+			fallback = data;
+			data = undefined;
+		}
+
+		return html(translate.call(this, key, escape(data ?? {}), fallback));
+	}
+
 	return reactive({
 		...parent,
 
@@ -96,6 +128,7 @@ export default function Translation() {
 			return this.state();
 		},
 
-		translate
+		translate,
+		translateHtml
 	});
 }

--- a/panel/src/types/vue.d.ts
+++ b/panel/src/types/vue.d.ts
@@ -11,11 +11,13 @@ declare module "vue" {
 		$esc: typeof helper.string.escapeHTML;
 		$events: Panel["events"];
 		$go: Panel["view"]["open"];
+		$h: Panel["html"];
 		$helper: typeof helper;
 		$library: typeof library;
 		$panel: Panel;
 		$reload: Panel["reload"];
 		$t: Panel["t"];
+		$th: Panel["th"];
 		$url: Panel["url"];
 	}
 }

--- a/panel/tests/unit/setup.ts
+++ b/panel/tests/unit/setup.ts
@@ -3,8 +3,10 @@ import { config } from "@vue/test-utils";
 import { vi } from "vitest";
 import Panel from "@/panel/panel";
 import Helpers from "@/helpers";
+import html from "@/panel/html";
 import Libraries from "@/libraries";
 import SafeHtml from "@/config/safeHtml";
+import Translation from "@/panel/translation";
 
 declare global {
 	var app: App;
@@ -12,38 +14,21 @@ declare global {
 }
 
 globalThis.app ??= createApp({});
-
-/**
- * The setup runs once per test file, but tests share one module
- * registry (due to `--no-isolate`), so globals below are assigned
- * rather than appended or defaulted: a test file may replace them
- * for its own purposes, and every following file starts clean again.
- */
-
-/**
- * The same plugins the real app installs, so components get
- * `$helper`, `$esc`, `$library` and `v-safe-html` without every
- * test having to mock them. They are self-contained and don't
- * depend on a running Panel.
- */
 config.global.plugins = [Helpers, Libraries, SafeHtml];
 
-/**
- * Minimal stand-in for the global panel object,
- * so components can emit deprecation warnings and
- * translate without a full Panel instance.
- */
+const translation = Translation();
+
 globalThis.panel = {
 	deprecated: vi.fn(),
-	t: (key: string) => key
+	html,
+	t: translation.translate.bind(translation),
+	th: translation.translateHtml.bind(translation)
 } as unknown as Panel;
 
-/**
- * `$t` is a global property in the real app. It delegates instead of
- * being bound once, so a test that replaces the panel is picked up.
- */
 config.global.mocks = {
-	$t: (...args: Parameters<Panel["t"]>) => window.panel.t(...args)
+	$h: (...args: Parameters<Panel["html"]>) => window.panel.html(...args),
+	$t: (...args: Parameters<Panel["t"]>) => window.panel.t(...args),
+	$th: (...args: Parameters<Panel["th"]>) => window.panel.th(...args)
 };
 
 /**


### PR DESCRIPTION
## Review

- [x] Design & concept
- [x] Rough pass


## Description

Follow-up to the `v-safe-html` groundwork. It migrates a few standalone strings (not coming from the backend) off `v-html`.

### `$th()`

A few translation keys carry markup on purpose, e.g.

    "field.blocks.fieldsets.paste": "Press <kbd>{{ shortcut }}</kbd> to import …"
    "installation.issues.extension": "The <code>{extension}</code> PHP extension is required"

Until now the only way to render those was `v-html="$t(…)"` plus an eslint-disable comment, which also handed the interpolated values straight to `innerHTML`. `$th()` splits the two halves of that string: the translation is authored and stays trusted, everything substituted into it is data and gets escaped. The result is an `HtmlString`, so `v-safe-html` renders it properly.

### `string.template()` no longer escapes placeholder keys

`template()` ran `escapeHTML()` over the *lookup key*. The key is never part of the output. A failed lookup resolves to `…`. So escaping it could only ever break lookups for keys containing `& < > " ' / \` =`. Removed.

## Changelog

### ✨ Enhancements

- New `$th()` helper for translations that contain markup. It marks the translation's own  HTML as trusted but escapes everything interpolated into it, so `v-safe-html="$th('some.key', { name })"`  is safe even when `name` contains HTML. Use `$h()` (shorthand for `$html()`) to mark a single value as trusted and pass it through unescaped.

### 🐛 Bug fixes

- `$helper.string.template()` no longer HTML-escapes the placeholder key, which prevented  lookups for keys containing characters like `/` or `&`.

### ♻️ Refactored

- The block pasteboard, block selector and installation view no longer use `v-html`.

