### PR TITLE
[sections 2 fields] #11 refact: Collect the blueprints of a model from its fields

### DIFF
--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -18,6 +18,7 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Form\Fields;
 use Kirby\Form\Form;
+use Kirby\Form\Interface\ProvidesAcceptedBlueprints;
 use Kirby\Panel\Model as PanelModel;
 use Kirby\Toolkit\BlockCollectionAccess;
 use Kirby\Toolkit\HtmlString;
@@ -80,18 +81,14 @@ abstract class ModelWithContent extends Model implements Identifiable
 	/**
 	 * Returns an array with all blueprints that are available
 	 */
-	public function blueprints(string|null $inSection = null): array
+	public function blueprints(string|null $inField = null): array
 	{
 		// helper function
-		$toBlueprints = static function (array $sections): array {
+		$toBlueprints = static function (iterable $fields): array {
 			$blueprints = [];
 
-			foreach ($sections as $section) {
-				if ($section === null) {
-					continue;
-				}
-
-				foreach ((array)$section->blueprints() as $blueprint) {
+			foreach ($fields as $field) {
+				foreach ($field->blueprints() as $blueprint) {
 					$blueprints[$blueprint['name']] = $blueprint;
 				}
 			}
@@ -99,14 +96,20 @@ abstract class ModelWithContent extends Model implements Identifiable
 			return array_values($blueprints);
 		};
 
-		$blueprint = $this->blueprint();
+		$fields = Fields::for($this);
 
-		// no caching for when collecting for specific section
-		if ($inSection !== null) {
-			return $toBlueprints([$blueprint->section($inSection)]);
+		// no caching for when collecting for a specific field
+		if ($inField !== null) {
+			$field = $fields->get($inField);
+
+			return $toBlueprints(
+				$field instanceof ProvidesAcceptedBlueprints ? [$field] : []
+			);
 		}
 
-		return $this->blueprints ??= $toBlueprints($blueprint->sections());
+		return $this->blueprints ??= $toBlueprints(
+			$fields->filter(fn ($field) => $field instanceof ProvidesAcceptedBlueprints)
+		);
 	}
 
 	/**

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -88,8 +88,10 @@ abstract class ModelWithContent extends Model implements Identifiable
 			$blueprints = [];
 
 			foreach ($fields as $field) {
-				foreach ($field->blueprints() as $blueprint) {
-					$blueprints[$blueprint['name']] = $blueprint;
+				if ($field instanceof ProvidesAcceptedBlueprints) {
+					foreach ($field->blueprints() as $blueprint) {
+						$blueprints[$blueprint['name']] = $blueprint;
+					}
 				}
 			}
 
@@ -100,16 +102,10 @@ abstract class ModelWithContent extends Model implements Identifiable
 
 		// no caching for when collecting for a specific field
 		if ($inField !== null) {
-			$field = $fields->get($inField);
-
-			return $toBlueprints(
-				$field instanceof ProvidesAcceptedBlueprints ? [$field] : []
-			);
+			return $toBlueprints([$fields->get($inField)]);
 		}
 
-		return $this->blueprints ??= $toBlueprints(
-			$fields->filter(fn ($field) => $field instanceof ProvidesAcceptedBlueprints)
-		);
+		return $this->blueprints ??= $toBlueprints($fields);
 	}
 
 	/**

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -216,10 +216,10 @@ class Page extends ModelWithContent
 	/**
 	 * Returns an array with all blueprints that are available for the page
 	 */
-	public function blueprints(string|null $inSection = null): array
+	public function blueprints(string|null $inField = null): array
 	{
-		if ($inSection !== null) {
-			return $this->blueprint()->section($inSection)->blueprints();
+		if ($inField !== null) {
+			return parent::blueprints($inField);
 		}
 
 		if ($this->blueprints !== null) {


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [ ] Design & concept
- [ ] Rough pass
- [x] Deep read
- [x] Security check

> [!NOTE]
> It's ok that the unit tests are failing. The PR is a temporary step, to be easier to review. The unit test issues are solved later.

## Description

Available blueprints for pages and files are no longer gathered from the sections of the blueprint, but from all fields that provide accepted blueprints. Fields are addressed by their own name, which also applies to the fields of a former `fields` section.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### 🚨 Breaking changes

- The `$inSection` argument in `Kirby\Cms\ModelWithContent::blueprints()` and `Kirby\Cms\Page::blueprints()` has been renamed to `$inField`

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
