### PR TITLE
fix: Console errors for cross-origin page previews

### DIFF
--- a/panel/src/components/Views/Preview/PreviewBrowser.vue
+++ b/panel/src/components/Views/Preview/PreviewBrowser.vue
@@ -58,11 +58,23 @@ export default {
 	},
 	methods: {
 		onLoad() {
-			const document = this.$refs.browser.contentDocument;
-			document.addEventListener("scroll", (e) => this.$emit("scroll", e));
+			// cross-origin previews, e.g. another domain or a PDF in Firefox,
+			// don't expose their document and thus cannot be synced
+			this.$refs.browser.contentDocument?.addEventListener("scroll", (e) =>
+				this.$emit("scroll", e)
+			);
 		},
 		reload() {
-			this.$refs.browser.contentWindow.location.reload();
+			const browser = this.$refs.browser;
+
+			// cross-origin frames don't allow to reload their location,
+			// but they can be navigated to the same URL again
+			if (browser.contentDocument === null) {
+				browser.contentWindow.location.replace(this.srcWithPreviewParam);
+				return;
+			}
+
+			browser.contentWindow.location.reload();
 		}
 	}
 };


### PR DESCRIPTION
## Description

Fixes the console errors when a page preview points to a different origin — a custom `options.preview` URL on another domain, or a PDF that Firefox renders in its own origin.

Two places assumed the preview iframe is same-origin:

- `onLoad()` attached a scroll listener to `contentDocument`, which is `null` for cross-origin frames → `TypeError`. The listener is now skipped; scroll syncing can't work across origins anyway.
- `reload()` called `contentWindow.location.reload()`, which throws a `SecurityError` on cross-origin frames (triggered by saving or discarding from the preview view). It now falls back to `location.replace()` with the preview URL, which is still allowed. Same-origin behaviour is unchanged.

## Changelog

### 🐛 Bug fixes

- Fix console errors for cross-origin page previews #8361

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion