### PR TITLE
[remove sections] #6 refact: Remove the section dialog and drawer routes

### DIFF
--- a/config/areas/account/dialogs.php
+++ b/config/areas/account/dialogs.php
@@ -31,10 +31,6 @@ return [
 		...$dialogs['user.fields'],
 		'pattern' => '(account)/fields/(:any)/(:all?)',
 	],
-	'account.sections' => [
-		...$dialogs['user.sections'],
-		'pattern' => '(account)/sections/(:any)/(:all?)',
-	],
 	'account.file.changeName' => [
 		...$dialogs['user.file.changeName'],
 		'pattern' => '(account)/files/(:any)/changeName',
@@ -54,9 +50,5 @@ return [
 	'account.file.fields' => [
 		...$dialogs['user.file.fields'],
 		'pattern' => '(account)/files/(:any)/fields/(:any)/(:all?)',
-	],
-	'account.file.sections' => [
-		...$dialogs['user.file.sections'],
-		'pattern' => '(account)/files/(:any)/sections/(:any)/(:all?)',
 	],
 ];

--- a/config/areas/account/drawers.php
+++ b/config/areas/account/drawers.php
@@ -24,16 +24,8 @@ return [
 		...$drawers['user.fields'],
 		'pattern' => '(account)/fields/(:any)/(:all?)',
 	],
-	'account.sections' => [
-		...$drawers['user.sections'],
-		'pattern' => '(account)/sections/(:any)/(:all?)',
-	],
 	'account.file.fields' => [
 		...$drawers['user.file.fields'],
 		'pattern' => '(account)/files/(:any)/fields/(:any)/(:all?)',
-	],
-	'account.file.sections' => [
-		...$drawers['user.file.sections'],
-		'pattern' => '(account)/files/(:any)/sections/(:any)/(:all?)',
 	],
 ];

--- a/config/areas/site/dialogs.php
+++ b/config/areas/site/dialogs.php
@@ -14,7 +14,6 @@ use Kirby\Panel\Controller\Dialog\PageCreateDialogController;
 use Kirby\Panel\Controller\Dialog\PageDeleteDialogController;
 use Kirby\Panel\Controller\Dialog\PageDuplicateDialogController;
 use Kirby\Panel\Controller\Dialog\PageMoveDialogController;
