### PR TITLE
fix: Remove session cookie on logout

### DIFF
--- a/src/Cms/Auth.php
+++ b/src/Cms/Auth.php
@@ -632,16 +632,20 @@ class Auth
 		// ensures that we log out the actually logged in user
 		$this->impersonate = null;
 
-		// logout the current user if it exists
-		$this->user()?->logout();
-
-		// clear the pending challenge
+		// clear the pending challenge and the CSRF token before the user
+		// is logged out; otherwise this leftover data would keep the session
+		// alive and its cookie would block the pages cache;
+		// a new CSRF token is generated on next use
 		$session = $this->kirby->session();
 		$session->remove('kirby.challenge.code');
 		$session->remove('kirby.challenge.email');
 		$session->remove('kirby.challenge.mode');
 		$session->remove('kirby.challenge.timeout');
 		$session->remove('kirby.challenge.type');
+		$session->remove('kirby.csrf');
+
+		// logout the current user if it exists
+		$this->user()?->logout();
 
 		// clear the status cache
 		$this->status = null;

--- a/tests/Cms/Auth/AuthTest.php
+++ b/tests/Cms/Auth/AuthTest.php
@@ -6,6 +6,7 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Exception\PermissionException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
+use Kirby\Http\Cookie;
 use Kirby\Session\AutoSession;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Throwable;
@@ -226,6 +227,23 @@ class AuthTest extends TestCase
 			'mode'      => null,
 			'status'    => 'inactive'
 		], $this->auth->status()->toArray());
+	}
+
+	public function testLogoutDestroysSession(): void
+	{
+		$session = $this->app->session();
+
+		$this->app->user('marge@simpsons.com')->loginPasswordless();
+
+		// the Panel stores a CSRF token in the session on every request
+		$this->app->csrf();
+
+		$this->assertTrue(Cookie::exists('kirby_session'));
+
+		$this->auth->logout();
+
+		$this->assertSame([], $session->data()->get());
+		$this->assertFalse(Cookie::exists('kirby_session'));
 	}
 
 	public function testLogoutPending(): void


### PR DESCRIPTION
## Review

- [x] Rough pass

## Description

`User::logout()` only destroys the session (and with it the cookie) when the session data is empty. The CSRF token stored by the Panel was left behind, so the session survived and its cookie kept blocking the pages cache.

The cleanup of Kirby's own session keys therefore had to move **before** `$this->user()?->logout()` — that's where the "is the session empty?" check happens, so cleaning up afterwards came too late to affect the decision. `kirby.csrf` was added to the list; a new token is simply generated on next use.

Open question: on multi-language installs `panel.language` is also kept in the session, so the session isn't empty there either. Should we clear that one on logout too?

## Changelog

### 🐛 Bug fixes

- The session cookie is now removed when logging out of the Panel, so the pages cache doesn't stay blocked #8375

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion