### PR TITLE
[remove sections] #1 refact: Use field error keys for model list fields

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -116,7 +116,15 @@
 	"error.email.preset.notFound": "The email preset \"{name}\" cannot be found",
 
 	"error.field.converter.invalid": "Invalid converter \"{converter}\"",
+	"error.field.filelist.max.plural": "You must not add more than {max} files to the \"{field}\" field",
+	"error.field.filelist.max.singular": "You must not add more than one file to the \"{field}\" field",
+	"error.field.filelist.min.plural": "The \"{field}\" field requires at least {min} files",
+	"error.field.filelist.min.singular": "The \"{field}\" field requires at least one file",
 	"error.field.link.options": "Invalid options: {options}",
+	"error.field.pagelist.max.plural": "You must not add more than {max} pages to the \"{field}\" field",
+	"error.field.pagelist.max.singular": "You must not add more than one page to the \"{field}\" field",
+	"error.field.pagelist.min.plural": "The \"{field}\" field requires at least {min} pages",
+	"error.field.pagelist.min.singular": "The \"{field}\" field requires at least one page",
 	"error.field.type.missing": "Field \"{ name }\": The field type \"{ type }\" does not exist",
 
 	"error.file.changeName.empty": "The name must not be empty",
@@ -231,16 +239,6 @@
 	"error.page.update.permission": "You are not allowed to update \"{slug}\"",
 
 	"error.role.notFound": "The role \"{name}\" cannot be found",
-
-	"error.section.files.max.plural": "You must not add more than {max} files to the \"{section}\" section",
-	"error.section.files.max.singular": "You must not add more than one file to the \"{section}\" section",
-	"error.section.files.min.plural": "The \"{section}\" section requires at least {min} files",
-	"error.section.files.min.singular": "The \"{section}\" section requires at least one file",
-
-	"error.section.pages.max.plural": "You must not add more than {max} pages to the \"{section}\" section",
-	"error.section.pages.max.singular": "You must not add more than one page to the \"{section}\" section",
-	"error.section.pages.min.plural": "The \"{section}\" section requires at least {min} pages",
-	"error.section.pages.min.singular": "The \"{section}\" section requires at least one page",
 
 	"error.section.notLoaded": "The section \"{name}\" could not be loaded",
 	"error.section.type.invalid": "The section type \"{type}\" is not valid",

--- a/src/Form/Field/ModelListField.php
+++ b/src/Form/Field/ModelListField.php
@@ -306,9 +306,9 @@ abstract class ModelListField extends DisplayField
 
 		if ($this->total() - count($ids) < $min) {
 			throw new Exception(
-				message: $this->i18n('error.section.' . static::TYPE . '.min.' . I18n::form($min), [
-					'min'     => $min,
-					'section' => $this->label()
+				message: $this->i18n('error.field.' . $this->type() . '.min.' . I18n::form($min), [
+					'min'   => $min,
+					'field' => $this->label()
 				])
 			);
 		}
@@ -342,8 +342,6 @@ abstract class ModelListField extends DisplayField
 	/**
 	 * Errors are only reported for the publish gate. The entries
 	 * themselves are not stored in the content of the model.
-	 *
-	 * @todo switch to dedicated field keys once the sections are gone
 	 */
 	public function errors(): array
 	{
@@ -352,19 +350,19 @@ abstract class ModelListField extends DisplayField
 		}
 
 		$errors = [];
-		$key    = 'error.section.' . static::TYPE;
+		$key    = 'error.field.' . $this->type();
 
 		if ($this->validateMax() === false) {
 			$errors['max'] = $this->i18n($key . '.max.' . I18n::form($this->max), [
-				'max'     => $this->max,
-				'section' => $this->label()
+				'max'   => $this->max,
+				'field' => $this->label()
 			]);
 		}
 
 		if ($this->validateMin() === false) {
 			$errors['min'] = $this->i18n($key . '.min.' . I18n::form($this->min), [
-				'min'     => $this->min,
-				'section' => $this->label()
+				'min'   => $this->min,
+				'field' => $this->label()
 			]);
 		}
 

--- a/tests/Cms/Page/PageErrorsTest.php
+++ b/tests/Cms/Page/PageErrorsTest.php
@@ -53,7 +53,7 @@ class PageErrorsTest extends ModelTestCase
 		$this->assertSame([], $page->errors());
 	}
 
-	public function testErrorsWithPagesSectionField(): void
+	public function testErrorsWithPageListField(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -61,10 +61,9 @@ class PageErrorsTest extends ModelTestCase
 				'name' => 'test',
 				'fields' => [
 					'drafts' => [
-						'type'    => 'section',
-						'section' => 'pages',
-						'status'  => 'drafts',
-						'min'     => 1
+						'type'   => 'pagelist',
+						'status' => 'drafts',
+						'min'    => 1
 					]
 				]
 			]
@@ -74,13 +73,13 @@ class PageErrorsTest extends ModelTestCase
 			'drafts' => [
 				'label'   => 'Drafts',
 				'message' => [
-					'min' => 'The "Drafts" section requires at least one page'
+					'min' => 'The "Drafts" field requires at least one page'
 				]
 			]
 		], $page->errors());
 	}
 