-use Kirby\Panel\Controller\Dialog\SectionDialogController;
 use Kirby\Panel\Controller\Dialog\SiteChangeTitleDialogController;
 
 return [
@@ -55,10 +54,6 @@ return [
 		'pattern' => '(pages/[^/]+)/fields/(:any)/(:all?)',
 		'action'  => FieldDialogController::class
 	],
-	'page.sections' => [
-		'pattern' => '(pages/[^/]+)/sections/(:any)/(:all?)',
-		'action'  => SectionDialogController::class
-	],
 	'page.file.changeName' => [
 		'pattern' => '(pages/[^/]+)/files/(:any)/changeName',
 		'action' => FileChangeNameDialogController::class
@@ -79,10 +74,6 @@ return [
 		'pattern' => '(pages/[^/]+)/files/(:any)/fields/(:any)/(:all?)',
 		'action'  => FieldDialogController::class
 	],
-	'page.file.sections' => [
-		'pattern' => '(pages/[^/]+)/files/(:any)/sections/(:any)/(:all?)',
-		'action'  => SectionDialogController::class
-	],
 
 	'site.changeTitle' => [
 		'pattern' => 'site/changeTitle',
@@ -92,10 +83,6 @@ return [
 	'site.fields' => [
 		'pattern' => '(site)/fields/(:any)/(:all?)',
 		'action'  => FieldDialogController::class
-	],
-	'site.sections' => [
-		'pattern' => '(site)/sections/(:any)/(:all?)',
-		'action'  => SectionDialogController::class
 	],
 	'site.file.changeName' => [
 		'pattern' => '(site)/files/(:any)/changeName',
@@ -116,10 +103,6 @@ return [
 	'site.file.fields' => [
 		'pattern' => '(site)/files/(:any)/fields/(:any)/(:all?)',
 		'action'  => FieldDialogController::class
-	],
-	'site.file.sections' => [
-		'pattern' => '(site)/files/(:any)/sections/(:any)/(:all?)',
-		'action'  => SectionDialogController::class
 	],
 
 	'changes' => [

--- a/config/areas/site/drawers.php
+++ b/config/areas/site/drawers.php
@@ -1,39 +1,22 @@
 <?php
 
 use Kirby\Panel\Controller\Drawer\FieldDrawerController;
-use Kirby\Panel\Controller\Drawer\SectionDrawerController;
 
 return [
 	'page.fields' => [
 		'pattern' => '(pages/[^/]+)/fields/(:any)/(:all?)',
 		'action'  => FieldDrawerController::class
 	],
-	'page.sections' => [
-		'pattern' => '(pages/[^/]+)/sections/(:any)/(:all?)',
-		'action'  => SectionDrawerController::class
-	],
 	'page.file.fields' => [
 		'pattern' => '(pages/[^/]+)/files/(:any)/fields/(:any)/(:all?)',
 		'action'  => FieldDrawerController::class
-	],
-	'page.file.sections' => [
-		'pattern' => '(pages/[^/]+)/files/(:any)/sections/(:any)/(:all?)',
-		'action'  => SectionDrawerController::class
 	],
 	'site.fields' => [
 		'pattern' => '(site)/fields/(:any)/(:all?)',
 		'action'  => FieldDrawerController::class
 	],
-	'site.sections' => [
-		'pattern' => '(site)/sections/(:any)/(:all?)',
-		'action'  => SectionDrawerController::class
-	],
 	'site.file.fields' => [
 		'pattern' => '(site)/files/(:any)/fields/(:any)/(:all?)',
 		'action'  => FieldDrawerController::class
-	],
-	'site.file.sections' => [
-		'pattern' => '(site)/files/(:any)/sections/(:any)/(:all?)',
-		'action'  => SectionDrawerController::class
 	],
 ];

--- a/config/areas/users/dialogs.php
+++ b/config/areas/users/dialogs.php
@@ -5,7 +5,6 @@ use Kirby\Panel\Controller\Dialog\FileChangeNameDialogController;
 use Kirby\Panel\Controller\Dialog\FileChangeSortDialogController;
 use Kirby\Panel\Controller\Dialog\FileChangeTemplateDialogController;
 use Kirby\Panel\Controller\Dialog\FileDeleteDialogController;
-use Kirby\Panel\Controller\Dialog\SectionDialogController;
 use Kirby\Panel\Controller\Dialog\UserChangeEmailDialogController;
 use Kirby\Panel\Controller\Dialog\UserChangeLanguageDialogController;
 use Kirby\Panel\Controller\Dialog\UserChangeNameDialogController;
@@ -48,10 +47,6 @@ return [
 		'pattern' => '(users/[^/]+)/fields/(:any)/(:all?)',
 		'action'  => FieldDialogController::class
 	],
-	'user.sections' => [
-		'pattern' => '(users/[^/]+)/sections/(:any)/(:all?)',
-		'action'  => SectionDialogController::class
-	],
 
 	'user.file.changeName' => [
 		'pattern' => '(users/[^/]+)/files/(:any)/changeName',
@@ -73,9 +68,5 @@ return [
 	'user.file.fields' => [
 		'pattern' => '(users/[^/]+)/files/(:any)/fields/(:any)/(:all?)',
 		'action'  => FieldDialogController::class
-	],
-	'user.file.sections' => [
-		'pattern' => '(users/[^/]+)/files/(:any)/sections/(:any)/(:all?)',
-		'action'  => SectionDialogController::class
 	],
 ];

--- a/config/areas/users/drawers.php
+++ b/config/areas/users/drawers.php
@@ -1,7 +1,6 @@
 <?php
 
 use Kirby\Panel\Controller\Drawer\FieldDrawerController;
-use Kirby\Panel\Controller\Drawer\SectionDrawerController;
 use Kirby\Panel\Controller\Drawer\UserSecurityCodeMethodDrawerController;
 use Kirby\Panel\Controller\Drawer\UserSecurityDrawerController;
 use Kirby\Panel\Controller\Drawer\UserTotpDrawerController;
@@ -28,16 +27,8 @@ return [
 		'pattern' => '(users/[^/]+)/fields/(:any)/(:all?)',
 		'action'  => FieldDrawerController::class
 	],
-	'user.sections' => [
-		'pattern' => '(users/[^/]+)/sections/(:any)/(:all?)',
-		'action'  => SectionDrawerController::class
-	],
 	'user.file.fields' => [
 		'pattern' => '(users/[^/]+)/files/(:any)/fields/(:any)/(:all?)',
 		'action'  => FieldDrawerController::class
-	],
-	'user.file.sections' => [
-		'pattern' => '(users/[^/]+)/files/(:any)/sections/(:any)/(:all?)',
-		'action'  => SectionDrawerController::class
 	],
 ];


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [ ] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

**Timing:** No rush

> [!NOTE]
> It's ok that the unit tests are failing. The PR is a temporary step, to be easier to review. The unit test issues are solved later.

## Description

Sections can no longer open dialogs or drawers of their own. The corresponding Panel routes for pages, files, the site and users are gone, so nothing references the section controllers anymore.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### 🚨 Breaking changes

- Removed all section dialog and drawer routes. 

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
