### PR TITLE
ci: Install apt packages without caching

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -71,20 +71,23 @@ jobs:
         with:
           fetch-depth: 2
 
+      # never cache these: a failed install would be cached as an empty result
       - name: Install system locales and imagemagick
-        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
-        with:
-          packages: locales-all imagemagick
-          version: 1
-          execute_install_scripts: true
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y locales-all imagemagick
 
-      - name: Ensure ImageMagick aliases exist
+      - name: Verify test dependencies
+        shell: bash
         run: |
-          if ! command -v convert > /dev/null; then
-            sudo ln -sf /usr/bin/convert-im6.q16 /usr/bin/convert
-            sudo ln -sf /usr/bin/identify-im6.q16 /usr/bin/identify
-          fi
-          convert -version | head -1
+          convert -version
+          identify -version
+          locales=$(locale -a)
+          for locale in de_AT.utf8 de_DE.utf8 pt_BR.utf8; do
+            grep -qx "$locale" <<< "$locales" || {
+              echo "::error::Missing locale $locale"
+              exit 1
+            }
+          done
 
       - name: Setup PHP environment
         uses: ./.github/actions/setup-php


### PR DESCRIPTION
## Review

- [x] Rough pass

**Timing:** Blocks every PR targeting `v6/develop`.

## Description

CI fails with 37 errors/failures across the locale and Darkroom tests. Neither the tests nor the core are at fault — `locales-all` and `imagemagick` never get installed on the runner.

#8305 replaced `apt-get install` with `awalsh128/cache-apt-pkgs-action`. When its install fails (a mirror 404 and an `apt-fast` download error have both happened), it swallows the error and caches the empty result under a fixed key, poisoning that branch scope. The guard step missed it because `convert -version | head -1` ran under GitHub's default `bash -e`, without `pipefail`, and exited 0.

- back to a plain `apt-get install`, same as `develop-patch`/`develop-minor`
- new `Verify test dependencies` step that fails fast when `convert`, `identify` or the required locales are missing

`--no-install-recommends` is deliberately not restored: it would drop `libmagickcore-6.q16-7-extra`, which the WebP fixtures need.

**Before merging:** the two poisoned cache entries need to be deleted, otherwise #8337 and #8377 stay red.

```
gh cache delete 6604860585 --repo getkirby/kirby
gh cache delete 6531441713 --repo getkirby/kirby
```

## Changelog

### 🧹 Housekeeping

- Fix backend CI failing when system packages were not installed on the runner

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion