### PR TITLE
fix: Skip local memcache tests properly

### DIFF
--- a/tests/Cache/MemCachedTest.php
+++ b/tests/Cache/MemCachedTest.php
@@ -12,7 +12,6 @@ class MemCachedTest extends TestCase
 	{
 		if (class_exists('Memcached') === false) {
 			$this->markTestSkipped('The Memcached extension is not available.');
-			return;
 		}
 
 		$connection = new \Memcached();
@@ -24,6 +23,10 @@ class MemCachedTest extends TestCase
 
 	protected function tearDown(): void
 	{
+		if (class_exists('Memcached') === false) {
+			return;
+		}
+
 		$connection = new \Memcached();
 		$connection->addServer('localhost', 11211);
 		$connection->flush();


### PR DESCRIPTION
## Changelog 
<!--
Add relevant release notes. Keep the target audience (Kirby user) in mind.
Reference issues from the `kirby` repo  or ideas from `feedback.getkirby.com`.
-->

### 🧹 Housekeeping

- Skip memcache tests locally if memcache is not installed. 

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion