### PR TITLE
perf: `Fieldset` lazily create tabs

### DIFF
--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -23,12 +23,12 @@ class Fieldset extends Item
 
 	protected bool $disabled;
 	protected bool $editable;
-	protected array $fields = [];
+	protected array|null $fields = null;
 	protected string|null $icon;
 	protected string|null $label;
 	protected string $name;
 	protected string|bool|null $preview;
-	protected array $tabs;
+	protected array|null $tabs = null;
 	protected bool $translate;
 	protected string $type;
 	protected bool $unset;
@@ -56,7 +56,6 @@ class Fieldset extends Item
 		$this->name        = $this->createName($params['title']) ?? Str::label($this->type);
 		$this->label       = $this->createLabel($params['label'] ?? null);
 		$this->preview     = $params['preview'] ?? null;
-		$this->tabs        = $this->createTabs($params);
 		$this->translate   = $params['translate'] ?? true;
 		$this->unset       = $params['unset'] ?? false;
 		$this->wysiwyg     = $params['wysiwyg'] ?? false;
@@ -78,7 +77,7 @@ class Fieldset extends Item
 		$fields = $this->form($fields)->fields()->toProps(defaults: true);
 
 		// collect all fields
-		$this->fields = [...$this->fields, ...$fields];
+		$this->fields = [...$this->fields ?? [], ...$fields];
 
 		return $fields;
 	}
@@ -140,7 +139,7 @@ class Fieldset extends Item
 			return false;
 		}
 
-		if ($this->fields === []) {
+		if ($this->fields() === []) {
 			return false;
 		}
 
@@ -149,7 +148,11 @@ class Fieldset extends Item
 
 	public function fields(): array
 	{
-		return $this->fields;
+		// the fields of all tabs are collected
+		// while creating the tabs, so ensure they are
+		$this->tabs();
+
+		return $this->fields ??= [];
 	}
 
 	/**
@@ -197,7 +200,7 @@ class Fieldset extends Item
 
 	public function tabs(): array
 	{
-		return $this->tabs;
+		return $this->tabs ??= $this->createTabs($this->params);
 	}
 
 	public function translate(): bool

--- a/tests/Cms/Fieldsets/FieldsetTest.php
+++ b/tests/Cms/Fieldsets/FieldsetTest.php
@@ -102,6 +102,20 @@ class FieldsetTest extends TestCase
 		$this->assertSame('text', $fieldset->fields()['text']['type']);
 	}
 
+	public function testFieldsWithDisabledTabs(): void
+	{
+		$fieldset = new Fieldset([
+			'type' => 'test',
+			'tabs' => [
+				'content' => false
+			]
+		]);
+
+		$this->assertSame([], $fieldset->tabs());
+		$this->assertSame([], $fieldset->fields());
+		$this->assertFalse($fieldset->editable());
+	}
+
 	public function testForm(): void
 	{
 		$fieldset = new Fieldset([


### PR DESCRIPTION

## Review

- [x] Deep read

**Timing:** no rush

## Description

`Fieldset::__construct()` eagerly called `createTabs()`, which builds a full `Form` for every tab of every fieldset. `Fieldsets::factory()` instantiates all registered fieldsets, so opening a page with a `blocks` field paid for every block type in the blueprint. Even the ones the content never uses.

`$tabs` and `$fields` are now nullable and built on first access. `fields()` calls `tabs()` first, because the fields of all tabs are collected while the tabs are created.

Measured on the benchmark page below: 10 fieldsets registered, only 4 used → 6 form trees that no longer get built on the save path.

Deliberately out of scope: `Fieldsets::toArray()` still resolves every fieldset, because the Panel genuinely needs all of them for the block picker. This PR only removes the cost where the fieldsets are *not* needed.

### Benchmarks

PHP 8.4.23, median of 31 samples, one fresh process per sample, boot excluded. Page: `blocks` field with all 10 core fieldsets registered and 40 blocks across 4 types, plus a 20-row `structure` and 6 query-driven option fields.

| Scenario | `v6/develop` | this branch | Δ |
| --- | ---: | ---: | ---: |
| `Form::for($page)->toStoredValues()` (save path) | 16114.8 µs | 13671.5 µs | **−15.2 %** |
| `Form::for($page)->toProps()` (Panel page view) | 20018.4 µs | 20430.7 µs | no change (noise) |

`Fieldset::createTabs()` call count on the save path: **10 → 4**.

## Changelog

### 🏎️ Performance

- Block fieldsets no longer build their forms upfront. Saving a page with a `blocks` field  is faster when the blueprint registers more block types than the content uses.


## For review team

- [x] Add changes & docs to release notes draft in Notion
