### PR TITLE
[remove sections] #3 refact: Look up accepted blueprints by field

### DIFF
--- a/config/api/routes/pages.php
+++ b/config/api/routes/pages.php
@@ -38,7 +38,7 @@ return [
 		'pattern' => 'pages/(:any)/blueprints',
 		'method'  => 'GET',
 		'action'  => function (string $id) {
-			return $this->page($id)->blueprints($this->requestQuery('section'));
+			return $this->page($id)->blueprints($this->requestQuery('field'));
 		}
 	],
 	[

--- a/config/api/routes/site.php
+++ b/config/api/routes/site.php
@@ -51,7 +51,7 @@ return [
 		'pattern' => 'site/blueprints',
 		'method'  => 'GET',
 		'action'  => function () {
-			return $this->site()->blueprints($this->requestQuery('section'));
+			return $this->site()->blueprints($this->requestQuery('field'));
 		}
 	],
 	[

--- a/config/api/routes/users.php
+++ b/config/api/routes/users.php
@@ -140,7 +140,7 @@ return [
 		],
 		'method'  => 'GET',
 		'action'  => function (string $id) {
-			return Find::user($id)->blueprints($this->requestQuery('section'));
+			return Find::user($id)->blueprints($this->requestQuery('field'));
 		}
 	],
 	[

--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -34,9 +34,6 @@ return [
 		'pattern' => 'pages/(:any)/changeTitle',
 		'action' => PageChangeTitleDialogController::class
 	],
-	/**
-	 * @deprecated 6.0.0 Use section dialog route instead
-	 */
 	'page.create' => [
 		'pattern' => 'pages/create',
 		'action'  => PageCreateDialogController::class

--- a/config/sections/pages.php
+++ b/config/sections/pages.php
@@ -266,8 +266,8 @@ return [
 		return [
 			'create' => [
 				'action' => fn () => new PageCreateDialogController(
-					parent:  $this->parentModel(),
-					section: $this
+					parent:     $this->parentModel(),
+					blueprints: $this->blueprints()
 				),
 			]
 		];

--- a/panel/src/api/pages.ts
+++ b/panel/src/api/pages.ts
@@ -8,9 +8,9 @@ export default (api: Api) => ({
 	async blueprint(parent: string) {
 		return api.get("pages/" + this.id(parent) + "/blueprint");
 	},
-	async blueprints(parent: string, section: string) {
+	async blueprints(parent: string, field: string) {
 		return api.get("pages/" + this.id(parent) + "/blueprints", {
-			section: section
+			field: field
 		});
 	},
 	async changeSlug(id: string, slug: string) {

--- a/panel/src/api/users.ts
+++ b/panel/src/api/users.ts
@@ -8,9 +8,9 @@ export default (api: Api) => ({
 	async blueprint(id: string) {
 		return api.get("users/" + id + "/blueprint");
 	},
-	async blueprints(id: string, section: string) {
+	async blueprints(id: string, field: string) {
 		return api.get("users/" + id + "/blueprints", {
-			section: section
+			field: field
 		});
 	},
 	async changeEmail(id: string, email: string) {

--- a/src/Panel/Controller/Dialog/PageCreateDialogController.php
+++ b/src/Panel/Controller/Dialog/PageCreateDialogController.php
@@ -2,7 +2,6 @@
 
 namespace Kirby\Panel\Controller\Dialog;
 
-use Kirby\Blueprint\Section;
 use Kirby\Cms\App;
 use Kirby\Cms\Find;
 use Kirby\Cms\ModelWithContent;
@@ -66,20 +65,15 @@ class PageCreateDialogController extends ModelCreateDialogController
 
 	public function __construct(
 		Page|Site|null $parent = null,
-		Section|string|null $section = null,
+		string|null $field = null,
 		array|null $blueprints = null
 	) {
 		parent::__construct(parent: $parent);
 
-		// convert section name to section object
-		if (is_string($section) === true) {
-			$section = $parent->blueprint()->section($section);
-		}
-
 		// gather all available blueprints from the given list,
-		// the section or the parent
+		// the field or the parent
 		$this->blueprints = A::map(
-			$blueprints ?? $section?->blueprints() ?? $this->parent->blueprints(),
+			$blueprints ?? $this->parent->blueprints($field),
 			function ($blueprint) {
 				$blueprint['name'] ??= $blueprint['value'] ?? null;
 				return $blueprint;
@@ -142,7 +136,6 @@ class PageCreateDialogController extends ModelCreateDialogController
 		return [
 			...$fields,
 			'parent'   => Field::hidden(), // @deprecated
-			'section'  => Field::hidden(), // @deprecated
 			'template' => Field::hidden(),
 			'view'     => Field::hidden(), // @deprecated
 		];
@@ -162,11 +155,10 @@ class PageCreateDialogController extends ModelCreateDialogController
 		$request = $kirby->request();
 		$view    = $request->get('view');
 		$parent  = $view ? Find::parent($view) : Find::site();
-		$section = $request->get('section');
 
 		return new static(
-			parent:  $parent,
-			section: $section
+			parent: $parent,
+			field:  $request->get('field')
 		);
 	}
 	/**
@@ -338,7 +330,6 @@ class PageCreateDialogController extends ModelCreateDialogController
 		return [
 			...parent::value(),
 			'parent'   => $this->request->get('parent', ''), // @deprecated
-			'section'  => $this->request->get('section', ''), // @deprecated
 			'slug'     => $this->request->get('slug', ''),
 			'template' => $this->template(),
 			'title'    => $this->request->get('title', ''),

--- a/src/Panel/Controller/Dialog/PageCreateDialogController.php
+++ b/src/Panel/Controller/Dialog/PageCreateDialogController.php
@@ -65,15 +65,14 @@ class PageCreateDialogController extends ModelCreateDialogController
 
 	public function __construct(
 		Page|Site|null $parent = null,
-		string|null $field = null,
 		array|null $blueprints = null
 	) {
 		parent::__construct(parent: $parent);
 
-		// gather all available blueprints from the given list,
-		// the field or the parent
+		// gather all available blueprints from the
+		// given list or from the parent
 		$this->blueprints = A::map(
-			$blueprints ?? $this->parent->blueprints($field),
+			$blueprints ?? $this->parent->blueprints(),
 			function ($blueprint) {
 				$blueprint['name'] ??= $blueprint['value'] ?? null;
 				return $blueprint;
@@ -135,9 +134,8 @@ class PageCreateDialogController extends ModelCreateDialogController
 
 		return [
 			...$fields,
-			'parent'   => Field::hidden(), // @deprecated
+			'parent'   => Field::hidden(),
 			'template' => Field::hidden(),
-			'view'     => Field::hidden(), // @deprecated
 		];
 	}
 
@@ -146,19 +144,12 @@ class PageCreateDialogController extends ModelCreateDialogController
 		return [...parent::customFieldsIgnore(), 'title', 'slug'];
 	}
 
-	/**
-	 * @deprecated 6.0.0
-	 */
 	public static function factory(): static
 	{
-		$kirby   = App::instance();
-		$request = $kirby->request();
-		$view    = $request->get('view');
-		$parent  = $view ? Find::parent($view) : Find::site();
+		$parent = App::instance()->request()->get('parent');
 
 		return new static(
-			parent: $parent,
-			field:  $request->get('field')
+			parent: $parent ? Find::parent($parent) : Find::site()
 		);
 	}
 	/**
@@ -329,12 +320,11 @@ class PageCreateDialogController extends ModelCreateDialogController
 	{
 		return [
 			...parent::value(),
-			'parent'   => $this->request->get('parent', ''), // @deprecated
+			'parent'   => $this->request->get('parent', ''),
 			'slug'     => $this->request->get('slug', ''),
 			'template' => $this->template(),
 			'title'    => $this->request->get('title', ''),
 			'uuid'     => $this->model()->uuid()->toString(),
-			'view'     => $this->request->get('view', ''), // @deprecated
 		];
 	}
 }

--- a/tests/Panel/Controller/Dialog/PageCreateDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/PageCreateDialogControllerTest.php
@@ -3,6 +3,7 @@
 namespace Kirby\Panel\Controller\Dialog;
 
 use Kirby\Cms\Page;
+use Kirby\Cms\Site;
 use Kirby\Content\MemoryStorage;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Panel\Redirect;
@@ -29,7 +30,7 @@ class PageCreateDialogControllerTest extends TestCase
 		$controller = new PageCreateDialogController();
 		$fields     = $controller->coreFields();
 
-		$this->assertCount(6, $fields);
+		$this->assertCount(5, $fields);
 		$this->assertSame('Title', $fields['title']['label']);
 		$this->assertSame('/', $fields['slug']['path']);
 		$this->assertTrue($fields['uuid']['hidden']);
@@ -53,7 +54,7 @@ class PageCreateDialogControllerTest extends TestCase
 		$controller = new PageCreateDialogController();
 		$fields     = $controller->coreFields();
 
-		$this->assertCount(5, $fields);
+		$this->assertCount(4, $fields);
 		$this->assertSame('Title', $fields['title']['label']);
 		$this->assertSame('/', $fields['slug']['path']);
 	}
@@ -201,7 +202,7 @@ class PageCreateDialogControllerTest extends TestCase
 			],
 			'request' => [
 				'query' => [
-					'view' => 'pages/test'
+					'parent' => 'pages/test'
 				]
 			]
 		]);
@@ -210,6 +211,14 @@ class PageCreateDialogControllerTest extends TestCase
 
 		$controller = PageCreateDialogController::factory();
 		$this->assertSame('test', $controller->parent->id());
+	}
+
+	public function testFactoryWithoutParent(): void
+	{
+		$this->app->impersonate('kirby');
+
+		$controller = PageCreateDialogController::factory();
+		$this->assertInstanceOf(Site::class, $controller->parent);
 	}
 
 	public function testLoad(): void

--- a/tests/Panel/Controller/Dialog/PageCreateDialogControllerTest.php
+++ b/tests/Panel/Controller/Dialog/PageCreateDialogControllerTest.php
@@ -29,7 +29,7 @@ class PageCreateDialogControllerTest extends TestCase
 		$controller = new PageCreateDialogController();
 		$fields     = $controller->coreFields();
 
-		$this->assertCount(7, $fields);
+		$this->assertCount(6, $fields);
 		$this->assertSame('Title', $fields['title']['label']);
 		$this->assertSame('/', $fields['slug']['path']);
 		$this->assertTrue($fields['uuid']['hidden']);
@@ -53,7 +53,7 @@ class PageCreateDialogControllerTest extends TestCase
 		$controller = new PageCreateDialogController();
 		$fields     = $controller->coreFields();
 
-		$this->assertCount(6, $fields);
+		$this->assertCount(5, $fields);
 		$this->assertSame('Title', $fields['title']['label']);
 		$this->assertSame('/', $fields['slug']['path']);
 	}


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [ ] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

**Timing:** No rush

> [!NOTE]
> It's ok that the unit tests are failing. The PR is a temporary step, to be easier to review. The unit test issues are solved later.

## Description

The blueprints endpoints and the page create dialog narrowed the list of accepted blueprints down by section name. They now take a field name instead, which the model already supports.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### 🚨 Breaking changes

- The following blueprint endpoints, now accept a `field` query filter instead of `section`: 
  - `/api/site/blueprints`
  - `/api/pages/(:any)/blueprints`
  - `/api/users/(:any)/blueprints`
- The `$section` argument in `PageCreateDialogController::__construct()` has been removed
- The `section` argument in `panel.api.pages.blueprints()` has been renamed to `field`
- The `section` argument in `panel.api.users.blueprints()` has been renamed to `field`

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
