### PR TITLE
fix: Various UUID-related bugfixes

### DIFF
--- a/src/Cms/PageCopy.php
+++ b/src/Cms/PageCopy.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Uuid\ModelUuid;
 use Kirby\Uuid\Uuid;
 use Kirby\Uuid\Uuids;
 
@@ -47,8 +48,9 @@ class PageCopy
 			return;
 		}
 
-		// store old UUID
-		$old = $this->copy->uuid()->toString();
+		// don't use `toString()` here: $this->copy still holds the original's
+		// UUID, so it would cache that UUID as pointing to the copy
+		$old = ModelUuid::retrieveId($this->copy);
 
 		// re-generate UUID for the page
 		$this->copy = $this->copy->save(
@@ -57,7 +59,9 @@ class PageCopy
 		);
 
 		// track UUID change
-		$this->uuids[$old] = $this->copy->uuid()->toString();
+		if ($old !== null) {
+			$this->uuids['page://' . $old] = $this->copy->uuid()->toString();
+		}
 
 		$this->convertFileUuids($language);
 		$this->convertChildrenUuids($language);
@@ -108,7 +112,7 @@ class PageCopy
 		if ($this->withFiles === true) {
 			foreach ($this->copy->files() as $file) {
 				// store old file UUID
-				$old = $file->uuid()->toString();
+				$old = ModelUuid::retrieveId($file);
 
 				// re-generate UUID for the file
 				$file = $file->save(
@@ -117,7 +121,9 @@ class PageCopy
 				);
 
 				// track UUID change
-				$this->uuids[$old] = $file->uuid()->toString();
+				if ($old !== null) {
+					$this->uuids['file://' . $old] = $file->uuid()->toString();
+				}
 			}
 		}
 

--- a/src/Uuid/BlockUuid.php
+++ b/src/Uuid/BlockUuid.php
@@ -24,11 +24,6 @@ class BlockUuid extends FieldUuid
 	protected const FIELD = 'blocks';
 
 	/**
-	 * @var \Kirby\Cms\Block|null
-	 */
-	public Identifiable|null $model = null;
-
-	/**
 	 * Converts content field to a Blocks collection
 	 * @unstable
 	 */

--- a/src/Uuid/FileUuid.php
+++ b/src/Uuid/FileUuid.php
@@ -36,8 +36,15 @@ class FileUuid extends ModelUuid
 			if ($value = Uuids::cache()->get($key)) {
 				// value is an array containing
 				// the UUID for the parent and the filename
+				/** @var HasFiles $parent */
 				$parent = Uuid::for($value['parent'])->model();
-				return $parent?->file($value['filename']);
+				$file   = $parent?->file($value['filename']);
+
+				// the cached parent/filename pair can be stale,
+				// e.g. when the file has been renamed or copied
+				if ($this->isFor($file) === true) {
+					return $file;
+				}
 			}
 		}
 

--- a/src/Uuid/FileUuid.php
+++ b/src/Uuid/FileUuid.php
@@ -5,25 +5,23 @@ namespace Kirby\Uuid;
 use Generator;
 use Kirby\Cms\App;
 use Kirby\Cms\File;
