### PR TITLE
[remove sections] #8 refact: Remove the section extension registry

### DIFF
--- a/config/aliases.php
+++ b/config/aliases.php
@@ -90,7 +90,6 @@ return [
 	'kirby\cms\plugin'         => 'Kirby\Plugin\Plugin',
 	'kirby\cms\pluginasset'    => 'Kirby\Plugin\Asset',
 	'kirby\cms\pluginassets'   => 'Kirby\Plugin\Assets',
-	'kirby\cms\section'        => 'Kirby\Blueprint\Section',
 	'kirby\cms\siteblueprint'  => 'Kirby\Blueprint\SiteBlueprint',
 	'kirby\cms\template'       => 'Kirby\Template\Template',
 	'kirby\cms\userblueprint'  => 'Kirby\Blueprint\UserBlueprint',

--- a/src/Cms/AppPlugins.php
+++ b/src/Cms/AppPlugins.php
@@ -5,7 +5,6 @@ namespace Kirby\Cms;
 use Closure;
 use Kirby\Auth\Challenges;
 use Kirby\Auth\Methods;
-use Kirby\Blueprint\Section;
 use Kirby\Content\Field;
 use Kirby\Exception\DuplicateException;
 use Kirby\Exception\InvalidArgumentException;
@@ -74,7 +73,6 @@ trait AppPlugins
 		'pageModels' => [],
 		'permissions' => [],
 		'routes' => [],
-		'sections' => [],
 		'siteMethods' => [],
 		'snippets' => [],
 		'structureMethods' => [],
@@ -588,17 +586,6 @@ trait AppPlugins
 	}
 
 	/**
-	 * Registers Panel sections
-	 */
-	protected function extendSections(array $sections): array
-	{
-		return $this->extensions['sections'] = Section::$types = [
-			...Section::$types,
-			...$sections
-		];
-	}
-
-	/**
 	 * Registers additional site methods
 	 */
 	protected function extendSiteMethods(array $methods): array
@@ -833,13 +820,9 @@ trait AppPlugins
 	 */
 	protected function extensionsFromSystem(): void
 	{
-		// Always start with fresh fields and sections
+		// Always start with fresh fields
 		// from the core and add plugins on top of that
 		FormField::$types = [];
-		Section::$types   = [];
-
-		// mixins
-		Section::$mixins = $this->core->sectionMixins();
 
 		// aliases
 		KirbyTag::$aliases = $this->core->kirbyTagAliases();
@@ -851,7 +834,6 @@ trait AppPlugins
 		$this->extendBlueprints($this->core->blueprints());
 		$this->extendFields($this->core->fields());
 		$this->extendFilePreviews($this->core->filePreviews());
-		$this->extendSections($this->core->sections());
 		$this->extendSnippets($this->core->snippets());
 		$this->extendTags($this->core->kirbyTags());
 		$this->extendTemplates($this->core->templates());

--- a/src/Cms/Core.php
+++ b/src/Cms/Core.php
@@ -41,7 +41,6 @@ use Kirby\Form\Field\PagePickerField;
 use Kirby\Form\Field\PasswordField;
 use Kirby\Form\Field\RadioField;
 use Kirby\Form\Field\RangeField;
-use Kirby\Form\Field\SectionField;
 use Kirby\Form\Field\SelectField;
 use Kirby\Form\Field\SlugField;
 use Kirby\Form\Field\StatsField;
@@ -278,7 +277,6 @@ class Core
 			'password'    => PasswordField::class,
 			'radio'       => RadioField::class,
 			'range'       => RangeField::class,
-			'section'     => SectionField::class,
 			'select'      => SelectField::class,
 			'slug'        => SlugField::class,
 			'stats'       => StatsField::class,
@@ -415,45 +413,6 @@ class Core
 			'blocks/table'    => $this->root . '/blocks/table/table.php',
 			'blocks/text'     => $this->root . '/blocks/text/text.php',
 			'blocks/video'    => $this->root . '/blocks/video/video.php',
-		];
-	}
-
-	/**
-	 * Returns a list of paths to section mixins
-	 *
-	 * They are located in `/kirby/config/sections/mixins`
-	 */
-	public function sectionMixins(): array
-	{
-		return [
-			'batch'      => $this->root . '/sections/mixins/batch.php',
-			'details'    => $this->root . '/sections/mixins/details.php',
-			'empty'      => $this->root . '/sections/mixins/empty.php',
-			'headline'   => $this->root . '/sections/mixins/headline.php',
-			'help'       => $this->root . '/sections/mixins/help.php',
-			'layout'     => $this->root . '/sections/mixins/layout.php',
-			'max'        => $this->root . '/sections/mixins/max.php',
-			'min'        => $this->root . '/sections/mixins/min.php',
-			'pagination' => $this->root . '/sections/mixins/pagination.php',
-			'parent'     => $this->root . '/sections/mixins/parent.php',
-			'search'     => $this->root . '/sections/mixins/search.php',
-			'sort'        => $this->root . '/sections/mixins/sort.php',
-		];
-	}
-
-	/**
-	 * Returns a list of all section definitions
-	 *
-	 * They are located in `/kirby/config/sections`
-	 */
-	public function sections(): array
-	{
-		return [
-			'fields' => $this->root . '/sections/fields.php',
-			'files'  => $this->root . '/sections/files.php',
-			'info'   => $this->root . '/sections/info.php',
-			'pages'  => $this->root . '/sections/pages.php',
-			'stats'  => $this->root . '/sections/stats.php',
 		];
 	}
 

