### PR TITLE
[remove sections] #2 refact: Rename the page move error key

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -222,7 +222,7 @@
 	"error.page.move.duplicate": "A sub page with the URL appendix \"{slug}\" already exists",
 	"error.page.move.errorPage": "The error page cannot be moved",
 	"error.page.move.homePage": "The home page cannot be moved",
-	"error.page.move.noSections": "The page \"{parent}\" cannot be a parent of any page because it lacks any pages sections in its blueprint",
+	"error.page.move.noBlueprints": "The page \"{parent}\" cannot be a parent of any page because it lacks any pages fields in its blueprint",
 	"error.page.move.notFound": "The moved page could not be found",
 	"error.page.move.permission": "You are not allowed to move \"{slug}\"",
 	"error.page.move.template": "The \"{template}\" template is not accepted as a subpage of \"{parent}\"",

--- a/src/Guards/PageValidators.php
+++ b/src/Guards/PageValidators.php
@@ -237,7 +237,7 @@ class PageValidators extends ModelValidators
 		// check if the parent has at least one page list field
 		if ($hasPageList === false) {
 			throw new LogicException(
-				key: 'page.move.noSections',
+				key: 'page.move.noBlueprints',
 				data: ['parent' => $parent->id() ?? '/']
 			);
 		}

--- a/tests/Cms/Page/PageRulesTest.php
+++ b/tests/Cms/Page/PageRulesTest.php
@@ -891,7 +891,7 @@ class PageRulesTest extends ModelTestCase
 		$child   = $this->app->page('parent-a/child');
 
 		$this->expectException(LogicException::class);
-		$this->expectExceptionMessage('The page "parent-b" cannot be a parent of any page because it lacks any pages sections in its blueprint');
+		$this->expectExceptionMessage('The page "parent-b" cannot be a parent of any page because it lacks any pages fields in its blueprint');
 
 		PageRules::move($child, $parentB);
 	}

--- a/tests/Guards/PageValidatorsTest.php
+++ b/tests/Guards/PageValidatorsTest.php
@@ -349,7 +349,7 @@ class PageValidatorsTest extends ModelTestCase
 		$validators = $this->validators($this->app->page('parent-a'));
 
 		$this->expectException(LogicException::class);
-		$this->expectExceptionCode('error.page.move.noSections');
+		$this->expectExceptionCode('error.page.move.noBlueprints');
 
 		$validators->validateMoveToTemplate($this->app->page('parent-b'));
 	}


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

**Timing:** No rush

> [!NOTE]
> It's ok that the unit tests are failing. The PR is a temporary step, to be easier to review. The unit test issues are solved later.

## Description

Page moves are validated against page list fields, not sections. The `error.page.move.noSections` key becomes
`error.page.move.noPageList` and the message speaks of fields.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
-->

### 🚨 Breaking changes

- The `error.page.move.noSections` translation string has been renamed to `error.page.move.noBlueprints`

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
