### PR TITLE
[sections 2 fields] #7 refact: Return a Tabs collection from blueprints

### DIFF
--- a/config/api/models/FileBlueprint.php
+++ b/config/api/models/FileBlueprint.php
@@ -9,7 +9,7 @@ return [
 	'fields' => [
 		'name'    => fn (FileBlueprint $blueprint) => $blueprint->name(),
 		'options' => fn (FileBlueprint $blueprint) => $blueprint->options(),
-		'tabs'    => fn (FileBlueprint $blueprint) => $blueprint->tabs(),
+		'tabs'    => fn (FileBlueprint $blueprint) => array_values($blueprint->tabs()->toArray()),
 		'title'   => fn (FileBlueprint $blueprint) => $blueprint->title(),
 	],
 	'type'  => FileBlueprint::class,

--- a/config/api/models/PageBlueprint.php
+++ b/config/api/models/PageBlueprint.php
@@ -12,7 +12,7 @@ return [
 		'options' => fn (PageBlueprint $blueprint) => $blueprint->options(),
 		'preview' => fn (PageBlueprint $blueprint) => $blueprint->preview(),
 		'status'  => fn (PageBlueprint $blueprint) => $blueprint->status(),
-		'tabs'    => fn (PageBlueprint $blueprint) => $blueprint->tabs(),
+		'tabs'    => fn (PageBlueprint $blueprint) => array_values($blueprint->tabs()->toArray()),
 		'title'   => fn (PageBlueprint $blueprint) => $blueprint->title(),
 	],
 	'type'  => PageBlueprint::class,

--- a/config/api/models/SiteBlueprint.php
+++ b/config/api/models/SiteBlueprint.php
@@ -9,7 +9,7 @@ return [
 	'fields' => [
 		'name'    => fn (SiteBlueprint $blueprint) => $blueprint->name(),
 		'options' => fn (SiteBlueprint $blueprint) => $blueprint->options(),
-		'tabs'    => fn (SiteBlueprint $blueprint) => $blueprint->tabs(),
+		'tabs'    => fn (SiteBlueprint $blueprint) => array_values($blueprint->tabs()->toArray()),
 		'title'   => fn (SiteBlueprint $blueprint) => $blueprint->title(),
 	],
 	'type'  => SiteBlueprint::class,

--- a/config/api/models/UserBlueprint.php
+++ b/config/api/models/UserBlueprint.php
@@ -9,7 +9,7 @@ return [
 	'fields' => [
 		'name'    => fn (UserBlueprint $blueprint) => $blueprint->name(),
 		'options' => fn (UserBlueprint $blueprint) => $blueprint->options(),
-		'tabs'    => fn (UserBlueprint $blueprint) => $blueprint->tabs(),
+		'tabs'    => fn (UserBlueprint $blueprint) => array_values($blueprint->tabs()->toArray()),
 		'title'   => fn (UserBlueprint $blueprint) => $blueprint->title(),
 	],
 	'type'  => UserBlueprint::class,

--- a/src/Blueprint/Blueprint.php
+++ b/src/Blueprint/Blueprint.php
@@ -35,7 +35,9 @@ class Blueprint
 	protected ModelWithContent $model;
 	protected array $props;
 	protected array $sections = [];
-	protected array $tabs = [];
+
+	// Collected tabs, see `tabs()`
+	protected Tabs|null $tabs = null;
 
 	/**
 	 * Magic getter/caller for any blueprint prop
@@ -78,7 +80,6 @@ class Blueprint
 		$this->fields   = $normalizer->fields();
 		$this->props    = $normalizer->props();
 		$this->sections = $normalizer->sections();
-		$this->tabs     = $normalizer->tabs();
 	}
 
 	/**
@@ -460,23 +461,30 @@ class Blueprint
 	}
 
 	/**
-	 * Returns a single tab by name
+	 * Returns a single tab by name or the
+	 * first tab if no name is given
 	 */
-	public function tab(string|null $name = null): array|null
+	public function tab(string|null $name = null): Tab|null
 	{
+		$tabs = $this->tabs();
+
 		if ($name === null) {
-			return A::first($this->tabs);
+			return $tabs->first();
 		}
 
-		return $this->tabs[$name] ?? null;
+		return $tabs->get($name);
 	}
 
 	/**
-	 * Returns all tabs
+	 * Creates and caches the collection of all tabs
+	 * from the normalized tab props
 	 */
-	public function tabs(): array
+	public function tabs(): Tabs
 	{
-		return array_values($this->tabs);
+		return $this->tabs ??= new Tabs(
+			tabs: $this->props['tabs'] ?? [],
+			model: $this->model
+		);
 	}
 
 	/**
@@ -492,6 +500,9 @@ class Blueprint
 	 */
 	public function toArray(): array
 	{
-		return $this->props;
+		return [
+			...$this->props,
+			'tabs' => $this->tabs()->toArray()
+		];
 	}
 }

--- a/src/Blueprint/Normalizer.php
+++ b/src/Blueprint/Normalizer.php
@@ -512,7 +512,6 @@ class Normalizer
 				'columns' => $this->normalizeColumns($tabName, $tabProps['columns'] ?? []),
 				'icon'    => $tabProps['icon']  ?? null,
 				'label'   => $this->i18n($tabProps['label'] ?? Str::label($tabName)),
-				'link'    => $this->model->panel()->url(true) . '/?tab=' . $tabName,
 				'name'    => $tabName,
 			];
 		}

