### PR TITLE
[fields] refact!: Restrict field extensions to class-based fields

### DIFF
--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -8,6 +8,7 @@ use Kirby\Auth\Methods;
 use Kirby\Blueprint\Section;
 use Kirby\Content\Field;
 use Kirby\Exception\DuplicateException;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Asset;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
@@ -410,9 +411,24 @@ trait AppPlugins
 
 	/**
 	 * Registers Panel fields
+	 *
+	 * @throws InvalidArgumentException if a field is not registered with a class name
 	 */
 	protected function extendFields(array $fields): array
 	{
+		foreach ($fields as $type => $field) {
+			// only check for a class name here, not for a valid field class:
+			// `is_subclass_of()` would autoload every registered field on boot
+			if (is_string($field) === false) {
+				throw new InvalidArgumentException(
+					message: 'The field type "' . $type . '" is registered as ' .
+					get_debug_type($field) . '. Array-based field definitions ' .
+					'have been removed in Kirby 6. Please register the name of ' .
+					'a class that extends ' . FormField::class . ' instead.'
+				);
+			}
+		}
+
 		return $this->extensions['fields'] = FormField::$types = [
 			...FormField::$types,
 			...$fields

--- a/src/Toolkit/Component.php
+++ b/src/Toolkit/Component.php
@@ -229,6 +229,16 @@ class Component
 
 		// load definitions from string
 		if (is_string($definition) === true) {
+			// a type that is registered as a class cannot be loaded
+			// as an array definition and thus not be extended by one
+			if (class_exists($definition) === true) {
+				throw new Exception(
+					'The "' . $type . '" component is defined by the class ' .
+					$definition . ' and cannot be extended with the array ' .
+					'syntax. Extend the class instead.'
+				);
+			}
+
 			if (is_file($definition) !== true) {
 				throw new Exception(
 					'Component definition ' . $definition . ' does not exist'

--- a/tests/Api/Routes/AccountRoutesTest.php
+++ b/tests/Api/Routes/AccountRoutesTest.php
@@ -9,6 +9,7 @@ use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\Form\Field;
+use Kirby\Form\Field\InputField;
 use Kirby\TestCase;
 
 class AccountRoutesTest extends TestCase
@@ -259,6 +260,24 @@ class AccountRoutesTest extends TestCase
 
 	public function testFields(): void
 	{
+		$field = new class () extends InputField {
+			protected mixed $value = null;
+
+			public function api(): array
+			{
+				return [
+					[
+						'pattern' => '/',
+						'action'  => fn () => 'Test home route'
+					],
+					[
+						'pattern' => 'nested',
+						'action'  => fn () => 'Test nested route'
+					],
+				];
+			}
+		};
+
 		$app = $this->app->clone([
 			'blueprints' => [
 				'users/admin' => [
@@ -270,18 +289,7 @@ class AccountRoutesTest extends TestCase
 				]
 			],
 			'fields' => [
-				'test' => [
-					'api' => fn () => [
-						[
-							'pattern' => '/',
-							'action'  => fn () => 'Test home route'
-						],
-						[
-							'pattern' => 'nested',
-							'action'  => fn () => 'Test nested route'
-						],
-					]
-				]
+				'test' => $field::class
 			]
 		]);
 

--- a/tests/Api/Routes/UsersRoutesTest.php
+++ b/tests/Api/Routes/UsersRoutesTest.php
@@ -10,6 +10,7 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\Dir;
 use Kirby\Form\Field;
+use Kirby\Form\Field\InputField;
 use Kirby\TestCase;
 
 class UsersRoutesTest extends TestCase
@@ -333,6 +334,24 @@ class UsersRoutesTest extends TestCase
 
 	public function testFields(): void
 	{
+		$field = new class () extends InputField {
+			protected mixed $value = null;
+
+			public function api(): array
+			{
+				return [
+					[
+						'pattern' => '/',
+						'action'  => fn () => 'Test home route'
+					],
+					[
+						'pattern' => 'nested',
+						'action'  => fn () => 'Test nested route'
+					],
+				];
+			}
+		};
+
 		$app = $this->app->clone([
 			'blueprints' => [
 				'users/admin' => [
@@ -344,18 +363,7 @@ class UsersRoutesTest extends TestCase
 				]
 			],
 			'fields' => [
-				'test' => [
-					'api' => fn () => [
-						[
-							'pattern' => '/',
-							'action'  => fn () => 'Test home route'
-						],
-						[
-							'pattern' => 'nested',
-							'action'  => fn () => 'Test nested route'
-						],
-					]
-				]
+				'test' => $field::class
 			]
 		]);
 

--- a/tests/Cms/App/AppPluginsTest.php
+++ b/tests/Cms/App/AppPluginsTest.php
@@ -7,6 +7,8 @@ use Kirby\Auth\Method;
 use Kirby\Auth\Pending;
 use Kirby\Auth\Status;
 use Kirby\Cache\FileCache;
+use Kirby\Cms\Fixtures\DummyField;
+use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
 use Kirby\Filesystem\Mime;
@@ -420,25 +422,65 @@ class AppPluginsTest extends TestCase
 
 	public function testField(): void
 	{
-		$app = new App([
+		require_once static::FIXTURES . '/fields/DummyField.php';
+
+		new App([
 			'roots' => [
 				'index' => '/dev/null'
 			],
 			'fields' => [
-				'dummy' => static::FIXTURES . '/fields/DummyField.php'
+				'dummy' => DummyField::class
 			]
 		]);
 
 		$page  = new Page(['slug' => 'test']);
-		$field = new FormField('dummy', [
+		$field = FormField::factory('dummy', [
 			'name'  => 'dummy',
 			'peter' => 'shaw',
 			'model' => $page
 		]);
 
-		$this->assertInstanceOf(FormField::class, $field);
+		$this->assertInstanceOf(DummyField::class, $field);
 		$this->assertSame('simpson', $field->homer());
 		$this->assertSame('shaw', $field->peter());
+	}
+
+	public function testFieldWithArrayDefinition(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage(
+			'The field type "dummy" is registered as array. Array-based field ' .
+			'definitions have been removed in Kirby 6. Please register the name ' .
+			'of a class that extends Kirby\Form\Field instead.'
+		);
+
+		new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'fields' => [
+				'dummy' => [
+					'props' => [
+						'foo' => fn ($foo = null) => $foo
+					]
+				]
+			]
+		]);
+	}
+
+	public function testFieldWithClosureDefinition(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('The field type "dummy" is registered as Closure.');
+
+		new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'fields' => [
+				'dummy' => fn () => 'dummy'
+			]
+		]);
 	}
 
 	public function testFilePreviews(): void

--- a/tests/Cms/App/fixtures/fields/DummyField.php
+++ b/tests/Cms/App/fixtures/fields/DummyField.php
@@ -1,8 +1,27 @@
 <?php
 
-return [
-	'props' => [
-		'homer' => fn ($homer = 'simpson') => $homer,
-		'peter' => fn ($peter = 'pan') => $peter
-	]
-];
+namespace Kirby\Cms\Fixtures;
+
+use Kirby\Form\Field\InputField;
+
+class DummyField extends InputField
+{
+	protected mixed $value = null;
+
+	public function __construct(
+		protected string $homer = 'simpson',
+		protected string $peter = 'pan'
+	) {
+		parent::__construct();
+	}
+
+	public function homer(): string
+	{
+		return $this->homer;
+	}
+
+	public function peter(): string
+	{
+		return $this->peter;
+	}
+}

--- a/tests/Toolkit/ComponentTest.php
+++ b/tests/Toolkit/ComponentTest.php
@@ -294,6 +294,19 @@ class ComponentTest extends TestCase
 		new Component('test');
 	}
 
+	public function testLoadClassDefinition(): void
+	{
+		Component::$types = ['foo' => Component::class];
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessage(
+			'The "foo" component is defined by the class ' .
+			Component::class . ' and cannot be extended with the array ' .
+			'syntax. Extend the class instead.'
+		);
+
+		Component::load('foo');
+	}
+
 	public function testLoadInvalidFile(): void
 	{
 		Component::$types = ['foo' => 'bar'];


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Rough pass

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### 🚨 Breaking changes
- Custom field extensions can no longer be defined in their array shape anymore. Please create classes based on `Kirby\Form\Field` for your custom fields and register them by passing their class name

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
