### PR TITLE
[remove sections] #7 refact: Remove the section adapter from blueprints

### DIFF
--- a/src/Blueprint/AcceptRules.php
+++ b/src/Blueprint/AcceptRules.php
@@ -8,7 +8,7 @@ use Kirby\Form\Mixin\Upload;
 
 /**
  * The AcceptRules class goes through all blueprint settings for
- * sections and fields and collects rules for accepted files
+ * fields and collects rules for accepted files
  *
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license

--- a/src/Blueprint/Blueprint.php
+++ b/src/Blueprint/Blueprint.php
@@ -10,7 +10,6 @@ use Kirby\Data\Data;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Exception\NotFoundException;
 use Kirby\Filesystem\F;
-use Kirby\Form\Field\SectionField;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
@@ -27,28 +26,12 @@ class Blueprint
 {
 	public static array $loaded = [];
 
-	/**
-	 * Maps section types onto their field equivalent.
-	 * Section types without an entry here are automatically
-	 * wrapped in a `section` field.
-	 *
-	 * @since 6.0.0
-	 * @unstable
-	 */
-	public static array $sectionFields = [
-		'files' => 'filelist',
-		'info'  => 'info',
-		'pages' => 'pagelist',
-		'stats' => 'stats',
-	];
-
 	protected AcceptRules|null $acceptRules = null;
 
 	protected array $fields = [];
 	protected array|null $fieldsLower = null;
 	protected ModelWithContent $model;
 	protected array $props;
-	protected array $sections = [];
 	protected Tabs|null $tabs = null;
 
 	/**
@@ -398,61 +381,6 @@ class Blueprint
 		}
 
 		return null;
-	}
-
-	/**
-	 * Returns a single section by name. Sections only exist
-	 * as fields with the `section` type after normalization.
-	 */
-	public function section(string $name): Section|null
-	{
-		if (array_key_exists($name, $this->sections) === true) {
-			return $this->sections[$name];
-		}
-
-		return $this->sections[$name] = $this->sectionFromField($name);
-	}
-
-	/**
-	 * Creates a section from a field with the `section` type
-	 * @since 6.0.0
-	 */
-	protected function sectionFromField(string $name): Section|null
-	{
-		$props = $this->field($name);
-
-		if ($props === null || $props['type'] !== 'section') {
-			return null;
-		}
-
-		unset($props['type']);
-
-		$field = new SectionField(...$props);
-		$field->setModel($this->model());
-
-		return $field->section();
-	}
-
-	/**
-	 * Returns all sections
-	 *
-	 * @return array<string, Section>
-	 */
-	public function sections(): array
-	{
-		$sections = [];
-
-		foreach ($this->fields as $name => $field) {
-			if ($field['type'] !== 'section') {
-				continue;
-			}
-
-			if ($section = $this->section((string)$name)) {
-				$sections[$name] = $section;
-			}
-		}
-
-		return $sections;
 	}
 
 	/**

--- a/src/Blueprint/Normalizer.php
+++ b/src/Blueprint/Normalizer.php
@@ -24,8 +24,22 @@ use Throwable;
 class Normalizer
 {
 	/**
+	 * Maps the legacy section types onto their field
+	 * equivalent. The `fields` section is not part of this
+	 * map, because it is unwrapped into its own fields.
+	 *
+	 * @unstable
+	 */
+	public static array $sectionFields = [
+		'files' => 'filelist',
+		'info'  => 'info',
+		'pages' => 'pagelist',
+		'stats' => 'stats',
+	];
+
+	/**
 	 * Global field definitions that can be referenced
-	 * in tabs, columns and sections.
+	 * in tabs, columns and fields.
 	 */
 	protected array $fieldDefinitions = [];
 
@@ -89,9 +103,8 @@ class Normalizer
 
 	/**
 	 * Converts all section definitions into field definitions.
-	 * Sections only exist as a legacy concept in blueprints and
-	 * are either mapped onto their field equivalent or wrapped
-	 * in the `section` field adapter.
+	 * Sections only exist as a legacy shortcut in blueprints and
+	 * are mapped onto their field equivalent.
 	 */
 	protected function convertSectionsToFields(array $props): array
 	{
@@ -535,19 +548,20 @@ class Normalizer
 	 */
 	protected static function sectionError(string $name, string $label): array
 	{
+		$types = ['fields', ...array_keys(static::$sectionFields)];
+
 		return [
 			'label' => $label,
 			'name'  => $name,
-			'text'  => 'The following section types are available: ' . Blueprint::helpList(array_keys(Section::$types)),
+			'text'  => 'The following section types are available: ' . Blueprint::helpList($types),
 			'theme' => 'negative',
 			'type'  => 'info',
 		];
 	}
 
 	/**
-	 * Converts a single section definition into a field definition.
-	 * Section types with a field equivalent are mapped onto that
-	 * field, all others are wrapped in the `section` field adapter.
+	 * Converts a single section definition into a field definition
+	 * by mapping the section type onto its field equivalent
 	 */
 	protected static function sectionToField(string $name, array $props): array
 	{
@@ -568,22 +582,11 @@ class Normalizer
 			);
 		}
 
