### PR TITLE
feat: Guards Preparations

### DIFF
--- a/src/Blueprint/Blueprint.php
+++ b/src/Blueprint/Blueprint.php
@@ -5,6 +5,7 @@ namespace Kirby\Blueprint;
 use Exception;
 use Kirby\Cms\App;
 use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\User;
 use Kirby\Data\Data;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
@@ -762,6 +763,38 @@ class Blueprint
 		}
 
 		return $this->tabs = $tabs;
+	}
+
+	/**
+	 * Return the option settings depending on the user role
+	 */
+	public function optionForUser(User $user, string $action): bool|null
+	{
+		$rules = $this->options()[$action] ?? null;
+
+		if ($rules === true || $rules === false) {
+			return $rules;
+		}
+
+		// only associative arrays hold role-based rules.
+		// Lists are used for other option settings,
+		// e.g. `changeTemplate` with a list of template names
+		if (
+			is_array($rules) === true &&
+			A::isAssociative($rules) === true
+		) {
+			$roleId = $user->role()->id();
+
+			if (isset($rules[$roleId]) === true) {
+				return $rules[$roleId];
+			}
+
+			if (isset($rules['*']) === true) {
+				return $rules['*'];
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -10,7 +10,6 @@ use Kirby\Filesystem\F;
 use Kirby\Toolkit\BlockCollectionAccess;
 use Kirby\Toolkit\Locale;
 use Kirby\Toolkit\Str;
-use Stringable;
 
 /**
  * The `$language` object represents
@@ -27,7 +26,7 @@ use Stringable;
  *
  * @use HasSiblings<Languages>
  */
-class Language implements Stringable
+class Language extends Model
 {
 	use HasSiblings;
 

--- a/src/Cms/Model.php
+++ b/src/Cms/Model.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Kirby\Cms;
+
+use Stringable;
+
+/**
+ * Model
+ *
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+abstract class Model implements Stringable
+{
+}

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -18,12 +18,11 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Form\Fields;
 use Kirby\Form\Form;
-use Kirby\Panel\Model;
+use Kirby\Panel\Model as PanelModel;
 use Kirby\Toolkit\BlockCollectionAccess;
 use Kirby\Toolkit\Str;
 use Kirby\Uuid\Identifiable;
 use Kirby\Uuid\Uuid;
-use Stringable;
 use Throwable;
 
 /**
@@ -32,7 +31,7 @@ use Throwable;
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  */
-abstract class ModelWithContent implements Identifiable, Stringable
+abstract class ModelWithContent extends Model implements Identifiable
 {
 	/**
 	 * Each model must define a CLASS_ALIAS
@@ -392,7 +391,7 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 * Returns the panel info of the model
 	 * @since 3.6.0
 	 */
-	abstract public function panel(): Model;
+	abstract public function panel(): PanelModel;
 
 	/**
 	 * Must return the permissions object for the model

--- a/src/Cms/Permissions.php
+++ b/src/Cms/Permissions.php
@@ -152,13 +152,15 @@ class Permissions
 	}
 
 	/**
+	 * @return ($default is null ? bool|null : bool)
+	 *
 	 * @todo Replace first param with `string $category` in v6
 	 */
 	public function for(
 		string|null $category = null,
 		string|null $action = null,
-		bool $default = false
-	): bool {
+		bool|null $default = false
+	): bool|null {
 		if (is_null($category) === true) {
 			Helpers::deprecated(
 				'Passing `$category = null` to `Permissions::for()` is not supported',

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -203,6 +203,11 @@ class User extends ModelWithContent
 		return $this->email ??= $this->credentials()['email'] ?? null;
 	}
 
+	public static function ensure(): self
+	{
+		return App::instance()->user() ?? static::nobody();
+	}
+
 	/**
 	 * Checks if the user exists
 	 */
@@ -530,6 +535,7 @@ class User extends ModelWithContent
 	{
 		return new static([
 			'email' => 'nobody@getkirby.com',
+			'id'    => 'nobody',
 			'role'  => 'nobody'
 		]);
 	}

--- a/src/Exception/AbilityException.php
+++ b/src/Exception/AbilityException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Kirby\Exception;
+
+/**
+ * Thrown when the current model action cannot be
+ * executed due to system logic issues
+ *
+ * @copyright Bastian Allgeier
+ * @license   https://opensource.org/licenses/MIT
+ */
+class AbilityException extends LogicException
+{
+	protected static string $defaultKey = 'ability';
+	protected static string $defaultFallback = 'This action cannot be executed';
+	protected static int $defaultHttpCode = 403;
+}

--- a/tests/Blueprint/BlueprintOptionsTest.php
+++ b/tests/Blueprint/BlueprintOptionsTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Kirby\Blueprint;
+
+use Kirby\Cms\App;
+use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Page;
+use Kirby\Cms\User;
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Blueprint::class)]
+class BlueprintOptionsTest extends TestCase
+{
+	public const TMP = KIRBY_TMP_DIR . '/Cms.BlueprintOptions';
+
+	protected ModelWithContent $model;
+
+	protected function setUp(): void
+	{
+		$this->app = new App([
+			'roles' => [
+				['name' => 'admin'],
+				['name' => 'editor']
+			],
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'users' => [
+				['email' => 'admin@getkirby.com', 'role' => 'admin'],
+				['email' => 'editor@getkirby.com', 'role' => 'editor']
+			]
+		]);
+
+		$this->model = new Page(['slug' => 'test']);
+	}
+
+	protected function blueprint(array $options): Blueprint
+	{
+		return new Blueprint([
+			'model'   => $this->model,
+			'options' => $options
+		]);
+	}
+
+	protected function user(string $role): User
+	{
+		return $this->app->user($role . '@getkirby.com');
+	}
+
+	public function testOptionForUserWithoutOptions(): void
+	{
+		$blueprint = new Blueprint(['model' => $this->model]);
+
+		$this->assertNull($blueprint->optionForUser($this->user('editor'), 'update'));
+	}
+
+	public function testOptionForUserWithUndefinedOption(): void
+	{
+		$blueprint = $this->blueprint(['update' => true]);
+
+		$this->assertNull($blueprint->optionForUser($this->user('editor'), 'delete'));
+	}
+
+	public function testOptionForUserWithTrue(): void
+	{
+		$blueprint = $this->blueprint(['update' => true]);
+
+		$this->assertTrue($blueprint->optionForUser($this->user('admin'), 'update'));
+		$this->assertTrue($blueprint->optionForUser($this->user('editor'), 'update'));
+	}
+
+	public function testOptionForUserWithFalse(): void
+	{
+		$blueprint = $this->blueprint(['update' => false]);
+
+		$this->assertFalse($blueprint->optionForUser($this->user('admin'), 'update'));
+		$this->assertFalse($blueprint->optionForUser($this->user('editor'), 'update'));
+	}
+
+	public function testOptionForUserWithRoles(): void
+	{
+		$blueprint = $this->blueprint([
+			'update' => [
+				'admin'  => true,
+				'editor' => false
+			]
+		]);
+
+		$this->assertTrue($blueprint->optionForUser($this->user('admin'), 'update'));
+		$this->assertFalse($blueprint->optionForUser($this->user('editor'), 'update'));
+	}
+
+	public function testOptionForUserWithWildcard(): void
+	{
+		$blueprint = $this->blueprint([
+			'update' => [
+				'admin' => true,
+				'*'     => false
+			]
+		]);
+
+		$this->assertTrue($blueprint->optionForUser($this->user('admin'), 'update'));
+		$this->assertFalse($blueprint->optionForUser($this->user('editor'), 'update'));
+	}
+
+	public function testOptionForUserWithMissingRole(): void
+	{
+		$blueprint = $this->blueprint([
+			'update' => [
+				'admin' => true
+			]
+		]);
+
+		$this->assertTrue($blueprint->optionForUser($this->user('admin'), 'update'));
+		$this->assertNull($blueprint->optionForUser($this->user('editor'), 'update'));
+	}
+
+	public function testOptionForUserWithList(): void
+	{
+		// a non-associative array is not a set of role rules
+		$blueprint = $this->blueprint([
+			'changeTemplate' => ['article', 'note']
+		]);
+
+		$this->assertNull(
+			$blueprint->optionForUser($this->user('admin'), 'changeTemplate')
+		);
+	}
+}

--- a/tests/Cms/Permissions/PermissionsTest.php
+++ b/tests/Cms/Permissions/PermissionsTest.php
@@ -254,6 +254,20 @@ class PermissionsTest extends TestCase
 		$this->assertTrue($p->for('access', 'foo', default:true));
 	}
 
+	public function testForNullDefault(): void
+	{
+		$p = new Permissions();
+
+		// existing permissions still return their bool value
+		$this->assertTrue($p->for('access', 'site', default: null));
+
+		// a null default is returned when the category does not exist
+		$this->assertNull($p->for('foo', default: null));
+
+		// a null default is returned when the action does not exist
+		$this->assertNull($p->for('access', 'foo', default: null));
+	}
+
 	public function testForNullCategory(): void
 	{
 		$p       = new Permissions();

--- a/tests/Cms/User/UserTest.php
+++ b/tests/Cms/User/UserTest.php
@@ -29,6 +29,52 @@ class UserTest extends ModelTestCase
 		$this->assertSame($credentials, $user->credentials());
 	}
 
+	public function testEnsure(): void
+	{
+		$this->app = $this->app->clone([
+			'users' => [
+				['email' => 'editor@getkirby.com', 'role' => 'editor']
+			]
+		]);
+
+		$this->app->impersonate('editor@getkirby.com');
+
+		$this->assertSame($this->app->user(), User::ensure());
+	}
+
+	public function testEnsureWithKirbyUser(): void
+	{
+		$this->app->impersonate('kirby');
+
+		$user = User::ensure();
+
+		$this->assertTrue($user->isKirby());
+		$this->assertSame('kirby', $user->id());
+	}
+
+	public function testEnsureWithoutAuthenticatedUser(): void
+	{
+		$this->app->impersonate(null);
+
+		$this->assertNull($this->app->user());
+
+		$user = User::ensure();
+
+		$this->assertTrue($user->isNobody());
+		$this->assertSame('nobody', $user->id());
+		$this->assertSame('nobody', $user->role()->id());
+		$this->assertSame('nobody@getkirby.com', $user->email());
+	}
+
+	public function testEnsureWithoutAuthenticatedUserReturnsNewInstance(): void
+	{
+		$this->app->impersonate(null);
+
+		// the virtual nobody user is not stored anywhere,
+		// so every call has to create it from scratch
+		$this->assertNotSame(User::ensure(), User::ensure());
+	}
+
 	public function testId(): void
 	{
 		$user = new User([


### PR DESCRIPTION
This PR extracts some of the preparing commits that are easier to review and independent from the new Guards classes. 

## Changelog

### Enhancements

- New `Kirby\Exception\AbilityException`
- New `Kirby\Cms\Model` base class, which is extended by `ModelWithContent` and `Language` classes. This helps to create easier unified type checks for valid models. 
- New `Kirby\Cms\User::ensure()` method, which will always return a user and fall back to a anonymous `nobody` user if nobody is logged in. 

### Breaking Changes

- Allow a `null` default in `Kirby\Cms\Permissions::for()`
