### PR TITLE
[sections 2 fields] #9 refact: Convert blueprint sections to fields

### DIFF
--- a/src/Blueprint/Blueprint.php
+++ b/src/Blueprint/Blueprint.php
@@ -44,16 +44,11 @@ class Blueprint
 
 	protected AcceptRules|null $acceptRules = null;
 
-	// Props of all fields in the blueprint
 	protected array $fields = [];
 	protected array|null $fieldsLower = null;
 	protected ModelWithContent $model;
 	protected array $props;
-
-	// Cache for sections created from `section` fields
 	protected array $sections = [];
-
-	// Collected tabs, see `tabs()`
 	protected Tabs|null $tabs = null;
 
 	/**

--- a/src/Blueprint/Blueprint.php
+++ b/src/Blueprint/Blueprint.php
@@ -27,6 +27,21 @@ class Blueprint
 {
 	public static array $loaded = [];
 
+	/**
+	 * Maps section types onto their field equivalent.
+	 * Section types without an entry here are automatically
+	 * wrapped in a `section` field.
+	 *
+	 * @since 6.0.0
+	 * @unstable
+	 */
+	public static array $sectionFields = [
+		'files' => 'filelist',
+		'info'  => 'info',
+		'pages' => 'pagelist',
+		'stats' => 'stats',
+	];
+
 	protected AcceptRules|null $acceptRules = null;
 
 	// Props of all fields in the blueprint
@@ -34,6 +49,8 @@ class Blueprint
 	protected array|null $fieldsLower = null;
 	protected ModelWithContent $model;
 	protected array $props;
+
+	// Cache for sections created from `section` fields
 	protected array $sections = [];
 
 	// Collected tabs, see `tabs()`
@@ -73,13 +90,11 @@ class Blueprint
 
 		// convert all shortcuts and normalize the props
 		$normalizer = new Normalizer(
-			model: $this->model,
 			props: $props
 		);
 
-		$this->fields   = $normalizer->fields();
-		$this->props    = $normalizer->props();
-		$this->sections = $normalizer->sections();
+		$this->fields = $normalizer->fields();
+		$this->props  = $normalizer->props();
 	}
 
 	/**
@@ -391,26 +406,16 @@ class Blueprint
 	}
 
 	/**
-	 * Returns a single section by name
+	 * Returns a single section by name. Sections only exist
+	 * as fields with the `section` type after normalization.
 	 */
 	public function section(string $name): Section|null
 	{
-		if (empty($this->sections[$name]) === true) {
-			return $this->sectionFromField($name);
+		if (array_key_exists($name, $this->sections) === true) {
+			return $this->sections[$name];
 		}
 
-		if ($this->sections[$name] instanceof Section) {
-			return $this->sections[$name]; //@codeCoverageIgnore
-		}
-
-		// get all props
-		$props = $this->sections[$name];
-
-		// inject the blueprint model
-		$props['model'] = $this->model();
-
-		// create a new section object
-		return $this->sections[$name] = new Section($props['type'], $props);
+		return $this->sections[$name] = $this->sectionFromField($name);
 	}
 
 	/**
@@ -430,8 +435,7 @@ class Blueprint
 		$field = new SectionField(...$props);
 		$field->setModel($this->model());
 
-		// cache the section under the original field name
-		return $this->sections[$props['name']] = $field->section();
+		return $field->section();
 	}
 
 	/**
@@ -441,19 +445,15 @@ class Blueprint
 	 */
 	public function sections(): array
 	{
-		$sections = A::map(
-			$this->sections,
-			fn ($section) => match (true) {
-				$section instanceof Section => $section,
-				default                     => $this->section($section['name'])
-			}
-		);
+		$sections = [];
 
-		// sections that are defined as fields are not part of the
-		// section definitions and need to be collected separately
 		foreach ($this->fields as $name => $field) {
-			if ($field['type'] === 'section') {
-				$sections[$name] ??= $this->section($name);
+			if ($field['type'] !== 'section') {
+				continue;
+			}
+
+			if ($section = $this->section((string)$name)) {
+				$sections[$name] = $section;
 			}
 		}
 

--- a/src/Blueprint/Normalizer.php
+++ b/src/Blueprint/Normalizer.php
@@ -2,19 +2,19 @@
 
 namespace Kirby\Blueprint;
 
-use Kirby\Cms\ModelWithContent;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Form\Field;
+use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
 use Throwable;
 
 /**
  * The Normalizer takes the raw props of a blueprint and
- * converts them into a proper tab layout. Loose fields are
- * wrapped in a section, loose sections in a column and loose
- * columns in a tab. On the way, it collects the props of all
- * sections and fields in the blueprint.
+ * converts them into a proper tab layout. Sections are
+ * converted to fields, loose fields are wrapped in a column
+ * and loose columns in a tab. On the way, it collects the
+ * props of all fields in the blueprint.
  *
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
@@ -35,13 +35,8 @@ class Normalizer
 	// Collected blueprint props
 	protected array $props;
 
-	// Collected props of all sections in the blueprint
-	protected array $sections = [];
-
-	public function __construct(
-		protected ModelWithContent $model,
-		array $props
-	) {
+	public function __construct(array $props)
+	{
 		$this->props = $this->normalize($props);
 	}
 
@@ -70,26 +65,20 @@ class Normalizer
 	}
 
 	/**
-	 * Converts all field definitions, that are not
-	 * wrapped in a fields section into a generic
-	 * fields section.
+	 * Converts all field definitions, that are not wrapped
+	 * in columns, into a single generic column.
 	 */
-	protected function convertFieldsToSections(
-		string $tabName,
-		array $props
-	): array {
+	protected function convertFieldsToColumns(array $props): array
+	{
 		if (isset($props['fields']) === false) {
 			return $props;
 		}
 
-		// Resolve field references and extract inline definitions
-		$fields = $this->resolveFieldReferences($props['fields']);
-
-		// wrap all fields in a section
-		$props['sections'] = [
-			$tabName . '-fields' => [
-				'type'   => 'fields',
-				'fields' => $fields
+		// wrap everything in one big column
+		$props['columns'] = [
+			[
+				'width'  => '1/1',
+				'fields' => $props['fields']
 			]
 		];
 
@@ -99,28 +88,77 @@ class Normalizer
 	}
 
 	/**
-	 * Converts all sections that are not wrapped in
-	 * columns, into a single generic column.
+	 * Converts all section definitions into field definitions.
+	 * Sections only exist as a legacy concept in blueprints and
+	 * are either mapped onto their field equivalent or wrapped
+	 * in the `section` field adapter.
 	 */
-	protected function convertSectionsToColumns(
-		string $tabName,
-		array $props
-	): array {
+	protected function convertSectionsToFields(array $props): array
+	{
 		if (isset($props['sections']) === false) {
 			return $props;
 		}
 
-		// wrap everything in one big column
-		$props['columns'] = [
-			[
-				'width'    => '1/1',
-				'sections' => $props['sections']
-			]
-		];
+		$fields = $props['fields'] ?? [];
+
+		// sections and fields share a single namespace
+		$add = static function (array $fields, $name, $props): array {
+			if (isset($fields[$name]) === true) {
+				$fields[$name] = static::duplicateFieldError($name, $props);
+				return $fields;
+			}
+
+			$fields[$name] = $props;
+			return $fields;
+		};
+
+		foreach ($props['sections'] as $name => $section) {
+			// unset / remove section if its property is false
+			if ($section === false) {
+				continue;
+			}
+
+			// fallback to default props when true is passed
+			if ($section === true) {
+				$section = [];
+			}
+
+			// inject all section extensions
+			$section = Blueprint::extend($section);
+
+			// a fields section is unwrapped into the parent's own fields
+			if (($section['type'] ?? $name) === 'fields') {
+				foreach (static::unwrapFieldsSection($section) as $key => $field) {
+					$fields = $add($fields, $key, $field);
+				}
+
+				continue;
+			}
+
+			$fields = $add($fields, $name, static::sectionToField($name, $section));
+		}
+
+		$props['fields'] = $fields;
 
 		unset($props['sections']);
 
 		return $props;
+	}
+
+	/**
+	 * Creates an error field for a field name that is already taken
+	 */
+	protected static function duplicateFieldError(
+		string|int $name,
+		array|string|bool|null $props = null
+	): array {
+		return [
+			'label' => (is_array($props) === true ? $props['label'] ?? null : null) ?? 'Error',
+			'name'  => $name,
+			'text'  => 'The field <strong>"' . $name . '"</strong> already exists in your blueprint',
+			'theme' => 'negative',
+			'type'  => 'info',
+		];
 	}
 
 	/**
@@ -188,8 +226,8 @@ class Normalizer
 		$props = $this->extractFieldReferences($props);
 
 		// convert all shortcuts
-		$props = $this->convertFieldsToSections('main', $props);
-		$props = $this->convertSectionsToColumns('main', $props);
+		$props = $this->convertSectionsToFields($props);
+		$props = $this->convertFieldsToColumns($props);
 		$props = $this->convertColumnsToTabs('main', $props);
 
 		// normalize all tabs
@@ -212,29 +250,23 @@ class Normalizer
 				continue;
 			}
 
-			$columnProps = $this->convertFieldsToSections(
-				$tabName . '-col-' . $columnKey,
-				$columnProps
-			);
+			$columnProps = $this->convertSectionsToFields($columnProps);
 
-			// inject getting started info, if the sections are empty
-			if (empty($columnProps['sections']) === true) {
-				$columnProps['sections'] = [
+			// inject getting started info, if the fields are empty
+			if (empty($columnProps['fields']) === true) {
+				$columnProps['fields'] = [
 					$tabName . '-info-' . $columnKey => [
 						'label' => 'Column (' . ($columnProps['width'] ?? '1/1') . ')',
 						'type'  => 'info',
-						'text'  => 'No sections yet'
+						'text'  => 'No fields yet'
 					]
 				];
 			}
 
 			$columns[$columnKey] = [
 				...$columnProps,
-				'width'    => $columnProps['width'] ?? '1/1',
-				'sections' => $this->normalizeSections(
-					$tabName,
-					$columnProps['sections'] ?? []
-				)
+				'width'  => $columnProps['width'] ?? '1/1',
+				'fields' => $this->normalizeFields($columnProps['fields'])
 			];
 		}
 
@@ -296,6 +328,32 @@ class Normalizer
 			'type'  => $type,
 			'width' => $props['width'] ?? '1/1',
 		];
+	}
+
+	/**
+	 * Normalizes all fields of a column and registers
+	 * them in the global field collection
+	 *
+	 * @return array<string, array>
+	 */
+	protected function normalizeFields(array $fields): array
+	{
+		// resolve field references before normalizing
+		$fields = $this->resolveFieldReferences($fields);
+		$fields = static::normalizeFieldsProps($fields);
+
+		foreach ($fields as $name => $props) {
+			if (isset($this->fields[$name]) === true) {
+				$this->fields[$name] = $fields[$name] =
+					static::duplicateFieldError($name, $props);
+
+				continue;
+			}
+
+			$this->fields[$name] = $props;
+		}
+
+		return $fields;
 	}
 
 	/**
@@ -399,91 +457,6 @@ class Normalizer
 	}
 
 	/**
-	 * Normalizes all required keys in sections
-	 *
-	 * @return array<string, array>
-	 */
-	protected function normalizeSections(
-		string $tabName,
-		array $sections
-	): array {
-		foreach ($sections as $sectionName => $sectionProps) {
-			// unset / remove section if its property is false
-			if ($sectionProps === false) {
-				unset($sections[$sectionName]);
-				continue;
-			}
-
-			// fallback to default props when true is passed
-			if ($sectionProps === true) {
-				$sectionProps = [];
-			}
-
-			// inject all section extensions
-			$sectionProps = Blueprint::extend($sectionProps);
-
-			$sections[$sectionName] = $sectionProps = [
-				...$sectionProps,
-				'name' => $sectionName,
-				'type' => $type = $sectionProps['type'] ?? $sectionName
-			];
-
-			if (empty($type) === true || is_string($type) === false) {
-				$sections[$sectionName] = [
-					'name'  => $sectionName,
-					'label' => 'Invalid section type for section "' . $sectionName . '"',
-					'type'  => 'info',
-					'text'  => 'The following section types are available: ' . Blueprint::helpList(array_keys(Section::$types))
-				];
-			} elseif (isset(Section::$types[$type]) === false) {
-				$sections[$sectionName] = [
-					'name'  => $sectionName,
-					'label' => 'Invalid section type ("' . $type . '")',
-					'type'  => 'info',
-					'text'  => 'The following section types are available: ' . Blueprint::helpList(array_keys(Section::$types))
-				];
-			}
-
-			if ($sectionProps['type'] === 'fields') {
-				// Resolve field references before normalizing
-				$sectionFields = $this->resolveFieldReferences($sectionProps['fields'] ?? []);
-				$fields = static::normalizeFieldsProps($sectionFields);
-
-				// inject guide fields guide
-				if ($fields === []) {
-					$fields = [
-						$tabName . '-info' => [
-							'label' => 'Fields',
-							'text'  => 'No fields yet',
-							'type'  => 'info'
-						]
-					];
-				} else {
-					foreach ($fields as $fieldName => $fieldProps) {
-						if (isset($this->fields[$fieldName]) === true) {
-							$this->fields[$fieldName] = $fields[$fieldName] = [
-								'type'  => 'info',
-								'label' => $fieldProps['label'] ?? 'Error',
-								'text'  => 'The field <strong>"' . $fieldName . '"</strong> already exists in your blueprint',
-								'theme' => 'negative'
-							];
-						} else {
-							$this->fields[$fieldName] = $fieldProps;
-						}
-					}
-				}
-
-				$sections[$sectionName]['fields'] = $fields;
-			}
-		}
-
-		// store all normalized sections
-		$this->sections = [...$this->sections, ...$sections];
-
-		return $sections;
-	}
-
-	/**
 	 * Normalizes all required keys in tabs
 	 *
 	 * @return array<string, array>
@@ -504,8 +477,8 @@ class Normalizer
 			// inject all tab extensions
 			$tabProps = Blueprint::extend($tabProps);
 
-			$tabProps = $this->convertFieldsToSections($tabName, $tabProps);
-			$tabProps = $this->convertSectionsToColumns($tabName, $tabProps);
+			$tabProps = $this->convertSectionsToFields($tabProps);
+			$tabProps = $this->convertFieldsToColumns($tabProps);
 
 			$tabs[$tabName] = [
 				...$tabProps,
@@ -558,13 +531,66 @@ class Normalizer
 	}
 
 	/**
-	 * Returns the props of all sections in the blueprint
-	 *
-	 * @return array<string, array>
+	 * Creates an error field for an invalid section type
 	 */
-	public function sections(): array
+	protected static function sectionError(string $name, string $label): array
 	{
-		return $this->sections;
+		return [
+			'label' => $label,
+			'name'  => $name,
+			'text'  => 'The following section types are available: ' . Blueprint::helpList(array_keys(Section::$types)),
+			'theme' => 'negative',
+			'type'  => 'info',
+		];
+	}
+
+	/**
+	 * Converts a single section definition into a field definition.
+	 * Section types with a field equivalent are mapped onto that
+	 * field, all others are wrapped in the `section` field adapter.
+	 */
+	protected static function sectionToField(string $name, array $props): array
+	{
+		$type = $props['type'] ?? $name;
+
+		// `headline` is the deprecated version of `label`
+		if (isset($props['headline']) === true) {
+			$props['label'] ??= $props['headline'];
+			unset($props['headline']);
+		}
+
+		unset($props['type']);
+
+		if (empty($type) === true || is_string($type) === false) {
+			return static::sectionError(
+				$name,
+				'Invalid section type for section "' . $name . '"'
+			);
+		}
+
+		// section type with a field equivalent
+		if ($field = Blueprint::$sectionFields[$type] ?? null) {
+			return [
+				...$props,
+				'name' => $name,
+				'type' => $field
+			];
+		}
+
+		// section type without a field equivalent
+		if (isset(Section::$types[$type]) === true) {
+			return [
+				...$props,
+				'name'    => $name,
+				'section' => $type,
+				'type'    => 'section'
+			];
+		}
+
+		return static::sectionError(
+			$name,
+			'Invalid section type ("' . $type . '")'
+		);
 	}
 
 	/**
@@ -575,5 +601,30 @@ class Normalizer
 	public function tabs(): array
 	{
 		return $this->props['tabs'] ?? [];
+	}
+
+	/**
+	 * Unwraps a `fields` section into its own fields. A `when`
+	 * condition on the section is pushed down onto every field,
+	 * the same way it works for field groups.
+	 */
+	protected static function unwrapFieldsSection(array $props): array
+	{
+		$fields = $props['fields'] ?? [];
+
+		if (is_array($fields) === false) {
+			return [];
+		}
+
+		if (isset($props['when']) === true) {
+			$fields = A::map(
+				$fields,
+				fn ($field) => is_array($field) === true
+					? array_replace_recursive(['when' => $props['when']], $field)
+					: $field
+			);
+		}
+
+		return $fields;
 	}
 }

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -184,10 +184,10 @@ class Core
 			// site blueprints
 			'site' => [
 				'title' => 'Site',
-				'sections' => [
+				'fields' => [
 					'pages' => [
-						'headline' => ['*' => 'pages'],
-						'type'	   => 'pages'
+						'label' => ['*' => 'pages'],
+						'type'	=> 'pagelist'
 					]
 				]
 			]

--- a/tests/Blueprint/BlueprintExtendAndUnsetTest.php
+++ b/tests/Blueprint/BlueprintExtendAndUnsetTest.php
@@ -103,16 +103,16 @@ class BlueprintExtendAndUnsetTest extends TestCase
 		]);
 
 		try {
-			$sections = $blueprint->tab('content')['columns'][0]['sections'];
+			$fields = $blueprint->tab('content')->columns()[0]['fields'];
 		} catch (Exception $e) {
-			$this->assertNull($e->getMessage(), 'Failed to getg sections.');
+			$this->assertNull($e->getMessage(), 'Failed to get fields.');
 		}
 
 		$this->assertSame('extended', $blueprint->title());
-		$this->assertIsArray($sections);
-		$this->assertCount(1, $sections);
-		$this->assertArrayHasKey('pages', $sections);
-		$this->assertArrayNotHasKey('files', $sections);
+		$this->assertIsArray($fields);
+		$this->assertCount(1, $fields);
+		$this->assertArrayHasKey('pages', $fields);
+		$this->assertArrayNotHasKey('files', $fields);
 	}
 
 	public function testExtendAndUnsetFields(): void
@@ -131,7 +131,7 @@ class BlueprintExtendAndUnsetTest extends TestCase
 		]);
 
 		try {
-			$fields = $blueprint->tab('seo')['columns'][0]['sections']['seo-fields']['fields'];
+			$fields = $blueprint->tab('seo')->columns()[0]['fields'];
 		} catch (Exception $e) {
 			$this->assertNull($e->getMessage(), 'Failed to get fields.');
 		}
@@ -161,12 +161,11 @@ class BlueprintExtendAndUnsetTest extends TestCase
 			]
 		]);
 
-		$tab = $blueprint->tab('additional');
+		$columns = $blueprint->tab('additional')->columns();
 
-		$this->assertIsArray($tab);
-		$this->assertCount(1, $tab['columns']);
-		$this->assertArrayHasKey('left', $tab['columns']);
-		$this->assertArrayNotHasKey('right', $tab['columns']);
-		$this->assertSame('1/1', $tab['columns']['left']['width']);
+		$this->assertCount(1, $columns);
+		$this->assertArrayHasKey('left', $columns);
+		$this->assertArrayNotHasKey('right', $columns);
+		$this->assertSame('1/1', $columns['left']['width']);
 	}
 }

--- a/tests/Blueprint/BlueprintFieldReferencesTest.php
+++ b/tests/Blueprint/BlueprintFieldReferencesTest.php
@@ -44,12 +44,12 @@ class BlueprintFieldReferencesTest extends TestCase
 		$this->assertSame('text', $blueprint->fields()['title']['type']);
 		$this->assertSame('date', $blueprint->fields()['date']['type']);
 
-		// Fields should still be wrapped in a section (backwards compatible)
+		// Fields should be placed in the main tab's column
 		$tabs = $blueprint->toArray()['tabs'];
 		$this->assertArrayHasKey('main', $tabs);
-		$sections = $tabs['main']['columns'][0]['sections'];
-		$this->assertArrayHasKey('main-fields', $sections);
-		$this->assertSame('fields', $sections['main-fields']['type']);
+		$fields = $tabs['main']['columns'][0]['fields'];
+		$this->assertArrayHasKey('title', $fields);
+		$this->assertArrayHasKey('date', $fields);
 	}
 
 	public function testFieldReferenceWithExtends(): void