--- a/src/Cms/Loader.php
+++ b/src/Cms/Loader.php
@@ -8,7 +8,7 @@ use Kirby\Filesystem\F;
 
 /**
  * The Loader class is an internal loader for
- * core parts, like areas, components, sections, etc.
+ * core parts, like areas, components, fields, etc.
  *
  * It's exposed in the `$kirby->load()` and the
  * `$kirby->core()->load()` methods.
@@ -176,22 +176,6 @@ class Loader
 		}
 
 		return $area;
-	}
-
-	/**
-	 * Loads a particular section definition
-	 */
-	public function section(string $name): array|null
-	{
-		return $this->resolve($this->extension('sections', $name));
-	}
-
-	/**
-	 * Loads all section defintions
-	 */
-	public function sections(): array
-	{
-		return $this->resolveAll($this->extensions('sections'));
 	}
 
 	/**

--- a/tests/Cms/CoreTest.php
+++ b/tests/Cms/CoreTest.php
@@ -142,7 +142,6 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('pages', $fields);
 		$this->assertArrayHasKey('radio', $fields);
 		$this->assertArrayHasKey('range', $fields);
-		$this->assertArrayHasKey('section', $fields);
 		$this->assertArrayHasKey('select', $fields);
 		$this->assertArrayHasKey('slug', $fields);
 		$this->assertArrayHasKey('structure', $fields);
@@ -256,29 +255,7 @@ class CoreTest extends TestCase
 		$this->assertArrayHasKey('video', $tags);
 	}
 
-	public function testSectionMixins(): void
-	{
-		$mixins = $this->core->sectionMixins();
 
-		$this->assertArrayHasKey('empty', $mixins);
-		$this->assertArrayHasKey('headline', $mixins);
-		$this->assertArrayHasKey('help', $mixins);
-		$this->assertArrayHasKey('layout', $mixins);
-		$this->assertArrayHasKey('max', $mixins);
-		$this->assertArrayHasKey('min', $mixins);
-		$this->assertArrayHasKey('pagination', $mixins);
-		$this->assertArrayHasKey('parent', $mixins);
-	}
-
-	public function testSections(): void
-	{
-		$sections = $this->core->sections();
-
-		$this->assertArrayHasKey('fields', $sections);
-		$this->assertArrayHasKey('files', $sections);
-		$this->assertArrayHasKey('info', $sections);
-		$this->assertArrayHasKey('pages', $sections);
-	}
 
 	public function testTemplates(): void
 	{

--- a/tests/Cms/Loader/LoaderTest.php
+++ b/tests/Cms/Loader/LoaderTest.php
@@ -172,22 +172,7 @@ class LoaderTest extends TestCase
 		$this->assertSame('Test', $resolved['test']['test']);
 	}
 
-	public function testSection(): void
-	{
-		$section = $this->loader->section('pages');
 
-		$this->assertArrayHasKey('props', $section);
-		$this->assertArrayHasKey('computed', $section);
-		$this->assertArrayHasKey('methods', $section);
-	}
-
-	public function testSections(): void
-	{
-		$sections = $this->loader->sections();
-
-		$this->assertArrayHasKey('pages', $sections);
-		$this->assertArrayHasKey('info', $sections);
-	}
 
 	public function testWithPlugins(): void
 	{


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [ ] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

**Timing:** No rush

> [!NOTE]
> It's ok that the unit tests are failing. The PR is a temporary step, to be easier to review. The unit test issues are solved later.

## Description

Sections are no longer a plugin extension type. This drops the `sections` extension, the core section and mixin definitions, the loader helpers and the `Kirby\Cms\Section` alias.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### 🚨 Breaking changes

- The class alias `Kirby\Cms\Section` has been removed
- The `sections` plugin endpoint has been removed (`Kirby\Cms\App::extendSections()`)
- `Kirby\Cms\Core::sections()` and `Kirby\Cms\Core::sectionMixins()` have been removed
- `Kirby\Cms\Loader::sections()` and `Kirby\Cms\Loader::section()` have been removed

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