-		// section type with a field equivalent
-		if ($field = Blueprint::$sectionFields[$type] ?? null) {
+		if ($field = static::$sectionFields[$type] ?? null) {
 			return [
 				...$props,
 				'name' => $name,
 				'type' => $field
-			];
-		}
-
-		// section type without a field equivalent
-		if (isset(Section::$types[$type]) === true) {
-			return [
-				...$props,
-				'name'    => $name,
-				'section' => $type,
-				'type'    => 'section'
 			];
 		}
 

--- a/tests/Blueprint/BlueprintTest.php
+++ b/tests/Blueprint/BlueprintTest.php
@@ -224,28 +224,6 @@ class BlueprintTest extends TestCase
 		$this->assertArrayNotHasKey('headline', $field);
 	}
 
-	public function testSectionsToFieldsWithCustomType(): void
-	{
-		$this->app = $this->app->clone([
-			'sections' => [
-				'test' => []
-			]
-		]);
-
-		$blueprint = new Blueprint([
-			'model'    => $this->model,
-			'sections' => [
-				'mysection' => [
-					'type' => 'test'
-				]
-			]
-		]);
-
-		$field = $blueprint->field('mysection');
-
-		$this->assertSame('section', $field['type']);
-		$this->assertSame('test', $field['section']);
-	}
 
 	public function testSectionsToFieldsWithUnknownType(): void
 	{
@@ -263,8 +241,13 @@ class BlueprintTest extends TestCase
 		$this->assertSame('info', $field['type']);
 		$this->assertSame('negative', $field['theme']);
 		$this->assertSame('Invalid section type ("does-not-exist")', $field['label']);
-		$this->assertStringStartsWith(
-			'The following section types are available:',
+		$this->assertSame(
+			'The following section types are available: ' . PHP_EOL .
+			'- *fields*' . PHP_EOL .
+			'- *files*' . PHP_EOL .
+			'- *info*' . PHP_EOL .
+			'- *pages*' . PHP_EOL .
+			'- *stats*',
 			$field['text']
 		);
 	}
@@ -703,171 +686,15 @@ class BlueprintTest extends TestCase
 		$this->assertSame('info', $blueprint->field('info')['type']);
 	}
 
-	public function testSectionFromField(): void
-	{
-		// with options
-		$blueprint = new Blueprint([
-			'model' => $this->model,
-			'fields' => [
-				'info' => [
-					'type'    => 'section',
-					'section' => 'info'
-				]
-			]
-		]);
 
-		$this->assertSame('info', $blueprint->section('info')->type());
-	}
 
-	public function testSectionIsCached(): void
-	{
-		$blueprint = new Blueprint([
-			'model'  => $this->model,
-			'fields' => [
-				'info' => [
-					'type'    => 'section',
-					'section' => 'info'
-				]
-			]
-		]);
 
-		// the section object is only created once
-		$this->assertSame($blueprint->section('info'), $blueprint->section('info'));
 
-		// the same applies to sections that cannot be found
-		$this->assertNull($blueprint->section('does-not-exist'));
-		$this->assertNull($blueprint->section('does-not-exist'));
-	}
 
-	public function testSectionFromFieldWithDifferentName(): void
-	{
-		$blueprint = new Blueprint([
-			'model'  => $this->model,
-			'fields' => [
-				'notes' => [
-					'type'    => 'section',
-					'section' => 'info'
-				]
-			]
-		]);
 
-		$section = $blueprint->section('notes');
 
-		$this->assertSame('info', $section->type());
-		$this->assertSame('notes', $section->name());
-	}
 