@@ -84,7 +84,7 @@ class BlueprintFieldReferencesTest extends TestCase
 
 		// Field should be resolved with extended properties
 		$tabs = $blueprint->toArray()['tabs'];
-		$sectionFields = $tabs['content']['columns'][0]['sections']['content-fields']['fields'];
+		$sectionFields = $tabs['content']['columns'][0]['fields'];
 		$this->assertArrayHasKey('myField', $sectionFields);
 		$this->assertSame('text', $sectionFields['myField']['type']);
 		$this->assertSame('Custom Text Field', $sectionFields['myField']['label']);
@@ -122,12 +122,12 @@ class BlueprintFieldReferencesTest extends TestCase
 		$columns = $tabs['main']['columns'];
 
 		// First column should have the text field
-		$this->assertArrayHasKey('text', $columns[0]['sections']['main-col-0-fields']['fields']);
-		$this->assertSame('textarea', $columns[0]['sections']['main-col-0-fields']['fields']['text']['type']);
+		$this->assertArrayHasKey('text', $columns[0]['fields']);
+		$this->assertSame('textarea', $columns[0]['fields']['text']['type']);
 
 		// Second column should have the date field
-		$this->assertArrayHasKey('date', $columns[1]['sections']['main-col-1-fields']['fields']);
-		$this->assertSame('date', $columns[1]['sections']['main-col-1-fields']['fields']['date']['type']);
+		$this->assertArrayHasKey('date', $columns[1]['fields']);
+		$this->assertSame('date', $columns[1]['fields']['date']['type']);
 	}
 
 	public function testGlobalFieldsInSections(): void
@@ -151,7 +151,7 @@ class BlueprintFieldReferencesTest extends TestCase
 
 		// Field should be resolved in the section
 		$tabs = $blueprint->toArray()['tabs'];
-		$sectionFields = $tabs['main']['columns'][0]['sections']['content']['fields'];
+		$sectionFields = $tabs['main']['columns'][0]['fields'];
 		$this->assertArrayHasKey('myField', $sectionFields);
 		$this->assertSame('text', $sectionFields['myField']['type']);
 	}
@@ -196,18 +196,16 @@ class BlueprintFieldReferencesTest extends TestCase
 		$tabs = $blueprint->toArray()['tabs'];
 
 		// Content tab should have the text field
-		$contentSections = $tabs['content']['columns'][0]['sections'];
-		$this->assertArrayHasKey('content-fields', $contentSections);
-		$this->assertArrayHasKey('text', $contentSections['content-fields']['fields']);
-		$this->assertSame('textarea', $contentSections['content-fields']['fields']['text']['type']);
+		$contentFields = $tabs['content']['columns'][0]['fields'];
+		$this->assertArrayHasKey('text', $contentFields);
+		$this->assertSame('textarea', $contentFields['text']['type']);
 
 		// Meta tab should have date and author fields