+use Kirby\Cms\HasFiles;
 
 /**
- * UUID for \Kirby\Cms\File
- * @since 3.8.0
+ * UUID for $file
  *
  * @package   Kirby Uuid
  * @author    Nico Hoffmann <nico@getkirby.com>
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ * @since     3.8.0
+ *
+ * @extends \Kirby\Uuid\ModelUuid<\Kirby\Cms\File>
  */
 class FileUuid extends ModelUuid
 {
 	protected const TYPE = 'file';
-
-	/**
-	 * @var \Kirby\Cms\File|null
-	 */
-	public Identifiable|null $model = null;
 
 	/**
 	 * Looks up UUID in cache and resolves to file object;

--- a/src/Uuid/ModelUuid.php
+++ b/src/Uuid/ModelUuid.php
@@ -5,24 +5,24 @@ namespace Kirby\Uuid;
 /**
  * Base for UUIDs for models where id string
  * is stored in the content, such as pages and files
- * @since 3.8.0
  *
  * @package   Kirby Uuid
  * @author    Nico Hoffmann <nico@getkirby.com>
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ * @since     3.8.0
+ *
+ * @template TModel of \Kirby\Cms\ModelWithContent
+ * @extends \Kirby\Uuid\Uuid<TModel>
  */
 abstract class ModelUuid extends Uuid
 {
 	/**
-	 * @var \Kirby\Cms\ModelWithContent|null
-	 */
-	public Identifiable|null $model = null;
-
-	/**
 	 * Looks up UUID in local and global index
 	 * and returns the identifiable model object
+	 *
+	 * @return TModel|null
 	 */
 	protected function findByIndex(): Identifiable|null
 	{

--- a/src/Uuid/ModelUuid.php
+++ b/src/Uuid/ModelUuid.php
@@ -58,6 +58,21 @@ abstract class ModelUuid extends Uuid
 	}
 
 	/**
+	 * Checks whether the model actually still holds the
+	 * UUID identifier that was looked up
+	 *
+	 * @param TModel|null $model
+	 */
+	protected function isFor(Identifiable|null $model): bool
+	{
+		if ($model === null) {
+			return false;
+		}
+
+		return static::retrieveId($model) === $this->uri->host();
+	}
+
+	/**
 	 * Retrieves the ID string (UUID without scheme) for the model
 	 * from the content file, if it is already stored there
 	 *

--- a/src/Uuid/PageUuid.php
+++ b/src/Uuid/PageUuid.php
@@ -49,7 +49,13 @@ class PageUuid extends ModelUuid
 	{
 		if ($key = $this->key()) {
 			if ($value = Uuids::cache()->get($key)) {
-				return App::instance()->page($value);
+				$page = App::instance()->page($value);
+
+				// the cached path can be stale,
+				// e.g. when the page has been moved or copied
+				if ($this->isFor($page) === true) {
+					return $page;
+				}
 			}
 		}
 

--- a/src/Uuid/PageUuid.php
+++ b/src/Uuid/PageUuid.php
@@ -36,7 +36,7 @@ class PageUuid extends ModelUuid
 		 * @var \Kirby\Cms\Page $model
 		 */
 		if ($recursive === true && $model = $this->model()) {
-			foreach ($model->children() as $child) {
+			foreach ($model->childrenAndDrafts() as $child) {
 				$child->uuid()->clear(true);
 			}
 		}
@@ -87,7 +87,7 @@ class PageUuid extends ModelUuid
 		 * @var \Kirby\Cms\Page $model
 		 */
 		if ($recursive === true && $model = $this->model()) {
-			foreach ($model->children() as $child) {
+			foreach ($model->childrenAndDrafts() as $child) {
 				$child->uuid()->populate($force, true);
 			}
 		}

--- a/src/Uuid/PageUuid.php
+++ b/src/Uuid/PageUuid.php
@@ -7,23 +7,20 @@ use Kirby\Cms\App;
 use Kirby\Cms\Page;
 
 /**
- * UUID for \Kirby\Cms\Page
- * @since 3.8.0
+ * UUID for $page
  *
  * @package   Kirby Uuid
  * @author    Nico Hoffmann <nico@getkirby.com>
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ * @since     3.8.0
+ *
+ * @extends \Kirby\Uuid\ModelUuid<\Kirby\Cms\Page>
  */
 class PageUuid extends ModelUuid
 {
 	protected const TYPE = 'page';
-
-	/**
-	 * @var \Kirby\Cms\Page|null
-	 */
-	public Identifiable|null $model = null;
 
 	/**
 	 * Removes the current UUID from cache,

--- a/src/Uuid/SiteUuid.php
+++ b/src/Uuid/SiteUuid.php
@@ -7,23 +7,20 @@ use Kirby\Cms\App;
 use Kirby\Cms\Site;
 
 /**
- * UUID for \Kirby\Cms\Site
- * @since 3.8.0
+ * UUID for $site
  *
  * @package   Kirby Uuid
  * @author    Nico Hoffmann <nico@getkirby.com>
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ * @since     3.8.0
+ *
+ * @extends \Kirby\Uuid\Uuid<\Kirby\Cms\Site>
  */
 class SiteUuid extends Uuid
 {
 	protected const TYPE = 'site';
-
-	/**
-	 * @var \Kirby\Cms\Site|null
-	 */
-	public Identifiable|null $model = null;
 
 	/*
 	 * Returns empty string since

--- a/src/Uuid/StructureUuid.php
+++ b/src/Uuid/StructureUuid.php
@@ -24,11 +24,6 @@ class StructureUuid extends FieldUuid
 	protected const FIELD = 'structure';
 
 	/**
-	 * @var \Kirby\Cms\StructureObject|null
-	 */
-	public Identifiable|null $model = null;
-
-	/**
 	 * Converts content field to a Structure collection
 	 * @unstable
 	 */

--- a/src/Uuid/UserUuid.php
+++ b/src/Uuid/UserUuid.php
@@ -7,23 +7,20 @@ use Kirby\Cms\App;
 use Kirby\Cms\User;
 
 /**
- * UUID for \Kirby\Cms\User
- * @since 3.8.0
+ * UUID for $user
  *
  * @package   Kirby Uuid
  * @author    Nico Hoffmann <nico@getkirby.com>
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ * @since     3.8.0
+ *
+ * @extends \Kirby\Uuid\Uuid<\Kirby\Cms\User>
  */
 class UserUuid extends Uuid
 {
 	protected const TYPE = 'user';
-
-	/**
-	 * @var \Kirby\Cms\User|null
-	 */
-	public Identifiable|null $model = null;
 
 	/*
 	 * Returns the user ID

--- a/src/Uuid/Uuid.php
+++ b/src/Uuid/Uuid.php
@@ -42,6 +42,8 @@ use Stringable;
  * @link      https://getkirby.com
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
+ *
+ * @template TModel of \Kirby\Uuid\Identifiable
  */
 abstract class Uuid implements Stringable
 {
@@ -56,9 +58,14 @@ abstract class Uuid implements Stringable
 	/**
 	 * Collection that is likely to contain the model and
 	 * that will be checked first to speed up the lookup
+	 *
+	 * @var \Kirby\Cms\Collection<TModel>|null
 	 */
 	public Collection|null $context;
 
+	/**
+	 * @var TModel|null
+	 */
 	public Identifiable|null $model;
 	public Uri $uri;
 
@@ -114,6 +121,8 @@ abstract class Uuid implements Stringable
 	 * collection, which takes priority when looking
 	 * up the UUID/model from index
 	 * @internal
+	 *
+	 * @return \Generator<TModel>
 	 */
 	final public function context(): Generator
 	{
@@ -124,6 +133,8 @@ abstract class Uuid implements Stringable
 	 * Looks up UUID in cache and resolves
 	 * to identifiable model object;
 	 * implemented on child classes
+	 *
+	 * @return TModel|null
 	 *
 	 * @codeCoverageIgnore
 	 */
@@ -138,6 +149,8 @@ abstract class Uuid implements Stringable
 	 * Looks up UUID in local and global index
 	 * and returns the identifiable model object;
 	 * implemented on child classes
+	 *
+	 * @return TModel|null
 	 *
 	 * @codeCoverageIgnore
 	 */
@@ -259,7 +272,7 @@ abstract class Uuid implements Stringable
 	 * into one iterator
 	 * @internal
 	 *
-	 * @return \Generator|\Kirby\Uuid\Identifiable[]
+	 * @return \Generator<TModel>
 	 */
 	final public function indexes(): Generator
 	{
@@ -334,6 +347,7 @@ abstract class Uuid implements Stringable
 	 * or index and returns the object
 	 *
 	 * @param bool $lazy If `true`, only lookup from cache
+	 * @return TModel|null
 	 */
 	public function model(bool $lazy = false): Identifiable|null
 	{

--- a/tests/Cms/Languages/LanguageRouterTest.php
+++ b/tests/Cms/Languages/LanguageRouterTest.php
@@ -20,7 +20,8 @@ class LanguageRouterTest extends TestCase
 			],
 			'languages' => [
 				[
-					'code' => 'en'
+					'code'    => 'en',
+					'default' => true
 				]
 			]
 		]);

--- a/tests/Cms/Page/PageCopyTest.php
+++ b/tests/Cms/Page/PageCopyTest.php
@@ -2,6 +2,9 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Filesystem\F;
+use Kirby\Uuid\Uuid;
+use Kirby\Uuid\Uuids;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(PageCopy::class)]
@@ -252,6 +255,39 @@ class PageCopyTest extends ModelTestCase
 		$this->assertNotSame('page://a', $normalized->uuid()->toString());
 		$this->assertNotSame('page://aa', $normalized->find('test-a')->uuid()->toString());
 		$this->assertNotSame('file://file-aa', $normalized->find('test-a')->file()->uuid()->toString());
+	}
+
+	public function testProcessKeepsUuidOfOriginal(): void
+	{
+		$this->app->impersonate('kirby');
+
+		F::write($source = static::TMP . '/source.md', '');
+
+		$page = Page::create([
+			'slug'    => 'test',
+			'content' => ['uuid' => 'a']
+		]);
+
+		$file = $page->createFile([
+			'filename' => 'test.md',
+			'source'   => $source,
+			'content'  => ['uuid' => 'file-a']
+		]);
+
+		$pageKey = $page->uuid()->key();
+		$fileKey = $file->uuid()->key();
+
+		// pretend the UUIDs of the original have not been looked up yet
+		Uuids::cache()->remove($pageKey);
+		Uuids::cache()->remove($fileKey);
+
+		// the copy still holds the UUIDs of the original while it is
+		// being processed and must not claim their cache entries
+		$page->duplicate('test-copy', ['files' => true]);
+
+		$this->assertNotSame('test-copy', Uuids::cache()->get($pageKey));
+		$this->assertSame('test', Uuid::for('page://a')->model()->id());
+		$this->assertSame('test/test.md', Uuid::for('file://file-a')->model()->id());
 	}
 
 	public function testRemoveSlug(): void

--- a/tests/Uuid/FileUuidTest.php
+++ b/tests/Uuid/FileUuidTest.php
@@ -29,6 +29,45 @@ class FileUuidTest extends TestCase
 		$this->assertIsFile($file, $uuid->model(true));
 	}
 
+	public function testFindByCacheRejectsForeignFile(): void
+	{
+		$file = $this->app->file('page-a/test.pdf');
+		$file->uuid()->populate();
+
+		// point the cache entry to a file
+		// that does not hold this UUID
+		Uuids::cache()->set($file->uuid()->key(), [
+			'parent'   => 'site://',
+			'filename' => 'site.txt'
+		]);
+
+		$uuid = new FileUuid('file://my-file');
+		$this->assertNull($uuid->model(true));
+
+		// the stale entry gets corrected from the index
+		$this->assertIsFile($file, $uuid->model());
+		$this->assertSame('test.pdf', Uuids::cache()->get($uuid->key())['filename']);
+	}
+
+	public function testFindByCacheRejectsMissingFile(): void
+	{
+		$file = $this->app->file('page-a/test.pdf');
+		$file->uuid()->populate();
+
+		// point the cache entry to a file that no longer exists
+		Uuids::cache()->set($file->uuid()->key(), [
+			'parent'   => 'page://my-page',
+			'filename' => 'deleted.pdf'
+		]);
+
+		$uuid = new FileUuid('file://my-file');
+		$this->assertNull($uuid->model(true));
+
+		// the stale entry gets corrected from the index
+		$this->assertIsFile($file, $uuid->model());
+		$this->assertSame('test.pdf', Uuids::cache()->get($uuid->key())['filename']);
+	}
+
 	public function testFindByIndex(): void
 	{
 		$file = $this->app->file('page-a/test.pdf');

--- a/tests/Uuid/PageUuidTest.php
+++ b/tests/Uuid/PageUuidTest.php
@@ -61,6 +61,39 @@ class PageUuidTest extends TestCase
 		$this->assertIsPage($page, $uuid->model(true));
 	}
 
+	public function testFindByCacheRejectsForeignPage(): void
+	{
+		$page = $this->app->page('page-a');
+		$page->uuid()->populate();
+
+		// point the cache entry to a page
+		// that does not hold this UUID
+		Uuids::cache()->set($page->uuid()->key(), 'page-b');
+
+		$uuid = new PageUuid('page://my-page');
+		$this->assertNull($uuid->model(true));
+
+		// the stale entry gets corrected from the index
+		$this->assertIsPage($page, $uuid->model());
+		$this->assertSame('page-a', Uuids::cache()->get($uuid->key()));
+	}
+
+	public function testFindByCacheRejectsMissingPage(): void
+	{
+		$page = $this->app->page('page-a');
+		$page->uuid()->populate();
+
+		// point the cache entry to a page that no longer exists
+		Uuids::cache()->set($page->uuid()->key(), 'deleted-page');
+
+		$uuid = new PageUuid('page://my-page');
+		$this->assertNull($uuid->model(true));
+
+		// the stale entry gets corrected from the index
+		$this->assertIsPage($page, $uuid->model());
+		$this->assertSame('page-a', Uuids::cache()->get($uuid->key()));
+	}
+
 	public function testFindByIndex(): void
 	{
 		$page = $this->app->page('page-a');

--- a/tests/Uuid/PageUuidTest.php
+++ b/tests/Uuid/PageUuidTest.php
@@ -12,6 +12,38 @@ class PageUuidTest extends TestCase
 {
 	public const TMP = KIRBY_TMP_DIR . '/Uuid.PageUuid';
 
+	public function testClearRecursiveIncludesDrafts(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'    => 'parent',
+						'content' => ['uuid' => 'my-parent'],
+						'drafts'  => [
+							[
+								'slug'    => 'draft',
+								'content' => ['uuid' => 'my-draft']
+							]
+						]
+					]
+				]
+			]
+		]);
+
+		$parent = $app->page('parent');
+		$draft  = $parent->drafts()->first();
+
+		$parent->uuid()->populate();
+		$draft->uuid()->populate();
+		$this->assertTrue($draft->uuid()->isCached());
+
+		$parent->uuid()->clear(recursive: true);
+
+		$this->assertFalse($parent->uuid()->isCached());
+		$this->assertFalse($draft->uuid()->isCached());
+	}
+
 	public function testFindByCache(): void
 	{
 		$page = $this->app->page('page-a');
@@ -74,6 +106,36 @@ class PageUuidTest extends TestCase
 		$this->assertInstanceOf(Generator::class, $index);
 		$this->assertIsPage($index->current());
 		$this->assertSame(3, iterator_count($index));
+	}
+
+	public function testPopulateRecursiveIncludesDrafts(): void
+	{
+		$app = $this->app->clone([
+			'site' => [
+				'children' => [
+					[
+						'slug'    => 'parent',
+						'content' => ['uuid' => 'my-parent'],
+						'drafts'  => [
+							[
+								'slug'    => 'draft',
+								'content' => ['uuid' => 'my-draft']
+							]
+						]
+					]
+				]
+			]
+		]);
+
+		$parent = $app->page('parent');
+		$draft  = $parent->drafts()->first();
+
+		$this->assertFalse($draft->uuid()->isCached());
+
+		$parent->uuid()->populate(recursive: true);
+
+		$this->assertTrue($parent->uuid()->isCached());
+		$this->assertTrue($draft->uuid()->isCached());
 	}
 
 	public function testRetrieveId(): void


### PR DESCRIPTION
## Review

- [x] Deep read, best done per commit

**Timing:** no rush

## Description

Three related defects in the UUID cache, all of which end with `page://…` and `file://…` resolving to the wrong model.

### `findByCache()` trusted the cache blindly

`PageUuid::findByCache()` returned a page without ever checking that this still holds the UUID in its content file that was looked up (same for `FileUuid`).

Both now verify that their content file holds the UUID id that was looked up via the new `ModelUuid::isFor()`.
A rejected entry falls through to `findByIndex()`.

### Copying a page claimed the original's UUID

`PageCopy::convertUuids()` did read the old UUID via `$this->copy->uuid()->toString()`. Because at this time, while already being a new page object, `$this->copy` still holds the old UUID string. And thus, `toString()` → `populate()` → writes to the cache the wrong relation. Same for the file loop in `PageCopy`.

Both now read the stored id via `ModelUuid::retrieveId()`, which does not touch the cache.

### Recursive clear/populate skipped drafts

`PageUuid::clear()` and `populate()` iterated `children()` (published only) while `index()` uses `childrenAndDrafts()`. A parent rename or move therefore never touched children that are drafts. Both loop now `childrenAndDrafts()` to match `index()`.

### Generic templates

In addition to the bugfixes above, this PR also adds `@template TModel` on `Uuid` plus `@extends` on each
subclass, so `PageUuid::model()` is typed `Page|null`, `FileUuid::model()` `File|null`, and so on. 

## Changelog

### 🐛 Bug fixes

- Copying a page no longer breaks the cached UUIDs of the original
- Renaming or moving a page now also updates the UUID cache entries of its drafts
- A UUID cache entry that points at a model which no longer holds that UUID is discarded

### ♻️ Refactored

- The `Uuid` classes carry generic type templates, so `PageUuid::model()`,  `FileUuid::model()` etc. are statically typed as the specific model
## For review team

- [x] Add changes & docs to release notes draft in Notion
