### PR TITLE
fix: Focusable `k-tag` when removable

### DIFF
--- a/panel/src/components/Navigation/Tag.vue
+++ b/panel/src/components/Navigation/Tag.vue
@@ -3,6 +3,7 @@
 		:is="element ?? (link ? 'k-link' : 'button')"
 		:aria-disabled="disabled"
 		:data-theme="theme"
+		:tabindex="tabindex"
 		:to="link"
 		class="k-tag"
 		type="button"
@@ -103,6 +104,11 @@ export default {
 	computed: {
 		isRemovable() {
 			return this.removable && !this.disabled;
+		},
+		tabindex() {
+			// removable tags need to be focusable, no matter which
+			// element they render as, to be removed by keyboard
+			return this.isRemovable === true ? 0 : null;
 		}
 	},
 	methods: {


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Design & concept

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### 🐛 Bug fixes
- Tags are always focusable when removable (and Backspace/Delete delete the tag when focused)


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add lab and/or sandbox examples (wherever helpful)
  - Already present in sandbox anyways
- [x] Add changes & docs to release notes draft in Notion
