### PR TITLE
[sections 2 fields] #5 fix: Throw NotFoundException for missing sections in section controllers

### DIFF
--- a/src/Panel/Controller/SectionController.php
+++ b/src/Panel/Controller/SectionController.php
@@ -4,6 +4,8 @@ namespace Kirby\Panel\Controller;
 
 use Kirby\Blueprint\Section;
 use Kirby\Cms\Find;
+use Kirby\Cms\ModelWithContent;
+use Kirby\Exception\NotFoundException;
 use Kirby\Http\Router;
 use Kirby\Panel\Area;
 
@@ -36,16 +38,34 @@ trait SectionController
 		// for page/user/site section dialogs
 		if ($path === null) {
 			return new static(
-				section: Find::parent($model)->blueprint()->section($filename),
+				section: static::findSection(Find::parent($model), $filename),
 				path: $section
 			);
 		}
 
 		// for file section dialogs
 		return new static(
-			section: Find::file($model, $filename)->blueprint()->section($section),
+			section: static::findSection(Find::file($model, $filename), $section),
 			path: $path
 		);
+	}
+
+	/**
+	 * @throws NotFoundException If the section cannot be found
+	 */
+	protected static function findSection(
+		ModelWithContent $model,
+		string $name
+	): Section {
+		$section = $model->blueprint()->section($name);
+
+		if ($section === null) {
+			throw new NotFoundException(
+				message: 'The section "' . $name . '" could not be found'
+			);
+		}
+
+		return $section;
 	}
 
 	public function load(): mixed

--- a/tests/Panel/Controller/Dialog/SectionDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/SectionDialogControllerTest.php
@@ -5,6 +5,7 @@ namespace Kirby\Panel\Controller\Dialog;
 use Exception;
 use Kirby\Blueprint\Section;
 use Kirby\Cms\Page;
+use Kirby\Exception\NotFoundException;
 use Kirby\Panel\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -105,6 +106,28 @@ class SectionDialogControllerTest extends TestCase
 		$this->assertSame($file, $controller->section->model());
 		$this->assertSame('test', $controller->section->name());
 		$this->assertSame('test', $controller->path);
+	}
+
+	public function testFactoryForMissingSection(): void
+	{
+		$this->app = $this->app->clone([
+			'site' => [
+				'children' => [
+					['slug' => 'test']
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		$this->expectException(NotFoundException::class);
+		$this->expectExceptionMessage('The section "test" could not be found');
+
+		SectionDialogController::factory(
+			model: 'pages/test',
+			filename: 'test',
+			section: 'test'
+		);
 	}
 
 	public function testLoad(): void


### PR DESCRIPTION
Replaces: https://github.com/getkirby/kirby/pull/8393

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [ ] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

## Changelog

### ✨ Enhancements

- Improve error handling in section controller by throwing a NotFoundException, if a section does not exist. 

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
