### PR TITLE
[remove sections] #4 refact: Drop the section endpoint from Panel forms

### DIFF
--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -210,7 +210,6 @@ export default {
 
 			for (const [tabName, tab] of Object.entries(tabs)) {
 				for (const [fieldName] of Object.entries(tab.fields ?? {})) {
-					tabs[tabName].fields[fieldName].section = this.name;
 					tabs[tabName].fields[fieldName].endpoints = {
 						field:
 							this.endpoints.field +
@@ -218,7 +217,6 @@ export default {
 							this.type +
 							"/fields/" +
 							fieldName,
-						section: this.endpoints.section,
 						model: this.endpoints.model
 					};
 				}

--- a/panel/src/components/Forms/Blocks/Types/Default.vue
+++ b/panel/src/components/Forms/Blocks/Types/Default.vue
@@ -17,7 +17,7 @@ export const props = {
 	props: {
 		/**
 		 * API endpoints
-		 * @value { field, model, section }
+		 * @value { field, model }
 		 */
 		endpoints: {
 			default: () => ({}),

--- a/panel/src/components/Forms/Layouts/Layout.vue
+++ b/panel/src/components/Forms/Layouts/Layout.vue
@@ -142,7 +142,6 @@ export default {
 				for (const fieldName in tab.fields) {
 					tabs[tabName].fields[fieldName].endpoints = {
 						field: this.endpoints.field + "/fields/" + fieldName,
-						section: this.endpoints.section,
 						model: this.endpoints.model
 					};
 				}

--- a/panel/src/components/Forms/Layouts/LayoutColumn.vue
+++ b/panel/src/components/Forms/Layouts/LayoutColumn.vue
@@ -30,7 +30,7 @@ export const props = {
 	props: {
 		/**
 		 * API endpoints
-		 * @value { field, model, section }
+		 * @value { field, model }
 		 */
 		endpoints: Object,
 		fieldsetGroups: Object,

--- a/panel/src/components/Forms/ModelForm.test.ts
+++ b/panel/src/components/Forms/ModelForm.test.ts
@@ -106,18 +106,6 @@ describe("ModelForm.fieldsWithAdditionalData()", () => {
 		});
 	});
 
-	it("points section fields at the section endpoint", () => {
-		const ctx = context();
-		const fields = ctx.fieldsWithAdditionalData({
-			mysection: { type: "section" }
-		});
-
-		expect(fields.mysection.endpoints).toStrictEqual({
-			model: "pages/test",
-			section: "pages/test/sections/mysection"
-		});
-	});
-
 	it("flags fields with unsaved changes", () => {
 		const ctx = context({ diff: { headline: "changed" } });
 		const fields = ctx.fieldsWithAdditionalData({

--- a/panel/src/components/Forms/ModelForm.vue
+++ b/panel/src/components/Forms/ModelForm.vue
@@ -31,9 +31,6 @@
 /**
  * Renders all columns of a model view tab as a single form.
  *
- * Sections are converted to fields on the blueprint level,
- * so a model view is nothing but a form.
- *
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
  * @since     6.0.0
@@ -76,19 +73,12 @@ export default {
 			const result = {};
 
 			for (const name in fields) {
-				const field = fields[name];
-
-				// section fields talk to the section endpoint,
-				// all other fields to the field endpoint
-				// TODO: drop this once we use field endpoints
-				const endpoints =
-					field.type === "section"
-						? { model: this.api, section: this.api + "/sections/" + name }
-						: { model: this.api, field: this.api + "/fields/" + name };
-
 				result[name] = {
-					...field,
-					endpoints,
+					...fields[name],
+					endpoints: {
+						model: this.api,
+						field: this.api + "/fields/" + name
+					},
 					hasDiff: Object.hasOwn(this.diff ?? {}, name)
 				};
 			}

--- a/panel/src/helpers/field.test.ts
+++ b/panel/src/helpers/field.test.ts
@@ -124,17 +124,13 @@ describe("$helper.field", () => {
 	});
 
 	describe("subfields()", () => {
-		it("should leave subfields without endpoints untouched", () => {
-			const result = subfields(
-				{ name: "structure" },
-				{ title: { type: "text" }, age: { type: "number" } }
-			);
+		it("should pass all subfields through when the field has no endpoints", () => {
+			const fields = { title: { type: "text" }, age: { type: "number" } };
 
-			expect(result.title.endpoints).toBeUndefined();
-			expect(result.age.endpoints).toBeUndefined();
+			expect(subfields({ name: "structure" }, fields)).toEqual(fields);
 		});
 
-		it("should rewrite endpoints when the field has endpoints", () => {
+		it("should give each subfield its own endpoint", () => {
 			const result = subfields(
 				{
 					name: "structure",
@@ -143,11 +139,15 @@ describe("$helper.field", () => {
 						model: "pages/x"
 					}
 				},
-				{ title: { type: "text" } }
+				{ title: { type: "text" }, age: { type: "number" } }
 			);
 
 			expect(result.title.endpoints).toEqual({
 				field: "pages/x/fields/structure+title",
+				model: "pages/x"
+			});
+			expect(result.age.endpoints).toEqual({
+				field: "pages/x/fields/structure+age",
 				model: "pages/x"
 			});
 		});

--- a/panel/src/helpers/field.test.ts
+++ b/panel/src/helpers/field.test.ts
@@ -124,15 +124,14 @@ describe("$helper.field", () => {
 	});
 
 	describe("subfields()", () => {
-		it("should set the section on each subfield", () => {
+		it("should leave subfields without endpoints untouched", () => {
 			const result = subfields(
 				{ name: "structure" },
 				{ title: { type: "text" }, age: { type: "number" } }
 			);
 
-			expect(result.title.section).toBe("structure");
-			expect(result.age.section).toBe("structure");
 			expect(result.title.endpoints).toBeUndefined();
+			expect(result.age.endpoints).toBeUndefined();
 		});
 
 		it("should rewrite endpoints when the field has endpoints", () => {
@@ -141,7 +140,6 @@ describe("$helper.field", () => {
 					name: "structure",
 					endpoints: {
 						field: "pages/x/fields/structure",
-						section: "content",
 						model: "pages/x"
 					}
 				},
@@ -150,10 +148,8 @@ describe("$helper.field", () => {
 
 			expect(result.title.endpoints).toEqual({
 				field: "pages/x/fields/structure+title",
-				section: "content",
 				model: "pages/x"
 			});
-			expect(result.title.section).toBe("structure");
 		});
 
 		it("should return an empty object for empty fields", () => {

--- a/panel/src/helpers/field.ts
+++ b/panel/src/helpers/field.ts
@@ -70,7 +70,7 @@ export function form(fields: Record<string, Field>): Record<string, unknown> {
 
 /**
  * Checks if a form field is visible based on its "when" conditions
- * and the current form values. Also works for sections.
+ * and the current form values.
  * @unstable
  *
  * @example
@@ -115,7 +115,7 @@ export function isVisible(
 }
 
 /**
- * Adds proper endpoint and section definitions
+ * Adds proper endpoint definitions
  * to subfields for a form field.
  * @unstable
  */
@@ -128,18 +128,14 @@ export function subfields(
 	for (const name in fields) {
 		const subfield = fields[name];
 
-		subfield.section = field.name;
-
 		if (field.endpoints) {
 			const endpoints = field.endpoints as {
 				field: string;
-				section: string;
 				model: string;
 			};
 
 			subfield.endpoints = {
 				field: endpoints.field + "+" + name,
-				section: endpoints.section,
 				model: endpoints.model
 			};
 		}


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [ ] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

**Timing:** No rush

## Description

Fields no longer carry a `section` name or a `section` endpoint. Every field talks to the field endpoint of its model, which also removes the special case for `section` fields in the model form.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### 🚨 Breaking changes

- The `endpoints` object in Field components no longer contains a `section` endpoint.

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
