### PR TITLE
fix: `url.buildQuery` to support nested params

### DIFF
--- a/panel/src/helpers/url.buildQuery.test.ts
+++ b/panel/src/helpers/url.buildQuery.test.ts
@@ -19,6 +19,55 @@ describe("$helper.url.buildQuery", () => {
 		expect(query.toString()).toStrictEqual("search=Test");
 	});
 
+	it("should remove null from origin", () => {
+		const query = url.buildQuery(
+			{
+				search: null
+			},
+			"?page=1&search=Test"
+		);
+
+		expect(query.toString()).toStrictEqual("page=1");
+	});
+
+	it("should nest objects", () => {
+		const query = url.buildQuery({
+			fields: {
+				gallery: { page: 2, searchterm: "Test" }
+			}
+		});
+
+		expect(decodeURIComponent(query.toString())).toStrictEqual(
+			"fields[gallery][page]=2&fields[gallery][searchterm]=Test"
+		);
+	});
+
+	it("should only replace the addressed scope", () => {
+		const query = url.buildQuery(
+			{
+				fields: { gallery: { page: 2 } }
+			},
+			"?fields%5Bcover%5D%5Bpage%5D=3&fields%5Bgallery%5D%5Bpage%5D=1"
+		);
+
+		expect(decodeURIComponent(query.toString())).toStrictEqual(
+			"fields[cover][page]=3&fields[gallery][page]=2"
+		);
+	});
+
+	it("should remove a nested null", () => {
+		const query = url.buildQuery(
+			{
+				fields: { gallery: { searchterm: null } }
+			},
+			"?fields%5Bgallery%5D%5Bpage%5D=1&fields%5Bgallery%5D%5Bsearchterm%5D=Test"
+		);
+
+		expect(decodeURIComponent(query.toString())).toStrictEqual(
+			"fields[gallery][page]=1"
+		);
+	});
+
 	it("should skip undefined", () => {
 		const query = url.buildQuery({
 			search: "Test",

--- a/panel/src/helpers/url.ts
+++ b/panel/src/helpers/url.ts
@@ -3,6 +3,8 @@
  * @license   https://opensource.org/licenses/MIT
  */
 
+import { isObject } from "@/helpers/object";
+
 /**
  * Returns the base URL from the <base> element
  * @since 4.0.0
@@ -25,14 +27,33 @@ export function buildQuery(
 	const search = origin instanceof URL ? origin.search : origin;
 	const params = new URLSearchParams(search);
 
-	// add all data params unless they are null or undefined
-	for (const [key, value] of Object.entries(query)) {
-		if (value != null) {
-			params.set(key, String(value));
-		}
-	}
+	addParams(params, query);
 
 	return params;
+}
+
+/**
+ * Adds all entries of the given object to the params.
+ * Nested objects turn into `parent[child]` keys, `null` removes
+ * a param, `undefined` keeps it.
+ * @since 6.0.0
+ */
+function addParams(
+	params: URLSearchParams,
+	query: Record<string, unknown>,
+	prefix?: string
+): void {
+	for (const [key, value] of Object.entries(query)) {
+		const name = prefix ? `${prefix}[${key}]` : key;
+
+		if (value === null) {
+			params.delete(name);
+		} else if (isObject(value) === true) {
+			addParams(params, value, name);
+		} else if (value !== undefined) {
+			params.set(name, String(value));
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- `$helper.url.buildQuery()` now supports nested objects as params


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion