### PR TITLE
[sections 2 fields] #8 refact: Count tab changes from the field names of a tab

### DIFF
--- a/panel/src/components/Navigation/ModelTabs.test.ts
+++ b/panel/src/components/Navigation/ModelTabs.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "@test/unit";
+import { mount } from "@vue/test-utils";
+import ModelTabs from "./ModelTabs.vue";
+
+const tabs = [
+	{
+		name: "main",
+		fields: ["headline", "Text"]
+	},
+	{
+		name: "meta",
+		fields: ["seo"]
+	}
+];
+
+type Badge = { text: number } | undefined;
+
+function badges(diff = {}): Badge[] {
+	const wrapper = mount(ModelTabs, { props: { tab: "main", tabs, diff } });
+	const withBadges = wrapper.vm.withBadges as { badge: Badge }[];
+	return withBadges.map((tab) => tab.badge);
+}
+
+describe("ModelTabs.vue", () => {
+	describe("element", () => {
+		it.rendersAs(() => mount(ModelTabs).find("k-tabs"), "K-TABS");
+	});
+
+	describe("withBadges", () => {
+		it("counts the changed fields of a tab", () => {
+			expect(badges({ headline: "a", seo: "b" })).toStrictEqual([
+				{ text: 1 },
+				{ text: 1 }
+			]);
+		});
+
+		it("compares the field names case-insensitively", () => {
+			expect(badges({ text: "a" })).toStrictEqual([{ text: 1 }, undefined]);
+		});
+
+		it("has no badge without changes", () => {
+			expect(badges()).toStrictEqual([undefined, undefined]);
+		});
+	});
+});

--- a/panel/src/components/Navigation/ModelTabs.vue
+++ b/panel/src/components/Navigation/ModelTabs.vue
@@ -25,19 +25,8 @@ export default {
 			const changes = Object.keys(this.diff);
 
 			return this.tabs.map((tab) => {
-				// collect all fields per tab
-				const fields = [];
-
-				for (const column in tab.columns) {
-					for (const section in tab.columns[column].sections) {
-						if (tab.columns[column].sections[section].type === "fields") {
-							for (const field in tab.columns[column].sections[section]
-								.fields) {
-								fields.push(field);
-							}
-						}
-					}
-				}
+				// all field names of the tab
+				const fields = tab.fields ?? [];
 
 				// get count of changed fields in this tab
 				const changesInTab = fields.filter((field) =>


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

## Description

The tab buttons no longer receive columns and sections. Each tab comes with a flat list of its field names instead, which is all the badge needs to count the unsaved changes.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### ✨ Enhancements

- The `ModelTabs.vue` component uses the new `tab.fields` prop from the backend to render the diff count badge

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
