### PR TITLE
fix: Allow plugins to disable Panel area definitions

### DIFF
--- a/src/Panel/Area.php
+++ b/src/Panel/Area.php
@@ -55,6 +55,50 @@ class Area
 	}
 
 	/**
+	 * All view buttons of the area that have not been disabled
+	 */
+	public function buttons(): array
+	{
+		return $this->filterEnabled($this->buttons);
+	}
+
+	/**
+	 * All dialogs of the area that have not been disabled
+	 */
+	public function dialogs(): array
+	{
+		return $this->filterEnabled($this->dialogs);
+	}
+
+	/**
+	 * All drawers of the area that have not been disabled
+	 */
+	public function drawers(): array
+	{
+		return $this->filterEnabled($this->drawers);
+	}
+
+	/**
+	 * All dropdowns of the area that have not been disabled
+	 */
+	public function dropdowns(): array
+	{
+		return $this->filterEnabled($this->dropdowns);
+	}
+
+	/**
+	 * Removes all definitions that have been disabled
+	 * by setting them to `false`, e.g. by a plugin
+	 */
+	protected function filterEnabled(array $definitions): array
+	{
+		return array_filter(
+			$definitions,
+			fn ($definition) => $definition !== false
+		);
+	}
+
+	/**
 	 * The label is used for the menu item and the breadcrumb
 	 * unless a custom breadcrumb label is defined
 	 */
@@ -80,6 +124,14 @@ class Area
 	}
 
 	/**
+	 * All requests of the area that have not been disabled
+	 */
+	public function requests(): array
+	{
+		return $this->filterEnabled($this->requests);
+	}
+
+	/**
 	 * Extract all routes for searches
 	 */
 	public function routes(): array
@@ -99,6 +151,14 @@ class Area
 			...$dropdownRoutes->toArray(),
 			...$requestRoutes->toArray(),
 		];
+	}
+
+	/**
+	 * All searches of the area that have not been disabled
+	 */
+	public function searches(): array
+	{
+		return $this->filterEnabled($this->searches);
 	}
 
 	/**
@@ -127,5 +187,13 @@ class Area
 			'search'          => $this->search(),
 			'title'           => $this->title(),
 		];
+	}
+
+	/**
+	 * All views of the area that have not been disabled
+	 */
+	public function views(): array
+	{
+		return $this->filterEnabled($this->views);
 	}
 }

--- a/tests/Panel/AreaTest.php
+++ b/tests/Panel/AreaTest.php
@@ -18,6 +18,28 @@ class AreaTest extends TestCase
 		$this->assertSame('Better', $area->breadcrumbLabel());
 	}
 
+	public function testDisabledDefinitions(): void
+	{
+		$area = new Area(
+			id: 'test',
+			buttons:   ['todos' => [], 'archived' => false],
+			dialogs:   ['todos' => [], 'archived' => false],
+			drawers:   ['todos' => [], 'archived' => false],
+			dropdowns: ['todos' => [], 'archived' => false],
+			requests:  ['todos' => [], 'archived' => false],
+			searches:  ['todos' => [], 'archived' => false],
+			views:     ['todos' => [], 'archived' => false]
+		);
+
+		$this->assertSame(['todos'], array_keys($area->buttons()));
+		$this->assertSame(['todos'], array_keys($area->dialogs()));
+		$this->assertSame(['todos'], array_keys($area->drawers()));
+		$this->assertSame(['todos'], array_keys($area->dropdowns()));
+		$this->assertSame(['todos'], array_keys($area->requests()));
+		$this->assertSame(['todos'], array_keys($area->searches()));
+		$this->assertSame(['todos'], array_keys($area->views()));
+	}
+
 	public function testLabel(): void
 	{
 		$area = new Area(id: 'test', label: 'Test');
@@ -44,6 +66,27 @@ class AreaTest extends TestCase
 	{
 		$area = new Area(id: 'test');
 		$this->assertSame([], $area->routes());
+	}
+
+	public function testRoutesForDisabledDefinitions(): void
+	{
+		$area = new Area(
+			id: 'test',
+			dialogs:  [
+				'todos'    => ['load' => fn () => []],
+				'archived' => false
+			],
+			searches: [
+				'todos'    => ['query' => fn () => []],
+				'archived' => false
+			]
+		);
+
+		$this->assertSame([
+			'search/todos',
+			'dialogs/todos',
+			'dialogs/todos'
+		], array_column($area->routes(), 'pattern'));
 	}
 
 	public function testRoutesForViews(): void

--- a/tests/Panel/StateTest.php
+++ b/tests/Panel/StateTest.php
@@ -456,6 +456,30 @@ class StateTest extends TestCase
 		$this->assertArrayHasKey('test', $searches);
 	}
 
+	public function testSearchesWithDisabledSearch(): void
+	{
+		$this->app = $this->app->clone([
+			'areas' => [
+				'site' => [
+					'searches' => [
+						'pages' => false
+					]
+				]
+			],
+			'users' => [
+				['email' => 'test@getkirby.com', 'role' => 'admin']
+			]
+		]);
+
+		$this->app->impersonate('test@getkirby.com');
+
+		$state    = new State();
+		$searches = $state->searches();
+
+		$this->assertArrayNotHasKey('pages', $searches);
+		$this->assertArrayHasKey('files', $searches);
+	}
+
 	public function testSystem(): void
 	{
 		// without custom data


### PR DESCRIPTION
## Description

Areas merge via `array_replace_recursive`, so `'searches' => ['pages' => false]` already lands as `false` in the area definition — but nothing interpreted it: `State::searches()` still listed the type, and `Routes::params()` received `false` and threw an uncaught `TypeError`, which 500'd every Panel request. `Area` now exposes getters that drop entries set to `false`, matching the idiom already used for menu items and view buttons. As discussed in the issue, this covers all definition types, since they were all affected by the same fatal.

Shorter options exist — handling it in `Area::__call()` against a list of definition names, or filtering once in the `Routes` base constructor — but the explicit getters read best, so I went with those.

No Panel frontend changes needed: if `panel.search.type` points at a disabled type, `SearchView` and `SearchBar` already fall back to the first available one.

## Changelog

### 🐛 Bug fixes

- Plugins can now disable Panel area definitions by setting them to `false` #8356

## Docs

Any core definition can be removed from an area by setting it to `false`, the same way it already works for menu items and view buttons:

```php
Kirby::plugin('my/plugin', [
	'areas' => [
		'site' => [
			'searches' => [
				'pages' => false
			]
		]
	]
]);
```