### PR TITLE
refact: Let browser size item images

### DIFF
--- a/panel/src/components/Collection/Item.vue
+++ b/panel/src/components/Collection/Item.vue
@@ -21,7 +21,6 @@
 					v-if="hasFigure"
 					:image="image"
 					:layout="layout"
-					:width="width"
 				/>
 			</slot>
 

--- a/panel/src/components/Collection/ItemImage.test.ts
+++ b/panel/src/components/Collection/ItemImage.test.ts
@@ -61,43 +61,4 @@ describe("ItemImage.vue", () => {
 			expect(wrapper.attributes("ratio")).toBe("16/9");
 		});
 	});
-
-	// computed: sizes
-	describe("width prop", () => {
-		it("defaults to 1/1 sizes", () => {
-			const wrapper = mount();
-			expect(wrapper.attributes("size")).toContain("88em");
-		});
-
-		it("sets sizes for 1/2 width", () => {
-			const wrapper = mount({ width: "1/2" });
-			expect(wrapper.attributes("size")).toContain("44em");
-		});
-
-		it("uses the same sizes for 2/4 as 1/2", () => {
-			const wrapper12 = mount({ width: "1/2" });
-			const wrapper24 = mount({ width: "2/4" });
-			expect(wrapper12.attributes("size")).toBe(wrapper24.attributes("size"));
-		});
-
-		it("sets sizes for 1/3 width", () => {
-			const wrapper = mount({ width: "1/3" });
-			expect(wrapper.attributes("size")).toContain("29.333em");
-		});
-
-		it("sets sizes for 1/4 width", () => {
-			const wrapper = mount({ width: "1/4" });
-			expect(wrapper.attributes("size")).toContain("22em");
-		});
-
-		it("sets sizes for 2/3 width", () => {
-			const wrapper = mount({ width: "2/3" });
-			expect(wrapper.attributes("size")).toContain("27em");
-		});
-
-		it("sets sizes for 3/4 width", () => {
-			const wrapper = mount({ width: "3/4" });
-			expect(wrapper.attributes("size")).toContain("66em");
-		});
-	});
 });

--- a/panel/src/components/Collection/ItemImage.vue
+++ b/panel/src/components/Collection/ItemImage.vue
@@ -16,15 +16,7 @@ export const props = {
 		/**
 		 * See `<k-image-frame>` or `<k-icon-frame>` for all available options
 		 */
-		image: [Object, Boolean],
-		/**
-		 * Width (e.g. `"1/2"`) of the parent column is used to set the srcset sizes accordingly
-		 * @todo refactor to remove this
-		 */
-		width: {
-			type: String,
-			default: "1/1"
-		}
+		image: [Object, Boolean]
 	}
 };
 
@@ -43,29 +35,11 @@ export default {
 				back: this.image.back,
 				cover: true,
 				...this.image,
-				ratio: this.layout === "list" ? "auto" : this.image.ratio,
-				size: this.sizes
+				ratio: this.layout === "list" ? "auto" : this.image.ratio
 			};
 		},
 		component() {
 			return this.image.src ? "k-image-frame" : "k-icon-frame";
-		},
-		sizes() {
-			switch (this.width) {
-				case "1/2":
-				case "2/4":
-					return "(min-width: 30em) and (max-width: 65em) 59em, (min-width: 65em) 44em, 27em";
-				case "1/3":
-					return "(min-width: 30em) and (max-width: 65em) 59em, (min-width: 65em) 29.333em, 27em";
-				case "1/4":
-					return "(min-width: 30em) and (max-width: 65em) 59em, (min-width: 65em) 22em, 27em";
-				case "2/3":
-					return "(min-width: 30em) and (max-width: 65em) 59em, (min-width: 65em) 27em, 27em";
-				case "3/4":
-					return "(min-width: 30em) and (max-width: 65em) 59em, (min-width: 65em) 66em, 27em";
-				default:
-					return "(min-width: 30em) and (max-width: 65em) 59em, (min-width: 65em) 88em, 27em";
-			}
 		}
 	}
 };

--- a/panel/src/components/Collection/Items.vue
+++ b/panel/src/components/Collection/Items.vue
@@ -43,7 +43,6 @@
 					:selectmode="selectmode"
 					:sortable="sortable && item.sortable !== false"
 					:theme="item.theme ?? theme"
-					:width="item.column"
 					@click="$emit('item', item, itemIndex)"
 					@drag="onDragStart($event, item.dragText)"
 					@mouseover="$emit('hover', $event, item, itemIndex)"

--- a/panel/src/components/Layout/Frame/ImageFrame.test.ts
+++ b/panel/src/components/Layout/Frame/ImageFrame.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "@test/unit";
+import {
+	flushPromises,
+	mount as vueMount,
+	type VueWrapper
+} from "@vue/test-utils";
+import type { ComponentPublicInstance } from "vue";
+import ImageFrame from "./ImageFrame.vue";
+
+type Props = Record<string, unknown>;
+
+const items = vi.fn();
+
+function mount(props: Props = {}, attrs: Props = {}) {
+	return vueMount(ImageFrame, {
+		props,
+		attrs,
+		global: {
+			mocks: {
+				$helper: { items }
+			}
+		}
+	}) as unknown as VueWrapper<ComponentPublicInstance<Props>>;
+}
+
+describe("ImageFrame.vue", () => {
+	beforeEach(() => {
+		items.mockReset();
+	});
+
+	// $el
+	describe("element", () => {
+		const component = (attrs?: Record<string, unknown>) => mount({}, attrs);
+
+		it.rendersAs(component, "K-FRAME", "k-image-frame");
+		it.acceptsClass(component);
+		it.acceptsStyle(component);
+		it.inheritsNoAttrs(component);
+
+		it("passes props to k-frame", () => {
+			const wrapper = mount({ ratio: "16/9", theme: "positive" });
+
+			expect(wrapper.attributes("element")).toBe("figure");
+			expect(wrapper.attributes("ratio")).toBe("16/9");
+			expect(wrapper.attributes("theme")).toBe("positive");
+		});
+	});
+
+	// props
+	describe("alt prop", () => {
+		it("renders the alt text", () => {
+			const img = mount({ src: "/image.jpg", alt: "A cat" }).find("img");
+			expect(img.attributes("alt")).toBe("A cat");
+		});
+
+		it("falls back to an empty alt attribute", () => {
+			const img = mount({ src: "/image.jpg" }).find("img");
+			expect(img.attributes("alt")).toBe("");
+		});
+	});
+
+	describe("file prop", () => {
+		it("resolves the image for a file id", async () => {
+			items.mockResolvedValue({
+				alt: "A cat",
+				image: { src: "/cat.jpg", srcset: "/cat.jpg 1x" }
+			});
+
+			const wrapper = mount({ file: "file://cat" });
+			await flushPromises();
+			const img = wrapper.find("img");
+
+			expect(img.attributes("src")).toBe("/cat.jpg");
+			expect(img.attributes("srcset")).toBe("/cat.jpg 1x");
+			expect(img.attributes("alt")).toBe("A cat");
+		});
+
+		it("requests the file with ratio and cover", async () => {
+			mount({ file: "file://cat", ratio: "16/9", cover: true });
+			await flushPromises();
+
+			expect(items).toHaveBeenCalledWith("items/files", "file://cat", {
+				layout: "auto",
+				image: JSON.stringify({ ratio: "16/9", cover: true })
+			});
+		});
+
+		it("renders no img when the file cannot be resolved", async () => {
+			items.mockResolvedValue(undefined);
+
+			const wrapper = mount({ file: "file://cat" });
+			await flushPromises();
+
+			expect(wrapper.find("img").exists()).toBe(false);
+		});
+
+		it("is overridden by explicit src and alt props", async () => {
+			items.mockResolvedValue({
+				alt: "A cat",
+				image: { src: "/cat.jpg" }
+			});
+
+			const wrapper = mount({
+				file: "file://cat",
+				src: "/dog.jpg",
+				alt: "A dog"
+			});
+			await flushPromises();
+			const img = wrapper.find("img");
+
+			expect(img.attributes("src")).toBe("/dog.jpg");
+			expect(img.attributes("alt")).toBe("A dog");
+		});
+	});
+
+	describe("lazy prop", () => {
+		it("loads lazily by default", () => {
+			const img = mount({ src: "/image.jpg" }).find("img");
+			expect(img.attributes("loading")).toBe("lazy");
+		});
+
+		it("loads eagerly when false", () => {
+			const img = mount({ src: "/image.jpg", lazy: false }).find("img");
+			expect(img.attributes("loading")).toBe("eager");
+		});
+	});
+
+	describe("src prop", () => {
+		it("renders an img", () => {
+			const img = mount({ src: "/image.jpg" }).find("img");
+
+			expect(img.attributes("src")).toBe("/image.jpg");
+			expect(img.attributes("decoding")).toBe("async");
+		});
+
+		it("renders no img when unset", () => {
+			const wrapper = mount();
+			expect(wrapper.find("img").exists()).toBe(false);
+		});
+	});
+
+	describe("srcset prop", () => {
+		it("renders the srcset attribute", () => {
+			const img = mount({
+				src: "/image.jpg",
+				srcset: "/image.jpg 1x, /image@2x.jpg 2x"
+			}).find("img");
+
+			expect(img.attributes("srcset")).toBe("/image.jpg 1x, /image@2x.jpg 2x");
+		});
+	});
+
+	// computed
+	describe("resolvedSizes", () => {
+		it("lets the browser measure a lazy image", () => {
+			const img = mount({ src: "/image.jpg" }).find("img");
+			expect(img.attributes("sizes")).toBe("auto");
+		});
+
+		it("omits sizes for an eager image", () => {
+			const img = mount({ src: "/image.jpg", lazy: false }).find("img");
+			expect(img.attributes("sizes")).toBeUndefined();
+		});
+
+		it("keeps an explicit sizes prop", () => {
+			const img = mount({ src: "/image.jpg", sizes: "50vw" }).find("img");
+			expect(img.attributes("sizes")).toBe("50vw");
+		});
+	});
+
+	// methods
+	describe("fetch()", () => {
+		it("fetches again when the file changes", async () => {
+			items.mockResolvedValueOnce({ image: { src: "/cat.jpg" } });
+			items.mockResolvedValueOnce({ image: { src: "/dog.jpg" } });
+
+			const wrapper = mount({ file: "file://cat" });
+			await wrapper.setProps({ file: "file://dog" });
+			await flushPromises();
+
+			expect(wrapper.find("img").attributes("src")).toBe("/dog.jpg");
+		});
+
+		it("drops a response that arrives after the file changed", async () => {
+			const cat = Promise.withResolvers();
+			items.mockReturnValueOnce(cat.promise);
+			items.mockResolvedValueOnce({ image: { src: "/dog.jpg" } });
+
+			const wrapper = mount({ file: "file://cat" });
+			await wrapper.setProps({ file: "file://dog" });
+			await flushPromises();
+
+			cat.resolve({ image: { src: "/cat.jpg" } });
+			await flushPromises();
+
+			expect(wrapper.find("img").attributes("src")).toBe("/dog.jpg");
+		});
+	});
+
+	// events
+	describe("dragstart event", () => {
+		it("prevents dragging the image out of the frame", () => {
+			const img = mount({ src: "/image.jpg" }).find("img");
+			const event = new Event("dragstart", { cancelable: true });
+			img.element.dispatchEvent(event);
+			expect(event.defaultPrevented).toBe(true);
+		});
+	});
+});

