### PR TITLE
[sections 2 fields] feat: New BlueprintsDefinition interface for fields

### DIFF
--- a/src/Form/Field/PageListField.php
+++ b/src/Form/Field/PageListField.php
@@ -7,6 +7,7 @@ use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
 use Kirby\Cms\Site;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Form\Interface\ProvidesAcceptedBlueprints;
 use Kirby\Panel\Collector\PagesCollector;
 use Kirby\Panel\Controller\Dialog\PageCreateDialogController;
 use Kirby\Panel\Ui\Item\PageItem;
@@ -22,7 +23,7 @@ use Throwable;
  *
  * @extends ModelListField<Page>
  */
-class PageListField extends ModelListField
+class PageListField extends ModelListField implements ProvidesAcceptedBlueprints
 {
 	public const string TYPE = 'pages';
 
@@ -209,7 +210,6 @@ class PageListField extends ModelListField
 
 	public function collector(): PagesCollector
 	{
-		/** @var Page|Site $parent */
 		$parent = $this->parentModel();
 
 		return $this->collector ??= new PagesCollector(
@@ -248,7 +248,7 @@ class PageListField extends ModelListField
 	/**
 	 * @throws InvalidArgumentException
 	 */
-	public function parentModel(): ModelWithContent
+	public function parentModel(): Page|Site
 	{
 		$parent = parent::parentModel();
 

--- a/src/Form/Field/SectionField.php
+++ b/src/Form/Field/SectionField.php
@@ -4,6 +4,7 @@ namespace Kirby\Form\Field;
 
 use Kirby\Blueprint\Section;
 use Kirby\Form\Fields;
+use Kirby\Form\Interface\ProvidesAcceptedBlueprints;
 
 /**
  * Section Field
@@ -12,7 +13,7 @@ use Kirby\Form\Fields;
  * @license   https://getkirby.com/license
  * @since     6.0.0
  */
-class SectionField extends BaseField
+class SectionField extends BaseField implements ProvidesAcceptedBlueprints
 {
 	protected Section|null $instance = null;
 	protected array $props;
@@ -35,6 +36,15 @@ class SectionField extends BaseField
 
 		// fall back to the field name as section type
 		$this->section = $section ?? $this->name();
+	}
+
+	/**
+	 * Returns the blueprints of the wrapped section,
+	 * if it supports them
+	 */
+	public function blueprints(): array
+	{
+		return (array)($this->section()->blueprints() ?? []);
 	}
 
 	/**

--- a/src/Form/Interface/ProvidesAcceptedBlueprints.php
+++ b/src/Form/Interface/ProvidesAcceptedBlueprints.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kirby\Form\Interface;
+
+/**
+ * Implemented by fields that list models of a parent
+ * and can tell which blueprints those models may use
+ *
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+interface ProvidesAcceptedBlueprints
+{
+	/**
+	 * Returns all blueprints that are available for the
+	 * models in this field
+	 */
+	public function blueprints(): array;
+}

--- a/tests/Form/Field/SectionFieldTest.php
+++ b/tests/Form/Field/SectionFieldTest.php
@@ -10,6 +10,31 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(SectionField::class)]
 class SectionFieldTest extends TestCase
 {
+	public function testBlueprints(): void
+	{
+		$field = $this->field('section', [
+			'name'      => 'drafts',
+			'section'   => 'pages',
+			'templates' => ['album', 'note']
+		]);
+
+		$this->assertSame([
+			['name' => 'album', 'title' => 'Album'],
+			['name' => 'note', 'title' => 'Note']
+		], $field->blueprints());
+	}
+
+	public function testBlueprintsForSectionWithoutBlueprints(): void
+	{
+		$field = $this->field('section', [
+			'name'    => 'notes',
+			'section' => 'info'
+		]);
+
+		// sections that don't know about blueprints have none
+		$this->assertSame([], $field->blueprints());
+	}
+
 	public function testErrors(): void
 	{
 		$field = $this->field('section', [


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [ ] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

## Description 

This will be needed in one of the next steps when fields need to be used in our AcceptRules class to find out which child blueprints are allowed. 

## Changelog

### ✨ Enhancements

- Adds a new `Kirby\Form\Interface\BlueprintDefinition` interface. Each field can implement this to indicate that it has blueprint definitions that should be taken into account when validating allowed child blueprints for pages. 
- `PageListField::parentModel` has a more specific return type. 

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
