### PR TITLE
[sections 2 fields] fix: Keep the first field of a duplicate name intact

### DIFF
--- a/src/Blueprint/Normalizer.php
+++ b/src/Blueprint/Normalizer.php
@@ -357,9 +357,7 @@ class Normalizer
 
 		foreach ($fields as $name => $props) {
 			if (isset($this->fields[$name]) === true) {
-				$this->fields[$name] = $fields[$name] =
-					static::duplicateFieldError($name, $props);
-
+				$fields[$name] = static::duplicateFieldError($name, $props);
 				continue;
 			}
 

--- a/tests/Blueprint/NormalizerTest.php
+++ b/tests/Blueprint/NormalizerTest.php
@@ -253,6 +253,43 @@ class NormalizerTest extends TestCase
 		);
 	}
 
+	public function testFieldsWithDuplicateNameAcrossTabs(): void
+	{
+		$normalizer = $this->normalizer([
+			'tabs' => [
+				'images' => [
+					'sections' => [
+						'files' => ['type' => 'files', 'template' => 'image']
+					]
+				],
+				'docs' => [
+					'sections' => [
+						'files' => ['type' => 'files', 'template' => 'document']
+					]
+				]
+			]
+		]);
+
+		// the first occurrence keeps the registry entry, so everything
+		// that reads the blueprint by name still gets a working field
+		$field = $normalizer->fields()['files'];
+
+		$this->assertSame('filelist', $field['type']);
+		$this->assertSame('image', $field['template']);
+
+		// only the duplicate is rendered as an error field
+		$tabs = $normalizer->tabs();
+
+		$this->assertSame(
+			'filelist',
+			$tabs['images']['columns'][0]['fields']['files']['type']
+		);
+		$this->assertSame(
+			'info',
+			$tabs['docs']['columns'][0]['fields']['files']['type']
+		);
+	}
+
 	public function testNormalizeFieldProps(): void
 	{
 		$props = Normalizer::normalizeFieldProps([


### PR DESCRIPTION
Sections and fields share a single namespace, so a name used twice across tabs or columns creates a duplicate-name error.
The error also overwrote the global registry entry of the first occurrence, which took the working field down with it.

The first occurrence now keeps the registry entry. Only the duplicate is replaced with an error field, in its own column.