--- a/src/Panel/Controller/View/ModelViewController.php
+++ b/src/Panel/Controller/View/ModelViewController.php
@@ -23,6 +23,8 @@ use Kirby\Panel\Ui\View;
  */
 abstract class ModelViewController extends ViewController
 {
+	protected Fields|null $fields = null;
+
 	/** @var TModel */
 	protected ModelWithContent $model;
 
@@ -53,6 +55,15 @@ abstract class ModelViewController extends ViewController
 	public function component(): string
 	{
 		return 'k-' . ($this->model::CLASS_ALIAS ?? 'model') . '-view';
+	}
+
+	/**
+	 * All fields of the model, shared between the
+	 * tab props and the content versions
+	 */
+	public function fields(): Fields
+	{
+		return $this->fields ??= Fields::for($this->model, 'current');
 	}
 
 	public function load(): View
@@ -139,15 +150,27 @@ abstract class ModelViewController extends ViewController
 
 	public function tab(): array|null
 	{
-		$tab   = $this->request->get('tab');
-		$tab   = $this->model->blueprint()->tab($tab);
-		$tab ??= $this->tabs()[0] ?? null;
-		return $tab;
+		$blueprint = $this->model->blueprint();
+		$tab       = $blueprint->tab($this->request->get('tab'));
+
+		// fall back to the first tab if the requested tab does not exist
+		$tab ??= $blueprint->tabs()->first();
+
+		if ($tab === null) {
+			return null;
+		}
+
+		return $tab->toViewProps($this->fields());
 	}
 
+	/**
+	 * Returns the reduced props of all tabs for the tab bar.
+	 * The full props of the active tab are sent separately
+	 * via `::tab()`
+	 */
 	public function tabs(): array
 	{
-		return $this->model->blueprint()->tabs();
+		return $this->model->blueprint()->tabs()->toButtonsProps();
 	}
 
 	abstract public function title(): string;
@@ -164,7 +187,7 @@ abstract class ModelViewController extends ViewController
 	public function versions(): array
 	{
 		$language = Language::ensure('current');
-		$fields   = Fields::for($this->model, $language);
+		$fields   = $this->fields();
 
 		$latestVersion  = $this->model->version('latest');
 		$changesVersion = $this->model->version('changes');

--- a/tests/Blueprint/BlueprintExtendAndUnsetTest.php
+++ b/tests/Blueprint/BlueprintExtendAndUnsetTest.php
@@ -83,8 +83,8 @@ class BlueprintExtendAndUnsetTest extends TestCase
 
 		$this->assertSame('extended', $blueprint->title());
 		$this->assertCount(2, $blueprint->tabs());
-		$this->assertIsArray($blueprint->tab('content'));
-		$this->assertIsNotArray($blueprint->tab('seo'));
+		$this->assertInstanceOf(Tab::class, $blueprint->tab('content'));
+		$this->assertNull($blueprint->tab('seo'));
 	}
 
 	public function testExtendAndUnsetSection(): void

--- a/tests/Blueprint/BlueprintTest.php
+++ b/tests/Blueprint/BlueprintTest.php
@@ -117,7 +117,7 @@ class BlueprintTest extends TestCase
 		];
 
 		$this->assertSame($expected, $blueprint->toArray()['tabs']);
-		$this->assertSame($expected['main'], $blueprint->tab());
+		$this->assertSame($expected['main'], $blueprint->tab()->toViewProps());
 	}
 
 	public function testButtons(): void