--- a/panel/src/components/Layout/Frame/ImageFrame.vue
+++ b/panel/src/components/Layout/Frame/ImageFrame.vue
@@ -10,7 +10,7 @@
 			:alt="alt ?? resolvedAlt ?? ''"
 			:src="src ?? resolvedSrc"
 			:srcset="srcset ?? resolvedSrcset"
-			:sizes="sizes"
+			:sizes="resolvedSizes"
 			:loading="lazy === true ? 'lazy' : 'eager'"
 			decoding="async"
 			@dragstart.prevent
@@ -43,7 +43,8 @@ export const props = {
 			default: true
 		},
 		/**
-		 * For responsive images, pass the `sizes` attribute
+		 * For responsive images, pass the `sizes` attribute.
+		 * Lazy images default to `auto`.
 		 */
 		sizes: String,
 		/**
@@ -77,6 +78,11 @@ export default {
 			resolvedSrc: null,
 			resolvedSrcset: null
 		};
+	},
+	computed: {
+		resolvedSizes() {
+			return this.sizes ?? (this.lazy === true ? "auto" : undefined);
+		}
 	},
 	watch: {
 		file: {

--- a/panel/src/components/Misc/Icon.test.ts
+++ b/panel/src/components/Misc/Icon.test.ts
@@ -3,7 +3,7 @@ import { mount as vueMount } from "@vue/test-utils";
 import { hasEmoji } from "@/helpers/string.js";
 import Icon from "./Icon.vue";
 
-const sprite = "/media/panel/1234/img/icons.svg";
+const sprite = "/panel/assets/1234/icons.svg";
 
 /**
  * Custom mount which injects $helper and $panel stubs

--- a/src/Panel/Assets.php
+++ b/src/Panel/Assets.php
@@ -182,23 +182,22 @@ class Assets
 	/**
 	 * URL for the SVG icon sprite, which is referenced by
 	 * all `<use>` elements in the Panel.
+	 *
+	 * The sprite is served by a Panel route to keep it on the same
+	 * origin as the Panel document. External `<use>` references are
+	 * limited to the same origin and CORS cannot open them up, so the
+	 * media URL is no option as it can point to a different origin.
 	 */
 	public function icons(): string
 	{
-		$path = '/panel/' . $this->kirby->versionHash() . '/img/icons.svg';
+		// the version hash busts the browser cache for every release;
+		// in dev mode, the sprite changes without a release, so the
+		// modification time of the source file is used instead
+		$version = $this->isDev === true
+			? F::modified($this->iconsRoot())
+			: $this->kirby->versionHash();
 
-		if ($this->isDev === true) {
-			$source   = $this->iconsRoot();
-			$target   = $this->kirby->root('media') . $path;
-			$modified = F::modified($source);
-
-			if (F::modified($target) !== $modified) {
-				F::copy($source, $target, true);
-				touch($target, $modified);
-			}
-		}
-
-		return $this->kirby->url('media') . $path;
+		return $this->kirby->url('panel') . '/assets/' . $version . '/icons.svg';
 	}
 
 	/**
@@ -218,6 +217,16 @@ class Assets
 		return array_filter([
 			'vue' => $this->vue()
 		]);
+	}
+
+	/**
+	 * Whether the Panel is running in dev mode
+	 * and the assets are served by the Vite dev server
+	 * @since 6.0.0
+	 */
+	public function isDev(): bool
+	{
+		return $this->isDev;
 	}
 
 	/**

--- a/src/Panel/Router.php
+++ b/src/Panel/Router.php
@@ -113,6 +113,28 @@ class Router
 	}
 
 	/**
+	 * Response for the SVG icon sprite, which is referenced
+	 * by all `<use>` elements in the Panel
+	 * @since 6.0.0
+	 */
+	public function icons(): Response
+	{
+		$assets = $this->panel->assets();
+
+		// the version hash in the URL only changes with a new release,
+		// so the sprite can be cached forever; the dev mode URL is busted
+		// by the modification time, which is only accurate to the second
+		$cache = $assets->isDev() === true
+			? 'no-store'
+			: 'public, max-age=31536000, immutable';
+
+		return Response::file(
+			$assets->iconsRoot(),
+			['headers' => ['Cache-Control' => $cache]]
+		);
+	}
+
+	/**
 	 * Creates a Response object from the result of
 	 * a Panel route call
 	 */
