### PR TITLE
refact: Move all normalisation logic into a normalizer class

### DIFF
--- a/src/Blueprint/Blueprint.php
+++ b/src/Blueprint/Blueprint.php
@@ -10,17 +10,15 @@ use Kirby\Data\Data;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\F;
-use Kirby\Form\Field;
 use Kirby\Form\Field\SectionField;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
-use Throwable;
 
 /**
- * The Blueprint class normalizes an array from a
- * blueprint file and converts sections, columns, fields
- * etc. into a correct tab layout.
+ * The Blueprint class gives access to all settings
+ * of a blueprint file. The raw props are converted
+ * into a proper tab layout by the `Normalizer`.
  *
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
@@ -31,13 +29,7 @@ class Blueprint
 
 	protected AcceptRules|null $acceptRules = null;
 
-	/**
-	 * Global field definitions that can be referenced
-	 * in tabs, columns and sections.
-	 */
-	protected array $fieldDefinitions = [];
-
-	// Cache for collected field props
+	// Props of all fields in the blueprint
 	protected array $fields = [];
 	protected array|null $fieldsLower = null;
 	protected ModelWithContent $model;
@@ -77,28 +69,16 @@ class Blueprint
 		// the model should not be included in the props array
 		unset($props['model']);
 
-		// extend the blueprint in general
-		$props = static::extend($props);
+		// convert all shortcuts and normalize the props
+		$normalizer = new Normalizer(
+			model: $this->model,
+			props: $props
+		);
 
-		// normalize the name
-		$props['name'] ??= 'default';
-
-		// normalize and translate the title
-		$props['title'] ??= Str::label($props['name']);
-		$props['title']   = $this->i18n($props['title']);
-
-		// extract global field definitions before normalization
-		$props = $this->extractFieldReferences($props);
-
-		// convert all shortcuts
-		$props = $this->convertFieldsToSections('main', $props);
-		$props = $this->convertSectionsToColumns('main', $props);
-		$props = $this->convertColumnsToTabs('main', $props);
-
-		// normalize all tabs
-		$props['tabs'] = $this->normalizeTabs($props['tabs'] ?? []);
-
-		$this->props = $props;
+		$this->fields   = $normalizer->fields();
+		$this->props    = $normalizer->props();
+		$this->sections = $normalizer->sections();
+		$this->tabs     = $normalizer->tabs();
 	}
 
 	/**
@@ -139,84 +119,6 @@ class Blueprint
 	}
 
 	/**
-	 * Converts all column definitions, that
-	 * are not wrapped in a tab, into a generic tab
-	 */
-	protected function convertColumnsToTabs(
-		string $tabName,
-		array $props
-	): array {
-		if (isset($props['columns']) === false) {
-			return $props;
-		}
-
-		// wrap everything in a main tab
-		$props['tabs'] = [
-			$tabName => [
-				'columns' => $props['columns']
-			]
-		];
-
-		unset($props['columns']);
-
-		return $props;
-	}
-
-	/**
-	 * Converts all field definitions, that are not
-	 * wrapped in a fields section into a generic
-	 * fields section.
-	 */
-	protected function convertFieldsToSections(
-		string $tabName,
-		array $props
-	): array {
-		if (isset($props['fields']) === false) {
-			return $props;
-		}
-
-		// Resolve field references and extract inline definitions
-		$fields = $this->resolveFieldReferences($props['fields']);
-
-		// wrap all fields in a section
-		$props['sections'] = [
-			$tabName . '-fields' => [
-				'type'   => 'fields',
-				'fields' => $fields
-			]
-		];
-
-		unset($props['fields']);
-
-		return $props;
-	}
-
-	/**
-	 * Converts all sections that are not wrapped in
-	 * columns, into a single generic column.
-	 */
-	protected function convertSectionsToColumns(
-		string $tabName,
-		array $props
-	): array {
-		if (isset($props['sections']) === false) {
-			return $props;
-		}
-
-		// wrap everything in one big column
-		$props['columns'] = [
-			[
-				'width'    => '1/1',
-				'sections' => $props['sections']
-			]
-		];
-
-		unset($props['sections']);
-
-		return $props;
-	}
-
-	/**
 	 * Extends the props with props from a given
 	 * mixin, when an extends key is set or the
 	 * props is just a string
@@ -244,36 +146,6 @@ class Blueprint
 
 			// remove the extends flag
 			unset($props['extends']);
-		}
-
-		return $props;
-	}
-
-	/**
-	 * Extracts global field definitions from root level.
-	 * When layout elements exist, adds fields to the registry
-	 * and removes them from props so they can be referenced.
-	 * When no layout exists, fields stay in props for the
-	 * existing backwards-compatible behavior.
-	 *
-	 * @since 6.0.0
-	 */
-	protected function extractFieldReferences(array $props): array
-	{
-		if (isset($props['fields']) === false) {
-			return $props;
-		}
-
-		// Check if layout elements exist
-		$hasLayout = isset($props['tabs']) === true ||
-					 isset($props['sections']) === true ||
-					 isset($props['columns']) === true;
-
-		// Only store definitions and remove from props when layout exists
-		// (fields will be referenced from layout, not processed inline)
-		if ($hasLayout === true) {
-			$this->fieldDefinitions = static::fieldsProps($props['fields']);
-			unset($props['fields']);
 		}
 
 		return $props;
@@ -332,60 +204,14 @@ class Blueprint
 	}
 
 	/**
-	 * Normalize field props for a single field
+	 * Normalize field props for a single field.
+	 * Facade for `Normalizer::normalizeFieldProps()`
 	 *
 	 * @throws InvalidArgumentException If the filed name is missing or the field type is invalid
 	 */
 	public static function fieldProps(array|string $props): array
 	{
-		$props = static::extend($props);
-
-		if (isset($props['name']) === false) {
-			throw new InvalidArgumentException(
-				message: 'The field name is missing'
-			);
-		}
-
-		$name = $props['name'];
-		$type = $props['type'] ?? $name;
-
-		if ($type !== 'group' && isset(Field::$types[$type]) === false) {
-			throw new InvalidArgumentException(
-				message: 'Invalid field type ("' . $type . '")'
-			);
-		}
-
-		// support for nested fields
-		if (isset($props['fields']) === true) {
-			$props['fields'] = static::fieldsProps($props['fields']);
-		}
-
-		// groups don't need all the crap
-		if ($type === 'group') {
-			$fields = $props['fields'];
-
-			if (isset($props['when']) === true) {
-				$fields = array_map(
-					fn ($field) => array_replace_recursive(['when' => $props['when']], $field),
-					$fields
-				);
-			}
-
-			return [
-				'fields' => $fields,
-				'name'   => $name,
-				'type'   => $type
-			];
-		}
-
-		// add some useful defaults
-		return [
-			...$props,
-			'label' => $props['label'] ?? Str::label($name),
-			'name'  => $name,
-			'type'  => $type,
-			'width' => $props['width'] ?? '1/1',
-		];
+		return Normalizer::normalizeFieldProps($props);
 	}
 
 	/**
@@ -399,64 +225,13 @@ class Blueprint
 	/**
 	 * Normalizes all fields and adds automatic labels,
 	 * types and widths.
+	 * Facade for `Normalizer::normalizeFieldsProps()`
+	 *
+	 * @return array<string, array>
 	 */