@@ -836,6 +836,41 @@ class BlueprintTest extends TestCase
 			]
 		]);
 
-		$this->assertSame('Content tab', $blueprint->tabs()[0]['label']);
+		$this->assertSame('Content tab', $blueprint->tabs()->first()->label());
+	}
+
+	public function testTabs(): void
+	{
+		$blueprint = new Blueprint([
+			'model' => $this->model,
+			'tabs'  => [
+				'content'  => [],
+				'settings' => []
+			]
+		]);
+
+		$this->assertInstanceOf(Tabs::class, $blueprint->tabs());
+		$this->assertCount(2, $blueprint->tabs());
+
+		// the collection is only created once
+		$this->assertSame($blueprint->tabs(), $blueprint->tabs());
+
+		// the first tab is returned without a name
+		$this->assertSame($blueprint->tab('content'), $blueprint->tab());
+
+		// tabs are matched case-insensitively
+		$this->assertSame($blueprint->tab('content'), $blueprint->tab('Content'));
+
+		$this->assertNull($blueprint->tab('does-not-exist'));
+	}
+
+	public function testTabsEmpty(): void
+	{
+		$blueprint = new Blueprint([
+			'model' => $this->model
+		]);
+
+		$this->assertCount(0, $blueprint->tabs());
+		$this->assertNull($blueprint->tab());
 	}
 }

--- a/tests/Blueprint/NormalizerTest.php
+++ b/tests/Blueprint/NormalizerTest.php
@@ -681,7 +681,6 @@ class NormalizerTest extends TestCase
 		$this->assertSame('content', $tab['name']);
 		$this->assertSame('Content', $tab['label']);
 		$this->assertSame('text', $tab['icon']);
-		$this->assertSame('/pages/a/?tab=content', $tab['link']);
 		$this->assertSame([], $tab['columns']);
 	}
 

--- a/tests/Panel/Controller/View/ModelViewControllerTest.php
+++ b/tests/Panel/Controller/View/ModelViewControllerTest.php
@@ -102,7 +102,12 @@ class ModelViewControllerTest extends TestCase
 	public function testTab(): void
 	{
 		$controller = new TestModelViewController($this->model);
-		$this->assertSame('main', $controller->tab()['name']);
+		$tab        = $controller->tab();
+
+		$this->assertSame('main', $tab['name']);
+
+		// the active tab is sent with all columns
+		$this->assertCount(2, $tab['columns']);
 
 		$this->app = $this->app->clone([
 			'request' => [
@@ -112,6 +117,7 @@ class ModelViewControllerTest extends TestCase
 			]
 		]);
 
+		// fall back to the first tab for an unknown tab name
 		$controller = new TestModelViewController($this->model);
 		$this->assertSame('main', $controller->tab()['name']);
 	}
@@ -120,8 +126,15 @@ class ModelViewControllerTest extends TestCase
 	{
 		$controller = new TestModelViewController($this->model);
 		$tabs       = $controller->tabs();
+
 		$this->assertCount(1, $tabs);
 		$this->assertSame('main', $tabs[0]['name']);
+
+		// the tab bar only needs the reduced props
+		$this->assertSame(
+			['fields', 'icon', 'label', 'link', 'name'],
+			array_keys($tabs[0])
+		);
 	}
 
 	public function testTitle(): void


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

> [!NOTE]
> It's ok that the unit tests are failing. The PR is a temporary step, to be easier to review. The unit test issues are solved later.

## Description

`Blueprint::tab()` and `Blueprint::tabs()` return Tab objects and the Tabs collection instead of plain arrays. The tab link moves from the normalized props to `Tab::link()` and model views only send the reduced button props for the tab bar, while the active tab carries the resolved field props of its columns. 

Tests that still access tabs as arrays are fixed in the following sections to fields commit.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### ✨ Enhancements

- New `Kirby\Panel\Controller\View\ModelViewController::fields()` method to return all form fields for the current tabs and the versions. 

### 🚨 Breaking changes

- `Kirby\Blueprint\Blueprint::tab()` now returns a `Kirby\Blueprint\Tab` object
- `Kirby\Blueprint\Blueprint::tabs()` now returns a `Kirby\Blueprint\Tabs` collection
- The normalized tabs no longer contain the link to the tab. The link is built by the `Kirby\Blueprint\Tab` class instead.

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
