### PR TITLE
[sections 2 fields] #13 refact: Validate page moves against page list fields

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -279,12 +279,6 @@
       <code><![CDATA[pattern]]></code>
     </UndefinedMethod>
   </file>
-  <file src="src/Guards/PageValidators.php">
-    <RedundantCondition>
-      <code><![CDATA[$allowed !== []]]></code>
-      <code><![CDATA[$allowed !== []]]></code>
-    </RedundantCondition>
-  </file>
   <file src="src/Http/Cookie.php">
     <InvalidArgument>
       <code><![CDATA[false]]></code>

--- a/src/Guards/PageValidators.php
+++ b/src/Guards/PageValidators.php
@@ -9,6 +9,8 @@ use Kirby\Cms\Site;
 use Kirby\Exception\DuplicateException;
 use Kirby\Exception\LogicException;
 use Kirby\Exception\PermissionException;
+use Kirby\Form\Field\PageListField;
+use Kirby\Form\Fields;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
 
@@ -210,31 +212,34 @@ class PageValidators extends ModelValidators
 	{
 		$allowed = [];
 
-		// collect all allowed subpage templates
-		// from all pages sections in the blueprint
-		// (only consider page sections that list pages
-		// of the targeted new parent page)
-		$sections = array_filter(
-			$parent->blueprint()->sections(),
-			fn ($section) =>
-				$section->type() === 'pages' &&
-				$section->parent()->is($parent)
-		);
+		// collect all allowed subpage templates from all page list
+		// fields in the blueprint (only consider fields that list
+		// pages of the targeted new parent page)
+		$hasPageList = false;
 
-		// check if the parent has at least one pages section
-		if ($sections === []) {
+		foreach (Fields::for($parent) as $field) {
+			if (
+				$field instanceof PageListField === false ||
+				$field->parentModel()->is($parent) === false
+			) {
+				continue;
+			}
+
+			$hasPageList = true;
+
+			// go through all allowed templates and
+			// add the name to the allowlist
+			foreach ($field->templates() as $template) {
+				$allowed[] = $template;
+			}
+		}
+
+		// check if the parent has at least one page list field
+		if ($hasPageList === false) {
 			throw new LogicException(
 				key: 'page.move.noSections',
 				data: ['parent' => $parent->id() ?? '/']
 			);
-		}
-
-		// go through all allowed templates and
-		// add the name to the allowlist
-		foreach ($sections as $section) {
-			foreach ($section->templates() as $template) {
-				$allowed[] = $template;
-			}
 		}
 
 		// check if the template of this page is allowed as subpage type


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [ ] Design & concept
- [ ] Rough pass
- [x] Deep read
- [x] Security check

**Timing:**

## Description
<!--
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.

You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR.

If something is deliberately out of scope, say so here.
-->

The list of allowed subpage templates for a new parent is collected from all page list fields of the parent blueprint instead of its pages sections.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### ♻️ Refactored

- The page validator for the move action will now collect allowed targets from pagelist fields. 

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