-	public function testSectionFromFieldWithLowercaseName(): void
-	{
-		$blueprint = new Blueprint([
-			'model'  => $this->model,
-			'fields' => [
-				'infoBox' => [
-					'type'    => 'section',
-					'section' => 'info'
-				]
-			]
-		]);
 
-		$section = $blueprint->section('infobox');
-
-		$this->assertSame('info', $section->type());
-		$this->assertSame('infobox', $section->name());
-	}
-
-	public function testSectionFromFieldWithMissingSectionType(): void
-	{
-		$blueprint = new Blueprint([
-			'model'  => $this->model,
-			'fields' => [
-				'info' => [
-					'type' => 'section'
-				]
-			]
-		]);
-
-		// the field name is used as fallback for the section type
-		$this->assertSame('info', $blueprint->section('info')->type());
-	}
-
-	public function testSectionFromFieldWithMissingField(): void
-	{
-		$blueprint = new Blueprint([
-			'model' => $this->model,
-		]);
-
-		$this->assertNull($blueprint->section('info'));
-	}
-
-	public function testSectionFromFieldWithModel(): void
-	{
-		$blueprint = new Blueprint([
-			'model'  => $this->model,
-			'fields' => [
-				'info' => [
-					'type'    => 'section',
-					'section' => 'info'
-				]
-			]
-		]);
-
-		$this->assertSame($this->model, $blueprint->section('info')->model());
-	}
-
-	public function testSectionFromFieldWithNonSectionField(): void
-	{
-		$blueprint = new Blueprint([
-			'model'  => $this->model,
-			'fields' => [
-				'info' => [
-					'type' => 'text'
-				]
-			]
-		]);
-
-		$this->assertNull($blueprint->section('info'));
-	}
-
-	public function testSectionFromFieldWithProps(): void
-	{
-		$blueprint = new Blueprint([
-			'model'  => $this->model,
-			'fields' => [
-				'info' => [
-					'type'    => 'section',
-					'section' => 'info',
-					'label'   => 'Notes',
-					'text'    => 'Some info',
-					'theme'   => 'negative'
-				]
-			]
-		]);
-
-		$section = $blueprint->section('info')->toArray();
-
-		$this->assertSame('Notes', $section['label']);
-		$this->assertSame('<p>Some info</p>', trim($section['text']));
-		$this->assertSame('negative', $section['theme']);
-	}
-
-	public function testSectionFromFieldWithAutomaticLabel(): void
-	{
-		$blueprint = new Blueprint([
-			'model'  => $this->model,
-			'fields' => [
-				'infoBox' => [
-					'type'    => 'section',
-					'section' => 'info'
-				]
-			]
-		]);
-
-		// the automatic field label is passed on to the section
-		$this->assertSame(
-			'Info box',
-			$blueprint->section('infoBox')->toArray()['label']
-		);
-	}
 
 	public function testSectionAndFieldOfSameName(): void
 	{
@@ -901,61 +728,7 @@ class BlueprintTest extends TestCase
 		);
 	}
 
-	public function testSectionsFromFields(): void
-	{
-		$blueprint = new Blueprint([
-			'model'  => $this->model,
-			'fields' => [
-				'text'   => [
-					'type' => 'text'
-				],
-				'drafts' => [
-					'type'    => 'section',
-					'section' => 'pages',
-					'status'  => 'drafts'
-				],
-				'listed' => [
-					'type'    => 'section',
-					'section' => 'pages',
-					'status'  => 'listed'
-				]
-			]
-		]);
 
-		$sections = $blueprint->sections();
-
-		// only the section fields, the regular field is not a section
-		$this->assertSame(
-			['drafts', 'listed'],
-			array_keys($sections)
-		);
-
-		// each section keeps its own field name
-		$this->assertSame('drafts', $sections['drafts']->name());
-		$this->assertSame('listed', $sections['listed']->name());
-		$this->assertSame('pages', $sections['drafts']->type());
-		$this->assertSame('pages', $sections['listed']->type());
-	}
-
-	public function testSectionsFromFieldsInGroup(): void
-	{
-		$blueprint = new Blueprint([
-			'model'  => $this->model,
-			'fields' => [
-				'group' => [
-					'type'   => 'group',
-					'fields' => [
-						'drafts' => [
-							'type'    => 'section',
-							'section' => 'pages'
-						]
-					]
-				]
-			]
-		]);
-
-		$this->assertArrayHasKey('drafts', $blueprint->sections());
-	}
 
 	public function testAutomaticLabelForFields()
 	{


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [ ] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

**Timing:** No rush

> [!NOTE]
> It's ok that the unit tests are failing. The PR is a temporary step, to be easier to review. The unit test issues are solved later.

## Description

Section definitions are only a legacy shortcut in blueprints from now on. The normalizer maps them onto their field equivalent and reports an error for every other type. The `section` field adapter and the `Blueprint::section()`/`sections()` accessors are gone.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### 🚨 Breaking changes

- Any section type, except our own sections with field equivalents, are now no longer supported in blueprints. 
- `Kirby\Blueprint\Blueprint::section()` and `Kirby\Blueprint\Blueprint::sections()` have been removed.

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