-	public static function fieldsProps($fields): array
+	public static function fieldsProps(mixed $fields): array
 	{
-		if (is_array($fields) === false) {
-			$fields = [];
-		}
-
-		foreach ($fields as $fieldName => $fieldProps) {
-			// extend field from string
-			if (is_string($fieldProps) === true) {
-				$fieldProps = [
-					'extends' => $fieldProps,
-					'name'    => $fieldName
-				];
-			}
-
-			// use the name as type definition
-			if ($fieldProps === true) {
-				$fieldProps = [];
-			}
-
-			// unset / remove field if its property is false
-			if ($fieldProps === false) {
-				unset($fields[$fieldName]);
-				continue;
-			}
-
-			// inject the name
-			$fieldProps['name'] = $fieldName;
-
-			// create all props
-			try {
-				$fieldProps = static::fieldProps($fieldProps);
-			} catch (Throwable $e) {
-				$fieldProps = static::fieldError($fieldName, $e->getMessage());
-			}
-
-			// resolve field groups
-			if ($fieldProps['type'] === 'group') {
-				if (
-					empty($fieldProps['fields']) === false &&
-					is_array($fieldProps['fields']) === true
-				) {
-					$index  = array_search($fieldName, array_keys($fields));
-					$fields = [
-						...array_slice($fields, 0, $index),
-						...$fieldProps['fields'] ?? [],
-						...array_slice($fields, $index + 1)
-					];
-				} else {
-					unset($fields[$fieldName]);
-				}
-			} else {
-				$fields[$fieldName] = $fieldProps;
-			}
-		}
-
-		return $fields;
+		return Normalizer::normalizeFieldsProps($fields);
 	}
 
 	/**
@@ -566,196 +341,20 @@ class Blueprint
 	}
 
 	/**
-	 * Normalizes all required props in a column setup
-	 */
-	protected function normalizeColumns(string $tabName, array $columns): array
-	{
-		foreach ($columns as $columnKey => $columnProps) {
-			// unset/remove column if its property is not array
-			if (is_array($columnProps) === false) {
-				unset($columns[$columnKey]);
-				continue;
-			}
-
-			$columnProps = $this->convertFieldsToSections(
-				$tabName . '-col-' . $columnKey,
-				$columnProps
-			);
-
-			// inject getting started info, if the sections are empty
-			if (empty($columnProps['sections']) === true) {
-				$columnProps['sections'] = [
-					$tabName . '-info-' . $columnKey => [
-						'label' => 'Column (' . ($columnProps['width'] ?? '1/1') . ')',
-						'type'  => 'info',
-						'text'  => 'No sections yet'
-					]
-				];
-			}
-
-			$columns[$columnKey] = [
-				...$columnProps,
-				'width'    => $columnProps['width'] ?? '1/1',
-				'sections' => $this->normalizeSections(
-					$tabName,
-					$columnProps['sections'] ?? []
-				)
-			];
-		}
-
-		return $columns;
-	}
-
-	/**
 	 * Normalizes blueprint options. This must be used in the
-	 * constructor of an extended class, if you want to make use of it.
+	 * constructor of an extended class, if you want to make use
+	 * of it. Facade for `Normalizer::normalizeOptions()`
 	 */
 	protected function normalizeOptions(
 		array|string|bool|null $options,
 		array $defaults,
 		array $aliases = []
 	): array {
-		// return defaults when options are not defined or set to true
-		if ($options === true) {
-			return $defaults;
-		}
-
-		// set all options to false
-		if ($options === false) {
-			return array_fill_keys(array_keys($defaults), false);
-		}
-
-		// extend options if possible
-		$options = static::extend($options);
-
-		foreach ($options as $key => $value) {
-			$alias = $aliases[$key] ?? null;
-
-			if ($alias !== null) {
-				$options[$alias] ??= $value;
-				unset($options[$key]);
-			}
-		}
-
-		return [...$defaults, ...$options];
-	}
-
-	/**
-	 * Normalizes all required keys in sections
-	 */
-	protected function normalizeSections(
-		string $tabName,
-		array $sections
-	): array {
-		foreach ($sections as $sectionName => $sectionProps) {
-			// unset / remove section if its property is false
-			if ($sectionProps === false) {
-				unset($sections[$sectionName]);
-				continue;
-			}
-
-			// fallback to default props when true is passed
-			if ($sectionProps === true) {
-				$sectionProps = [];
-			}
-
-			// inject all section extensions
-			$sectionProps = static::extend($sectionProps);
-
-			$sections[$sectionName] = $sectionProps = [
-				...$sectionProps,
-				'name' => $sectionName,
-				'type' => $type = $sectionProps['type'] ?? $sectionName
-			];
-
-			if (empty($type) === true || is_string($type) === false) {
-				$sections[$sectionName] = [
-					'name'  => $sectionName,
-					'label' => 'Invalid section type for section "' . $sectionName . '"',
-					'type'  => 'info',
-					'text'  => 'The following section types are available: ' . static::helpList(array_keys(Section::$types))
-				];
-			} elseif (isset(Section::$types[$type]) === false) {
-				$sections[$sectionName] = [
-					'name'  => $sectionName,
-					'label' => 'Invalid section type ("' . $type . '")',
-					'type'  => 'info',
-					'text'  => 'The following section types are available: ' . static::helpList(array_keys(Section::$types))
-				];
-			}
-
-			if ($sectionProps['type'] === 'fields') {
-				// Resolve field references before normalizing
-				$sectionFields = $this->resolveFieldReferences($sectionProps['fields'] ?? []);
-				$fields = Blueprint::fieldsProps($sectionFields);
-
-				// inject guide fields guide
-				if ($fields === []) {
-					$fields = [
-						$tabName . '-info' => [
-							'label' => 'Fields',
-							'text'  => 'No fields yet',
-							'type'  => 'info'
-						]
-					];
-				} else {
-					foreach ($fields as $fieldName => $fieldProps) {
-						if (isset($this->fields[$fieldName]) === true) {
-							$this->fields[$fieldName] = $fields[$fieldName] = [
-								'type'  => 'info',
-								'label' => $fieldProps['label'] ?? 'Error',
-								'text'  => 'The field <strong>"' . $fieldName . '"</strong> already exists in your blueprint',
-								'theme' => 'negative'
-							];
-						} else {
-							$this->fields[$fieldName] = $fieldProps;
-						}
-					}
-				}
-
-				$sections[$sectionName]['fields'] = $fields;
-			}
-		}
-
-		// store all normalized sections
-		$this->sections = [...$this->sections, ...$sections];
-
-		return $sections;
-	}
-
-	/**
-	 * Normalizes all required keys in tabs
-	 */
-	protected function normalizeTabs($tabs): array
-	{
-		if (is_array($tabs) === false) {
-			$tabs = [];
-		}
-
-		foreach ($tabs as $tabName => $tabProps) {
-			// unset / remove tab if its property is false
-			if ($tabProps === false) {
-				unset($tabs[$tabName]);
-				continue;
-			}
-
-			// inject all tab extensions
-			$tabProps = static::extend($tabProps);
-
-			$tabProps = $this->convertFieldsToSections($tabName, $tabProps);
-			$tabProps = $this->convertSectionsToColumns($tabName, $tabProps);
-
-			$tabs[$tabName] = [
-				...$tabProps,
-				'columns' => $this->normalizeColumns($tabName, $tabProps['columns'] ?? []),
-				'icon'    => $tabProps['icon']  ?? null,
-				'label'   => $this->i18n($tabProps['label'] ?? Str::label($tabName)),
-				'link'    => $this->model->panel()->url(true) . '/?tab=' . $tabName,
-				'name'    => $tabName,
-			];
-		}
-
-		return $this->tabs = $tabs;
+		return Normalizer::normalizeOptions(
+			options: $options,
+			defaults: $defaults,
+			aliases: $aliases
+		);
 	}
 
 	/**
@@ -788,38 +387,6 @@ class Blueprint
 		}
 
 		return null;
-	}
-
-	/**
-	 * Resolves field references (numeric keys with string values)
-	 * to full definitions from the global registry
-	 *
-	 * @since 6.0.0
-	 */
-	protected function resolveFieldReferences(array $fields): array
-	{
-		$resolved = [];
-
-		foreach ($fields as $key => $value) {
-			// Numeric key with string value = field reference
-			if (is_int($key) === true && is_string($value) === true) {
-				$fieldName = $value;
-
-				if (isset($this->fieldDefinitions[$fieldName]) === true) {
-					$resolved[$fieldName] = $this->fieldDefinitions[$fieldName];
-				} else {
-					$resolved[$fieldName] = static::fieldError(
-						$fieldName,
-						'Referenced field "' . $fieldName . '" is not defined in fields'
-					);
-				}
-			} else {
-				// Inline field definition - keep as is
-				$resolved[$key] = $value;
-			}
-		}
-
-		return $resolved;
 	}
 
 	/**

--- a/src/Blueprint/Normalizer.php
+++ b/src/Blueprint/Normalizer.php
@@ -1,0 +1,580 @@
+<?php
+
+namespace Kirby\Blueprint;
+
+use Kirby\Cms\ModelWithContent;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\Form\Field;
+use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Str;
+use Throwable;
+
+/**
+ * The Normalizer takes the raw props of a blueprint and
+ * converts them into a proper tab layout. Loose fields are
+ * wrapped in a section, loose sections in a column and loose
+ * columns in a tab. On the way, it collects the props of all
+ * sections and fields in the blueprint.
+ *
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ * @unstable
+ */
+class Normalizer
+{
+	/**
+	 * Global field definitions that can be referenced
+	 * in tabs, columns and sections.
+	 */
+	protected array $fieldDefinitions = [];
+
+	// Collected props of all fields in the blueprint
+	protected array $fields = [];
+
+	// Collected blueprint props
+	protected array $props;
+
+	// Collected props of all sections in the blueprint
+	protected array $sections = [];
+
+	public function __construct(
+		protected ModelWithContent $model,
+		array $props
+	) {
+		$this->props = $this->normalize($props);
+	}
+
+	/**
+	 * Converts all column definitions, that
+	 * are not wrapped in a tab, into a generic tab
+	 */
+	protected function convertColumnsToTabs(
+		string $tabName,
+		array $props
+	): array {
+		if (isset($props['columns']) === false) {
+			return $props;
+		}
+
+		// wrap everything in a main tab
+		$props['tabs'] = [
+			$tabName => [
+				'columns' => $props['columns']
+			]
+		];
+
+		unset($props['columns']);
+
+		return $props;
+	}
+
+	/**
+	 * Converts all field definitions, that are not
+	 * wrapped in a fields section into a generic
+	 * fields section.
+	 */
+	protected function convertFieldsToSections(
+		string $tabName,
+		array $props
+	): array {
+		if (isset($props['fields']) === false) {
+			return $props;
+		}
+
+		// Resolve field references and extract inline definitions
+		$fields = $this->resolveFieldReferences($props['fields']);
+
+		// wrap all fields in a section
+		$props['sections'] = [
+			$tabName . '-fields' => [
+				'type'   => 'fields',
+				'fields' => $fields
+			]
+		];
+
+		unset($props['fields']);
+
+		return $props;
+	}
+
+	/**
+	 * Converts all sections that are not wrapped in
+	 * columns, into a single generic column.
+	 */
+	protected function convertSectionsToColumns(
+		string $tabName,
+		array $props
+	): array {
+		if (isset($props['sections']) === false) {
+			return $props;
+		}
+
+		// wrap everything in one big column
+		$props['columns'] = [
+			[
+				'width'    => '1/1',
+				'sections' => $props['sections']
+			]
+		];
+
+		unset($props['sections']);
+
+		return $props;
+	}
+
+	/**
+	 * Extracts global field definitions from root level.
+	 * When layout elements exist, adds fields to the registry
+	 * and removes them from props so they can be referenced.
+	 * When no layout exists, fields stay in props for the
+	 * existing backwards-compatible behavior.
+	 */
+	protected function extractFieldReferences(array $props): array
+	{
+		if (isset($props['fields']) === false) {
+			return $props;
+		}
+
+		// Check if layout elements exist
+		$hasLayout = isset($props['tabs']) === true ||
+					 isset($props['sections']) === true ||
+					 isset($props['columns']) === true;
+
+		// Only store definitions and remove from props when layout exists
+		// (fields will be referenced from layout, not processed inline)
+		if ($hasLayout === true) {
+			$this->fieldDefinitions = static::normalizeFieldsProps($props['fields']);
+			unset($props['fields']);
+		}
+
+		return $props;
+	}
+
+	/**
+	 * Returns the props of all fields in the blueprint
+	 *
+	 * @return array<string, array>
+	 */
+	public function fields(): array
+	{
+		return $this->fields;
+	}
+
+	/**
+	 * Used to translate any label, heading, etc.
+	 */
+	protected function i18n(mixed $value, mixed $fallback = null): mixed
+	{
+		return I18n::translate($value, $fallback) ?? $value;
+	}
+
+	/**
+	 * Normalizes the raw props of the blueprint
+	 */
+	protected function normalize(array $props): array
+	{
+		// extend the blueprint in general
+		$props = Blueprint::extend($props);
+
+		// normalize the name
+		$props['name'] ??= 'default';
+
+		// normalize and translate the title
+		$props['title'] ??= Str::label($props['name']);
+		$props['title']   = $this->i18n($props['title']);
+
+		// extract global field definitions before normalization
+		$props = $this->extractFieldReferences($props);
+
+		// convert all shortcuts
+		$props = $this->convertFieldsToSections('main', $props);
+		$props = $this->convertSectionsToColumns('main', $props);
+		$props = $this->convertColumnsToTabs('main', $props);
+
+		// normalize all tabs
+		$props['tabs'] = $this->normalizeTabs($props['tabs'] ?? []);
+
+		return $props;
+	}
+
+	/**
+	 * Normalizes all required props in a column setup
+	 *
+	 * @return array<string|int, array>
+	 */
+	protected function normalizeColumns(string $tabName, array $columns): array
+	{
+		foreach ($columns as $columnKey => $columnProps) {
+			// unset/remove column if its property is not array
+			if (is_array($columnProps) === false) {
+				unset($columns[$columnKey]);
+				continue;
+			}
+
+			$columnProps = $this->convertFieldsToSections(
+				$tabName . '-col-' . $columnKey,
+				$columnProps
+			);
+
+			// inject getting started info, if the sections are empty
+			if (empty($columnProps['sections']) === true) {
+				$columnProps['sections'] = [
+					$tabName . '-info-' . $columnKey => [
+						'label' => 'Column (' . ($columnProps['width'] ?? '1/1') . ')',
+						'type'  => 'info',
+						'text'  => 'No sections yet'
+					]
+				];
+			}
+
+			$columns[$columnKey] = [
+				...$columnProps,
+				'width'    => $columnProps['width'] ?? '1/1',
+				'sections' => $this->normalizeSections(
+					$tabName,
+					$columnProps['sections'] ?? []
+				)
+			];
+		}
+
+		return $columns;
+	}
+
+	/**
+	 * Normalize field props for a single field
+	 *
+	 * @throws InvalidArgumentException If the filed name is missing or the field type is invalid
+	 */
+	public static function normalizeFieldProps(array|string $props): array
+	{
+		$props = Blueprint::extend($props);
+
+		if (isset($props['name']) === false) {
+			throw new InvalidArgumentException(
+				message: 'The field name is missing'
+			);
+		}
+
+		$name = $props['name'];
+		$type = $props['type'] ?? $name;
+
+		if ($type !== 'group' && isset(Field::$types[$type]) === false) {
+			throw new InvalidArgumentException(
+				message: 'Invalid field type ("' . $type . '")'
+			);
+		}
+
+		// support for nested fields
+		if (isset($props['fields']) === true) {
+			$props['fields'] = static::normalizeFieldsProps($props['fields']);
+		}
+
+		// groups don't need all the crap
+		if ($type === 'group') {
+			$fields = $props['fields'];
+
+			if (isset($props['when']) === true) {
+				$fields = array_map(
+					fn ($field) => array_replace_recursive(['when' => $props['when']], $field),
+					$fields
+				);
+			}
+
+			return [
+				'fields' => $fields,
+				'name'   => $name,
+				'type'   => $type
+			];
+		}
+
+		// add some useful defaults
+		return [
+			...$props,
+			'label' => $props['label'] ?? Str::label($name),
+			'name'  => $name,
+			'type'  => $type,
+			'width' => $props['width'] ?? '1/1',
+		];
+	}
+
+	/**
+	 * Normalizes all fields and adds automatic labels,
+	 * types and widths.
+	 *
+	 * @return array<string, array>
+	 */
+	public static function normalizeFieldsProps(mixed $fields): array
+	{
+		if (is_array($fields) === false) {
+			$fields = [];
+		}
+
+		foreach ($fields as $fieldName => $fieldProps) {
+			// extend field from string
+			if (is_string($fieldProps) === true) {
+				$fieldProps = [
+					'extends' => $fieldProps,
+					'name'    => $fieldName
+				];
+			}
+
+			// use the name as type definition
+			if ($fieldProps === true) {
+				$fieldProps = [];
+			}
+
+			// unset / remove field if its property is false
+			if ($fieldProps === false) {
+				unset($fields[$fieldName]);
+				continue;
+			}
+
+			// inject the name
+			$fieldProps['name'] = $fieldName;
+
+			// create all props
+			try {
+				$fieldProps = static::normalizeFieldProps($fieldProps);
+			} catch (Throwable $e) {
+				$fieldProps = Blueprint::fieldError($fieldName, $e->getMessage());
+			}
+
+			// resolve field groups
+			if ($fieldProps['type'] === 'group') {
+				if (
+					empty($fieldProps['fields']) === false &&
+					is_array($fieldProps['fields']) === true
+				) {
+					$index  = array_search($fieldName, array_keys($fields));
+					$fields = [
+						...array_slice($fields, 0, $index),
+						...$fieldProps['fields'] ?? [],
+						...array_slice($fields, $index + 1)
+					];
+				} else {
+					unset($fields[$fieldName]);
+				}
+			} else {
+				$fields[$fieldName] = $fieldProps;
+			}
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Normalizes blueprint options. This must be used in the
+	 * constructor of an extended blueprint class, if you want
+	 * to make use of it.
+	 */
+	public static function normalizeOptions(
+		array|string|bool|null $options,
+		array $defaults,
+		array $aliases = []
+	): array {
+		// return defaults when options are not defined or set to true
+		if ($options === true) {
+			return $defaults;
+		}
+
+		// set all options to false
+		if ($options === false) {
+			return array_fill_keys(array_keys($defaults), false);
+		}
+
+		// extend options if possible
+		$options = Blueprint::extend($options);
+
+		foreach ($options as $key => $value) {
+			$alias = $aliases[$key] ?? null;
+
+			if ($alias !== null) {
+				$options[$alias] ??= $value;
+				unset($options[$key]);
+			}
+		}
+
+		return [...$defaults, ...$options];
+	}
+
+	/**
+	 * Normalizes all required keys in sections
+	 *
+	 * @return array<string, array>
+	 */
+	protected function normalizeSections(
+		string $tabName,
+		array $sections
+	): array {
+		foreach ($sections as $sectionName => $sectionProps) {
+			// unset / remove section if its property is false
+			if ($sectionProps === false) {
+				unset($sections[$sectionName]);
+				continue;
+			}
+
+			// fallback to default props when true is passed
+			if ($sectionProps === true) {
+				$sectionProps = [];
+			}
+
+			// inject all section extensions
+			$sectionProps = Blueprint::extend($sectionProps);
+
+			$sections[$sectionName] = $sectionProps = [
+				...$sectionProps,
+				'name' => $sectionName,
+				'type' => $type = $sectionProps['type'] ?? $sectionName
+			];
+
+			if (empty($type) === true || is_string($type) === false) {
+				$sections[$sectionName] = [
+					'name'  => $sectionName,
+					'label' => 'Invalid section type for section "' . $sectionName . '"',
+					'type'  => 'info',
+					'text'  => 'The following section types are available: ' . Blueprint::helpList(array_keys(Section::$types))
+				];
+			} elseif (isset(Section::$types[$type]) === false) {
+				$sections[$sectionName] = [
+					'name'  => $sectionName,
+					'label' => 'Invalid section type ("' . $type . '")',
+					'type'  => 'info',
+					'text'  => 'The following section types are available: ' . Blueprint::helpList(array_keys(Section::$types))
+				];
+			}
+
+			if ($sectionProps['type'] === 'fields') {
+				// Resolve field references before normalizing
+				$sectionFields = $this->resolveFieldReferences($sectionProps['fields'] ?? []);
+				$fields = static::normalizeFieldsProps($sectionFields);
+
+				// inject guide fields guide
+				if ($fields === []) {
+					$fields = [
+						$tabName . '-info' => [
+							'label' => 'Fields',
+							'text'  => 'No fields yet',
+							'type'  => 'info'
+						]
+					];
+				} else {
+					foreach ($fields as $fieldName => $fieldProps) {
+						if (isset($this->fields[$fieldName]) === true) {
+							$this->fields[$fieldName] = $fields[$fieldName] = [
+								'type'  => 'info',
+								'label' => $fieldProps['label'] ?? 'Error',
+								'text'  => 'The field <strong>"' . $fieldName . '"</strong> already exists in your blueprint',
+								'theme' => 'negative'
+							];
+						} else {
+							$this->fields[$fieldName] = $fieldProps;
+						}
+					}
+				}
+
+				$sections[$sectionName]['fields'] = $fields;
+			}
+		}
+
+		// store all normalized sections
+		$this->sections = [...$this->sections, ...$sections];
+
+		return $sections;
+	}
+
+	/**
+	 * Normalizes all required keys in tabs
+	 *
+	 * @return array<string, array>
+	 */
+	protected function normalizeTabs(mixed $tabs): array
+	{
+		if (is_array($tabs) === false) {
+			$tabs = [];
+		}
+
+		foreach ($tabs as $tabName => $tabProps) {
+			// unset / remove tab if its property is false
+			if ($tabProps === false) {
+				unset($tabs[$tabName]);
+				continue;
+			}
+
+			// inject all tab extensions
+			$tabProps = Blueprint::extend($tabProps);
+
+			$tabProps = $this->convertFieldsToSections($tabName, $tabProps);
+			$tabProps = $this->convertSectionsToColumns($tabName, $tabProps);
+
+			$tabs[$tabName] = [
+				...$tabProps,
+				'columns' => $this->normalizeColumns($tabName, $tabProps['columns'] ?? []),
+				'icon'    => $tabProps['icon']  ?? null,
+				'label'   => $this->i18n($tabProps['label'] ?? Str::label($tabName)),
+				'link'    => $this->model->panel()->url(true) . '/?tab=' . $tabName,
+				'name'    => $tabName,
+			];
+		}
+
+		return $tabs;
+	}
+
+	/**
+	 * Returns the normalized props of the blueprint
+	 */
+	public function props(): array
+	{
+		return $this->props;
+	}
+
+	/**
+	 * Resolves field references (numeric keys with string values)
+	 * to full definitions from the global registry
+	 */
+	protected function resolveFieldReferences(array $fields): array
+	{
+		$resolved = [];
+
+		foreach ($fields as $key => $value) {
+			// Numeric key with string value = field reference
+			if (is_int($key) === true && is_string($value) === true) {
+				$fieldName = $value;
+
+				if (isset($this->fieldDefinitions[$fieldName]) === true) {
+					$resolved[$fieldName] = $this->fieldDefinitions[$fieldName];
+				} else {
+					$resolved[$fieldName] = Blueprint::fieldError(
+						$fieldName,
+						'Referenced field "' . $fieldName . '" is not defined in fields'
+					);
+				}
+			} else {
+				// Inline field definition - keep as is
+				$resolved[$key] = $value;
+			}
+		}
+
+		return $resolved;
+	}
+
+	/**
+	 * Returns the props of all sections in the blueprint
+	 *
+	 * @return array<string, array>
+	 */
+	public function sections(): array
+	{
+		return $this->sections;
+	}
+
+	/**
+	 * Returns the normalized tabs of the blueprint
+	 *
+	 * @return array<string, array>
+	 */
+	public function tabs(): array
+	{
+		return $this->props['tabs'] ?? [];
+	}
+}

--- a/tests/Blueprint/BlueprintFieldReferencesTest.php
+++ b/tests/Blueprint/BlueprintFieldReferencesTest.php
@@ -8,6 +8,7 @@ use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(Blueprint::class)]
+#[CoversClass(Normalizer::class)]
 class BlueprintFieldReferencesTest extends TestCase
 {
 	protected Page $model;

--- a/tests/Blueprint/BlueprintTest.php
+++ b/tests/Blueprint/BlueprintTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use stdClass;
 
 #[CoversClass(Blueprint::class)]
+#[CoversClass(Normalizer::class)]
 class BlueprintTest extends TestCase
 {
 	public const string TMP = KIRBY_TMP_DIR . '/Cms.Blueprint';

--- a/tests/Blueprint/NormalizerTest.php
+++ b/tests/Blueprint/NormalizerTest.php
@@ -1,0 +1,743 @@
+<?php
+
+namespace Kirby\Blueprint;
+
+use Kirby\Cms\App;
+use Kirby\Cms\ModelWithContent;
+use Kirby\Exception\InvalidArgumentException;
+use Kirby\TestCase;
+use Kirby\Toolkit\I18n;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Normalizer::class)]
+class NormalizerTest extends TestCase
+{
+	public const string TMP = KIRBY_TMP_DIR . '/Blueprint.Normalizer';
+
+	protected ModelWithContent $model;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->setUpSingleLanguage([
+			'children' => [
+				['slug' => 'a']
+			]
+		]);
+
+		$this->model = $this->app->page('a');
+		$this->setUpTmp();
+	}
+
+	protected function tearDown(): void
+	{
+		App::destroy();
+
+		$this->tearDownTmp();
+
+		parent::tearDown();
+	}
+
+	protected function normalizer(array $props = []): Normalizer
+	{
+		return new Normalizer(
+			model: $this->model,
+			props: $props
+		);
+	}
+
+	public function testColumnsWithEmptySections(): void
+	{
+		$normalizer = $this->normalizer([
+			'columns' => [
+				['width' => '1/3'],
+				['width' => '2/3']
+			]
+		]);
+
+		$columns = $normalizer->tabs()['main']['columns'];
+
+		$this->assertSame([
+			'label' => 'Column (1/3)',
+			'type'  => 'info',
+			'text'  => 'No sections yet',
+			'name'  => 'main-info-0'
+		], $columns[0]['sections']['main-info-0']);
+
+		$this->assertSame([
+			'label' => 'Column (2/3)',
+			'type'  => 'info',
+			'text'  => 'No sections yet',
+			'name'  => 'main-info-1'
+		], $columns[1]['sections']['main-info-1']);
+	}
+
+	public function testColumnsWithFields(): void
+	{
+		$normalizer = $this->normalizer([
+			'columns' => [
+				[
+					'width'  => '1/2',
+					'fields' => [
+						'title' => ['type' => 'text']
+					]
+				]
+			]
+		]);
+
+		$sections = $normalizer->tabs()['main']['columns'][0]['sections'];
+
+		$this->assertArrayHasKey('main-col-0-fields', $sections);
+		$this->assertSame('fields', $sections['main-col-0-fields']['type']);
+		$this->assertArrayHasKey('title', $sections['main-col-0-fields']['fields']);
+	}
+
+	public function testColumnsWithInvalidColumn(): void
+	{
+		$normalizer = $this->normalizer([
+			'columns' => [
+				'a' => 'nonsense',
+				'b' => ['width' => '1/1']
+			]
+		]);
+
+		$columns = $normalizer->tabs()['main']['columns'];
+
+		$this->assertSame(['b'], array_keys($columns));
+	}
+
+	public function testColumnsWithoutWidth(): void
+	{
+		$normalizer = $this->normalizer([
+			'columns' => [
+				['sections' => ['info' => ['type' => 'info']]]
+			]
+		]);
+
+		$this->assertSame(
+			'1/1',
+			$normalizer->tabs()['main']['columns'][0]['width']
+		);
+	}
+
+	public function testConvertColumnsToTabs(): void
+	{
+		$normalizer = $this->normalizer([
+			'columns' => [
+				['width' => '1/1']
+			]
+		]);
+
+		$this->assertArrayNotHasKey('columns', $normalizer->props());
+		$this->assertSame(['main'], array_keys($normalizer->tabs()));
+	}
+
+	public function testConvertFieldsToSections(): void
+	{
+		$normalizer = $this->normalizer([
+			'fields' => [
+				'title' => ['type' => 'text']
+			]
+		]);
+
+		$this->assertArrayNotHasKey('fields', $normalizer->props());
+
+		$sections = $normalizer->sections();
+
+		$this->assertSame(['main-fields'], array_keys($sections));
+		$this->assertSame('fields', $sections['main-fields']['type']);
+	}
+
+	public function testConvertSectionsToColumns(): void
+	{
+		$normalizer = $this->normalizer([
+			'sections' => [
+				'pages' => ['type' => 'pages']
+			]
+		]);
+
+		$this->assertArrayNotHasKey('sections', $normalizer->props());
+
+		$columns = $normalizer->tabs()['main']['columns'];
+
+		$this->assertCount(1, $columns);
+		$this->assertSame('1/1', $columns[0]['width']);
+		$this->assertSame(['pages'], array_keys($columns[0]['sections']));
+	}
+
+	public function testFieldReference(): void
+	{
+		$normalizer = $this->normalizer([
+			'fields' => [
+				'title' => ['type' => 'text']
+			],
+			'sections' => [
+				'content' => [
+					'type'   => 'fields',
+					'fields' => ['title']
+				]
+			]
+		]);
+
+		$fields = $normalizer->fields();
+
+		$this->assertSame(['title'], array_keys($fields));
+		$this->assertSame('text', $fields['title']['type']);
+		$this->assertSame('Title', $fields['title']['label']);
+	}
+
+	public function testFieldReferenceMissing(): void
+	{
+		$normalizer = $this->normalizer([
+			'fields' => [
+				'title' => ['type' => 'text']
+			],
+			'sections' => [
+				'content' => [
+					'type'   => 'fields',
+					'fields' => ['nonsense']
+				]
+			]
+		]);
+
+		$field = $normalizer->fields()['nonsense'];
+
+		$this->assertSame('info', $field['type']);
+		$this->assertSame('Error', $field['label']);
+		$this->assertSame(
+			'Referenced field "nonsense" is not defined in fields',
+			$field['text']
+		);
+	}
+
+	public function testFields(): void
+	{
+		$normalizer = $this->normalizer([
+			'fields' => [
+				'title' => ['type' => 'text'],
+				'date'  => ['type' => 'date']
+			]
+		]);
+
+		$fields = $normalizer->fields();
+
+		$this->assertSame(['title', 'date'], array_keys($fields));
+		$this->assertSame('Title', $fields['title']['label']);
+		$this->assertSame('1/1', $fields['title']['width']);
+		$this->assertSame('date', $fields['date']['type']);
+	}
+
+	public function testFieldsEmpty(): void
+	{
+		$this->assertSame([], $this->normalizer()->fields());
+	}
+
+	public function testFieldsWithDuplicateName(): void
+	{
+		$normalizer = $this->normalizer([
+			'sections' => [
+				'a' => [
+					'type'   => 'fields',
+					'fields' => ['title' => ['type' => 'text']]
+				],
+				'b' => [
+					'type'   => 'fields',
+					'fields' => ['title' => ['type' => 'text']]
+				]
+			]
+		]);
+
+		$field = $normalizer->fields()['title'];
+
+		$this->assertSame('info', $field['type']);
+		$this->assertSame('negative', $field['theme']);
+		$this->assertSame(
+			'The field <strong>"title"</strong> already exists in your blueprint',
+			$field['text']
+		);
+	}
+
+	public function testNormalizeFieldProps(): void
+	{
+		$props = Normalizer::normalizeFieldProps([
+			'name' => 'title',
+			'type' => 'text'
+		]);
+
+		$this->assertSame('title', $props['name']);
+		$this->assertSame('text', $props['type']);
+		$this->assertSame('Title', $props['label']);
+		$this->assertSame('1/1', $props['width']);
+	}
+
+	public function testNormalizeFieldPropsWithGroup(): void
+	{
+		$props = Normalizer::normalizeFieldProps([
+			'name'   => 'meta',
+			'type'   => 'group',
+			'when'   => ['title' => 'test'],
+			'fields' => [
+				'date' => ['type' => 'date']
+			]
+		]);
+
+		$this->assertSame([
+			'fields' => [
+				'date' => [
+					'when'  => ['title' => 'test'],
+					'type'  => 'date',
+					'name'  => 'date',
+					'label' => 'Date',
+					'width' => '1/1'
+				]
+			],
+			'name' => 'meta',
+			'type' => 'group'
+		], $props);
+	}
+
+	public function testNormalizeFieldPropsWithInvalidType(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid field type ("nonsense")');
+
+		Normalizer::normalizeFieldProps([
+			'name' => 'title',
+			'type' => 'nonsense'
+		]);
+	}
+
+	public function testNormalizeFieldPropsWithMissingName(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('The field name is missing');
+
+		Normalizer::normalizeFieldProps(['type' => 'text']);
+	}
+
+	public function testNormalizeFieldPropsWithNestedFields(): void
+	{
+		$props = Normalizer::normalizeFieldProps([
+			'name'   => 'entries',
+			'type'   => 'structure',
+			'fields' => [
+				'date' => ['type' => 'date']
+			]
+		]);
+
+		$this->assertSame('Date', $props['fields']['date']['label']);
+		$this->assertSame('date', $props['fields']['date']['type']);
+	}
+
+	public function testNormalizeFieldPropsWithTypeFromName(): void
+	{
+		$props = Normalizer::normalizeFieldProps(['name' => 'text']);
+
+		$this->assertSame('text', $props['type']);
+	}
+
+	public function testNormalizeFieldsProps(): void
+	{
+		$fields = Normalizer::normalizeFieldsProps([
+			'title' => ['type' => 'text']
+		]);
+
+		$this->assertSame([
+			'title' => [
+				'type'  => 'text',
+				'name'  => 'title',
+				'label' => 'Title',
+				'width' => '1/1'
+			]
+		], $fields);
+	}
+
+	public function testNormalizeFieldsPropsWithEmptyGroup(): void
+	{
+		$fields = Normalizer::normalizeFieldsProps([
+			'meta' => [
+				'type'   => 'group',
+				'fields' => []
+			]
+		]);
+
+		$this->assertSame([], $fields);
+	}
+
+	public function testNormalizeFieldsPropsWithFalse(): void
+	{
+		$fields = Normalizer::normalizeFieldsProps([
+			'title' => ['type' => 'text'],
+			'date'  => false
+		]);
+
+		$this->assertSame(['title'], array_keys($fields));
+	}
+
+	public function testNormalizeFieldsPropsWithGroup(): void
+	{
+		$fields = Normalizer::normalizeFieldsProps([
+			'meta' => [
+				'type'   => 'group',
+				'fields' => [
+					'date' => ['type' => 'date']
+				]
+			],
+			'title' => ['type' => 'text']
+		]);
+
+		$this->assertSame(['date', 'title'], array_keys($fields));
+	}
+
+	public function testNormalizeFieldsPropsWithInvalidType(): void
+	{
+		$fields = Normalizer::normalizeFieldsProps([
+			'title' => ['type' => 'nonsense']
+		]);
+
+		$this->assertSame([
+			'label' => 'Error',
+			'name'  => 'title',
+			'text'  => 'Invalid field type ("nonsense")',
+			'theme' => 'negative',
+			'type'  => 'info',
+		], $fields['title']);
+	}
+
+	public function testNormalizeFieldsPropsWithNonArray(): void
+	{
+		$this->assertSame([], Normalizer::normalizeFieldsProps(false));
+		$this->assertSame([], Normalizer::normalizeFieldsProps(null));
+		$this->assertSame([], Normalizer::normalizeFieldsProps('nonsense'));
+	}
+
+	public function testNormalizeFieldsPropsWithString(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'fields/headline' => [
+					'type'  => 'text',
+					'label' => 'Headline'
+				]
+			]
+		]);
+
+		$fields = Normalizer::normalizeFieldsProps([
+			'title' => 'fields/headline'
+		]);
+
+		$this->assertSame('text', $fields['title']['type']);
+		$this->assertSame('Headline', $fields['title']['label']);
+	}
+
+	public function testNormalizeFieldsPropsWithTrue(): void
+	{
+		$fields = Normalizer::normalizeFieldsProps([
+			'text' => true
+		]);
+
+		$this->assertSame('text', $fields['text']['type']);
+	}
+
+	public function testNormalizeOptionsWithAliases(): void
+	{
+		$options = Normalizer::normalizeOptions(
+			options: ['create' => false],
+			defaults: ['changeTitle' => true, 'create' => true],
+			aliases: ['create' => 'changeTitle']
+		);
+
+		$this->assertSame([
+			'changeTitle' => false,
+			'create'      => true
+		], $options);
+	}
+
+	public function testNormalizeOptionsWithArray(): void
+	{
+		$options = Normalizer::normalizeOptions(
+			options: ['delete' => false],
+			defaults: ['delete' => true, 'update' => true]
+		);
+
+		$this->assertSame([
+			'delete' => false,
+			'update' => true
+		], $options);
+	}
+
+	public function testNormalizeOptionsWithFalse(): void
+	{
+		$options = Normalizer::normalizeOptions(
+			options: false,
+			defaults: ['delete' => true, 'update' => true]
+		);
+
+		$this->assertSame([
+			'delete' => false,
+			'update' => false
+		], $options);
+	}
+
+	public function testNormalizeOptionsWithString(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'options/default' => ['delete' => false]
+			]
+		]);
+
+		$options = Normalizer::normalizeOptions(
+			options: 'options/default',
+			defaults: ['delete' => true, 'update' => true]
+		);
+
+		$this->assertSame([
+			'delete' => false,
+			'update' => true
+		], $options);
+	}
+
+	public function testNormalizeOptionsWithTrue(): void
+	{
+		$options = Normalizer::normalizeOptions(
+			options: true,
+			defaults: ['delete' => true, 'update' => false]
+		);
+
+		$this->assertSame([
+			'delete' => true,
+			'update' => false
+		], $options);
+	}
+
+	public function testProps(): void
+	{
+		$this->assertSame([
+			'name'  => 'default',
+			'title' => 'Default',
+			'tabs'  => []
+		], $this->normalizer()->props());
+	}
+
+	public function testPropsWithExtends(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'test' => ['title' => 'Extension Test']
+			]
+		]);
+
+		$props = $this->normalizer(['extends' => 'test'])->props();
+
+		$this->assertArrayNotHasKey('extends', $props);
+		$this->assertSame('Extension Test', $props['title']);
+	}
+
+	public function testPropsWithName(): void
+	{
+		$props = $this->normalizer(['name' => 'article'])->props();
+
+		$this->assertSame('article', $props['name']);
+		$this->assertSame('Article', $props['title']);
+	}
+
+	public function testPropsWithTitle(): void
+	{
+		$props = $this->normalizer([
+			'name'  => 'article',
+			'title' => 'Blog post'
+		])->props();
+
+		$this->assertSame('Blog post', $props['title']);
+	}
+
+	public function testPropsWithTranslatedTitle(): void
+	{
+		I18n::$locale       = 'de';
+		I18n::$translations = [
+			'de' => ['blueprint.title' => 'Artikel']
+		];
+
+		$props = $this->normalizer([
+			'title' => 'blueprint.title'
+		])->props();
+
+		$this->assertSame('Artikel', $props['title']);
+	}
+
+	public function testSections(): void
+	{
+		$normalizer = $this->normalizer([
+			'sections' => [
+				'pages' => ['type' => 'pages'],
+				'files' => ['type' => 'files']
+			]
+		]);
+
+		$this->assertSame(['pages', 'files'], array_keys($normalizer->sections()));
+	}
+
+	public function testSectionsEmpty(): void
+	{
+		$this->assertSame([], $this->normalizer()->sections());
+	}
+
+	public function testSectionsWithFalse(): void
+	{
+		$normalizer = $this->normalizer([
+			'sections' => [
+				'pages' => ['type' => 'pages'],
+				'files' => false
+			]
+		]);
+
+		$this->assertSame(['pages'], array_keys($normalizer->sections()));
+	}
+
+	public function testSectionsWithInvalidType(): void
+	{
+		$normalizer = $this->normalizer([
+			'sections' => [
+				'test' => ['type' => []]
+			]
+		]);
+
+		$section = $normalizer->sections()['test'];
+
+		$this->assertSame('info', $section['type']);
+		$this->assertSame(
+			'Invalid section type for section "test"',
+			$section['label']
+		);
+	}
+
+	public function testSectionsWithTrue(): void
+	{
+		$normalizer = $this->normalizer([
+			'sections' => [
+				'pages' => true
+			]
+		]);
+
+		$this->assertSame('pages', $normalizer->sections()['pages']['type']);
+	}
+
+	public function testSectionsWithTypeFromName(): void
+	{
+		$normalizer = $this->normalizer([
+			'sections' => [
+				'pages' => []
+			]
+		]);
+
+		$this->assertSame('pages', $normalizer->sections()['pages']['type']);
+	}
+
+	public function testSectionsWithUnknownType(): void
+	{
+		$normalizer = $this->normalizer([
+			'sections' => [
+				'test' => ['type' => 'nonsense']
+			]
+		]);
+
+		$section = $normalizer->sections()['test'];
+
+		$this->assertSame('info', $section['type']);
+		$this->assertSame('Invalid section type ("nonsense")', $section['label']);
+	}
+
+	public function testSectionsWithoutFields(): void
+	{
+		$normalizer = $this->normalizer([
+			'sections' => [
+				'content' => ['type' => 'fields']
+			]
+		]);
+
+		$this->assertSame([
+			'main-info' => [
+				'label' => 'Fields',
+				'text'  => 'No fields yet',
+				'type'  => 'info'
+			]
+		], $normalizer->sections()['content']['fields']);
+	}
+
+	public function testTabs(): void
+	{
+		$normalizer = $this->normalizer([
+			'tabs' => [
+				'content' => [
+					'icon' => 'text'
+				]
+			]
+		]);
+
+		$tab = $normalizer->tabs()['content'];
+
+		$this->assertSame('content', $tab['name']);
+		$this->assertSame('Content', $tab['label']);
+		$this->assertSame('text', $tab['icon']);
+		$this->assertSame('/pages/a/?tab=content', $tab['link']);
+		$this->assertSame([], $tab['columns']);
+	}
+
+	public function testTabsEmpty(): void
+	{
+		$this->assertSame([], $this->normalizer()->tabs());
+	}
+
+	public function testTabsWithExtends(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'tabs/seo' => [
+					'label' => 'SEO',
+					'icon'  => 'search'
+				]
+			]
+		]);
+
+		$normalizer = $this->normalizer([
+			'tabs' => [
+				'seo' => ['extends' => 'tabs/seo']
+			]
+		]);
+
+		$tab = $normalizer->tabs()['seo'];
+
+		$this->assertSame('SEO', $tab['label']);
+		$this->assertSame('search', $tab['icon']);
+	}
+
+	public function testTabsWithFalse(): void
+	{
+		$normalizer = $this->normalizer([
+			'tabs' => [
+				'content' => [],
+				'seo'     => false
+			]
+		]);
+
+		$this->assertSame(['content'], array_keys($normalizer->tabs()));
+	}
+
+	public function testTabsWithInvalidValue(): void
+	{
+		$this->assertSame([], $this->normalizer(['tabs' => 'nonsense'])->tabs());
+	}
+
+	public function testTabsWithLabel(): void
+	{
+		$normalizer = $this->normalizer([
+			'tabs' => [
+				'content' => ['label' => 'My content']
+			]
+		]);
+
+		$this->assertSame('My content', $normalizer->tabs()['content']['label']);
+	}
+}


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [ ] Design & concept
- [x] Rough pass (simple migration to a new class without breaking changes)
- [ ] Deep read
- [ ] Security check

## Description

This is a first step to move towards the section to fields translation. Moving all normalization logic into a new Normalizer class will help us drastically to focus on the needed changes, while keeping the Blueprint classes cleaner. This will also help us in a next step to simplify the caching logic in https://github.com/getkirby/kirby/pull/8304

## Changelog

### ♻️ Refactored

- Move all Blueprint normalization logic into a new `Kirby\Blueprint\Normalizer` class. 

### 🚨 Breaking changes

- None

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
