### PR TITLE
[sections 2 fields] #14 feat: Render model views with the model form

### DIFF
--- a/panel/src/components/Sections/FieldsSection.vue
+++ b/panel/src/components/Sections/FieldsSection.vue
@@ -26,6 +26,10 @@
 import SectionMixin from "@/mixins/section.js";
 
 /**
+ * A `fields` section is unwrapped into its fields on the
+ * blueprint level and never reaches the Panel anymore.
+ *
+ * @deprecated 6.0.0
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  */

--- a/panel/src/components/Sections/Sections.vue
+++ b/panel/src/components/Sections/Sections.vue
@@ -51,6 +51,10 @@
 
 <script>
 /**
+ * Sections are converted to fields on the blueprint level.
+ * Model views render `k-model-form` instead.
+ *
+ * @deprecated 6.0.0
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  */

--- a/panel/src/components/Views/Files/FileView.vue
+++ b/panel/src/components/Views/Files/FileView.vue
@@ -43,17 +43,17 @@
 
 		<k-model-tabs :diff="diff" :tab="tab.name" :tabs="tabs" />
 
-		<k-sections
-			:blueprint="blueprint"
+		<k-model-form
+			:api="api"
+			:columns="tab.columns"
 			:content="content"
+			:diff="diff"
 			:empty="
 				$panel.config.debug
 					? $panel.html($t('file.blueprint', { blueprint: $esc(blueprint) }))
 					: null
 			"
 			:lock="lock"
-			:parent="api"
-			:tab="tab"
 			@input="onInput"
 			@submit="onSubmit"
 		/>

--- a/panel/src/components/Views/Pages/PageView.vue
+++ b/panel/src/components/Views/Pages/PageView.vue
@@ -36,17 +36,17 @@
 
 		<k-model-tabs :diff="diff" :tab="tab.name" :tabs="tabs" />
 
-		<k-sections
-			:blueprint="blueprint"
+		<k-model-form
+			:api="api"
+			:columns="tab.columns"
 			:content="content"
+			:diff="diff"
 			:empty="
 				$panel.config.debug
 					? $panel.html($t('page.blueprint', { blueprint: $esc(blueprint) }))
 					: null
 			"
 			:lock="lock"
-			:parent="api"
-			:tab="tab"
 			@input="onInput"
 			@submit="onSubmit"
 		/>

--- a/panel/src/components/Views/Pages/SiteView.vue
+++ b/panel/src/components/Views/Pages/SiteView.vue
@@ -40,13 +40,13 @@
 
 		<k-model-tabs :diff="diff" :tab="tab.name" :tabs="tabs" />
 
-		<k-sections
-			:blueprint="blueprint"
+		<k-model-form
+			:api="api"
+			:columns="tab.columns"
 			:content="content"
+			:diff="diff"
 			:empty="$panel.config.debug ? $panel.html($t('site.blueprint')) : null"
 			:lock="lock"
-			:tab="tab"
-			parent="site"
 			@input="onInput"
 			@submit="onSubmit"
 		/>

