### PR TITLE
[sections 2 fields] #12 refact: Validate model errors with the form

### DIFF
--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -294,20 +294,7 @@ abstract class ModelWithContent extends Model implements Identifiable
 	 */
 	public function errors(): array
 	{
-		$errors = [];
-
-		foreach ($this->blueprint()->sections() as $section) {
-			// sections that are wrapped in a `section` field are
-			// validated as part of the form, where `when` conditions
-			// can be evaluated against the other fields
-			if ($section->field() !== null) {
-				continue;
-			}
-
-			$errors = [...$errors, ...$section->errors()];
-		}
-
-		return $errors;
+		return Form::for($this)->errors();
 	}
 
 	/**


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [ ] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

> [!NOTE]
> It's ok that the unit tests are failing. The PR is a temporary step, to be easier to review. The unit test issues are solved later.

## Description
<!--
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.

You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR.

If something is deliberately out of scope, say so here.
-->

All sections are fields now, which means that the entire model can be validated by its form. This also evaluates `when` conditions against the other fields, which was not possible for standalone sections.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### ♻️ Refactored

- `Kirby\Cms\ModelWithContent::errors()` will now only collect errors from fields

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
