### PR TITLE
fix: Clean up media folder when moving a page

### DIFF
--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -712,6 +712,9 @@ trait PageActions
 				);
 			}
 
+			// media folder is bound to the page id, which just changed
+			Dir::remove($page->mediaRoot());
+
 			// flush all collection caches to be sure that
 			// the new child is included afterwards
 			$parent->purge();

--- a/tests/Cms/Page/PageMoveTest.php
+++ b/tests/Cms/Page/PageMoveTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Filesystem\F;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(Page::class)]
@@ -45,6 +46,60 @@ class PageMoveTest extends ModelTestCase
 		$moved = $child->move($parentB);
 
 		$this->assertTrue($moved->parent()->is($parentB));
+	}
+
+	public function testMoveRemovesTheOldMediaFolder(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/parent' => [
+					'sections' => [
+						'subpages' => [
+							'type'     => 'pages',
+							'template' => 'child'
+						]
+					]
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		$parentA = Page::create([
+			'slug'     => 'parent-a',
+			'template' => 'parent'
+		]);
+
+		$parentB = Page::create([
+			'slug'     => 'parent-b',
+			'template' => 'parent'
+		]);
+
+		$child = Page::create([
+			'parent'   => $parentA,
+			'slug'     => 'child',
+			'template' => 'child'
+		]);
+
+		// simulate published media for the page and one of its subpages
+		$grandchild = Page::create([
+			'parent'   => $child,
+			'slug'     => 'grandchild',
+			'template' => 'child'
+		]);
+
+		F::write($media = $child->mediaRoot() . '/1234-5678/test.jpg', '');
+		F::write($mediaOfGrandchild = $grandchild->mediaRoot() . '/1234-5678/test.jpg', '');
+
+		$this->assertFileExists($media);
+		$this->assertFileExists($mediaOfGrandchild);
+
+		$moved = $child->move($parentB);
+
+		$this->assertFileDoesNotExist($media);
+		$this->assertFileDoesNotExist($mediaOfGrandchild);
+		$this->assertDirectoryDoesNotExist($child->mediaRoot());
+		$this->assertNotSame($child->mediaRoot(), $moved->mediaRoot());
 	}
 
 	public function testMoveWhenTheParentIsTheSame(): void


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Deep read

**Timing:** No rush


## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".
-->

### 🐛 Bug fixes
- Removes old media folder when a page is moved


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
