### PR TITLE
fix: Clear WebAuthn data on login/logout

### DIFF
--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -74,6 +74,10 @@ class Auth
 
 		if ($result instanceof User === true) {
 			$this->setUser($result);
+
+			$session = $this->kirby->session();
+			$this->challenges->clear($session);
+			$this->methods->clear($session);
 		}
 
 		return $result;
@@ -394,17 +398,16 @@ class Auth
 	 */
 	public function logout(): void
 	{
-		// stop impersonating;
 		// ensures that we log out the actually logged in user
 		$this->user->impersonate(null);
 
-		// logout the current user if it exists
 		$this->user()?->logout();
 
-		// clear the pending challenge
-		$this->challenges->clear($this->kirby->session());
+		$session = $this->kirby->session();
 
-		// clear the status cache
+		$this->challenges->clear($session);
+		$this->methods->clear($session);
+
 		$this->status = null;
 	}
 

--- a/src/Auth/Method/WebauthnMethod.php
+++ b/src/Auth/Method/WebauthnMethod.php
@@ -29,11 +29,6 @@ use SensitiveParameter;
 class WebauthnMethod extends Method
 {
 	/**
-	 * Session key for the pending login challenge
-	 */
-	protected string $sessionKey = 'kirby.webauthn.login';
-
-	/**
 	 * Verifies the WebAuthn assertion, identifies the user
 	 * via the user handle and logs them in
 	 */
@@ -47,7 +42,7 @@ class WebauthnMethod extends Method
 
 		// consume the single-use challenge up front so a failed attempt
 		// cannot be retried against the same challenge
-		$challenge = $kirby->session()->pull($this->sessionKey);
+		$challenge = $kirby->session()->pull('kirby.method.data');
 
 		// run identification and verification inside the shared rate-limit
 		// envelope. The user is only known from the credential, so the
@@ -112,7 +107,7 @@ class WebauthnMethod extends Method
 		$kirby   = $this->auth->kirby();
 		$options = Webauthn::site($kirby)->loginOptions([]);
 
-		$kirby->session()->set($this->sessionKey, $options['challenge']);
+		$kirby->session()->set('kirby.method.data', $options['challenge']);
 
 		return new Component(
 			component: 'k-login-webauthn-method-form',

--- a/src/Auth/Methods.php
+++ b/src/Auth/Methods.php
@@ -7,6 +7,7 @@ use Kirby\Cms\User;
 use Kirby\Exception\Exception;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
+use Kirby\Session\Session;
 use Kirby\Toolkit\A;
 
 /**
@@ -73,6 +74,14 @@ class Methods
 		throw new NotFoundException(
 			message: 'No auth method class for: ' . $type
 		);
+	}
+
+	/**
+	 * Removes the pending login state of the auth methods
+	 */
+	public function clear(Session $session): void
+	{
+		$session->remove('kirby.method.data');
 	}
 
 	/**

--- a/tests/Auth/AuthTest.php
+++ b/tests/Auth/AuthTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Auth;
 
 use Exception;
+use Kirby\Cms\App;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\PermissionException;
@@ -90,17 +91,13 @@ class AuthTest extends TestCase
 				};
 			});
 
-		$auth = new class ($methods) extends Auth {
+		$auth = new class ($this->app, $methods) extends Auth {
 			public bool $didResetUser = false;
 
-			public function __construct(
-				protected Methods $methods
-			) {
-			}
-
-			public function methods(): Methods
+			public function __construct(App $kirby, Methods $methods)
 			{
-				return $this->methods;
+				parent::__construct($kirby);
+				$this->methods = $methods;
 			}
 
 			public function setUser(User $user): void
@@ -116,6 +113,27 @@ class AuthTest extends TestCase
 		$result = $auth->authenticate('password', 'lisa@simpson.de');
 		$this->assertSame($user, $result);
 		$this->assertTrue($auth->didResetUser);
+	}
+
+	public function testAuthenticateClearsPendingState(): void
+	{
+		$session = $this->app->session();
+
+		// a started challenge and a passkey nonce from the login
+		// form are stale once another method completed the login
+		$this->auth->createChallenge('marge@simpsons.com');
+		$session->set('kirby.method.data', 'nonce');
+
+		$this->auth->authenticate(
+			'password',
+			'marge@simpsons.com',
+			'springfield123'
+		);
+
+		$this->assertNull($session->get('kirby.method.data'));
+		$this->assertNull($session->get('kirby.challenge.email'));
+		$this->assertNull($session->get('kirby.challenge.data'));
+		$this->assertNull($session->get('kirby.challenge.timeout'));
 	}
 
 	public function testChallenges(): void
@@ -503,6 +521,16 @@ class AuthTest extends TestCase
 			'mode'      => null,
 			'status'    => 'inactive'
 		], $this->auth->status()->toArray());
+	}
+
+	public function testLogoutClearsMethodState(): void
+	{
+		$session = $this->app->session();
+		$session->set('kirby.method.data', 'nonce');
+
+		$this->auth->logout();
+
+		$this->assertNull($session->get('kirby.method.data'));
 	}
 
 	public function testMethods(): void

--- a/tests/Auth/Method/WebauthnMethodTest.php
+++ b/tests/Auth/Method/WebauthnMethodTest.php
@@ -84,7 +84,7 @@ class WebauthnMethodTest extends TestCase
 		);
 
 		// persist the challenge for the login verification
-		$this->app->session()->set('kirby.webauthn.login', $assert['challenge']);
+		$this->app->session()->set('kirby.method.data', $assert['challenge']);
 
 		$payload = $assert['payload'];
 
@@ -137,7 +137,7 @@ class WebauthnMethodTest extends TestCase
 		// the challenge is persisted for the follow-up verification
 		$this->assertSame(
 			$rendered['props']['publicKey']['challenge'],
-			$this->app->session()->get('kirby.webauthn.login')
+			$this->app->session()->get('kirby.method.data')
 		);
 	}
 
@@ -176,7 +176,7 @@ class WebauthnMethodTest extends TestCase
 	public function testAuthenticateFailsVerification(): void
 	{
 		$payload = $this->register('marge');
-		$this->app->session()->set('kirby.webauthn.login', 'wrong-challenge');
+		$this->app->session()->set('kirby.method.data', 'wrong-challenge');
 
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('The passkey could not be verified');

--- a/tests/Auth/MethodsTest.php
+++ b/tests/Auth/MethodsTest.php
@@ -143,6 +143,16 @@ class MethodsTest extends TestCase
 		$methods->class('unknown');
 	}
 
+	public function testClear(): void
+	{
+		$session = $this->app->session();
+		$session->set('kirby.method.data', 'nonce');
+
+		$this->app->auth()->methods()->clear($session);
+
+		$this->assertNull($session->get('kirby.method.data'));
+	}
+
 	public function testEnabledWith2FA(): void
 	{
 		$this->app = $this->app->clone([


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Security check (conceptual, does this make sense as described)

**Timing:**

## Description
<!--
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.

You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR.

If something is deliberately out of scope, say so here.
-->

We now clear both challenge as well as method session data (the latter is used for the first time by the WebatuhnMethod) after successful login and logout (to be safe).

Once the login is complete, there is no need for this data to stick around in the challenge. And after a logout even less.


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
