### PR TITLE
[sections 2 fields] #10 refact: Collect accepted file templates from fields

### DIFF
--- a/src/Blueprint/AcceptRules.php
+++ b/src/Blueprint/AcceptRules.php
@@ -3,6 +3,8 @@
 namespace Kirby\Blueprint;
 
 use Kirby\Cms\App;
+use Kirby\Form\Field;
+use Kirby\Form\Mixin\Upload;
 
 /**
  * The AcceptRules class goes through all blueprint settings for
@@ -25,41 +27,24 @@ class AcceptRules
 	 * Gathers what file templates are allowed in
 	 * this model based on the blueprint
 	 */
-	public function fileTemplates(string|null $inSection = null): array
+	public function fileTemplates(string|null $inField = null): array
 	{
 		// get cached results for the current file model
-		// (except when collecting for a specific section)
-		if ($inSection === null && $this->fileTemplates !== null) {
+		// (except when collecting for a specific field)
+		if ($inField === null && $this->fileTemplates !== null) {
 			return $this->fileTemplates; // @codeCoverageIgnore
 		}
 
-		$templates = [];
-
 		// collect all allowed file templates from blueprint…
-		foreach ($this->blueprint->sections() as $section) {
-			// if collecting for a specific section, skip all others
-			if ($inSection !== null && $section->name() !== $inSection) {
-				continue;
-			}
+		$fields = match ($inField) {
+			null    => $this->blueprint->fields(),
+			default => array_filter([$this->blueprint->field($inField)])
+		};
 
-			$template  = $section->template();
-			$templates = match ($section->type()) {
-				'files'  => [
-					...$templates,
-					...($template
-						? [$template]
-						: App::instance()->blueprints('files'))
-				],
-				'fields' => [
-					...$templates,
-					...$this->fileTemplatesFromFields($section->fields())
-				],
-				default  => $templates
-			};
-		}
+		$templates = $this->fileTemplatesFromFields($fields);
 
-		// no caching for when collecting for specific section
-		if ($inSection !== null) {
+		// no caching for when collecting for a specific field
+		if ($inField !== null) {
 			return $templates; // @codeCoverageIgnore
 		}
 
@@ -74,11 +59,31 @@ class AcceptRules
 		$templates = [];
 
 		foreach ($fields as $field) {
-			// fields with uploads settings
-			if (isset($field['uploads']) === true && is_array($field['uploads']) === true) {
+			// file lists accept uploads for their own template
+			if (($field['type'] ?? null) === 'filelist') {
+				$template  = $field['template'] ?? null;
 				$templates = [
 					...$templates,
-					...$this->fileTemplatesFromFieldUploads($field['uploads'])
+					...($template
+						? [$template]
+						: App::instance()->blueprints('files'))
+				];
+				continue;
+			}
+
+			// fields that support uploads. The blueprint props are not
+			// normalized yet, so the string shortcut and the default
+			// settings have to be resolved here as well
+			$uploads = $field['uploads'] ?? null;
+
+			if ($uploads !== false && $this->supportsUploads($field['type'] ?? null) === true) {
+				$templates = [
+					...$templates,
+					...$this->fileTemplatesFromFieldUploads(match (true) {
+						is_string($uploads) => ['template' => $uploads],
+						is_array($uploads)  => $uploads,
+						default             => []
+					})
 				];
 				continue;
 			}
@@ -113,7 +118,13 @@ class AcceptRules
 		$templates = [];
 
 		foreach ($fieldsets as $fieldset) {
-			foreach (($fieldset['tabs'] ?? []) as $tab) {
+			// the blueprint props are not normalized yet, so a fieldset
+			// can still use the `fields` shortcut instead of tabs
+			$tabs = $fieldset['tabs'] ?? [
+				['fields' => $fieldset['fields'] ?? []]
+			];
+
+			foreach ($tabs as $tab) {
 				$templates = [
 					...$templates,
 					...$this->fileTemplatesFromFields($tab['fields'] ?? [])
@@ -122,6 +133,27 @@ class AcceptRules
 		}
 
 		return $templates;
+	}
+
+	/**
+	 * Checks if a field type supports file uploads
+	 * @since 6.0.0
+	 */
+	protected function supportsUploads(string|null $type): bool
+	{
+		$class = Field::$types[$type] ?? null;
+
+		if (is_string($class) === false || class_exists($class) === false) {
+			return false;
+		}
+
+		$traits = [];
+
+		for ($parent = $class; $parent !== false; $parent = get_parent_class($parent)) {
+			$traits = [...$traits, ...(class_uses($parent) ?: [])];
+		}
+
+		return isset($traits[Upload::class]);
 	}
 
 	/**

--- a/src/Blueprint/Blueprint.php
+++ b/src/Blueprint/Blueprint.php
@@ -116,9 +116,9 @@ class Blueprint
 	 * Gathers what file templates are allowed in
 	 * this model based on the blueprint
 	 */
-	public function acceptedFileTemplates(string|null $inSection = null): array
+	public function acceptedFileTemplates(string|null $inField = null): array
 	{
-		return $this->acceptRules()->fileTemplates($inSection);
+		return $this->acceptRules()->fileTemplates($inField);
 	}
 
 	/**

--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -162,20 +162,20 @@ class File extends ModelWithContent
 
 	/**
 	 * Returns an array with all blueprints that are available for the file
-	 * by comparing files sections and files fields of the parent model
+	 * by comparing the file list fields of the parent model
 	 */
-	public function blueprints(string|null $inSection = null): array
+	public function blueprints(string|null $inField = null): array
 	{
 		// get cached results for the current file model
-		// (except when collecting for a specific section)
-		if ($inSection === null && $this->blueprints !== null) {
+		// (except when collecting for a specific field)
+		if ($inField === null && $this->blueprints !== null) {
 			return $this->blueprints; // @codeCoverageIgnore
 		}
 
 		// always include the current template as option
 		$templates = [
 			$this->template() ?? 'default',
-			...$this->parent()->blueprint()->acceptedFileTemplates($inSection)
+			...$this->parent()->blueprint()->acceptedFileTemplates($inField)
 		];
 
 		// make sure every template is only included once
@@ -221,8 +221,8 @@ class File extends ModelWithContent
 			default => strnatcmp($a['title'], $b['title'])
 		});
 
-		// no caching for when collecting for specific section
-		if ($inSection !== null) {
+		// no caching for when collecting for a specific field
+		if ($inField !== null) {
 			return $blueprints; // @codeCoverageIgnore
 		}
 

--- a/tests/Blueprint/AcceptRulesTest.php
+++ b/tests/Blueprint/AcceptRulesTest.php
@@ -107,6 +107,38 @@ class AcceptRulesTest extends BlueprintTest
 		$this->assertSame(['a', 'b', 'c', 'd', 'e'], $rules->fileTemplates());
 	}
 
+	public function testFileTemplatesFromFieldsWithUnknownType(): void
+	{
+		$blueprint = new Blueprint([
+			'model'  => $this->model,
+			'name'   => 'default',
+			'fields' => [
+				'blocks' => [
+					'type'      => 'blocks',
+					'fieldsets' => [
+						'text' => [
+							'fields' => [
+								// fieldsets are not normalized, so the field
+								// type can be anything at this point
+								'text' => [
+									'type'    => 'does-not-exist',
+									'uploads' => [
+										'template' => 'a'
+									]
+								]
+							]
+						]
+					]
+				]
+			]
+		]);
+
+		$rules = new AcceptRules($blueprint);
+
+		// a field type that cannot be resolved does not support uploads
+		$this->assertSame([], $rules->fileTemplates());
+	}
+
 	public function testFileTemplatesFromFieldsWithDifferentParent(): void
 	{
 		$this->app = $this->app->clone([

--- a/tests/Cms/File/FileBlueprintsTest.php
+++ b/tests/Cms/File/FileBlueprintsTest.php
@@ -138,7 +138,7 @@ class FileBlueprintsTest extends ModelTestCase
 		$this->assertSame('for-section/b', $blueprints[8]['name']);
 	}
 
-	public function testBlueprintsInSection(): void
+	public function testBlueprintsInField(): void
 	{
 		$this->app = $this->app->clone([
 			'blueprints' => [
@@ -155,27 +155,27 @@ class FileBlueprintsTest extends ModelTestCase
 						'section-c' => [
 							'type' => 'fields',
 							'fields' => [
-								[
+								'field-a' => [
 									'type' => 'files'
 								],
-								[
+								'field-b' => [
 									'type'    => 'files',
 									'uploads' => 'for-fields/a'
 								],
-								[
+								'field-c' => [
 									'type'    => 'files',
 									'uploads' => [
 										'template' => 'for-fields/b'
 									]
 								],
-								[
+								'field-d' => [
 									'type'    => 'files',
 									'uploads' => [
 										'parent'   => 'site',
 										'template' => 'for-fields/c'
 									]
 								],
-								[
+								'field-e' => [
 									'type'    => 'files',
 									'uploads' => 'for-fields/c'
 								]
@@ -216,16 +216,32 @@ class FileBlueprintsTest extends ModelTestCase
 			'parent'   => $page
 		]);
 
+		// a files section is converted into a file list field
 		$blueprints = $file->blueprints('section-a');
 		$this->assertCount(2, $blueprints);
 		$this->assertSame('current', $blueprints[0]['name']);
 		$this->assertSame('for-section/a', $blueprints[1]['name']);
 
-		$blueprints = $file->blueprints('section-c');
-		$this->assertCount(4, $blueprints);
+		// a fields section is unwrapped, so its fields
+		// have to be addressed individually
+		$blueprints = $file->blueprints('field-a');
+		$this->assertCount(2, $blueprints);
 		$this->assertSame('default', $blueprints[0]['name']);
-		$this->assertSame('for-fields/a', $blueprints[1]['name']);
-		$this->assertSame('for-fields/b', $blueprints[2]['name']);
-		$this->assertSame('current', $blueprints[3]['name']);
+		$this->assertSame('current', $blueprints[1]['name']);
+
+		$blueprints = $file->blueprints('field-b');
+		$this->assertCount(2, $blueprints);
+		$this->assertSame('for-fields/a', $blueprints[0]['name']);
+		$this->assertSame('current', $blueprints[1]['name']);
+
+		$blueprints = $file->blueprints('field-c');
+		$this->assertCount(2, $blueprints);
+		$this->assertSame('for-fields/b', $blueprints[0]['name']);
+		$this->assertSame('current', $blueprints[1]['name']);
+
+		// the uploads parent is not this model
+		$blueprints = $file->blueprints('field-d');
+		$this->assertCount(1, $blueprints);
+		$this->assertSame('current', $blueprints[0]['name']);
 	}
 }


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [ ] Design & concept
- [ ] Rough pass
- [x] Deep read
- [x] Security check

> [!NOTE]
> It's ok that the unit tests are failing. The PR is a temporary step, to be easier to review. The unit test issues are solved later.

## Description

The AcceptRules no longer walk through the sections of a blueprint. File lists accept uploads for their own template and all other fields are checked for the upload mixin instead. Since the props are not normalized at this point, the `uploads` string shortcut and the `fields` shortcut of fieldsets have to be resolved on the way.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### 🚨 Breaking changes

- The `$inSection` argument in `Kirby\Blueprint\AcceptRules::fileTemplates()`, `Kirby\Blueprint\Blueprint::acceptedFileTemplates()` and `Kirby\Cms\File::blueprints()` is renamed to `$inField`

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