-		$metaSections = $tabs['meta']['columns'][0]['sections'];
-		$this->assertArrayHasKey('meta-fields', $metaSections);
-		$this->assertArrayHasKey('date', $metaSections['meta-fields']['fields']);
-		$this->assertArrayHasKey('author', $metaSections['meta-fields']['fields']);
-		$this->assertSame('date', $metaSections['meta-fields']['fields']['date']['type']);
-		$this->assertSame('users', $metaSections['meta-fields']['fields']['author']['type']);
+		$metaFields = $tabs['meta']['columns'][0]['fields'];
+		$this->assertArrayHasKey('date', $metaFields);
+		$this->assertArrayHasKey('author', $metaFields);
+		$this->assertSame('date', $metaFields['date']['type']);
+		$this->assertSame('users', $metaFields['author']['type']);
 	}
 
 	public function testInlineFieldsExtractedToGlobal(): void
@@ -260,7 +258,7 @@ class BlueprintFieldReferencesTest extends TestCase
 
 		// Field should be present in section
 		$tabs = $blueprint->toArray()['tabs'];
-		$sectionFields = $tabs['content']['columns'][0]['sections']['content-fields']['fields'];
+		$sectionFields = $tabs['content']['columns'][0]['fields'];
 		$this->assertSame('text', $sectionFields['myField']['type']);
 	}
 
@@ -294,7 +292,7 @@ class BlueprintFieldReferencesTest extends TestCase
 
 		// Both fields should be in the tab
 		$tabs = $blueprint->toArray()['tabs'];
-		$sectionFields = $tabs['content']['columns'][0]['sections']['content-fields']['fields'];
+		$sectionFields = $tabs['content']['columns'][0]['fields'];
 		$this->assertArrayHasKey('globalField', $sectionFields);
 		$this->assertArrayHasKey('inlineField', $sectionFields);
 	}
@@ -326,13 +324,13 @@ class BlueprintFieldReferencesTest extends TestCase
 		$tabs = $blueprint->toArray()['tabs'];
 
 		// First tab should have the field
-		$tab1Fields = $tabs['tab1']['columns'][0]['sections']['tab1-fields']['fields'];
+		$tab1Fields = $tabs['tab1']['columns'][0]['fields'];
 		$this->assertArrayHasKey('sharedField', $tab1Fields);
 		$this->assertSame('text', $tab1Fields['sharedField']['type']);
 		$this->assertSame('Shared', $tab1Fields['sharedField']['label']);
 
 		// Second tab should show an error because field is already used
-		$tab2Fields = $tabs['tab2']['columns'][0]['sections']['tab2-fields']['fields'];
+		$tab2Fields = $tabs['tab2']['columns'][0]['fields'];
 		$this->assertArrayHasKey('sharedField', $tab2Fields);
 		$this->assertSame('info', $tab2Fields['sharedField']['type']);
 		$this->assertSame('negative', $tab2Fields['sharedField']['theme']);
@@ -359,7 +357,7 @@ class BlueprintFieldReferencesTest extends TestCase
 
 		// The non-existent field should be converted to an error field
 		$tabs = $blueprint->toArray()['tabs'];
-		$sectionFields = $tabs['content']['columns'][0]['sections']['content-fields']['fields'];
+		$sectionFields = $tabs['content']['columns'][0]['fields'];
 
 		$this->assertArrayHasKey('nonExistentField', $sectionFields);
 		$this->assertSame('info', $sectionFields['nonExistentField']['type']);

--- a/tests/Blueprint/BlueprintTest.php
+++ b/tests/Blueprint/BlueprintTest.php
@@ -88,23 +88,25 @@ class BlueprintTest extends TestCase
 				'columns' => [
 					[
 						'width' => '1/3',
-						'sections' => [
+						'fields' => [
 							'main-info-0' => [
 								'label' => 'Column (1/3)',
 								'type'  => 'info',
-								'text'  => 'No sections yet',
-								'name'  => 'main-info-0'
+								'text'  => 'No fields yet',
+								'name'  => 'main-info-0',
+								'width' => '1/1'
 							]
 						]
 					],
 					[
 						'width' => '2/3',
-						'sections' => [
+						'fields' => [
 							'main-info-1' => [
 								'label' => 'Column (2/3)',
 								'type'  => 'info',
-								'text'  => 'No sections yet',
-								'name'  => 'main-info-1'
+								'text'  => 'No fields yet',
+								'name'  => 'main-info-1',
+								'width' => '1/1'
 							]
 						]
 					]
@@ -158,22 +160,18 @@ class BlueprintTest extends TestCase
 		$this->assertSame($expected, $blueprint->__debugInfo());
 	}
 
-	public function testSectionsToColumns(): void
+	public function testSectionsToFields(): void
 	{
-		$sections = [
-			'pages' => [
-				'name' => 'pages',
-				'type' => 'pages'
-			],
-			'files' => [
-				'name' => 'files',
-				'type' => 'files'
-			]
-		];
-
 		$blueprint = new Blueprint([
 			'model'    => $this->model,
-			'sections' => $sections
+			'sections' => [
+				'pages' => [
+					'type' => 'pages'
+				],
+				'files' => [
+					'type' => 'files'
+				]
+			]
 		]);
 
 		$expected = [
@@ -182,8 +180,21 @@ class BlueprintTest extends TestCase
 				'label'   => 'Main',
 				'columns' => [
 					[
-						'width'    => '1/1',
-						'sections' => $sections
+						'width'  => '1/1',
+						'fields' => [
+							'pages' => [
+								'label' => 'Pages',
+								'name'  => 'pages',
+								'type'  => 'pagelist',
+								'width' => '1/1'
+							],
+							'files' => [
+								'label' => 'Files',
+								'name'  => 'files',
+								'type'  => 'filelist',
+								'width' => '1/1'
+							]
+						]
 					]
 				],
 				'icon'    => null,
@@ -194,7 +205,122 @@ class BlueprintTest extends TestCase
 		$this->assertEquals($expected, $blueprint->toArray()['tabs']); // cannot use strict assertion (array order)
 	}
 
-	public function testFieldsToSections(): void
+	public function testSectionsToFieldsWithHeadline(): void
+	{
+		$blueprint = new Blueprint([
+			'model'    => $this->model,
+			'sections' => [
+				'pages' => [
+					'headline' => 'My pages',
+					'type'     => 'pages'
+				]
+			]
+		]);
+
+		$field = $blueprint->field('pages');
+
+		$this->assertSame('pagelist', $field['type']);
+		$this->assertSame('My pages', $field['label']);
+		$this->assertArrayNotHasKey('headline', $field);
+	}
+
+	public function testSectionsToFieldsWithCustomType(): void
+	{
+		$this->app = $this->app->clone([
+			'sections' => [
+				'test' => []
+			]
+		]);
+
+		$blueprint = new Blueprint([
+			'model'    => $this->model,
+			'sections' => [
+				'mysection' => [
+					'type' => 'test'
+				]
+			]
+		]);
+
+		$field = $blueprint->field('mysection');
+
+		$this->assertSame('section', $field['type']);
+		$this->assertSame('test', $field['section']);
+	}
+
+	public function testSectionsToFieldsWithUnknownType(): void
+	{
+		$blueprint = new Blueprint([
+			'model'    => $this->model,
+			'sections' => [
+				'mysection' => [
+					'type' => 'does-not-exist'
+				]
+			]
+		]);
+
+		$field = $blueprint->field('mysection');
+
+		$this->assertSame('info', $field['type']);
+		$this->assertSame('negative', $field['theme']);
+		$this->assertSame('Invalid section type ("does-not-exist")', $field['label']);
+		$this->assertStringStartsWith(
+			'The following section types are available:',
+			$field['text']
+		);
+	}
+
+	public function testFieldsSectionWithWhen(): void
+	{
+		$blueprint = new Blueprint([
+			'model'    => $this->model,
+			'sections' => [
+				'mysection' => [
+					'type'   => 'fields',
+					'when'   => ['toggle' => true],
+					'fields' => [
+						'a' => [
+							'type' => 'text'
+						],
+						'b' => [
+							'type' => 'text',
+							'when' => ['other' => true]
+						]
+					]
+				]
+			]
+		]);
+
+		// the condition of the section is pushed down onto its fields
+		$this->assertSame(['toggle' => true], $blueprint->field('a')['when']);
+
+		// while an own condition of a field wins
+		$this->assertSame(
+			['toggle' => true, 'other' => true],
+			$blueprint->field('b')['when']
+		);
+	}
+
+	public function testFieldsSectionWithInvalidFields(): void
+	{
+		$blueprint = new Blueprint([
+			'model'    => $this->model,
+			'sections' => [
+				'mysection' => [
+					'type'   => 'fields',
+					'fields' => 'nonsense'
+				]
+			]
+		]);
+
+		$fields = $blueprint->tab('main')->columns()[0]['fields'];
+
+		// the section is unwrapped into no fields at all,
+		// which leaves the column with the guide field
+		$this->assertSame(['main-info-0'], array_keys($fields));
+		$this->assertSame('No fields yet', $fields['main-info-0']['text']);
+	}
+
+	public function testFieldsToColumns(): void
 	{
 		$fields = [
 			'headline' => [
@@ -216,14 +342,8 @@ class BlueprintTest extends TestCase
 				'label'   => 'Main',
 				'columns' => [
 					[
-						'width'    => '1/1',
-						'sections' => [
-							'main-fields' => [
-								'name'   => 'main-fields',
-								'type'   => 'fields',
-								'fields' => $fields
-							]
-						]
+						'width'  => '1/1',
+						'fields' => $fields
 					]
 				],
 				'icon'    => null,
@@ -537,16 +657,16 @@ class BlueprintTest extends TestCase
 		]);
 
 		try {
-			$sections = $blueprint->tab('main')['columns'][0]['sections'];
+			$fields = $blueprint->tab('main')->columns()[0]['fields'];
 		} catch (Exception $e) {
-			$this->assertNull($e->getMessage(), 'Failed to get sections.');
+			$this->assertNull($e->getMessage(), 'Failed to get fields.');
 		}
 
-		$this->assertIsArray($sections);
-		$this->assertCount(1, $sections);
-		$this->assertArrayHasKey('main', $sections);
-		$this->assertArrayHasKey('label', $sections['main']);
-		$this->assertSame('Invalid section type for section "main"', $sections['main']['label']);
+		$this->assertIsArray($fields);
+		$this->assertCount(1, $fields);
+		$this->assertArrayHasKey('main', $fields);
+		$this->assertSame('info', $fields['main']['type']);
+		$this->assertSame('Invalid section type for section "main"', $fields['main']['label']);
 	}
 
 	public function testIsDefault(): void
@@ -570,7 +690,7 @@ class BlueprintTest extends TestCase
 			]
 		]);
 
-		$this->assertSame('info', $blueprint->sections()['info']->type());
+		$this->assertSame('info', $blueprint->field('info')['type']);
 
 		// by just passing true
 		$blueprint = new Blueprint([
@@ -580,7 +700,7 @@ class BlueprintTest extends TestCase
 			]
 		]);
 
-		$this->assertSame('info', $blueprint->sections()['info']->type());
+		$this->assertSame('info', $blueprint->field('info')['type']);
 	}
 
 	public function testSectionFromField(): void
@@ -597,6 +717,26 @@ class BlueprintTest extends TestCase
 		]);
 
 		$this->assertSame('info', $blueprint->section('info')->type());
+	}
+
+	public function testSectionIsCached(): void
+	{
+		$blueprint = new Blueprint([
+			'model'  => $this->model,
+			'fields' => [
+				'info' => [
+					'type'    => 'section',
+					'section' => 'info'
+				]
+			]
+		]);
+
+		// the section object is only created once
+		$this->assertSame($blueprint->section('info'), $blueprint->section('info'));
+
+		// the same applies to sections that cannot be found
+		$this->assertNull($blueprint->section('does-not-exist'));
+		$this->assertNull($blueprint->section('does-not-exist'));
 	}
 
 	public function testSectionFromFieldWithDifferentName(): void
@@ -729,18 +869,19 @@ class BlueprintTest extends TestCase
 		);
 	}
 
-	public function testSectionFromFieldWithSectionOfSameName(): void
+	public function testSectionAndFieldOfSameName(): void
 	{
 		$blueprint = new Blueprint([
 			'model'    => $this->model,
-			'fields'   => [
-				'info' => [
-					'type'    => 'section',
-					'section' => 'info',
-					'text'    => 'From the field'
-				]
-			],
 			'sections' => [
+				'fields' => [
+					'type'   => 'fields',
+					'fields' => [
+						'info' => [
+							'type' => 'text'
+						]
+					]
+				],
 				'info' => [
 					'type' => 'info',
 					'text' => 'From the section'
@@ -748,10 +889,15 @@ class BlueprintTest extends TestCase
 			]
 		]);
 
-		// the section definition takes precedence over the field
+		// sections and fields share a single namespace, so the
+		// second definition is replaced by a duplicate name error
+		$field = $blueprint->field('info');
+
+		$this->assertSame('info', $field['type']);
+		$this->assertSame('negative', $field['theme']);
 		$this->assertSame(
-			'<p>From the section</p>',
-			trim($blueprint->section('info')->toArray()['text'])
+			'The field <strong>"info"</strong> already exists in your blueprint',
+			$field['text']
 		);
 	}
 
@@ -778,9 +924,9 @@ class BlueprintTest extends TestCase
 
 		$sections = $blueprint->sections();
 
-		// the fields section and both section fields
+		// only the section fields, the regular field is not a section
 		$this->assertSame(
-			['main-fields', 'drafts', 'listed'],
+			['drafts', 'listed'],
 			array_keys($sections)
 		);
 

--- a/tests/Blueprint/NormalizerTest.php
+++ b/tests/Blueprint/NormalizerTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Blueprint;
 
 use Kirby\Cms\App;
-use Kirby\Cms\ModelWithContent;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\TestCase;
 use Kirby\Toolkit\I18n;
@@ -13,8 +12,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 class NormalizerTest extends TestCase
 {
 	public const string TMP = KIRBY_TMP_DIR . '/Blueprint.Normalizer';
-
-	protected ModelWithContent $model;
 
 	protected function setUp(): void
 	{
@@ -26,7 +23,6 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$this->model = $this->app->page('a');
 		$this->setUpTmp();
 	}
 
@@ -41,13 +37,10 @@ class NormalizerTest extends TestCase
 
 	protected function normalizer(array $props = []): Normalizer
 	{
-		return new Normalizer(
-			model: $this->model,
-			props: $props
-		);
+		return new Normalizer(props: $props);
 	}
 
-	public function testColumnsWithEmptySections(): void
+	public function testColumnsWithEmptyFields(): void
 	{
 		$normalizer = $this->normalizer([
 			'columns' => [
@@ -61,16 +54,18 @@ class NormalizerTest extends TestCase
 		$this->assertSame([
 			'label' => 'Column (1/3)',
 			'type'  => 'info',
-			'text'  => 'No sections yet',
-			'name'  => 'main-info-0'
-		], $columns[0]['sections']['main-info-0']);
+			'text'  => 'No fields yet',
+			'name'  => 'main-info-0',
+			'width' => '1/1'
+		], $columns[0]['fields']['main-info-0']);
 
 		$this->assertSame([
 			'label' => 'Column (2/3)',
 			'type'  => 'info',
-			'text'  => 'No sections yet',
-			'name'  => 'main-info-1'
-		], $columns[1]['sections']['main-info-1']);
+			'text'  => 'No fields yet',
+			'name'  => 'main-info-1',
+			'width' => '1/1'
+		], $columns[1]['fields']['main-info-1']);
 	}
 
 	public function testColumnsWithFields(): void
@@ -86,11 +81,10 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$sections = $normalizer->tabs()['main']['columns'][0]['sections'];
+		$fields = $normalizer->tabs()['main']['columns'][0]['fields'];
 
-		$this->assertArrayHasKey('main-col-0-fields', $sections);
-		$this->assertSame('fields', $sections['main-col-0-fields']['type']);
-		$this->assertArrayHasKey('title', $sections['main-col-0-fields']['fields']);
+		$this->assertArrayHasKey('title', $fields);
+		$this->assertSame('text', $fields['title']['type']);
 	}
 
 	public function testColumnsWithInvalidColumn(): void
@@ -111,7 +105,7 @@ class NormalizerTest extends TestCase
 	{
 		$normalizer = $this->normalizer([
 			'columns' => [
-				['sections' => ['info' => ['type' => 'info']]]
+				['fields' => ['info' => ['type' => 'info']]]
 			]
 		]);
 
@@ -133,7 +127,7 @@ class NormalizerTest extends TestCase
 		$this->assertSame(['main'], array_keys($normalizer->tabs()));
 	}
 
-	public function testConvertFieldsToSections(): void
+	public function testConvertFieldsToColumns(): void
 	{
 		$normalizer = $this->normalizer([
 			'fields' => [
@@ -143,13 +137,14 @@ class NormalizerTest extends TestCase
 
 		$this->assertArrayNotHasKey('fields', $normalizer->props());
 
-		$sections = $normalizer->sections();
+		$columns = $normalizer->tabs()['main']['columns'];
 
-		$this->assertSame(['main-fields'], array_keys($sections));
-		$this->assertSame('fields', $sections['main-fields']['type']);
+		$this->assertCount(1, $columns);
+		$this->assertSame('1/1', $columns[0]['width']);
+		$this->assertSame(['title'], array_keys($columns[0]['fields']));
 	}
 
-	public function testConvertSectionsToColumns(): void
+	public function testConvertSectionsToFields(): void
 	{
 		$normalizer = $this->normalizer([
 			'sections' => [
@@ -163,7 +158,7 @@ class NormalizerTest extends TestCase
 
 		$this->assertCount(1, $columns);
 		$this->assertSame('1/1', $columns[0]['width']);
-		$this->assertSame(['pages'], array_keys($columns[0]['sections']));
+		$this->assertSame(['pages'], array_keys($columns[0]['fields']));
 	}
 
 	public function testFieldReference(): void
@@ -572,16 +567,19 @@ class NormalizerTest extends TestCase
 		$normalizer = $this->normalizer([
 			'sections' => [
 				'pages' => ['type' => 'pages'],
-				'files' => ['type' => 'files']
+				'files' => ['type' => 'files'],
+				'notes' => ['type' => 'pages', 'status' => 'listed']
 			]
 		]);
 
-		$this->assertSame(['pages', 'files'], array_keys($normalizer->sections()));
-	}
+		$fields = $normalizer->fields();
 
-	public function testSectionsEmpty(): void
-	{
-		$this->assertSame([], $this->normalizer()->sections());
+		$this->assertSame(['pages', 'files', 'notes'], array_keys($fields));
+
+		// section types with a field equivalent are mapped onto that field
+		$this->assertSame('pagelist', $fields['pages']['type']);
+		$this->assertSame('filelist', $fields['files']['type']);
+		$this->assertSame('listed', $fields['notes']['status']);
 	}
 
 	public function testSectionsWithFalse(): void
@@ -593,7 +591,22 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$this->assertSame(['pages'], array_keys($normalizer->sections()));
+		$this->assertSame(['pages'], array_keys($normalizer->fields()));
+	}
+
+	public function testSectionsWithFieldsType(): void
+	{
+		$normalizer = $this->normalizer([
+			'sections' => [
+				'content' => [
+					'type'   => 'fields',
+					'fields' => ['title' => ['type' => 'text']]
+				]
+			]
+		]);
+
+		// a fields section is unwrapped into the parent's own fields
+		$this->assertSame(['title'], array_keys($normalizer->fields()));
 	}
 
 	public function testSectionsWithInvalidType(): void
@@ -604,12 +617,12 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$section = $normalizer->sections()['test'];
+		$field = $normalizer->fields()['test'];
 
-		$this->assertSame('info', $section['type']);
+		$this->assertSame('info', $field['type']);
 		$this->assertSame(
 			'Invalid section type for section "test"',
-			$section['label']
+			$field['label']
 		);
 	}
 
@@ -621,7 +634,7 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$this->assertSame('pages', $normalizer->sections()['pages']['type']);
+		$this->assertSame('pagelist', $normalizer->fields()['pages']['type']);
 	}
 
 	public function testSectionsWithTypeFromName(): void
@@ -632,7 +645,7 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$this->assertSame('pages', $normalizer->sections()['pages']['type']);
+		$this->assertSame('pagelist', $normalizer->fields()['pages']['type']);
 	}
 
 	public function testSectionsWithUnknownType(): void
@@ -643,10 +656,10 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$section = $normalizer->sections()['test'];
+		$field = $normalizer->fields()['test'];
 
-		$this->assertSame('info', $section['type']);
-		$this->assertSame('Invalid section type ("nonsense")', $section['label']);
+		$this->assertSame('info', $field['type']);
+		$this->assertSame('Invalid section type ("nonsense")', $field['label']);
 	}
 
 	public function testSectionsWithoutFields(): void
@@ -658,12 +671,12 @@ class NormalizerTest extends TestCase
 		]);
 
 		$this->assertSame([
-			'main-info' => [
-				'label' => 'Fields',
-				'text'  => 'No fields yet',
-				'type'  => 'info'
-			]
-		], $normalizer->sections()['content']['fields']);
+			'label' => 'Column (1/1)',
+			'type'  => 'info',
+			'text'  => 'No fields yet',
+			'name'  => 'main-info-0',
+			'width' => '1/1'
+		], $normalizer->fields()['main-info-0']);
 	}
 
 	public function testTabs(): void

--- a/tests/Panel/Controller/Dialog/SectionDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/SectionDialogControllerTest.php
@@ -48,9 +48,12 @@ class SectionDialogControllerTest extends TestCase
 			'blueprints' => [
 				'pages/default' => [
 					'sections' => [
-						'test' => 'info'
+						'test' => ['type' => 'test']
 					]
 				]
+			],
+			'sections' => [
+				'test' => []
 			]
 		]);
 
@@ -86,9 +89,12 @@ class SectionDialogControllerTest extends TestCase
 			'blueprints' => [
 				'files/default' => [
 					'sections' => [
-						'test' => 'info'
+						'test' => ['type' => 'test']
 					]
 				]
+			],
+			'sections' => [
+				'test' => []
 			]
 		]);
 

--- a/tests/Panel/Controller/Drawer/SectionDrawerControllerTest.php
+++ b/tests/Panel/Controller/Drawer/SectionDrawerControllerTest.php
@@ -47,9 +47,12 @@ class SectionDrawerControllerTest extends TestCase
 			'blueprints' => [
 				'pages/default' => [
 					'sections' => [
-						'test' => 'info'
+						'test' => ['type' => 'test']
 					]
 				]
+			],
+			'sections' => [
+				'test' => []
 			]
 		]);
 
@@ -85,9 +88,12 @@ class SectionDrawerControllerTest extends TestCase
 			'blueprints' => [
 				'files/default' => [
 					'sections' => [
-						'test' => 'info'
+						'test' => ['type' => 'test']
 					]
 				]
+			],
+			'sections' => [
+				'test' => []
 			]
 		]);
 


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

> [!NOTE]
> It's ok that the unit tests are failing. The PR is a temporary step, to be easier to review. The unit test issues are solved later.

## Description

Sections are a legacy concept in blueprints from now on. The Normalizer converts every section definition into a field definition: a `fields` section is unwrapped into the fields of its parent, section types with a field equivalent are mapped onto that field and all remaining types are wrapped in the `section` field adapter. Sections and fields share a single namespace, which is why duplicate names are turned into an error field.

Columns hold fields instead of sections as a result and `Blueprint::sections()` only collects the sections of `section` fields.

Consumers that still resolve sections are converted in the following commits.

### Note

When we remove sections in the [remove sections] stack, this will change again and the section field will be removed as well, but this temporary step still reads easier at this point. 

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### ✨ Enhancements

- Sections in blueprint definitions are automatically converted to the matching field types

### ♻️ Refactored

- The default site blueprint now uses the `pagelist` field instead of a `pages` section. 

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
