### PR TITLE
[remove sections] #13 refact: Remove the section translations

### DIFF
--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -240,9 +240,6 @@
 
 	"error.role.notFound": "The role \"{name}\" cannot be found",
 
-	"error.section.notLoaded": "The section \"{name}\" could not be loaded",
-	"error.section.type.invalid": "The section type \"{type}\" is not valid",
-
 	"error.site.changeTitle.empty": "The title must not be empty",
 	"error.site.changeTitle.permission": "You are not allowed to change the title of the site",
 	"error.site.notAccessible": "The site is not accessible",
@@ -737,9 +734,6 @@
 	"search.all": "Show all {count} results",
 	"search.results.none": "No results",
 
-	"section.invalid": "The section is invalid",
-	"section.required": "The section is required",
-
 	"security": "Security",
 	"select": "Select",
 	"select.all": "Select all",
@@ -844,7 +838,7 @@
 	"url.placeholder": "https://example.com",
 
 	"user": "User",
-	"user.blueprint": "You can define additional sections and form fields for this user role in <strong>/site/blueprints/users/{blueprint}.yml</strong>",
+	"user.blueprint": "You can define additional form fields for this user role in <strong>/site/blueprints/users/{blueprint}.yml</strong>",
 	"user.changeEmail": "Change email",
 	"user.changeLanguage": "Change language",
 	"user.changeName": "Rename this user",


### PR DESCRIPTION
## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [ ] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

**Timing:** No rush

> [!NOTE]
> It's ok that the unit tests are failing. The PR is a temporary step, to be easier to review. The unit test issues are solved later.

## Description

Drops the last leftover section strings now that no code refers to them anymore.

## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
-->

### 🚨 Breaking changes

- The following translation keys for sections have been removed: 
  - `error.section.notLoaded` 
  - `error.section.type.invalid`

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
