### PR TITLE
fix: Remove session cookie on logout

### DIFF
--- a/src/Auth/Auth.php
+++ b/src/Auth/Auth.php
@@ -401,12 +401,16 @@ class Auth
 		// ensures that we log out the actually logged in user
 		$this->user->impersonate(null);
 
-		$this->user()?->logout();
-
+		// clear our own session data before the user is logged out;
+		// otherwise this leftover data would keep the session alive
+		// and its cookie would block the pages cache
 		$session = $this->kirby->session();
 
 		$this->challenges->clear($session);
+		$this->csrf->clear($session);
 		$this->methods->clear($session);
+
+		$this->user()?->logout();
 
 		$this->status = null;
 	}

--- a/src/Auth/Csrf.php
+++ b/src/Auth/Csrf.php
@@ -3,6 +3,7 @@
 namespace Kirby\Auth;
 
 use Kirby\Cms\App;
+use Kirby\Session\Session;
 
 /**
  * Handler for the auth CSRF token
@@ -16,6 +17,15 @@ class Csrf
 	public function __construct(
 		protected App $kirby
 	) {
+	}
+
+	/**
+	 * Removes the token from the session;
+	 * a new token is generated on next use
+	 */
+	public function clear(Session $session): void
+	{
+		$session->remove('kirby.csrf');
 	}
 
 	/**

--- a/tests/Auth/AuthTest.php
+++ b/tests/Auth/AuthTest.php
@@ -9,6 +9,7 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\PermissionException;
 use Kirby\Exception\UserNotFoundException;
 use Kirby\Filesystem\F;
+use Kirby\Http\Cookie;
 use Kirby\Http\Request\Auth\BasicAuth;
 use Kirby\Session\Session;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -521,6 +522,23 @@ class AuthTest extends TestCase
 			'mode'      => null,
 			'status'    => 'inactive'
 		], $this->auth->status()->toArray());
+	}
+
+	public function testLogoutDestroysSession(): void
+	{
+		$session = $this->app->session();
+
+		$this->app->user('marge@simpsons.com')->loginPasswordless();
+
+		// the Panel stores a CSRF token in the session on every request
+		$this->app->csrf();
+
+		$this->assertTrue(Cookie::exists('kirby_session'));
+
+		$this->auth->logout();
+
+		$this->assertSame([], $session->data()->get());
+		$this->assertFalse(Cookie::exists('kirby_session'));
 	}
 
 	public function testLogoutClearsMethodState(): void

--- a/tests/Auth/CsrfTest.php
+++ b/tests/Auth/CsrfTest.php
@@ -17,6 +17,16 @@ class CsrfTest extends TestCase
 		$this->csrf = new Csrf($this->app);
 	}
 
+	public function testClear(): void
+	{
+		$session = $this->app->session();
+		$session->set('kirby.csrf', 'session-csrf');
+
+		$this->csrf->clear($session);
+
+		$this->assertNull($session->get('kirby.csrf'));
+	}
+
 	public function testFromSession1(): void
 	{
 		$this->app->session()->set('kirby.csrf', 'session-csrf');


### PR DESCRIPTION
## Review

- [x] Rough pass

**Timing:**

## Description

Forward-port of #8376 to v6.

Same fix: Kirby's own session data is cleared *before* `$this->user()?->logout()`, because that's where the "is the session empty?" check decides between `destroy()` and `regenerateToken()`.

Since v6 moved auth into the `Kirby\Auth` namespace, the token removal is implemented as `Csrf::clear()`, matching the existing `Challenges::clear()` and `Methods::clear()` handlers.

## Changelog

### 🐛 Bug fixes

- The session cookie is now removed when logging out of the Panel, so the pages cache doesn't stay blocked #8375

## Docs

No docs changes needed.

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion