### PR TITLE
perf: Panel router get controller lazily

### DIFF
--- a/src/Panel/Routes/Routes.php
+++ b/src/Panel/Routes/Routes.php
@@ -72,21 +72,25 @@ abstract class Routes
 	 */
 	protected function controllerFromClass(string $class): Closure
 	{
-		// Ensure controller uses the correct interface
-		$expect = 'Kirby\Panel\Controller\\' . ucfirst(static::$type) . 'Controller';
+		// resolve the class lazily to not autoload
+		// every controller of every area
+		return function (...$args) use ($class) {
+			// Ensure controller uses the correct interface
+			$expect = 'Kirby\Panel\Controller\\' . ucfirst(static::$type) . 'Controller';
 
-		if (is_subclass_of($class, $expect) === false) {
-			throw new InvalidArgumentException(
-				message: 'Invalid controller class "' . $class . '" expected child of"' . $expect . '"'
-			);
-		}
+			if (is_subclass_of($class, $expect) === false) {
+				throw new InvalidArgumentException(
+					message: 'Invalid controller class "' . $class . '" expected child of"' . $expect . '"'
+				);
+			}
 
-		// Use factory method if available
-		if (method_exists($class, 'factory') === true) {
-			return $class::factory(...);
-		}
+			// Use factory method if available
+			if (method_exists($class, 'factory') === true) {
+				return $class::factory(...$args);
+			}
 
-		return fn (...$args) => new $class(...$args);
+			return new $class(...$args);
+		};
 	}
 
 	public function params(

--- a/tests/Panel/Routes/DialogRoutesTest.php
+++ b/tests/Panel/Routes/DialogRoutesTest.php
@@ -36,13 +36,14 @@ class DialogRoutesTest extends TestCase
 	public function testControllerWithInvalidClass(): void
 	{
 		$routes = new DialogRoutes($this->area, []);
+		$params = $routes->params([
+			'action' => Closure::class
+		]);
 
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid controller class "Closure" expected child of"Kirby\Panel\Controller\DialogController"');
 
-		$routes->params([
-			'action' => Closure::class
-		]);
+		$params['load']();
 	}
 
 	public function testParamsWithController(): void

--- a/tests/Panel/Routes/RoutesTest.php
+++ b/tests/Panel/Routes/RoutesTest.php
@@ -109,13 +109,14 @@ class RoutesTest extends TestCase
 	public function testControllerWithInvalidClassname(): void
 	{
 		$routes = new TestRoutes($this->area, []);
+		$params = $routes->controller([
+			'action' => Closure::class
+		]);
 
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid controller class "Closure" expected child of"Kirby\Panel\Controller\Controller"');
 
-		$routes->controller([
-			'action' => Closure::class
-		]);
+		$params['load']();
 	}
 
 	public function testControllerWithControllerObject(): void


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Design & concept
- [x] Rough pass

## Description
<!--
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.

You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR.

If something is deliberately out of scope, say so here.
-->

This is a small change to shield Panel routes in v6 from autoloading many controllers right away, by wrapping the class controller lookup in the closure itself.

This came up during hunt for a larger performance issue. It is not the decisive factor. In the grand picture, I do not think this makes a difference for UX. But given the small scope of the fix, it felt wrong to just discard it but to maybe still implement it.

### Benchmarks
<!--
Only if this PR claims a performance gain: numbers and the benchmark code
that produced them. Delete this section otherwise.
-->

version | route table build | full dropdown request| files included | controllers autoloaded 
-- | -- | -- | -- | -- 
v5.5.3 | 0.22 ms | 22.3 ms | 256 | 0
v6/develop | 4.48 ms | 26.8 ms | 373 | 76
v6 + fix3 | 0.49 ms3 | 23.8 ms | 297 | 0


## Changelog

not needed


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