--- a/panel/src/components/Views/Preview/PreviewForm.test.ts
+++ b/panel/src/components/Views/Preview/PreviewForm.test.ts
@@ -14,8 +14,9 @@ function factory() {
 			api: "pages/test",
 			blueprint: "default",
 			content: {},
-			tab: { name: "main" },
-			tabs: [{ name: "main" }]
+			diff: {},
+			tab: { name: "main", columns: {} },
+			tabs: [{ name: "main" }, { name: "meta" }]
 		},
 		shallow: true,
 		global: {
@@ -63,83 +64,104 @@ describe("PreviewForm.vue", () => {
 		original.mockClear();
 	});
 
-	it("listens to loaded fields and sections while mounted", () => {
-		const wrapper = factory();
+	describe("events", () => {
+		it("listens to loaded fields and sections while mounted", () => {
+			const wrapper = factory();
 
-		expect(events.on).toHaveBeenCalledWith("field.loaded", wrapper.vm.fixLinks);
-		expect(events.on).toHaveBeenCalledWith(
-			"section.loaded",
-			wrapper.vm.fixLinks
-		);
+			expect(events.on).toHaveBeenCalledWith(
+				"field.loaded",
+				wrapper.vm.fixLinks
+			);
+			expect(events.on).toHaveBeenCalledWith(
+				"section.loaded",
+				wrapper.vm.fixLinks
+			);
 
-		const fixLinks = wrapper.vm.fixLinks;
-		wrapper.unmount();
+			const fixLinks = wrapper.vm.fixLinks;
+			wrapper.unmount();
 
-		expect(events.off).toHaveBeenCalledWith("field.loaded", fixLinks);
-		expect(events.off).toHaveBeenCalledWith("section.loaded", fixLinks);
+			expect(events.off).toHaveBeenCalledWith("field.loaded", fixLinks);
+			expect(events.off).toHaveBeenCalledWith("section.loaded", fixLinks);
+		});
 	});
 
-	it("redirects page links to the preview form", () => {
-		const wrapper = factory();
-		const { $el, links } = loaded("/pages/test+child");
+	describe("form", () => {
+		it("passes on the events of the form and its controls", async () => {
+			const wrapper = factory();
 
-		wrapper.vm.fixLinks({ $el });
+			await wrapper.find("k-model-form").trigger("input");
+			await wrapper.find("k-model-form").trigger("submit");
+			await wrapper.find("k-form-controls").trigger("discard");
 
-		const event = { preventDefault: vi.fn() };
-		links[0].__vue__.onClick(event as unknown as Event);
-
-		expect(event.preventDefault).toHaveBeenCalled();
-		expect(original).not.toHaveBeenCalled();
-		expect(wrapper.emitted("navigate")).toStrictEqual([
-			["/pages/test+child/preview/form"]
-		]);
+			expect(wrapper.emitted("input")).toHaveLength(1);
+			expect(wrapper.emitted("submit")).toHaveLength(1);
+			expect(wrapper.emitted("discard")).toHaveLength(1);
+		});
 	});
 
-	it("redirects all page links of the element", () => {
-		const wrapper = factory();
-		const { $el, links } = loaded("/pages/a", "/pages/b");
+	describe("fixLinks", () => {
+		it("redirects page links to the preview form", () => {
+			const wrapper = factory();
+			const { $el, links } = loaded("/pages/test+child");
 
-		wrapper.vm.fixLinks({ $el });
+			wrapper.vm.fixLinks({ $el });
 
-		for (const link of links) {
-			link.__vue__.onClick({ preventDefault: vi.fn() } as unknown as Event);
-		}
+			const event = { preventDefault: vi.fn() };
+			links[0].__vue__.onClick(event as unknown as Event);
 
-		expect(wrapper.emitted("navigate")).toStrictEqual([
-			["/pages/a/preview/form"],
-			["/pages/b/preview/form"]
-		]);
-	});
+			expect(event.preventDefault).toHaveBeenCalled();
+			expect(original).not.toHaveBeenCalled();
+			expect(wrapper.emitted("navigate")).toStrictEqual([
+				["/pages/test+child/preview/form"]
+			]);
+		});
 
-	it("keeps links that don't point to a page view", () => {
-		const wrapper = factory();
-		const { $el, links } = loaded(
-			"/pages/test+child/files/test.jpg",
-			"/users/test",
-			undefined
-		);
+		it("redirects all page links of the element", () => {
+			const wrapper = factory();
+			const { $el, links } = loaded("/pages/a", "/pages/b");
 
-		wrapper.vm.fixLinks({ $el });
+			wrapper.vm.fixLinks({ $el });
 
-		for (const link of links) {
-			expect(link.__vue__.onClick).toBe(original);
+			for (const link of links) {
+				link.__vue__.onClick({ preventDefault: vi.fn() } as unknown as Event);
+			}
 
-			link.__vue__.onClick({ preventDefault: vi.fn() } as unknown as Event);
-		}
+			expect(wrapper.emitted("navigate")).toStrictEqual([
+				["/pages/a/preview/form"],
+				["/pages/b/preview/form"]
+			]);
+		});
 
-		expect(original).toHaveBeenCalledTimes(3);
-		expect(wrapper.emitted("navigate")).toBeUndefined();
-	});
+		it("keeps links that don't point to a page view", () => {
+			const wrapper = factory();
+			const { $el, links } = loaded(
+				"/pages/test+child/files/test.jpg",
+				"/users/test",
+				undefined
+			);
 
-	it("ignores links outside of item titles", () => {
-		const wrapper = factory();
-		const { $el, links } = loaded("/pages/test+child");
+			wrapper.vm.fixLinks({ $el });
 
-		// move the link out of the item title
-		$el.append(links[0]);
+			for (const link of links) {
+				expect(link.__vue__.onClick).toBe(original);
 
-		wrapper.vm.fixLinks({ $el });
+				link.__vue__.onClick({ preventDefault: vi.fn() } as unknown as Event);
+			}
 
-		expect(links[0].__vue__.onClick).toBe(original);
+			expect(original).toHaveBeenCalledTimes(3);
+			expect(wrapper.emitted("navigate")).toBeUndefined();
+		});
+
+		it("ignores links outside of item titles", () => {
+			const wrapper = factory();
+			const { $el, links } = loaded("/pages/test+child");
+
+			// move the link out of the item title
+			$el.append(links[0]);
+
+			wrapper.vm.fixLinks({ $el });
+
+			expect(links[0].__vue__.onClick).toBe(original);
+		});
 	});
 });

--- a/panel/src/components/Views/Preview/PreviewForm.vue
+++ b/panel/src/components/Views/Preview/PreviewForm.vue
@@ -21,17 +21,17 @@
 		</header>
 
 		<div class="k-preview-form-body">
-			<k-sections
-				:blueprint="blueprint"
+			<k-model-form
+				:api="api"
+				:columns="tab.columns"
 				:content="content"
+				:diff="diff"
 				:empty="
 					$panel.config.debug
 						? $panel.html($t('page.blueprint', { blueprint: $esc(blueprint) }))
 						: null
 				"
 				:lock="lock"
-				:parent="api"
-				:tab="tab"
 				@input="$emit('input', $event)"
 				@submit="$emit('submit', $event)"
 			/>

--- a/panel/src/components/Views/Users/UserView.vue
+++ b/panel/src/components/Views/Users/UserView.vue
@@ -61,17 +61,17 @@
 
 		<k-model-tabs :diff="diff" :tab="tab.name" :tabs="tabs" />
 
-		<k-sections
-			:blueprint="blueprint"
+		<k-model-form
+			:api="api"
+			:columns="tab.columns"
 			:content="content"
+			:diff="diff"
 			:empty="
 				$panel.config.debug
 					? $panel.html($t('user.blueprint', { blueprint: $esc(blueprint) }))
 					: null
 			"
 			:lock="lock"
-			:parent="api"
-			:tab="tab"
 			@input="onInput"
 			@submit="onSubmit"
 		/>


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

**Timing:**

## Description
<!--
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.

You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR.

If something is deliberately out of scope, say so here.
-->

Model views and the preview form render `k-model-form` with the columns of the active tab instead of `k-sections`. The section components are deprecated as a result, because sections are converted to fields on the blueprint level and no longer reach the Panel.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### ♻️ Refactored

- The new `<k-model-form>` component is now used in all model views.

### ☠️ Deprecated

- The `<k-fields-section>` is now deprecated. Use the new `<k-model-form>` instead without wrapping fields in a section. 
- The `<k-sections>` component is now deprecated. Use the new `<k-model-form>` instead.

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
