### PR TITLE
[remove sections] #5 refact: Remove the section API routes

### DIFF
--- a/config/api/routes/files.php
+++ b/config/api/routes/files.php
@@ -21,22 +21,6 @@ return [
 		}
 	],
 	[
-		'pattern' => $filePattern . '/sections/(:any)',
-		'method'  => 'GET',
-		'action'  => function (string $path, string $filename, string $sectionName) {
-			return $this->file($path, $filename)->blueprint()->section($sectionName)?->toResponse();
-		}
-	],
-	[
-		'pattern' => $filePattern . '/sections/(:any)/(:all?)',
-		'method'  => 'ALL',
-		'action'  => function (string $parent, string $filename, string $sectionName, string|null $path = null) {
-			if ($file = $this->file($parent, $filename)) {
-				return $this->sectionApi($file, $sectionName, $path);
-			}
-		}
-	],
-	[
 		'pattern' => $parentPattern,
 		'method'  => 'GET',
 		'action'  => function (string $path) {

--- a/config/api/routes/pages.php
+++ b/config/api/routes/pages.php
@@ -109,21 +109,5 @@ return [
 			}
 		}
 	],
-	[
-		'pattern' => 'pages/(:any)/sections/(:any)',
-		'method'  => 'GET',
-		'action'  => function (string $id, string $sectionName) {
-			return $this->page($id)->blueprint()->section($sectionName)?->toResponse();
-		}
-	],
-	[
-		'pattern' => 'pages/(:any)/sections/(:any)/(:all?)',
-		'method'  => 'ALL',
-		'action'  => function (string $id, string $sectionName, string|null $path = null) {
-			if ($page = $this->page($id)) {
-				return $this->sectionApi($page, $sectionName, $path);
-			}
-		}
-	],
 	// @codeCoverageIgnoreEnd
 ];

--- a/config/api/routes/site.php
+++ b/config/api/routes/site.php
@@ -96,19 +96,5 @@ return [
 			return $this->fieldApi($this->site(), $fieldName, $path);
 		}
 	],
-	[
-		'pattern' => 'site/sections/(:any)',
-		'method'  => 'GET',
-		'action'  => function (string $sectionName) {
-			return $this->site()->blueprint()->section($sectionName)?->toResponse();
-		}
-	],
-	[
-		'pattern' => 'site/sections/(:any)/(:all?)',
-		'method'  => 'ALL',
-		'action'  => function (string $sectionName, string|null $path = null) {
-			return $this->sectionApi($this->site(), $sectionName, $path);
-		}
-	],
 	// @codeCoverageIgnoreEnd
 ];

--- a/config/api/routes/users.php
+++ b/config/api/routes/users.php
@@ -229,27 +229,5 @@ return [
 			return $this->fieldApi(Find::user($id), $fieldName, $path);
 		}
 	],
