### PR TITLE
fix: Stuck unsaved changes for untouched fields

### DIFF
--- a/config/fields/object.php
+++ b/config/fields/object.php
@@ -63,6 +63,9 @@ return [
 		}
 	],
 	'methods' => [
+		'emptyValue' => function () {
+			return '';
+		},
 		'form' => function (array $values = []) {
 			return new Form([
 				'fields' => $this->attrs['fields'],

--- a/config/fields/toggle.php
+++ b/config/fields/toggle.php
@@ -55,6 +55,9 @@ return [
 		}
 	],
 	'methods' => [
+		'emptyValue' => function () {
+			return false;
+		},
 		'toBool' => function ($value) {
 			return in_array($value, [true, 'true', 1, '1', 'on'], true) === true;
 		}

--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -321,8 +321,11 @@ class Field extends Component
 	#[BlockCollectionAccess]
 	public function fillWithEmptyValue(): static
 	{
-		$this->value = $this->emptyValue();
-		return $this;
+		// go through `::fill()` to reevaluate the computed props;
+		// otherwise a field that has never been filled could end up
+		// with a different form value than the same field filled with
+		// its own empty value
+		return $this->fill($this->emptyValue());
 	}
 
 	/**

--- a/tests/Form/Field/ObjectFieldTest.php
+++ b/tests/Form/Field/ObjectFieldTest.php
@@ -70,6 +70,30 @@ class ObjectFieldTest extends TestCase
 		$this->assertSame($expected, $field->default());
 	}
 
+	public function testEmptyValue(): void
+	{
+		$field = $this->field('object', [
+			'fields' => [
+				'text' => [
+					'type' => 'text'
+				]
+			]
+		]);
+
+		$this->assertSame('', $field->emptyValue());
+
+		// an untouched field and a field filled with its own stored
+		// value must produce the same form value
+		$field->fillWithEmptyValue();
+
+		$this->assertSame('', $field->toFormValue());
+		$this->assertSame('', $field->toStoredValue());
+
+		$field->fill($field->toStoredValue());
+
+		$this->assertSame('', $field->toFormValue());
+	}
+
 	public function testErrors(): void
 	{
 		$field = $this->field('object', [

--- a/tests/Form/Field/ToggleFieldTest.php
+++ b/tests/Form/Field/ToggleFieldTest.php
@@ -16,6 +16,24 @@ class ToggleFieldTest extends TestCase
 		$this->assertTrue($field->save());
 	}
 
+	public function testEmptyValue(): void
+	{
+		$field = $this->field('toggle');
+
+		$this->assertFalse($field->emptyValue());
+
+		// an untouched field and a field filled with its own stored
+		// value must produce the same form value
+		$field->fillWithEmptyValue();
+
+		$this->assertFalse($field->toFormValue());
+		$this->assertSame('false', $field->toStoredValue());
+
+		$field->fill($field->toStoredValue());
+
+		$this->assertFalse($field->toFormValue());
+	}
+
 	public function testText(): void
 	{
 		$field = $this->field('toggle', [

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -397,6 +397,31 @@ class FieldTest extends TestCase
 		$this->assertSame('foo', $field->toFormValue());
 	}
 
+	public function testFillWithEmptyValueRunsComputed(): void
+	{
+		Field::$types = [
+			'test' => [
+				'computed' => [
+					'value' => fn () => $this->value ?? 'normalized'
+				]
+			]
+		];
+
+		$page = new Page(['slug' => 'test']);
+
+		$field = new Field('test', [
+			'model' => $page
+		]);
+
+		// a field that has never been filled must end up with the same
+		// form value as a field filled with its own empty value;
+		// otherwise untouched fields show up as changes
+		$field->fillWithEmptyValue();
+
+		$this->assertSame('normalized', $field->toFormValue());
+		$this->assertSame($field->fill($field->emptyValue())->toFormValue(), $field->toFormValue());
+	}
+
 	public function testFillWithRestoredState(): void
 	{
 		Field::$types = [


### PR DESCRIPTION
## Description
<!-- 
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.
 
You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR. 

Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

When a changes version is created, `Changes::save()` writes `$fields->toStoredValues()` =>  every field of the blueprint, not just the ones present in `latest`. That is fine in itself, but it exposed an asymmetry in how a field's empty state is computed:

- For `latest`: the key is absent from the content file, so `Fields::fill()` skips the field and it keeps whatever `reset()` left behind.
- For `changes`: the key is present, so `Field::fill()` runs and reevaluates  `computed.value`

`Field::fillWithEmptyValue()` set `$this->value` directly and never reevaluated the computed props, so for any field whose `computed.value` normalises empty input to something other than its `emptyValue()`, the two sides disagree permanently.

Across all core field types that is exactly `object` (`null` vs `''`) and `toggle` (`null` vs `false`).

In turn, once a page with an untouched `object` or `toggle` field gets a changes version for any reason, `Version::isIdentical()` never returns `true` again. The changes version is therefore never auto-deleted, and the Panel shows a permanent unsaved-changes indicator on fields the user never edited. Reverting the actual edit does not clear its, only an explicit discard or publish does.

#### Example
1. Go to https://sandbox.test/panel/pages/fields+text?tab=general
2. Type something in the first text field
3. Reload
4. See the changes indicator also on the Preview tab
5. Clear the text field you changed in the first place
6. Changes indicator on Preview will remain



v6 is already not affected (besides the legal fields) - the new field classes do not have this quirk anymore.

## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->


### 🐛 Bug fixes
<!-- 
e.g. Fix broken feature X. See issue #123
-->
- Fixed a permanent "unsaved changes" state in the Panel for pages with an untouched `object` or `toggle`


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion