### PR TITLE
[sections 2 fields] #6 feat: New Tab and Tabs classes for blueprints

### DIFF
--- a/src/Blueprint/Tab.php
+++ b/src/Blueprint/Tab.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Kirby\Blueprint;
+
+use Kirby\Cms\ModelWithContent;
+use Kirby\Form\Fields;
+use Kirby\Toolkit\I18n;
+use Kirby\Toolkit\Str;
+
+/**
+ * Represents a single tab of a blueprint. Tabs are
+ * the top level of the blueprint layout. They hold
+ * columns, which hold fields.
+ *
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ */
+class Tab
+{
+	public function __construct(
+		protected ModelWithContent $model,
+		protected string $name,
+		protected array $columns = [],
+		protected string|null $icon = null,
+		protected array|string|null $label = null,
+		protected array $props = []
+	) {
+	}
+
+	/**
+	 * Returns all normalized columns of the tab.
+	 *
+	 * If a `Fields` collection is passed, the blueprint field
+	 * definitions of each column are replaced by the resolved
+	 * field props for the Panel.
+	 */
+	public function columns(Fields|null $fields = null): array
+	{
+		if ($fields === null) {
+			return $this->columns;
+		}
+
+		$columns = $this->columns;
+
+		foreach ($columns as $key => $column) {
+			$names = array_map(
+				'strtolower',
+				array_keys($column['fields'] ?? [])
+			);
+
+			// only resolve the props of the fields in this tab,
+			// as that can be expensive for list fields
+			$columns[$key]['fields'] = $fields
+				->filter(fn ($field) => in_array($field->name(), $names, true))
+				->toProps();
+		}
+
+		return $columns;
+	}
+
+	/**
+	 * Returns a flat list of the lowercase names of all
+	 * fields in the tab. The Panel uses this list to count
+	 * the unsaved changes per tab.
+	 */
+	public function fieldNames(): array
+	{
+		$names = [];
+
+		foreach ($this->columns as $column) {
+			foreach (array_keys($column['fields'] ?? []) as $name) {
+				$names[] = Str::lower($name);
+			}
+		}
+
+		return $names;
+	}
+
+	/**
+	 * Returns the icon of the tab
+	 */
+	public function icon(): string|null
+	{
+		return $this->icon;
+	}
+
+	/**
+	 * Returns the translated label of the tab and
+	 * falls back to an automatic label
+	 */
+	public function label(): string
+	{
+		$label = I18n::translate($this->label, $this->label);
+
+		if (is_string($label) === true) {
+			return $label;
+		}
+
+		return Str::label($this->name);
+	}
+
+	/**
+	 * Returns the Panel link to the tab
+	 */
+	public function link(): string
+	{
+		return $this->model->panel()->url(true) . '/?tab=' . $this->name;
+	}
+
+	/**
+	 * Returns the parent model
+	 */
+	public function model(): ModelWithContent
+	{
+		return $this->model;
+	}
+
+	/**
+	 * Returns the name of the tab
+	 */
+	public function name(): string
+	{
+		return $this->name;
+	}
+
+	/**
+	 * Returns the reduced props for the Panel tab bar.
+	 * The columns are not included here, as the tab bar
+	 * only needs to render a button per tab.
+	 */
+	public function toButtonProps(): array
+	{
+		return [
+			'fields' => $this->fieldNames(),
+			'icon'   => $this->icon(),
+			'label'  => $this->label(),
+			'link'   => $this->link(),
+			'name'   => $this->name(),
+		];
+	}
+
+	/**
+	 * Converts the tab to a plain array with all
+	 * columns and fields.
+	 *
+	 * If a `Fields` collection is passed, the columns
+	 * carry the resolved field props for the Panel.
+	 */
+	public function toViewProps(Fields|null $fields = null): array
+	{
+		return [
+			...$this->props,
+			'columns' => $this->columns($fields),
+			'icon'    => $this->icon(),
+			'label'   => $this->label(),
+			'link'    => $this->link(),
+			'name'    => $this->name(),
+		];
+	}
+}

--- a/src/Blueprint/Tabs.php
+++ b/src/Blueprint/Tabs.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Kirby\Blueprint;
+
+use Closure;
+use Kirby\Cms\App;
+use Kirby\Cms\ModelWithContent;
+use Kirby\Toolkit\A;
+use Kirby\Toolkit\Collection;
+
+/**
+ * A collection of Tab objects
+ *
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ *
+ * @extends Collection<Tab>
+ */
+class Tabs extends Collection
+{
+	protected ModelWithContent $model;
+
+	public function __construct(
+		array $tabs = [],
+		ModelWithContent|null $model = null
+	) {
+		$this->model = $model ?? App::instance()->site();
+
+		foreach ($tabs as $name => $tab) {
+			$this->__set($name, $tab);
+		}
+	}
+
+	/**
+	 * Internal setter for each object in the collection.
+	 * This converts the normalized props of a tab into
+	 * a proper Tab object.
+	 *
+	 * @param Tab|array $tab
+	 */
+	public function __set(string $name, $tab): void
+	{
+		if (is_array($tab) === true) {
+			$tab = new Tab(
+				model: $this->model,
+				name: $tab['name'] ?? $name,
+				columns: $tab['columns'] ?? [],
+				icon: $tab['icon'] ?? null,
+				label: $tab['label'] ?? null,
+				props: A::without($tab, ['columns', 'icon', 'label', 'link', 'name'])
+			);
+		}
+
+		parent::__set($tab->name(), $tab);
+	}
+
+	/**
+	 * Returns the parent model
+	 */
+	public function model(): ModelWithContent
+	{
+		return $this->model;
+	}
+
+	/**
+	 * Converts the collection to an array and also
+	 * does that for every included tab
+	 */
+	public function toArray(Closure|null $map = null): array
+	{
+		return A::map($this->data, $map ?? fn ($tab) => $tab->toViewProps());
+	}
+
+	/**
+	 * Returns the reduced props of each tab
+	 * for the Panel tab bar
+	 */
+	public function toButtonsProps(): array
+	{
+		return array_values(
+			A::map($this->data, fn ($tab) => $tab->toButtonProps())
+		);
+	}
+}

--- a/tests/Blueprint/TabTest.php
+++ b/tests/Blueprint/TabTest.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace Kirby\Blueprint;
+
+use Kirby\Cms\App;
+use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Page;
+use Kirby\Form\Fields;
+use Kirby\Toolkit\I18n;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Tab::class)]
+class TabTest extends TestCase
+{
+	protected ModelWithContent $model;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			]
+		]);
+
+		$this->model = new Page(['slug' => 'a']);
+	}
+
+	protected function fields(): Fields
+	{
+		return new Fields(
+			fields: ['title' => ['type' => 'text']],
+			model: $this->model
+		);
+	}
+
+	protected function tab(array $props = []): Tab
+	{
+		return new Tab(...[
+			'model' => $this->model,
+			'name'  => 'content',
+			...$props
+		]);
+	}
+
+	public function testColumns(): void
+	{
+		$columns = [
+			[
+				'width'  => '1/1',
+				'fields' => []
+			]
+		];
+
+		$this->assertSame([], $this->tab()->columns());
+		$this->assertSame($columns, $this->tab(['columns' => $columns])->columns());
+	}
+
+	public function testColumnsWithFieldProps(): void
+	{
+		$tab = $this->tab([
+			'columns' => [
+				[
+					'width'  => '1/1',
+					'fields' => [
+						'title'   => ['type' => 'text'],
+						'missing' => ['type' => 'text']
+					]
+				]
+			]
+		]);
+
+		$columns = $tab->columns($this->fields());
+		$fields  = $columns[0]['fields'];
+
+		// only fields that exist in the collection are resolved
+		$this->assertSame(['title'], array_keys($fields));
+
+		// the blueprint definition is replaced by the resolved props
+		$this->assertSame('text', $fields['title']['type']);
+		$this->assertSame('Title', $fields['title']['label']);
+
+		// all other column props are kept
+		$this->assertSame('1/1', $columns[0]['width']);
+	}
+
+	public function testFieldNames(): void
+	{
+		$tab = $this->tab([
+			'columns' => [
+				[
+					'width'  => '1/2',
+					'fields' => [
+						'title' => ['type' => 'text'],
+						'text'  => ['type' => 'textarea']
+					]
+				],
+				[
+					'width'  => '1/2',
+					'fields' => [
+						'gallery'  => ['type' => 'filelist'],
+						'seoTitle' => ['type' => 'text']
+					]
+				]
+			]
+		]);
+
+		$this->assertSame(
+			['title', 'text', 'gallery', 'seotitle'],
+			$tab->fieldNames()
+		);
+	}
+
+	public function testFieldNamesEmpty(): void
+	{
+		$this->assertSame([], $this->tab()->fieldNames());
+	}
+
+	public function testIcon(): void
+	{
+		$this->assertNull($this->tab()->icon());
+		$this->assertSame('text', $this->tab(['icon' => 'text'])->icon());
+	}
+
+	public function testLabel(): void
+	{
+		$this->assertSame('Content', $this->tab(['label' => 'Content'])->label());
+	}
+
+	public function testLabelAutomatic(): void
+	{
+		$tab = new Tab(
+			model: $this->model,
+			name: 'contentTab'
+		);
+
+		$this->assertSame('Content tab', $tab->label());
+	}
+
+	public function testLabelTranslated(): void
+	{
+		$this->assertSame(
+			'Inhalt',
+			$this->tab(['label' => ['de' => 'Inhalt']])->label()
+		);
+	}
+
+	public function testLabelTranslatedWithI18nKey(): void
+	{
+		I18n::$translations = [
+			'en' => [
+				'tab.content' => 'Content'
+			]
+		];
+
+		$this->assertSame('Content', $this->tab(['label' => 'tab.content'])->label());
+
+		I18n::$translations = [];
+	}
+
+	public function testLink(): void
+	{
+		$this->assertSame('/pages/a/?tab=content', $this->tab()->link());
+	}
+
+	public function testModel(): void
+	{
+		$this->assertSame($this->model, $this->tab()->model());
+	}
+
+	public function testName(): void
+	{
+		$this->assertSame('content', $this->tab()->name());
+	}
+
+	public function testToButtonProps(): void
+	{
+		$tab = $this->tab([
+			'columns' => [
+				[
+					'width'  => '1/1',
+					'fields' => [
+						'title' => ['type' => 'text']
+					]
+				]
+			],
+			'icon'  => 'text',
+			'label' => 'Content'
+		]);
+
+		$this->assertSame([
+			'fields' => ['title'],
+			'icon'   => 'text',
+			'label'  => 'Content',
+			'link'   => '/pages/a/?tab=content',
+			'name'   => 'content'
+		], $tab->toButtonProps());
+	}
+
+	public function testToViewProps(): void
+	{
+		$columns = [
+			[
+				'width'  => '1/1',
+				'fields' => []
+			]
+		];
+
+		$tab = $this->tab([
+			'columns' => $columns,
+			'icon'    => 'text',
+			'label'   => 'Content'
+		]);
+
+		$this->assertSame([
+			'columns' => $columns,
+			'icon'    => 'text',
+			'label'   => 'Content',
+			'link'    => '/pages/a/?tab=content',
+			'name'    => 'content'
+		], $tab->toViewProps());
+	}
+
+	public function testToViewPropsWithCustomProps(): void
+	{
+		$tab = $this->tab([
+			'props' => ['foo' => 'bar']
+		]);
+
+		$this->assertSame([
+			'foo'     => 'bar',
+			'columns' => [],
+			'icon'    => null,
+			'label'   => 'Content',
+			'link'    => '/pages/a/?tab=content',
+			'name'    => 'content'
+		], $tab->toViewProps());
+	}
+
+	public function testToViewPropsWithFieldProps(): void
+	{
+		$tab = $this->tab([
+			'columns' => [
+				[
+					'width'  => '1/1',
+					'fields' => [
+						'title' => ['type' => 'text']
+					]
+				]
+			]
+		]);
+
+		$array = $tab->toViewProps($this->fields());
+
+		$this->assertSame(
+			'Title',
+			$array['columns'][0]['fields']['title']['label']
+		);
+	}
+}

--- a/tests/Blueprint/TabsTest.php
+++ b/tests/Blueprint/TabsTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Kirby\Blueprint;
+
+use Kirby\Cms\App;
+use Kirby\Cms\ModelWithContent;
+use Kirby\Cms\Page;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(Tabs::class)]
+class TabsTest extends TestCase
+{
+	protected ModelWithContent $model;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			]
+		]);
+
+		$this->model = new Page(['slug' => 'a']);
+	}
+
+	protected function tabs(array $tabs = []): Tabs
+	{
+		return new Tabs($tabs, $this->model);
+	}
+
+	public function testConstructFromNormalizedProps(): void
+	{
+		$tabs = $this->tabs([
+			'content' => [
+				'columns' => [],
+				'icon'    => 'text',
+				'label'   => 'Content',
+				'name'    => 'content'
+			]
+		]);
+
+		$this->assertCount(1, $tabs);
+		$this->assertInstanceOf(Tab::class, $tabs->get('content'));
+		$this->assertSame('text', $tabs->get('content')->icon());
+		$this->assertSame('Content', $tabs->get('content')->label());
+	}
+
+	public function testConstructFromTabObjects(): void
+	{
+		$tab  = new Tab(model: $this->model, name: 'content');
+		$tabs = $this->tabs(['content' => $tab]);
+
+		$this->assertSame($tab, $tabs->get('content'));
+	}
+
+	public function testConstructWithoutModel(): void
+	{
+		$tabs = new Tabs([
+			'content' => []
+		]);
+
+		$this->assertSame($this->app->site(), $tabs->model());
+		$this->assertSame('/site/?tab=content', $tabs->get('content')->link());
+	}
+
+	public function testEmpty(): void
+	{
+		$tabs = $this->tabs();
+
+		$this->assertCount(0, $tabs);
+		$this->assertNull($tabs->first());
+		$this->assertSame([], $tabs->toArray());
+		$this->assertSame([], $tabs->toButtonsProps());
+	}
+
+	public function testFirst(): void
+	{
+		$tabs = $this->tabs([
+			'content'  => [],
+			'settings' => []
+		]);
+
+		$this->assertSame('content', $tabs->first()->name());
+	}
+
+	public function testGetCaseInsensitive(): void
+	{
+		$tabs = $this->tabs([
+			'contentTab' => []
+		]);
+
+		$this->assertSame($tabs->get('contentTab'), $tabs->get('contenttab'));
+
+		// the tab keeps its authored name for the link
+		$this->assertSame('contentTab', $tabs->get('contenttab')->name());
+		$this->assertSame(
+			'/pages/a/?tab=contentTab',
+			$tabs->get('contenttab')->link()
+		);
+	}
+
+	public function testGetMissing(): void
+	{
+		$this->assertNull($this->tabs()->get('does-not-exist'));
+	}
+
+	public function testModel(): void
+	{
+		$this->assertSame($this->model, $this->tabs()->model());
+	}
+
+	public function testNameFromKey(): void
+	{
+		$tabs = $this->tabs([
+			'content' => ['label' => 'Content']
+		]);
+
+		$this->assertSame('content', $tabs->get('content')->name());
+	}
+
+	public function testToArray(): void
+	{
+		$tabs = $this->tabs([
+			'content'  => ['icon' => 'text'],
+			'settings' => []
+		]);
+
+		$this->assertSame([
+			'content' => [
+				'columns' => [],
+				'icon'    => 'text',
+				'label'   => 'Content',
+				'link'    => '/pages/a/?tab=content',
+				'name'    => 'content'
+			],
+			'settings' => [
+				'columns' => [],
+				'icon'    => null,
+				'label'   => 'Settings',
+				'link'    => '/pages/a/?tab=settings',
+				'name'    => 'settings'
+			]
+		], $tabs->toArray());
+	}
+
+	public function testToArrayWithMap(): void
+	{
+		$tabs = $this->tabs([
+			'content'  => [],
+			'settings' => []
+		]);
+
+		$this->assertSame(
+			['content' => 'content', 'settings' => 'settings'],
+			$tabs->toArray(fn ($tab) => $tab->name())
+		);
+	}
+
+	public function testToButtonsProps(): void
+	{
+		$tabs = $this->tabs([
+			'content' => [
+				'columns' => [
+					[
+						'width'  => '1/1',
+						'fields' => [
+							'title' => ['type' => 'text']
+						]
+					]
+				],
+				'icon' => 'text'
+			],
+			'settings' => []
+		]);
+
+		$this->assertSame([
+			[
+				'fields' => ['title'],
+				'icon'   => 'text',
+				'label'  => 'Content',
+				'link'   => '/pages/a/?tab=content',
+				'name'   => 'content'
+			],
+			[
+				'fields' => [],
+				'icon'   => null,
+				'label'  => 'Settings',
+				'link'   => '/pages/a/?tab=settings',
+				'name'   => 'settings'
+			]
+		], $tabs->toButtonsProps());
+	}
+}


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

**Timing:** No rush

## Description

Blueprint tabs are only arrays of normalized props so far. The new `Tab` and `Tabs` classes wrap those props and take over the tab label, link and the list of field names per tab.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### ✨ Enhancements

- New `Kirby\Blueprint\Tab` and `Kirby\Blueprint\Tabs` classes to provide a nicer interface to work with tabs and their props in blueprints. 

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