@@ -155,11 +177,17 @@ class Router
 	{
 		$kirby   = $this->kirby;
 		$panel   = $this->panel;
+		$router  = $this;
 		$areas ??= $panel->areas();
 
-		// the browser incompatibility
-		// warning is always needed
+		// the icon sprite and the browser incompatibility
+		// warning are always needed, no matter the areas
 		$routes = [
+			[
+				'pattern' => 'assets/(:any)/icons.svg',
+				'auth'    => false,
+				'action'  => fn () => $router->icons(),
+			],
 			[
 				'pattern' => 'browser',
 				'auth'    => false,

--- a/tests/Panel/AssetsTest.php
+++ b/tests/Panel/AssetsTest.php
@@ -307,7 +307,7 @@ class AssetsTest extends TestCase
 		$assets = new Assets();
 
 		$this->assertSame(
-			'/media/panel/' . $this->app->versionHash() . '/img/icons.svg',
+			'/panel/assets/' . $this->app->versionHash() . '/icons.svg',
 			$assets->icons()
 		);
 	}
@@ -316,55 +316,62 @@ class AssetsTest extends TestCase
 	{
 		$this->setDevMode();
 
-		$assets = new Assets();
-		$target = $this->app->root('media') . '/panel/' . $this->app->versionHash() . '/img/icons.svg';
+		// the sprite is never served by Vite, as `<use>` references
+		// are limited to the same origin as the Panel document
+		$assets   = new Assets();
+		$modified = F::modified($this->app->root('panel') . '/public/img/icons.svg');
 
-		$this->assertFileDoesNotExist($target);
-
-		// the sprite is not served by Vite, but synced to the media folder
 		$this->assertSame(
-			'/media/panel/' . $this->app->versionHash() . '/img/icons.svg',
+			'/panel/assets/' . $modified . '/icons.svg',
 			$assets->icons()
 		);
+	}
 
-		$this->assertFileEquals(
-			$this->app->root('panel') . '/public/img/icons.svg',
-			$target
+	public function testIconsInDevModeAfterProduction(): void
+	{
+		$production = (new Assets())->icons();
+
+		$this->setDevMode();
+
+		// the dev URL must differ from the production URL, which the
+		// browser has cached as immutable and would not request again
+		$this->assertNotSame($production, (new Assets())->icons());
+	}
+
+	public function testIconsWithCustomMediaUrl(): void
+	{
+		$this->app = $this->app->clone([
+			'urls' => [
+				'media' => 'https://cdn.getkirby.com/media'
+			]
+		]);
+
+		// the sprite must stay on the Panel origin, even if
+		// the media folder is served from a CDN
+		$assets = new Assets();
+
+		$this->assertSame(
+			'/panel/assets/' . $this->app->versionHash() . '/icons.svg',
+			$assets->icons()
 		);
 	}
 
-	public function testIconsInDevModeWithCurrentCopy(): void
+	public function testIconsWithCustomPanelSlug(): void
 	{
-		$this->setDevMode();
+		$this->app = $this->app->clone([
+			'options' => [
+				'panel' => [
+					'slug' => 'admin'
+				]
+			]
+		]);
 
 		$assets = new Assets();
-		$source = $this->app->root('panel') . '/public/img/icons.svg';
-		$target = $this->app->root('media') . '/panel/' . $this->app->versionHash() . '/img/icons.svg';
 
-		F::write($target, 'current');
-		touch($target, F::modified($source));
-
-		$assets->icons();
-
-		// the copy is up to date and does not get repeated
-		$this->assertSame('current', F::read($target));
-	}
-
-	public function testIconsInDevModeWithOutdatedCopy(): void
-	{
-		$this->setDevMode();
-
-		$assets = new Assets();
-		$source = $this->app->root('panel') . '/public/img/icons.svg';
-		$target = $this->app->root('media') . '/panel/' . $this->app->versionHash() . '/img/icons.svg';
-
-		F::write($target, 'outdated');
-		touch($target, 1);
-
-		$assets->icons();
-
-		$this->assertFileEquals($source, $target);
-		$this->assertSame(F::modified($source), F::modified($target));
+		$this->assertSame(
+			'/admin/assets/' . $this->app->versionHash() . '/icons.svg',
+			$assets->icons()
+		);
 	}
 
 	public function testIconsRoot(): void
@@ -395,6 +402,15 @@ class AssetsTest extends TestCase
 		$importMaps = $assets->importMaps();
 
 		$this->assertSame('/media/panel/' . $this->app->versionHash() . '/js/vue.esm-browser.prod.js', $importMaps['vue']);
+	}
+
+	public function testIsDev(): void
+	{
+		$this->assertFalse((new Assets())->isDev());
+
+		$this->setDevMode();
+
+		$this->assertTrue((new Assets())->isDev());
 	}
 
 	public function testJs(): void

--- a/tests/Panel/RouterTest.php
+++ b/tests/Panel/RouterTest.php
@@ -2,15 +2,91 @@
 
 namespace Kirby\Panel;
 
+use Kirby\Cms\Url;
 use Kirby\Exception\Exception;
 use Kirby\Exception\NotFoundException;
+use Kirby\Filesystem\F;
 use Kirby\Http\Response;
+use Kirby\Toolkit\Str;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(Router::class)]
 class RouterTest extends TestCase
 {
-	public const string TMP = KIRBY_TMP_DIR . '/Panel.Panel';
+	public const string TMP               = KIRBY_TMP_DIR . '/Panel.Panel';
+	public const string VITE_RUNNING_PATH = KIRBY_DIR . '/panel/.vite-running';
+
+	protected bool $hadViteRunning;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		// initialize development mode to a known state
+		$this->hadViteRunning = is_file(static::VITE_RUNNING_PATH);
+		F::remove(static::VITE_RUNNING_PATH);
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+
+		// reset development mode
+		if ($this->hadViteRunning === true) {
+			touch(static::VITE_RUNNING_PATH);
+		} else {
+			F::remove(static::VITE_RUNNING_PATH);
+		}
+	}
+
+	public function testCallIcons(): void
+	{
+		$router   = new Router($this->app->panel());
+		$response = $router->call('assets/' . $this->app->versionHash() . '/icons.svg');
+
+		// the sprite is served before any area route can catch the path
+		$this->assertSame(200, $response->code());
+		$this->assertSame('image/svg+xml', $response->type());
+		$this->assertStringContainsString('id="icon-accessibility"', $response->body());
+	}
+
+	public function testIcons(): void
+	{
+		$router   = new Router($this->app->panel());
+		$response = $router->icons();
+
+		$this->assertSame('image/svg+xml', $response->type());
+		$this->assertSame(
+			'public, max-age=31536000, immutable',
+			$response->header('Cache-Control')
+		);
+		$this->assertStringContainsString('id="icon-accessibility"', $response->body());
+	}
+
+	public function testIconsInDevMode(): void
+	{
+		$this->app = $this->app->clone([
+			'options' => [
+				'panel' => [
+					'dev' => true
+				]
+			]
+		]);
+
+		touch(static::VITE_RUNNING_PATH);
+
+		$panel = $this->app->panel();
+		$path  = Str::after(Url::path($panel->assets()->icons()), 'panel/');
+
+		// the modification time in the dev URL must resolve to the same route
+		$response = $panel->router()->call($path);
+
+		$this->assertSame(200, $response->code());
+		$this->assertStringContainsString('id="icon-accessibility"', $response->body());
+
+		// the sprite must not be cached while it is still being edited
+		$this->assertSame('no-store', $response->header('Cache-Control'));
+	}
 
 	public function testResponse(): void
 	{
@@ -70,14 +146,16 @@ class RouterTest extends TestCase
 		$router = new Router($panel);
 		$routes = $router->routes($areas);
 
-		$this->assertSame('browser', $routes[0]['pattern']);
-		$this->assertSame(['/', 'installation', 'login'], $routes[1]['pattern']);
-		$this->assertSame('(:all)', $routes[2]['pattern']);
+		$this->assertSame('assets/(:any)/icons.svg', $routes[0]['pattern']);
+		$this->assertFalse($routes[0]['auth']);
+		$this->assertSame('browser', $routes[1]['pattern']);
+		$this->assertSame(['/', 'installation', 'login'], $routes[2]['pattern']);
+		$this->assertSame('(:all)', $routes[3]['pattern']);
 
 		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Could not find Panel route: foo');
 
-		$routes[2]['action']('foo');
+		$routes[3]['action']('foo');
 	}
 
 	public function testSetLanguageWithoutRequest(): void

--- a/tests/Panel/StateTest.php
+++ b/tests/Panel/StateTest.php
@@ -159,7 +159,7 @@ class StateTest extends TestCase
 			'a' => 'A',
 			'urls' => [
 				'api'   => '/api',
-				'icons' => '/media/panel/' . $this->app->versionHash() . '/img/icons.svg',
+				'icons' => '/panel/assets/' . $this->app->versionHash() . '/icons.svg',
 				'panel' => '/panel',
 				'site'  => '/'
 			]


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check


## Description
<!--
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.

You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR.

If something is deliberately out of scope, say so here.
-->

`ItemImage` translated the width of the layout column into an srcset `sizes` hint, which meant the column width had to be
threaded from the blueprint through the section, the collection, the items and finally the image.

Though, so far it never arrived. The computed hint was handed over as `size`, while `k-image-frame` reads `sizes`, so it landed in `$attrs` and was dropped. No item image has rendered a `sizes` attribute since the frame components were introduced, and the existing tests only asserted the prop on the component, never the attribute on the `img`.

Lazy images now use `sizes="auto"` instead, which is what the whole guess was approximating: the browser measures the rendered image, tracks the container queries of the item grid and needs no knowledge of the blueprint layout at all. Browsers without support treat it as invalid and fall back to `100vw`, which is exactly what a missing `sizes` does today.


## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🐛 Bug fixes
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### ✨ Enhancements
- `<k-image-frame>` uses `sizes="auto"` for lazy-loaded images, if not `sizes` is specified


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
