### PR TITLE
[fields] refact!: Remove deprecated form and field value methods

### DIFF
--- a/config/sections/mixins/layout.php
+++ b/config/sections/mixins/layout.php
@@ -161,7 +161,7 @@ return [
 			// @codeCoverageIgnoreEnd
 
 			// Use form to get the proper values for the columns
-			$form = Form::for($model)->values();
+			$form = Form::for($model)->toFormValues();
 
 			foreach ($this->columns as $columnName => $column) {
 				$item[$columnName] = match (empty($column['value'])) {

--- a/panel/lab/components/blocks/code/index.php
+++ b/panel/lab/components/blocks/code/index.php
@@ -3,7 +3,7 @@
 use Kirby\Cms\Fieldsets;
 
 $fieldset = Fieldsets::factory()->get('code');
-$defaults = $fieldset->form($fieldset->fields())->data(true);
+$defaults = $fieldset->form($fieldset->fields())->fill(defaults: true)->toFormValues();
 
 return [
 	'docs'     => 'k-block-type-code',

--- a/panel/lab/components/blocks/gallery/index.php
+++ b/panel/lab/components/blocks/gallery/index.php
@@ -3,7 +3,7 @@
 use Kirby\Cms\Fieldsets;
 
 $fieldset = Fieldsets::factory()->get('gallery');
-$defaults = $fieldset->form($fieldset->fields())->data(true);
+$defaults = $fieldset->form($fieldset->fields())->fill(defaults: true)->toFormValues();
 
 return [
 	'docs'     => 'k-block-type-gallery',

--- a/panel/lab/components/blocks/heading/index.php
+++ b/panel/lab/components/blocks/heading/index.php
@@ -3,7 +3,7 @@
 use Kirby\Cms\Fieldsets;
 
 $fieldset = Fieldsets::factory()->get('heading');
-$defaults = $fieldset->form($fieldset->fields())->data(true);
+$defaults = $fieldset->form($fieldset->fields())->fill(defaults: true)->toFormValues();
 
 return [
 	'docs'     => 'k-block-type-heading',

--- a/panel/lab/components/blocks/image/index.php
+++ b/panel/lab/components/blocks/image/index.php
@@ -3,7 +3,7 @@
 use Kirby\Cms\Fieldsets;
 
 $fieldset = Fieldsets::factory()->get('image');
-$defaults = $fieldset->form($fieldset->fields())->data(true);
+$defaults = $fieldset->form($fieldset->fields())->fill(defaults: true)->toFormValues();
 
 return [
 	'docs'     => 'k-block-type-image',

--- a/panel/lab/components/blocks/list/index.php
+++ b/panel/lab/components/blocks/list/index.php
@@ -3,7 +3,7 @@
 use Kirby\Cms\Fieldsets;
 
 $fieldset = Fieldsets::factory()->get('list');
-$defaults = $fieldset->form($fieldset->fields())->data(true);
+$defaults = $fieldset->form($fieldset->fields())->fill(defaults: true)->toFormValues();
 
 return [
 	'docs'     => 'k-block-type-list',

--- a/panel/lab/components/blocks/markdown/index.php
+++ b/panel/lab/components/blocks/markdown/index.php
@@ -3,7 +3,7 @@
 use Kirby\Cms\Fieldsets;
 
 $fieldset = Fieldsets::factory()->get('markdown');
-$defaults = $fieldset->form($fieldset->fields())->data(true);
+$defaults = $fieldset->form($fieldset->fields())->fill(defaults: true)->toFormValues();
 
 return [
 	'docs'     => 'k-block-type-markdown',

--- a/panel/lab/components/blocks/quote/index.php
+++ b/panel/lab/components/blocks/quote/index.php
@@ -3,7 +3,7 @@
 use Kirby\Cms\Fieldsets;
 
 $fieldset = Fieldsets::factory()->get('quote');
-$defaults = $fieldset->form($fieldset->fields())->data(true);
+$defaults = $fieldset->form($fieldset->fields())->fill(defaults: true)->toFormValues();
 
 return [
 	'docs'     => 'k-block-type-quote',

--- a/panel/lab/components/blocks/text/index.php
+++ b/panel/lab/components/blocks/text/index.php
@@ -3,7 +3,7 @@
 use Kirby\Cms\Fieldsets;
 
 $fieldset = Fieldsets::factory()->get('text');
-$defaults = $fieldset->form($fieldset->fields())->data(true);
+$defaults = $fieldset->form($fieldset->fields())->fill(defaults: true)->toFormValues();
 
 return [
 	'docs'     => 'k-block-type-text',

--- a/panel/lab/components/blocks/video/index.php
+++ b/panel/lab/components/blocks/video/index.php
@@ -3,7 +3,7 @@
 use Kirby\Cms\Fieldsets;
 
 $fieldset = Fieldsets::factory()->get('video');
-$defaults = $fieldset->form($fieldset->fields())->data(true);
+$defaults = $fieldset->form($fieldset->fields())->fill(defaults: true)->toFormValues();
 
 return [
 	'docs'     => 'k-block-type-video',

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -249,14 +249,6 @@
       <code><![CDATA[toFormValue]]></code>
     </UndefinedMethod>
   </file>
-  <file src="src/Form/Form.php">
-    <UndefinedMethod>
-      <code><![CDATA[fill]]></code>
-      <code><![CDATA[isEmpty]]></code>
-      <code><![CDATA[isStorable]]></code>
-      <code><![CDATA[toStoredValue]]></code>
-    </UndefinedMethod>
-  </file>
   <file src="src/Form/Validations.php">
     <UndefinedMethod>
       <code><![CDATA[max]]></code>

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -268,8 +268,9 @@ abstract class ModelWithContent extends Model implements Identifiable
 	 */
 	public function createDefaultContent(): array
 	{
-		$fields = Fields::for($this, 'default');
-		return $fields->fill($fields->defaults())->toStoredValues();
+		return Fields::for($this, 'default')
+			->fill(defaults: true)
+			->toStoredValues();
 	}
 
 	/**

--- a/src/Form/Field/BlocksField.php
+++ b/src/Form/Field/BlocksField.php
@@ -125,7 +125,7 @@ class BlocksField extends InputField
 					$fields = $field->fields($fieldsetType);
 					$form   = $field->form($fields);
 
-					$form->fill(input: $form->defaults());
+					$form->fill(defaults: true);
 
 					return Block::factory([
 						'content' => $form->toFormValues(),

--- a/src/Form/Field/LayoutField.php
+++ b/src/Form/Field/LayoutField.php
@@ -103,7 +103,7 @@ class LayoutField extends BlocksField
 				$columns = $request->get('columns') ?? ['1/1'];
 				$form    = $field->attrsForm();
 
-				$form->fill(input: $form->defaults());
+				$form->fill(defaults: true);
 				$form->submit(input: $request->get('attrs') ?? []);
 
 				return Layout::factory([
@@ -339,7 +339,7 @@ class LayoutField extends BlocksField
 			}
 
 			foreach ($layout['columns'] as $columnIndex => $column) {
-				$value[$layoutIndex]['columns'][$columnIndex]['blocks'] = $this->blocksToValues($column['blocks'] ?? [], 'content');
+				$value[$layoutIndex]['columns'][$columnIndex]['blocks'] = $this->blocksToValues($column['blocks'] ?? [], 'toStoredValues');
 			}
 		}
 

--- a/src/Form/Field/ObjectField.php
+++ b/src/Form/Field/ObjectField.php
@@ -88,13 +88,8 @@ class ObjectField extends InputField
 			return [];
 		}
 
-		$form     = $this->form();
-		$defaults = $form->defaults();
-
-		return $form
-			->fill(
-				input: $defaults,
-			)
+		return $this->form()
+			->fill(defaults: true)
 			->submit(
 				input: $this->value,
 				passthrough: true

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -124,8 +124,9 @@ class Fields extends Collection
 	 * @since 5.0.0
 	 */
 	public function fill(
-		array $input,
-		bool $passthrough = true
+		array $input = [],
+		bool $passthrough = true,
+		bool $defaults = false
 	): static {
 		if ($passthrough === true) {
 			$this->passthrough($input);
@@ -147,6 +148,17 @@ class Fields extends Collection
 			}
 
 			$field->fill($value);
+		}
+
+		// fall back to the default value for each field
+		// that is still empty after the input has been filled
+		if ($defaults === true) {
+			$this->fill(
+				input: $this
+					->filter(fn ($field) => $field->hasValue() ? $field->isEmpty() : false)
+					->toArray(fn ($field) => $field->default()),
+				passthrough: false
+			);
 		}
 
 		return $this;

--- a/src/Form/Form.php
+++ b/src/Form/Form.php
@@ -4,10 +4,8 @@ namespace Kirby\Form;
 
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
-use Kirby\Data\Data;
 use Kirby\Exception\FormValidationException;
 use Kirby\Exception\NotFoundException;
-use Kirby\Toolkit\A;
 
 /**
  * The main form class, that is being
@@ -29,70 +27,15 @@ class Form
 	 * Form constructor
 	 */
 	public function __construct(
-		array $props = [],
 		array $fields = [],
 		ModelWithContent|null $model = null,
 		Language|string|null $language = null
 	) {
-		if ($props !== []) {
-			$this->legacyConstruct(...$props);
-			return;
-		}
-
 		$this->fields = new Fields(
 			fields: $fields,
 			model: $model,
 			language: $language
 		);
-	}
-
-	/**
-	 * Returns the data required to write to the content file
-	 * Doesn't include default and null values
-	 *
-	 * @deprecated 5.0.0 Use `::toStoredValues()` instead
-	 */
-	public function content(): array
-	{
-		return $this->data(false, false);
-	}
-
-	/**
-	 * Returns data for all fields in the form
-	 *
-	 * @deprecated 5.0.0 Use `::toStoredValues()` instead
-	 */
-	public function data($defaults = false, bool $includeNulls = true): array
-	{
-		$data     = [];
-		$language = $this->fields->language();
-
-		foreach ($this->fields as $field) {
-			if (
-				$field->hasValue() === false ||
-				$field->isStorable($language) === false
-			) {
-				if ($includeNulls === true) {
-					$data[$field->name()] = null;
-				}
-
-				continue;
-			}
-
-			if ($defaults === true && $field->isEmpty() === true) {
-				$field->fill($field->default());
-			}
-
-			$data[$field->name()] = $field->toStoredValue();
-		}
-
-		foreach ($this->fields->passthrough() as $key => $value) {
-			if (isset($data[$key]) === false) {
-				$data[$key] = $value;
-			}
-		}
-
-		return $data;
 	}
 
 	/**
@@ -138,12 +81,14 @@ class Form
 	 * @since 5.0.0
 	 */
 	public function fill(
-		array $input,
-		bool $passthrough = true
+		array $input = [],
+		bool $passthrough = true,
+		bool $defaults = false
 	): static {
 		$this->fields->fill(
 			input:       $input,
-			passthrough: $passthrough
+			passthrough: $passthrough,
+			defaults:    $defaults
 		);
 		return $this;
 	}
@@ -154,16 +99,8 @@ class Form
 	 */
 	public static function for(
 		ModelWithContent $model,
-		array $props = [],
 		Language|string|null $language = null,
 	): static {
-		if ($props !== []) {
-			return static::legacyFor(
-				$model,
-				...$props
-			);
-		}
-
 		$form = new static(
 			fields: $model->blueprint()->fields(),
 			model: $model,
@@ -203,67 +140,6 @@ class Form
 	}
 
 	/**
-	 * Legacy constructor to support the old props array
-	 *
-	 * @deprecated 5.0.0 Use the new constructor with named parameters instead
-	 */
-	protected function legacyConstruct(
-		array $fields = [],
-		ModelWithContent|null $model = null,
-		Language|string|null $language = null,
-		array $values = [],
-		array $input = [],
-		bool $strict = false
-	): void {
-		$this->__construct(
-			fields: $fields,
-			model: $model,
-			language: $language
-		);
-
-		$this->fill(
-			input: $values,
-			passthrough: $strict === false
-		);
-
-		$this->submit(
-			input: $input,
-			passthrough: $strict === false
-		);
-	}
-
-	/**
-	 * Legacy for method to support the old props array
-	 *
-	 * @deprecated 5.0.0 Use `::for()` with named parameters instead
-	 */
-	protected static function legacyFor(
-		ModelWithContent $model,
-		Language|string|null $language = null,
-		bool $strict = false,
-		array|null $input = [],
-		array|null $values = [],
-		bool $ignoreDisabled = false
-	): static {
-		$form = static::for(
-			model: $model,
-			language: $language,
-		);
-
-		$form->fill(
-			input: $values ?? [],
-			passthrough: $strict === false
-		);
-
-		$form->submit(
-			input: $input ?? [],
-			passthrough: $strict === false
-		);
-
-		return $form;
-	}
-
-	/**
 	 * Adds values to the passthrough array
 	 * which will be added to the form data
 	 * if the field does not exist
@@ -295,22 +171,6 @@ class Form
 	{
 		$this->fields->reset();
 		return $this;
-	}
-
-	/**
-	 * Converts the data of fields to strings
-	 *
-	 * @deprecated 5.0.0 Use `::toStoredValues()` instead
-	 */
-	public function strings($defaults = false): array
-	{
-		return A::map(
-			$this->data($defaults),
-			fn ($value) => match (true) {
-				is_array($value) => Data::encode($value, 'yaml'),
-				default		     => $value
-			}
-		);
 	}
 
 	/**
@@ -391,13 +251,4 @@ class Form
 		$this->fields->validate();
 	}
 
-	/**
-	 * Returns form values
-	 *
-	 * @deprecated 5.0.0 Use `::toFormValues()` instead
-	 */
-	public function values(): array
-	{
-		return $this->fields->toFormValues();
-	}
 }

--- a/src/Form/Mixin/Value.php
+++ b/src/Form/Mixin/Value.php
@@ -20,23 +20,6 @@ use ReflectionProperty;
  */
 trait Value
 {
-	/**
-	 * @deprecated 5.0.0 Use `::toStoredValue()` instead to receive
-	 * the value in the format that will be needed for content files.
-	 *
-	 * If you need to get the value with the default as fallback,
-	 * you should use the fill method first
-	 * `$field->fill($field->default())->toStoredValue()`
-	 */
-	public function data(bool $default = false): mixed
-	{
-		if ($default === true && $this->isEmpty() === true) {
-			$this->fill($this->default());
-		}
-
-		return $this->toStoredValue();
-	}
-
 	abstract public function default(): mixed;
 
 	/**
@@ -126,15 +109,6 @@ trait Value
 		/** @psalm-suppress UndefinedThisPropertyAssignment using classes declare `$value` */
 		$this->value = $this->emptyValue();
 		return $this;
-	}
-
-	/**
-	 * Checks if the field is saveable
-	 * @deprecated 5.0.0 Use `::hasValue()` instead
-	 */
-	public function save(): bool
-	{
-		return $this->hasValue();
 	}
 
 	/**

--- a/src/Panel/Controller/Dialog/PageCreateDialogController.php
+++ b/src/Panel/Controller/Dialog/PageCreateDialogController.php
@@ -257,10 +257,11 @@ class PageCreateDialogController extends ModelCreateDialogController
 
 		// create temporary form to sanitize the input
 		// and add default values
-		$form = Form::for($this->model())->fill(input: $content);
+		$form = Form::for($this->model());
+		$form->fill(input: $content, defaults: true);
 
 		return [
-			'content'  => $form->strings(true),
+			'content'  => $form->toStoredValues(),
 			'slug'     => $input['slug'],
 			'template' => $this->template()
 		];

--- a/tests/Form/Field/InputFieldTest.php
+++ b/tests/Form/Field/InputFieldTest.php
@@ -151,25 +151,6 @@ class InputFieldTest extends BaseTestCase
 		$this->assertSame('Test', $field->before());
 	}
 
-	public function testData(): void
-	{
-		$field = new TestField();
-		$this->assertNull($field->data());
-
-		// use default value
-		$field = new TestField(default: 'default value');
-		$this->assertSame('default value', $field->data(true));
-
-		// don't use default value
-		$field = new TestField(default: 'default value');
-		$this->assertNull($field->data());
-
-		// use existing value
-		$field = new TestField();
-		$field->fill('test');
-		$this->assertSame('test', $field->data());
-	}
-
 	public function testDefault(): void
 	{
 		$field = new TestField();
@@ -629,12 +610,6 @@ class InputFieldTest extends BaseTestCase
 			'when'        => $when,
 			'width'       => $width
 		], $field->props());
-	}
-
-	public function testSave(): void
-	{
-		$field = new TestField();
-		$this->assertTrue($field->save());
 	}
 
 	public function testSiblings(): void

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -267,6 +267,45 @@ class FieldsTest extends TestCase
 		], $fields->toFormValues());
 	}
 
+	public function testFillWithDefaults(): void
+	{
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type'    => 'text',
+					'default' => 'A'
+				],
+				'b' => [
+					'type'    => 'text',
+					'default' => 'B'
+				],
+				'c' => [
+					'type'    => 'text',
+					'default' => 'C'
+				],
+			],
+			model: $this->model
+		);
+
+		$response = $fields->fill(
+			input: [
+				'a' => 'Custom A',
+				'b' => ''
+			],
+			defaults: true
+		);
+
+		$this->assertSame($fields, $response);
+		$this->assertSame([
+			// the submitted value is kept
+			'a' => 'Custom A',
+			// an empty value falls back to the default
+			'b' => 'B',
+			// a missing value falls back to the default
+			'c' => 'C'
+		], $fields->toFormValues());
+	}
+
 	public function testFillWithNoValueField(): void
 	{
 		$fields = new Fields(
@@ -326,14 +365,14 @@ class FieldsTest extends TestCase
 		$motherClass = new class () extends Field {
 			public function form(): Form
 			{
-				return new Form([
-					'fields' => [
+				return new Form(
+					fields: [
 						'child' => [
 							'type' => 'text',
 						],
 					],
-					'model' => $this->model
-				]);
+					model: $this->model
+				);
 			}
 		};
 

--- a/tests/Form/FormTest.php
+++ b/tests/Form/FormTest.php
@@ -39,230 +39,39 @@ class FormTest extends TestCase
 		$this->tearDownTmp();
 	}
 
-	public function testContent(): void
-	{
-		$form = new Form([
-			'fields' => [],
-			'values' => $values = [
-				'a' => 'A',
-				'b' => 'B'
-			]
-		]);
-
-		$this->assertSame($values, $form->content());
-	}
-
-	public function testContentAndDataFromUnsaveableFields(): void
-	{
-		$form = new Form([
-			'fields' => [
-				'info' => [
-					'type' => 'info',
-				]
-			],
-			'model' => $this->model,
-			'values' => [
-				'info' => 'Yay'
-			]
-		]);
-
-		$this->assertCount(0, $form->content());
-		$this->assertArrayNotHasKey('info', $form->content());
-		$this->assertCount(1, $form->data());
-		$this->assertArrayHasKey('info', $form->data());
-	}
-
-	public function testDataWithoutFields(): void
-	{
-		$form = new Form([
-			'fields' => [],
-			'values' => $values = [
-				'a' => 'A',
-				'b' => 'B'
-			]
-		]);
-
-		$this->assertSame($values, $form->data());
-	}
-
-	public function testDataFromUnsaveableFields(): void
-	{
-		$form = new Form([
-			'fields' => [
-				'info' => [
-					'type' => 'info',
-				]
-			],
-			'model' => $this->model,
-			'values' => [
-				'info' => 'Yay'
-			]
-		]);
-
-		$this->assertNull($form->data()['info']);
-	}
-
-	public function testDataFromNestedFields(): void
-	{
-		$form = new Form([
-			'fields' => [
-				'structure' => [
-					'type'   => 'structure',
-					'fields' => [
-						'tags' => [
-							'type'  => 'tags',
-						]
-					]
-				]
-			],
-			'model' => $this->model,
-			'values' => $values = [
-				'structure' => [
-					[
-						'tags' => 'a, b'
-					]
-				]
-			]
-		]);
-
-		$this->assertSame('a, b', $form->data()['structure'][0]['tags']);
-	}
-
-	public function testDataWithCorrectFieldOrder(): void
-	{
-		$form = new Form([
-			'fields' => [
-				'a' => [
-					'type' => 'text',
-				],
-				'b' => [
-					'type' => 'text',
-				]
-			],
-			'input' => [
-				'b' => 'B modified'
-			],
-			'model' => $this->model,
-			'values' => [
-				'c' => 'C',
-				'b' => 'B',
-				'a' => 'A',
-			],
-		]);
-
-		$this->assertTrue(['a' => 'A', 'b' => 'B modified', 'c' => 'C'] === $form->data());
-		$this->assertTrue(['a' => 'A', 'b' => 'B modified', 'c' => 'C'] === $form->values());
-	}
-
-	public function testDataWithStrictMode(): void
-	{
-		$form = new Form([
-			'fields' => [
-				'a' => [
-					'type' => 'text',
-				],
-				'b' => [
-					'type' => 'text',
-				]
-			],
-			'input' => [
-				'c' => 'C'
-			],
-			'model' => $this->model,
-			'strict' => true,
-			'values' => [
-				'b' => 'B',
-				'a' => 'A'
-			],
-		]);
-
-		$this->assertTrue(['a' => 'A', 'b' => 'B'] === $form->data());
-		$this->assertTrue(['a' => 'A', 'b' => 'B'] === $form->values());
-	}
-
-	public function testDataWithUntranslatedFields(): void
-	{
-		$this->setUpMultiLanguage();
-
-		$this->model = new Page([
-			'slug' => 'test',
-			'blueprint' => [
-				'fields' => [
-					'a' => [
-						'type' => 'text'
-					],
-					'b' => [
-						'type' => 'text',
-						'translate' => false
-					]
-				],
-			]
-		]);
-
-		// default language
-		$form = Form::for($this->model, [
-			'input' => [
-				'a' => 'A',
-				'b' => 'B'
-			]
-		]);
-
-		$expected = [
-			'a' => 'A',
-			'b' => 'B'
-		];
-
-		$this->assertSame($expected, $form->values());
-
-		// secondary language
-		$form = Form::for($this->model, [
-			'language' => 'de',
-			'input' => [
-				'a' => 'A',
-				'b' => 'B'
-			]
-		]);
-
-		$expected = [
-			'a' => 'A',
-			'b' => ''
-		];
-
-		$this->assertSame($expected, $form->values());
-	}
-
 	public function testDefaults(): void
 	{
-		$form = new Form([
-			'fields' => [
+		$form = new Form(
+			fields: [
 				'test' => [
-					'type' => 'text',
+					'type'    => 'text',
 					'default' => 'Test Value'
 				]
 			]
-		]);
+		);
 
 		$this->assertSame(['test' => 'Test Value'], $form->defaults());
 	}
 
 	public function testErrors(): void
 	{
-		$form = new Form([
-			'fields' => [
+		$form = new Form(
+			fields: [
 				'a' => [
 					'label' => 'Email',
-					'type' => 'email',
+					'type'  => 'email',
 				],
 				'b' => [
 					'label' => 'Url',
-					'type' => 'url',
+					'type'  => 'url',
 				]
 			],
-			'model' => $this->model,
-			'values' => [
-				'a' => 'A',
-				'b' => 'B',
-			]
+			model: $this->model
+		);
+
+		$form->fill(input: [
+			'a' => 'A',
+			'b' => 'B',
 		]);
 
 		$this->assertTrue($form->isInvalid());
@@ -294,25 +103,25 @@ class FormTest extends TestCase
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Field "test": The field type "does-not-exist" does not exist');
 
-		new Form([
-			'fields' => [
+		new Form(
+			fields: [
 				'test' => [
 					'type'  => 'does-not-exist',
 					'model' => $this->model
 				]
 			]
-		]);
+		);
 	}
 
 	public function testFill(): void
 	{
-		$form = new Form([
-			'fields' => [
+		$form = new Form(
+			fields: [
 				'test' => [
 					'type' => 'text',
 				]
-			],
-		]);
+			]
+		);
 
 		$response = $form->fill([
 			'test' => 'Test Value'
@@ -320,6 +129,30 @@ class FormTest extends TestCase
 
 		$this->assertSame($form, $response);
 		$this->assertSame(['test' => 'Test Value'], $response->toFormValues());
+	}
+
+	public function testFillWithDefaults(): void
+	{
+		$form = new Form(
+			fields: [
+				'a' => [
+					'type'    => 'text',
+					'default' => 'A'
+				],
+				'b' => [
+					'type'    => 'text',
+					'default' => 'B'
+				]
+			]
+		);
+
+		$response = $form->fill(
+			input:    ['b' => 'Custom B'],
+			defaults: true
+		);
+
+		$this->assertSame($form, $response);
+		$this->assertSame(['a' => 'A', 'b' => 'Custom B'], $form->toFormValues());
 	}
 
 	public function testForFileWithoutBlueprint(): void
@@ -330,11 +163,10 @@ class FormTest extends TestCase
 			'content'  => []
 		]);
 
-		$form = Form::for($file, [
-			'values' => ['a' => 'A', 'b' => 'B']
-		]);
+		$form = Form::for($file);
+		$form->fill(input: ['a' => 'A', 'b' => 'B']);
 
-		$this->assertSame(['a' => 'A', 'b' => 'B'], $form->data());
+		$this->assertSame(['a' => 'A', 'b' => 'B'], $form->toStoredValues());
 	}
 
 	public function testForPage(): void
@@ -356,14 +188,13 @@ class FormTest extends TestCase
 			]
 		]);
 
-		$form = Form::for($page, [
-			'values' => [
-				'title' => 'Updated Title',
-				'date'  => null
-			]
+		$form = Form::for($page);
+		$form->fill(input: [
+			'title' => 'Updated Title',
+			'date'  => null
 		]);
 
-		$values = $form->values();
+		$values = $form->toFormValues();
 
 		// the title must always be transfered, even if not in the blueprint
 		$this->assertSame('Updated Title', $values['title']);
@@ -381,14 +212,13 @@ class FormTest extends TestCase
 			]
 		]);
 
-		$form = Form::for($page, [
-			'values' => [
-				'a' => fn ($value) => $value . 'A',
-				'b' => fn ($value) => $value . 'B'
-			]
+		$form = Form::for($page);
+		$form->fill(input: [
+			'a' => fn ($value) => $value . 'A',
+			'b' => fn ($value) => $value . 'B'
 		]);
 
-		$values = $form->values();
+		$values = $form->toFormValues();
 
 		$this->assertSame('AA', $values['a']);
 		$this->assertSame('B', $values['b']);
@@ -396,20 +226,20 @@ class FormTest extends TestCase
 
 	public function testLanguage(): void
 	{
-		$form = new Form([
-			'fields' => [
+		$form = new Form(
+			fields: [
 				'test' => [
 					'type' => 'text',
 				]
-			],
-		]);
+			]
+		);
 
 		$this->assertInstanceOf(Language::class, $form->language());
 	}
 
 	public function testPassthrough(): void
 	{
-		$form = new Form([]);
+		$form = new Form();
 
 		$response = $form->passthrough([
 			'test' => 'Test Value'
@@ -422,13 +252,13 @@ class FormTest extends TestCase
 
 	public function testReset(): void
 	{
-		$form = new Form([
-			'fields' => [
+		$form = new Form(
+			fields: [
 				'test' => [
 					'type' => 'text',
 				]
-			],
-		]);
+			]
+		);
 
 		$this->assertSame(['test' => ''], $form->toFormValues());
 
@@ -444,36 +274,15 @@ class FormTest extends TestCase
 		$this->assertSame(['test' => ''], $form->toFormValues());
 	}
 
-	public function testStrings(): void
-	{
-		$form = new Form([
-			'fields' => [],
-			'values' => [
-				'a' => 'A',
-				'b' => 'B',
-				'c' => [
-					'd' => 'D',
-					'e' => 'E'
-				]
-			]
-		]);
-
-		$this->assertSame([
-			'a' => 'A',
-			'b' => 'B',
-			'c' => "d: D\ne: E\n"
-		], $form->strings());
-	}
-
 	public function testSubmit(): void
 	{
-		$form = new Form([
-			'fields' => [
+		$form = new Form(
+			fields: [
 				'test' => [
 					'type' => 'text',
 				]
-			],
-		]);
+			]
+		);
 
 		$response = $form->submit([
 			'test' => 'Test Value'
@@ -485,8 +294,8 @@ class FormTest extends TestCase
 
 	public function testToArray(): void
 	{
-		$form = new Form([
-			'fields' => [
+		$form = new Form(
+			fields: [
 				'a' => [
 					'label' => 'A',
 					'type'  => 'text',
@@ -496,11 +305,12 @@ class FormTest extends TestCase
 					'type'  => 'text',
 				]
 			],
-			'model' => $this->model,
-			'values' => [
-				'a' => 'A',
-				'b' => 'B',
-			]
+			model: $this->model
+		);
+
+		$form->fill(input: [
+			'a' => 'A',
+			'b' => 'B',
 		]);
 
 		$this->assertSame([], $form->toArray()['errors']);
@@ -512,16 +322,16 @@ class FormTest extends TestCase
 
 	public function testToArrayInvalid(): void
 	{
-		$form = new Form([
-			'fields' => [
+		$form = new Form(
+			fields: [
 				'a' => [
 					'label'    => 'A',
 					'type'     => 'text',
 					'required' => true,
 				]
 			],
-			'model' => $this->model,
-		]);
+			model: $this->model
+		);
 
 		$array = $form->toArray();
 
@@ -531,34 +341,94 @@ class FormTest extends TestCase
 
 	public function testToFormValues(): void
 	{
-		$form = new Form([
-			'fields' => [
+		$form = new Form(
+			fields: [
 				'a' => [
 					'type' => 'text',
 				],
 				'b' => [
 					'type' => 'text',
 				]
-			],
-			'values' => $values = [
-				'a' => 'A',
-				'b' => 'B',
 			]
+		);
+
+		$form->fill(input: $values = [
+			'a' => 'A',
+			'b' => 'B',
 		]);
 
 		$this->assertSame($values, $form->toFormValues());
 	}
 
+	public function testToFormValuesWithoutFields(): void
+	{
+		$form = new Form();
+		$form->fill(input: $values = [
+			'a' => 'A',
+			'b' => 'B'
+		]);
+
+		$this->assertSame($values, $form->toFormValues());
+	}
+
+	public function testToFormValuesWithUntranslatedFields(): void
+	{
+		$this->setUpMultiLanguage();
+
+		$this->model = new Page([
+			'slug' => 'test',
+			'blueprint' => [
+				'fields' => [
+					'a' => [
+						'type' => 'text'
+					],
+					'b' => [
+						'type' => 'text',
+						'translate' => false
+					]
+				],
+			]
+		]);
+
+		// default language
+		$form = Form::for($this->model);
+		$form->submit(input: [
+			'a' => 'A',
+			'b' => 'B'
+		]);
+
+		$expected = [
+			'a' => 'A',
+			'b' => 'B'
+		];
+
+		$this->assertSame($expected, $form->toFormValues());
+
+		// secondary language
+		$form = Form::for($this->model, language: 'de');
+		$form->submit(input: [
+			'a' => 'A',
+			'b' => 'B'
+		]);
+
+		$expected = [
+			'a' => 'A',
+			'b' => ''
+		];
+
+		$this->assertSame($expected, $form->toFormValues());
+	}
+
 	public function testToProps(): void
 	{
-		$form = new Form([
-			'fields' => [
+		$form = new Form(
+			fields: [
 				'test' => [
 					'label' => 'Test',
 					'type'  => 'text',
 				],
 			]
-		]);
+		);
 
 		$this->assertSame($form->fields()->toProps(), $form->toProps());
 	}
@@ -576,19 +446,20 @@ class FormTest extends TestCase
 
 		Field::$types['test'] = $field::class;
 
-		$form = new Form([
-			'fields' => [
+		$form = new Form(
+			fields: [
 				'a' => [
 					'type' => 'test',
 				],
 				'b' => [
 					'type' => 'test',
 				]
-			],
-			'values' => [
-				'a' => 'A',
-				'b' => 'B',
 			]
+		);
+
+		$form->fill(input: [
+			'a' => 'A',
+			'b' => 'B',
 		]);
 
 		$expected = [
@@ -599,16 +470,121 @@ class FormTest extends TestCase
 		$this->assertSame($expected, $form->toStoredValues());
 	}
 
-	public function testValuesWithoutFields(): void
+	public function testToStoredValuesFromNestedFields(): void
 	{
-		$form = new Form([
-			'fields' => [],
-			'values' => $values = [
-				'a' => 'A',
-				'b' => 'B'
+		$form = new Form(
+			fields: [
+				'structure' => [
+					'type'   => 'structure',
+					'fields' => [
+						'tags' => [
+							'type'  => 'tags',
+						]
+					]
+				]
+			],
+			model: $this->model
+		);
+
+		$form->fill(input: [
+			'structure' => [
+				[
+					'tags' => 'a, b'
+				]
 			]
 		]);
 
-		$this->assertSame($values, $form->values());
+		$this->assertSame('a, b', $form->toStoredValues()['structure'][0]['tags']);
+	}
+
+	public function testToStoredValuesFromUnsaveableFields(): void
+	{
+		$form = new Form(
+			fields: [
+				'info' => [
+					'type' => 'info',
+				]
+			],
+			model: $this->model
+		);
+
+		$form->fill(input: [
+			'info' => 'Yay'
+		]);
+
+		$this->assertCount(0, $form->toStoredValues());
+		$this->assertArrayNotHasKey('info', $form->toStoredValues());
+	}
+
+	public function testToStoredValuesWithCorrectFieldOrder(): void
+	{
+		$form = new Form(
+			fields: [
+				'a' => [
+					'type' => 'text',
+				],
+				'b' => [
+					'type' => 'text',
+				]
+			],
+			model: $this->model
+		);
+
+		$form->fill(input: [
+			'c' => 'C',
+			'b' => 'B',
+			'a' => 'A',
+		]);
+
+		$form->submit(input: [
+			'b' => 'B modified'
+		]);
+
+		$this->assertTrue(['a' => 'A', 'b' => 'B modified', 'c' => 'C'] === $form->toStoredValues());
+		$this->assertTrue(['a' => 'A', 'b' => 'B modified', 'c' => 'C'] === $form->toFormValues());
+	}
+
+	public function testToStoredValuesWithoutFields(): void
+	{
+		$form = new Form();
+		$form->fill(input: $values = [
+			'a' => 'A',
+			'b' => 'B'
+		]);
+
+		$this->assertSame($values, $form->toStoredValues());
+	}
+
+	public function testToStoredValuesWithoutPassthrough(): void
+	{
+		$form = new Form(
+			fields: [
+				'a' => [
+					'type' => 'text',
+				],
+				'b' => [
+					'type' => 'text',
+				]
+			],
+			model: $this->model
+		);
+
+		$form->fill(
+			input: [
+				'b' => 'B',
+				'a' => 'A'
+			],
+			passthrough: false
+		);
+
+		$form->submit(
+			input: [
+				'c' => 'C'
+			],
+			passthrough: false
+		);
+
+		$this->assertTrue(['a' => 'A', 'b' => 'B'] === $form->toStoredValues());
+		$this->assertTrue(['a' => 'A', 'b' => 'B'] === $form->toFormValues());
 	}
 }

--- a/tests/Panel/Controller/Dialog/PageCreateDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/PageCreateDialogControllerTest.php
@@ -589,6 +589,60 @@ class PageCreateDialogControllerTest extends TestCase
 		], $input);
 	}
 
+	public function testSanitizeWithEmptyFields(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'content.uuid' => false
+			],
+			'blueprints' => [
+				'pages/test' => [
+					'create' => [
+						'fields' => ['foo', 'bar']
+					],
+					'fields' => [
+						'foo' => [
+							'type'    => 'text',
+							'default' => 'foo'
+						],
+						'bar' => [
+							'type'    => 'text',
+							'default' => 'bar'
+						]
+					]
+				]
+			],
+			'request' => [
+				'query' => [
+					'template' => 'test'
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		// the dialog submits an empty string for each field
+		// that has been left untouched
+		$controller = new PageCreateDialogController();
+		$input      = $controller->sanitize([
+			'slug'  => 'foo',
+			'title' => 'Foo',
+			'foo'   => 'custom',
+			'bar'   => ''
+		]);
+
+		$this->assertSame([
+			'content'  => [
+				'foo'   => 'custom',
+				'bar'   => 'bar',
+				'title' => 'Foo',
+				'uuid'  => null,
+			],
+			'slug'     => 'foo',
+			'template' => 'test',
+		], $input);
+	}
+
 	public function testSubmit(): void
 	{
 		$this->app = $this->app->clone([


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Rough pass

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
-->

### ✨ Enhancements
- `Form::fill()` has a new named argument `defaults: true` 

### 🚨 Breaking changes
- `Form::content()` → `Form::toStoredValues()`
- `Form::data()` → `Form::toStoredValues()` with `::fill($defaults)`
- `Form::strings()` → `Form::toStoredValues()` with `::fill($defaults)`
- `Form::values()` → `Form::toFormValues()`
- `Mixin\Value::data()` → `Mixin\Value::toStoredValue()`
- `Mixin\Value::save()` → `Mixin\Value::hasValue()`
- `Form::for()` and `new Form()` have to be used with named arguments now. No $props array can be passed anymore.


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
