### PR TITLE
perf: Cache `Constructor:: getParameterNames()`

### DIFF
--- a/src/Reflection/Constructor.php
+++ b/src/Reflection/Constructor.php
@@ -15,6 +15,8 @@ use ReflectionParameter;
  */
 class Constructor extends ReflectionMethod
 {
+	protected static array $names = [];
+
 	public function __construct(object|string $objectOrClass)
 	{
 		parent::__construct($objectOrClass, '__construct');
@@ -88,7 +90,10 @@ class Constructor extends ReflectionMethod
 	 */
 	public function getParameterNames(): array
 	{
-		return array_values(array_map(fn (ReflectionParameter $param) => $param->name, $this->getAllParameters()));
+		return static::$names[$this->class] ??= array_values(array_map(
+			fn (ReflectionParameter $param) => $param->name,
+			$this->getAllParameters()
+		));
 	}
 
 	/**


### PR DESCRIPTION

## Review

- [x] Rough pass

**Timing:** no rush

## Description

`Constructor::getParameterNames()` walked all reflection parameters on every call, and it is called from `Constructor::__construct()` itself. The parameter names of a constructor cannot change within a request, so the result is now cached.

### Benchmarks

Instrumented on `v6/develop`: one Panel page view triggers*53 calls across 16 field classes, so 37 of them are repeats. The micro benchmark replays that exact distribution.

| Scenario | `v6/develop` | this branch | Δ |
| --- | ---: | ---: | ---: |
| 53 `getParameterNames()` calls / 16 classes | 2693.5 µs | 2603.3 µs | **−3.3 %** (−90 µs) |

Modest, and worth due to the minimal change.

## Changelog

### 🏎️ Performance

- Constructor parameter names are resolved once per class instead of once per reflection.


## For review team

- [ ] Add changes & docs to release notes draft in Notion
