### PR TITLE
[sections 2 fields] fix: Resolve field references before merging sections

### DIFF
--- a/src/Blueprint/Normalizer.php
+++ b/src/Blueprint/Normalizer.php
@@ -112,7 +112,9 @@ class Normalizer
 			return $props;
 		}
 
-		$fields = $props['fields'] ?? [];
+		// field references have to be resolved before the merge,
+		// otherwise their numeric keys collide with each other
+		$fields = $this->resolveFieldReferences($props['fields'] ?? []);
 
 		// sections and fields share a single namespace
 		$add = static function (array $fields, $name, $props): array {
@@ -141,7 +143,7 @@ class Normalizer
 
 			// a fields section is unwrapped into the parent's own fields
 			if (($section['type'] ?? $name) === 'fields') {
-				foreach (static::unwrapFieldsSection($section) as $key => $field) {
+				foreach ($this->unwrapFieldsSection($section) as $key => $field) {
 					$fields = $add($fields, $key, $field);
 				}
 
@@ -611,13 +613,17 @@ class Normalizer
 	 * condition on the section is pushed down onto every field,
 	 * the same way it works for field groups.
 	 */
-	protected static function unwrapFieldsSection(array $props): array
+	protected function unwrapFieldsSection(array $props): array
 	{
 		$fields = $props['fields'] ?? [];
 
 		if (is_array($fields) === false) {
 			return [];
 		}
+
+		// references are resolved first, so that the `when` condition
+		// can be pushed down onto them just like onto inline fields
+		$fields = $this->resolveFieldReferences($fields);
 
 		if (isset($props['when']) === true) {
 			$fields = A::map(

--- a/tests/Blueprint/BlueprintFieldReferencesTest.php
+++ b/tests/Blueprint/BlueprintFieldReferencesTest.php
@@ -130,6 +130,83 @@ class BlueprintFieldReferencesTest extends TestCase
 		$this->assertSame('date', $columns[1]['fields']['date']['type']);
 	}
 
+	public function testGlobalFieldsInMultipleSections(): void
+	{
+		$blueprint = new Blueprint([
+			'model'  => $this->model,
+			'fields' => [
+				'title' => [
+					'type' => 'text'
+				],
+				'date' => [
+					'type' => 'date'
+				],
+				'tags' => [
+					'type' => 'tags'
+				]
+			],
+			'tabs' => [
+				'main' => [
+					'sections' => [
+						'a' => [
+							'type'   => 'fields',
+							'fields' => ['title']
+						],
+						'b' => [
+							'type'   => 'fields',
+							'fields' => ['date', 'tags']
+						]
+					]
+				]
+			]
+		]);
+
+		// references keep their own name instead of colliding
+		// on the numeric key they are written with
+		$fields = $blueprint->fields();
+		$this->assertSame(['title', 'date', 'tags'], array_keys($fields));
+		$this->assertSame('text', $fields['title']['type']);
+		$this->assertSame('date', $fields['date']['type']);
+		$this->assertSame('tags', $fields['tags']['type']);
+
+		$tabs = $blueprint->toArray()['tabs'];
+		$this->assertSame(
+			['title', 'date', 'tags'],
+			array_keys($tabs['main']['columns'][0]['fields'])
+		);
+	}
+
+	public function testGlobalFieldsInSectionAndLevelFields(): void
+	{
+		$blueprint = new Blueprint([
+			'model'  => $this->model,
+			'fields' => [
+				'title' => [
+					'type' => 'text'
+				],
+				'date' => [
+					'type' => 'date'
+				]
+			],
+			'tabs' => [
+				'main' => [
+					'fields'   => ['title'],
+					'sections' => [
+						's' => [
+							'type'   => 'fields',
+							'fields' => ['date']
+						]
+					]
+				]
+			]
+		]);
+
+		$fields = $blueprint->fields();
+		$this->assertSame(['title', 'date'], array_keys($fields));
+		$this->assertSame('text', $fields['title']['type']);
+		$this->assertSame('date', $fields['date']['type']);
+	}
+
 	public function testGlobalFieldsInSections(): void
 	{
 		$blueprint = new Blueprint([
@@ -335,6 +412,34 @@ class BlueprintFieldReferencesTest extends TestCase
 		$this->assertSame('info', $tab2Fields['sharedField']['type']);
 		$this->assertSame('negative', $tab2Fields['sharedField']['theme']);
 		$this->assertStringContainsString('already exists', $tab2Fields['sharedField']['text']);
+	}
+
+	public function testSectionWhenPushedToReferencedFields(): void
+	{
+		$blueprint = new Blueprint([
+			'model'  => $this->model,
+			'fields' => [
+				'title' => [
+					'type' => 'text'
+				]
+			],
+			'sections' => [
+				'meta' => [
+					'type' => 'fields',
+					'when' => ['category' => 'a'],
+					'fields' => [
+						'title',
+						'inline' => ['type' => 'text']
+					]
+				]
+			]
+		]);
+
+		// the section condition is pushed down onto referenced
+		// fields just like onto inline ones
+		$fields = $blueprint->fields();
+		$this->assertSame(['category' => 'a'], $fields['title']['when']);
+		$this->assertSame(['category' => 'a'], $fields['inline']['when']);
 	}
 
 	public function testUndefinedFieldReference(): void


### PR DESCRIPTION
Section fields were merged into the parent's own fields before field references were resolved, so two `fields` sections in the
same level collided on the numeric keys. The first reference was replaced by a duplicate-name error field, the rest silently disappeared.

References are now resolved in `convertSectionsToFields()` and `unwrapFieldsSection()`, before the merge. As a side effect a section-level `when` condition is pushed down onto referenced fields as well.