-	[
-		'pattern' => [
-			'(account)/sections/(:any)',
-			'users/(:any)/sections/(:any)',
-		],
-		'method'  => 'GET',
-		'action'  => function (string $id, string $sectionName) {
-			if ($section = Find::user($id)->blueprint()->section($sectionName)) {
-				return $section->toResponse();
-			}
-		}
-	],
-	[
-		'pattern' => [
-			'(account)/sections/(:any)/(:all?)',
-			'users/(:any)/sections/(:any)/(:all?)',
-		],
-		'method'  => 'ALL',
-		'action'  => function (string $id, string $sectionName, string|null $path = null) {
-			return $this->sectionApi(Find::user($id), $sectionName, $path);
-		}
-	],
 	// @codeCoverageIgnoreEnd
 ];

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -736,34 +736,6 @@ class Api
 	}
 
 	/**
-	 * @throws NotFoundException if the section type cannot be found or the section cannot be loaded
-	 */
-	public function sectionApi(
-		ModelWithContent $model,
-		string $name,
-		string|null $path = null
-	): mixed {
-		$section = $model->blueprint()->section($name);
-
-		if ($section === null) {
-			throw new NotFoundException(
-				message: 'The section "' . $name . '" could not be found'
-			);
-		}
-
-		$sectionApi = $this->clone([
-			'data'   => [...$this->data(), 'section' => $section],
-			'routes' => $section->api(),
-		]);
-
-		return $sectionApi->call(
-			$path,
-			$this->requestMethod(),
-			$this->requestData()
-		);
-	}
-
-	/**
 	 * Returns the current Session instance
 	 *
 	 * @param array $options Additional options, see the session component

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -1438,65 +1438,6 @@ class ApiTest extends TestCase
 		$this->assertSame('a', $api->searchPages()->first()->id());
 	}
 
-	public function testSectionApi(): void
-	{
-		$app = $this->app->clone([
-			'sections' => [
-				'test' => [
-					'api' => fn () => [
-						[
-							'pattern' => '/message',
-							'action'  => fn () => [
-								'message' => 'Test'
-							]
-						]
-					]
-				]
-			],
-			'blueprints' => [
-				'pages/test' => [
-					'title' => 'Test',
-					'name' => 'test',
-					'sections' => [
-						'test' => [
-							'type' => 'test',
-						]
-					]
-				]
-			],
-			'site' => [
-				'children' => [
-					[
-						'slug'     => 'test',
-						'template' => 'test',
-					]
-				]
-			]
-		]);
-
-		$app->impersonate('kirby');
-		$page = $app->page('test');
-
-		$response = $app->api()->sectionApi($page, 'test', 'message');
-		$this->assertSame('Test', $response['message']);
-	}
-
-	public function testSectionApiWithInvalidSection(): void
-	{
-		$app = $this->app->clone([
-			'site' => [
-				'children' => [
-					['slug' => 'test']
-				]
-			]
-		]);
-
-		$this->expectException(NotFoundException::class);
-		$this->expectExceptionMessage('The section "nonexists" could not be found');
-
-		$page = $app->page('test');
-		$app->api()->sectionApi($page, 'nonexists');
-	}
 
 	public function testSite(): void
 	{

--- a/tests/Api/Routes/AccountRoutesTest.php
+++ b/tests/Api/Routes/AccountRoutesTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Api;
 
 use Kirby\Blueprint\Blueprint;
-use Kirby\Blueprint\Section;
 use Kirby\Cms\App;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
@@ -64,7 +63,6 @@ class AccountRoutesTest extends TestCase
 	{
 		$this->app->session()->destroy();
 		Field::$types = [];
-		Section::$types = [];
 		Dir::remove(static::TMP);
 		App::destroy();
 	}
@@ -410,41 +408,6 @@ class AccountRoutesTest extends TestCase
 		$this->assertCount(2, $response['data']);
 		$this->assertSame('admin', $response['data'][0]['name']);
 		$this->assertSame('editor', $response['data'][1]['name']);
-	}
-
-	public function testSections(): void
-	{
-		$app = $this->app->clone([
-			'blueprints' => [
-				'users/admin' => [
-					'sections' => [
-						'test' => [
-							'type' => 'test'
-						]
-					]
-				]
-			],
-			'sections' => [
-				'test' => [
-					'toArray' => fn () => [
-						'foo' => 'bar'
-					]
-				]
-			]
-		]);
-
-		$app->impersonate('test@getkirby.com');
-
-		$response = $app->api()->call('account/sections/test');
-		$expected = [
-			'status' => 'ok',
-			'code'   => 200,
-			'name'   => 'test',
-			'type'   => 'test',
-			'foo'    => 'bar'
-		];
-
-		$this->assertSame($expected, $response);
 	}
 
 	public function testUpdate(): void

--- a/tests/Api/Routes/UsersRoutesTest.php
+++ b/tests/Api/Routes/UsersRoutesTest.php
@@ -3,7 +3,6 @@
 namespace Kirby\Api;
 
 use Kirby\Blueprint\Blueprint;
-use Kirby\Blueprint\Section;
 use Kirby\Cms\App;
 use Kirby\Cms\User;
 use Kirby\Exception\InvalidArgumentException;
@@ -70,7 +69,6 @@ class UsersRoutesTest extends TestCase
 		$this->app->session()->destroy();
 		App::destroy();
 		Field::$types = [];
-		Section::$types = [];
 		Dir::remove(static::TMP);
 	}
 
@@ -625,41 +623,6 @@ class UsersRoutesTest extends TestCase
 		]);
 
 		$this->assertCount(2, $response['data']);
-	}
-
-	public function testSections(): void
-	{
-		$app = $this->app->clone([
-			'blueprints' => [
-				'users/admin' => [
-					'sections' => [
-						'test' => [
-							'type' => 'test'
-						]
-					]
-				]
-			],
-			'sections' => [
-				'test' => [
-					'toArray' => fn () => [
-						'foo' => 'bar'
-					]
-				]
-			]
-		]);
-
-		$app->impersonate('kirby');
-
-		$response = $app->api()->call('users/admin@getkirby.com/sections/test');
-		$expected = [
-			'status' => 'ok',
-			'code'   => 200,
-			'name'   => 'test',
-			'type'   => 'test',
-			'foo'    => 'bar'
-		];
-
-		$this->assertSame($expected, $response);
 	}
 
 	public function testUpdate(): void


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [ ] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

**Timing:** No rush

> [!NOTE]
> It's ok that the unit tests are failing. The PR is a temporary step, to be easier to review. The unit test issues are solved later.

## Description

Drops the `sections/(:any)` routes for files, pages, the site and users together with `Api::sectionApi()`. Sections are no longer addressable through the REST API.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### 🚨 Breaking changes

- The following section API routes have been removed
  - `/api/site/sections/(:any)`
  - `/api/site/sections/(:any)/(:all?)`
  - `/api/site/files/(:any)/sections/(:any)`
  - `/api/site/files/(:any)/sections/(:any)/(:all?)`
  - `/api/pages/(:any)/sections/(:any)`
  - `/api/pages/(:any)/sections/(:any)/(:all?)`
  - `/api/pages/(:any)/files/(:any)/sections/(:any)`
  - `/api/pages/(:any)/files/(:any)/sections/(:any)/(:all?)`
  - `/api/users/(:any)/sections/(:any)`
  - `/api/users/(:any)/sections/(:any)/(:all?)`
  - `/api/users/(:any)/files/(:any)/sections/(:any)`
  - `/api/users/(:any)/files/(:any)/sections/(:any)/(:all?)`
- `Kirby\Api\Api::sectionApi()` has been removed

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
