### PR TITLE
[sections 2 fields] fix: Enforce the content lock in the model form

### DIFF
--- a/panel/src/components/Forms/ModelForm.test.ts
+++ b/panel/src/components/Forms/ModelForm.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "@test/unit";
 import { mount } from "@vue/test-utils";
 import ModelForm from "./ModelForm.vue";
 
-const { disabled, isEmpty, resolvedColumns } = ModelForm.computed!;
+const { isEmpty, isLocked, resolvedColumns } = ModelForm.computed!;
 const { fieldsWithAdditionalData } = ModelForm.methods!;
 
 type Field = Record<string, unknown>;
@@ -58,6 +58,38 @@ describe("ModelForm.vue", () => {
 		expect(rendered[0].attributes("width")).toBe("1/2");
 		expect(rendered[1].attributes("sticky")).toBe("true");
 		expect(wrapper.findAll("k-fieldset").length).toBe(2);
+	});
+
+	it("disables the fieldsets of a locked model", () => {
+		const wrapper = mount(ModelForm, {
+			props: {
+				api: "pages/test",
+				columns,
+				lock: { isLegacy: false, isLocked: true, modified: null, user: {} }
+			}
+		});
+
+		expect(wrapper.attributes("data-locked")).toBe("true");
+
+		for (const fieldset of wrapper.findAll("k-fieldset")) {
+			expect(fieldset.attributes("disabled")).toBe("true");
+		}
+	});
+
+	it("keeps the fieldsets of an unlocked model editable", () => {
+		const wrapper = mount(ModelForm, {
+			props: {
+				api: "pages/test",
+				columns,
+				lock: { isLegacy: false, isLocked: false, modified: null, user: {} }
+			}
+		});
+
+		expect(wrapper.attributes("data-locked")).toBe("false");
+
+		for (const fieldset of wrapper.findAll("k-fieldset")) {
+			expect(fieldset.attributes("disabled")).toBe("false");
+		}
 	});
 
 	it("renders the empty state instead of the form", () => {
@@ -144,11 +176,12 @@ describe("ModelForm.resolvedColumns()", () => {
 	});
 });
 
-describe("ModelForm.disabled()", () => {
-	it("is disabled while the model is locked", () => {
-		expect(disabled.call({ lock: { state: "lock" } })).toBe(true);
-		expect(disabled.call({ lock: { state: "unlock" } })).toBe(false);
-		expect(disabled.call({ lock: false })).toBe(false);
+describe("ModelForm.isLocked()", () => {
+	it("reads the lock state from the lock payload", () => {
+		expect(isLocked.call({ lock: { isLocked: true } })).toBe(true);
+		expect(isLocked.call({ lock: { isLocked: false } })).toBe(false);
+		expect(isLocked.call({ lock: false })).toBe(false);
+		expect(isLocked.call({})).toBe(false);
 	});
 });
 

--- a/panel/src/components/Forms/ModelForm.vue
+++ b/panel/src/components/Forms/ModelForm.vue
@@ -3,6 +3,7 @@
 
 	<form
 		v-else
+		:data-locked="isLocked"
 		class="k-model-form"
 		method="POST"
 		@submit.prevent="$emit('submit', $event)"
@@ -16,7 +17,7 @@
 			>
 				<k-fieldset
 					ref="fieldsets"
-					:disabled="disabled"
+					:disabled="isLocked"
 					:fields="column.fields"
 					:value="content"
 					@input="$emit('input', $event)"
@@ -49,11 +50,11 @@ export default {
 	},
 	emits: ["input", "submit"],
 	computed: {
-		disabled() {
-			return this.lock?.state === "lock";
-		},
 		isEmpty() {
 			return Object.keys(this.columns ?? {}).length === 0 && this.empty;
+		},
+		isLocked() {
+			return this.lock?.isLocked === true;
 		},
 		resolvedColumns() {
 			const columns = {};
@@ -88,3 +89,10 @@ export default {
 	}
 };
 </script>
+
+<style>
+.k-model-form[data-locked="true"] {
+	opacity: 0.2;
+	pointer-events: none;
+}
+</style>

--- a/panel/src/components/Views/Preview/PreviewForm.vue
+++ b/panel/src/components/Views/Preview/PreviewForm.vue
@@ -55,7 +55,7 @@ export default {
 		diff: Object,
 		tab: Object,
 		tabs: Array,
-		lock: Boolean
+		lock: [Boolean, Object]
 	},
 	emits: ["discard", "input", "navigate", "submit"],
 	computed: {


### PR DESCRIPTION
`ModelForm` read `lock.state`, a key the backend never sends. `Kirby\Content\Lock::toArray()` carries `isLocked`.

PR is also adding the CSS for the locked state that `.k-fields-section` used to have.