### PR TITLE
fix: Discard message for other user's changes

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -416,6 +416,7 @@
 
 	"form.discard": "Discard changes",
 	"form.discard.confirm": "Do you really want to <strong>discard all your changes</strong>?",
+	"form.discard.confirm.editor": "Do you really want to <strong>discard the unsaved changes</strong> made by <strong>{editor}</strong>?",
 	"form.locked": "This content is disabled for you as it is currently edited by another user",
 	"form.unsaved": "The current changes have not yet been saved",
 	"form.preview": "Preview changes",

--- a/panel/src/components/Forms/FormControls.vue
+++ b/panel/src/components/Forms/FormControls.vue
@@ -121,6 +121,8 @@ export default {
 	},
 	methods: {
 		discard() {
+			const isCurrentUser = this.editor === this.$panel.user.email;
+
 			this.$panel.dialog.open({
 				component: "k-remove-dialog",
 				props: {
@@ -130,7 +132,11 @@ export default {
 						icon: "undo",
 						text: this.$t("form.discard")
 					},
-					text: this.$t("form.discard.confirm")
+					text: isCurrentUser
+						? this.$t("form.discard.confirm")
+						: this.$t("form.discard.confirm.editor", {
+								editor: this.$helper.string.stripHTML(this.editor)
+							})
 				},
 				on: {
 					submit: () => {


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Show clearer Panel dialog message when discarding changes of another user
https://github.com/getkirby/kirby/issues/8065

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion