### PR TITLE
[fields] refact: Move field `::reset()` to the `Value` mixin

### DIFF
--- a/src/Form/Field/HiddenField.php
+++ b/src/Form/Field/HiddenField.php
@@ -3,7 +3,6 @@
 namespace Kirby\Form\Field;
 
 use Kirby\Form\Mixin;
-use Kirby\Toolkit\BlockCollectionAccess;
 
 /**
  * Hidden field
@@ -44,16 +43,5 @@ class HiddenField extends BaseField
 			'saveable' => $this->hasValue(),
 			'type'     => $this->type(),
 		];
-	}
-
-	/**
-	 * @since 5.2.0
-	 * @todo Move to `Value` mixin once array-based fields are unsupported
-	 */
-	#[BlockCollectionAccess]
-	public function reset(): static
-	{
-		$this->value = $this->emptyValue();
-		return $this;
 	}
 }

--- a/src/Form/Field/InputField.php
+++ b/src/Form/Field/InputField.php
@@ -66,16 +66,4 @@ abstract class InputField extends BaseField
 			'width'     => $this->width(),
 		];
 	}
-
-	/**
-	 * @since 5.2.0
-	 * @todo Move to `Value` mixin once array-based fields are unsupported
-	 */
-	#[BlockCollectionAccess]
-	public function reset(): static
-	{
-		/** @psalm-suppress UndefinedThisPropertyAssignment concrete subclasses declare `$value` */
-		$this->value = $this->emptyValue();
-		return $this;
-	}
 }

--- a/src/Form/Field/InputField.php
+++ b/src/Form/Field/InputField.php
@@ -3,7 +3,6 @@
 namespace Kirby\Form\Field;
 
 use Kirby\Form\Mixin;
-use Kirby\Toolkit\BlockCollectionAccess;
 
 /**
  * Input class for fields that have a value

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -117,6 +117,18 @@ trait Value
 	}
 
 	/**
+	 * Resets the value back to the empty value
+	 * @since 5.2.0
+	 */
+	#[BlockCollectionAccess]
+	public function reset(): static
+	{
+		/** @psalm-suppress UndefinedThisPropertyAssignment using classes declare `$value` */
+		$this->value = $this->emptyValue();
+		return $this;
+	}
+
+	/**
 	 * Checks if the field is saveable
 	 * @deprecated 5.0.0 Use `::hasValue()` instead
 	 */


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Rough pass

## Description
<!--
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.

You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR.

If something is deliberately out of scope, say so here.
-->

Now that the array-based fields are out the door, we can move `::reset()` into `Mixin\Value`.