-	public function testErrorsWithPagesSectionFieldWhenInactive(): void
+	public function testErrorsWithPageListFieldWhenInactive(): void
 	{
 		$page = new Page([
 			'slug' => 'test',
@@ -92,17 +91,16 @@ class PageErrorsTest extends ModelTestCase
 						'default' => false
 					],
 					'drafts' => [
-						'type'    => 'section',
-						'section' => 'pages',
-						'status'  => 'drafts',
-						'min'     => 1,
-						'when'    => ['toggle' => true]
+						'type'   => 'pagelist',
+						'status' => 'drafts',
+						'min'    => 1,
+						'when'   => ['toggle' => true]
 					]
 				]
 			]
 		]);
 
-		// the section is hidden by the `when` condition
+		// the field is hidden by the `when` condition
 		// and must not block changing the page status
 		$this->assertSame([], $page->errors());
 	}

--- a/tests/Form/Field/FileListFieldTest.php
+++ b/tests/Form/Field/FileListFieldTest.php
@@ -405,7 +405,7 @@ class FileListFieldTest extends TestCase
 
 		$this->assertFalse($field->validateMin());
 		$this->assertSame(
-			'The "Gallery" section requires at least 5 files',
+			'The "Gallery" field requires at least 5 files',
 			$field->errors()['min']
 		);
 	}
@@ -416,7 +416,7 @@ class FileListFieldTest extends TestCase
 
 		$this->assertFalse($field->validateMax());
 		$this->assertSame(
-			'You must not add more than 2 files to the "Gallery" section',
+			'You must not add more than 2 files to the "Gallery" field',
 			$field->errors()['max']
 		);
 	}
@@ -551,7 +551,7 @@ class FileListFieldTest extends TestCase
 		]);
 
 		$this->expectException(Exception::class);
-		$this->expectExceptionMessage('The "Gallery" section requires at least 3 files');
+		$this->expectExceptionMessage('The "Gallery" field requires at least 3 files');
 
 		$field->deleteSelected(['photography/a.jpg']);
 	}

--- a/tests/Form/Field/PageListFieldTest.php
+++ b/tests/Form/Field/PageListFieldTest.php
@@ -320,7 +320,7 @@ class PageListFieldTest extends TestCase
 		$field = $this->pagelist(['min' => 10]);
 
 		$this->assertSame(
-			'The "Albums" section requires at least 10 pages',
+			'The "Albums" field requires at least 10 pages',
 			$field->errors()['min']
 		);
 	}


### PR DESCRIPTION
## Merge first

- [x] The [sections 2 fields] stack

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

**Timing:** No rush

> [!NOTE]
> It's ok that the unit tests are failing. The PR is a temporary step, to be easier to review. The unit test issues are solved later.

## Description

The `filelist` and `pagelist` fields reported their min/max errors with the `error.section.files` and `error.section.pages` keys and labelled the offending element as a section. They now use their own `error.field.filelist` and `error.field.pagelist` keys instead.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### 🚨 Breaking changes

- All `error.section.files.*` translation strings have been renamed to `error.field.filelist.*`
- All `error.section.pages.*` translation strings have been renamed to `error.field.pagelist.*`

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
