### PR TITLE
perf: Improve modellist field table layout

### DIFF
--- a/src/Form/Field/ModelListField.php
+++ b/src/Form/Field/ModelListField.php
@@ -46,6 +46,7 @@ abstract class ModelListField extends DisplayField
 	protected array|null $columns;
 
 	protected array|null $columnsCache = null;
+	protected array|null $columnFieldsCache = null;
 
 	/**
 	 * If `true`, the order of the entries is reversed
@@ -181,14 +182,111 @@ abstract class ModelListField extends DisplayField
 
 	abstract public function collector(): ModelsCollector;
 
+	/**
+	 * Column definitions for `layout: table`, with the type of
+	 * each column resolved from the blueprint of the entries
+	 */
 	public function columns(): array
 	{
 		if ($this->columnsCache !== null) {
 			return $this->columnsCache;
 		}
 
-		if ($this->layout() !== 'table') {
+		$columns = $this->defineColumns();
+
+		if ($columns === []) {
 			return $this->columnsCache = [];
+		}
+
+		if ($blueprint = $this->models()->first()?->blueprint()) {
+			foreach ($columns as $name => $column) {
+				if ($id = $column['id'] ?? null) {
+					$columns[$name]['type'] ??= $blueprint->field($id)['type'] ?? null;
+				}
+			}
+		}
+
+		return $this->columnsCache = $columns;
+	}
+
+	/**
+	 * Blueprint field names behind all columns that read their
+	 * value from the model instead of from their own query
+	 */
+	protected function columnFields(): array
+	{
+		if ($this->columnFieldsCache !== null) {
+			return $this->columnFieldsCache;
+		}
+
+		$fields = [];
+
+		foreach ($this->columns() as $column) {
+			// only columns from the `columns` prop carry an id;
+			// the built-in ones are filled by the item itself
+			if (($id = $column['id'] ?? null) === null) {
+				continue;
+			}
+
+			if (($column['value'] ?? '') === '') {
+				$fields[] = $id;
+			}
+		}
+
+		return $this->columnFieldsCache = $fields;
+	}
+
+	/**
+	 * Values of the column fields for a single entry.
+	 *
+	 * Only the blueprint fields the columns actually read are
+	 * instantiated. Building the full form for every row makes the
+	 * table layout scale with the size of the blueprint instead of
+	 * the number of columns.
+	 *
+	 * @param TModel $model
+	 */
+	protected function columnValues(ModelWithContent $model): array
+	{
+		$form = new Form(
+			fields: array_intersect_key(
+				$model->blueprint()->fields(),
+				array_flip($this->columnFields())
+			),
+			model: $model
+		);
+
+		// values for columns without a matching field are passed through
+		$form->fill(input: $model->content($form->language())->toArray());
+
+		return $form->toFormValues();
+	}
+
+	/**
+	 * The props for all entries of the current page
+	 */
+	public function data(): array
+	{
+		$table = $this->layout() === 'table';
+		$data  = [];
+
+		foreach ($this->collector()->models(paginated: true) as $model) {
+			/** @var TModel $model */
+			$data[] = $table === true ? $this->row($model) : $this->toItem($model);
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Builds the column definitions for `layout: table`.
+	 * Subclasses extend this instead of `columns()`,
+	 * so that the cache holds the final set.
+	 */
+	protected function defineColumns(): array
+	{
+		if ($this->layout() !== 'table') {
+			return [];
 		}
 
 		$columns = [];
@@ -235,55 +333,7 @@ abstract class ModelListField extends DisplayField
 			$columns[$name] = [...$columns[$name] ?? [], ...$column];
 		}
 
-		return $this->columnsCache = $columns;
-	}
-
-	public function columnsWithTypes(): array
-	{
-		$columns   = $this->columns();
-		$blueprint = $this->models()->first()?->blueprint();
-
-		if ($blueprint === null) {
-			return $columns;
-		}
-
-		foreach ($columns as $name => $column) {
-			if ($id = $column['id'] ?? null) {
-				$columns[$name]['type'] ??= $blueprint->field($id)['type'] ?? null;
-			}
-		}
-
 		return $columns;
-	}
-
-	/**
-	 * @param TModel $model
-	 */
-	public function columnsValues(array $item, ModelWithContent $model): array
-	{
-		$item['title'] = [
-			// override toSafeString() coming from `$item`
-			// because the table cells don't use v-html
-			'text' => $model->toString($this->text()),
-			'href' => $model->panel()->url(true)
-		];
-
-		if ($info = $this->info()) {
-			$item['info'] = $model->toString($info);
-		}
-
-		$values = Form::for($model)->toFormValues();
-
-		foreach ($this->columns() as $name => $column) {
-			$item[$name] = match (empty($column['value'])) {
-				// if a column value is defined, resolve the query
-				false   => $model->toString($column['value']),
-				// otherwise use the form value, but don't overwrite columns
-				default => $item[$name] ?? $values[$column['id'] ?? $name] ?? null
-			};
-		}
-
-		return $item;
 	}
 
 	/**
@@ -316,27 +366,6 @@ abstract class ModelListField extends DisplayField
 		$this->models()->delete($ids);
 
 		return true;
-	}
-
-	/**
-	 * The props for all entries of the current page
-	 */
-	public function data(): array
-	{
-		$data = [];
-
-		foreach ($this->collector()->models(paginated: true) as $model) {
-			/** @var TModel $model */
-			$item = $this->toItem($model);
-
-			if ($this->layout() === 'table') {
-				$item = $this->columnsValues($item, $model);
-			}
-
-			$data[] = $item;
-		}
-
-		return $data;
 	}
 
 	/**
@@ -503,6 +532,37 @@ abstract class ModelListField extends DisplayField
 		return $this->query;
 	}
 
+	/**
+	 * The props for a single entry in `layout: table`
+	 *
+	 * @param TModel $model
+	 */
+	protected function row(ModelWithContent $model): array
+	{
+		$item   = $this->toItem($model);
+		$values = null;
+
+		// the title cell carries the link to the model
+		$item['title'] = [
+			'text' => $item['text'],
+			'href' => $item['link']
+		];
+
+		foreach ($this->columns() as $name => $column) {
+			// a column query is resolved against the model
+			if (($query = $column['value'] ?? '') !== '') {
+				$item[$name] = $model->toString($query);
+				continue;
+			}
+
+			// otherwise fall back to the form value,
+			// without overwriting what the item already provides
+			$item[$name] ??= ($values ??= $this->columnValues($model))[$column['id'] ?? $name] ?? null;
+		}
+
+		return $item;
+	}
+
 	public function searchable(): bool
 	{
 		return $this->searchable ?? false;
@@ -541,10 +601,11 @@ abstract class ModelListField extends DisplayField
 			$this->flip() === false;
 	}
 
+
 	public function state(): array
 	{
 		return [
-			'columns'    => $this->columnsWithTypes(),
+			'columns'    => $this->columns(),
 			'models'     => $this->data(),
 			'pagination' => $this->pagination(),
 			'sortable'   => $this->sortable(),

--- a/src/Form/Field/ModelListField.php
+++ b/src/Form/Field/ModelListField.php
@@ -557,7 +557,10 @@ abstract class ModelListField extends DisplayField
 
 			// otherwise fall back to the form value,
 			// without overwriting what the item already provides
-			$item[$name] ??= ($values ??= $this->columnValues($model))[$column['id'] ?? $name] ?? null;
+			if (isset($item[$name]) === false) {
+				$values ??= $this->columnValues($model);
+				$item[$name] = $values[$column['id'] ?? $name] ?? null;
+			}
 		}
 
 		return $item;

--- a/src/Form/Field/PageListField.php
+++ b/src/Form/Field/PageListField.php
@@ -187,27 +187,6 @@ class PageListField extends ModelListField implements ProvidesAcceptedBlueprints
 		return array_diff($blueprints, $this->templatesIgnore());
 	}
 
-	/**
-	 * The table layout shows the page status in its own column
-	 */
-	public function columns(): array
-	{
-		$columns = parent::columns();
-
-		if ($this->layout() !== 'table') {
-			return $columns;
-		}
-
-		$columns['flag'] = [
-			'label'  => ' ',
-			'mobile' => true,
-			'type'   => 'flag',
-			'width'  => 'var(--table-row-height)',
-		];
-
-		return $columns;
-	}
-
 	public function collector(): PagesCollector
 	{
 		$parent = $this->parentModel();
@@ -229,6 +208,27 @@ class PageListField extends ModelListField implements ProvidesAcceptedBlueprints
 	public function create(): array|string|bool|null
 	{
 		return $this->create;
+	}
+
+	/**
+	 * The table layout shows the page status in its own column
+	 */
+	protected function defineColumns(): array
+	{
+		$columns = parent::defineColumns();
+
+		if ($this->layout() !== 'table') {
+			return $columns;
+		}
+
+		$columns['flag'] = [
+			'label'  => ' ',
+			'mobile' => true,
+			'type'   => 'flag',
+			'width'  => 'var(--table-row-height)',
+		];
+
+		return $columns;
 	}
 
 	// @codeCoverageIgnoreStart

--- a/src/Panel/Ui/Item/ModelItem.php
+++ b/src/Panel/Ui/Item/ModelItem.php
@@ -45,9 +45,16 @@ class ModelItem extends Item
 		$this->panel = $model->panel();
 	}
 
-	protected function info(): HtmlString|null
+	protected function info(): string|HtmlString|null
 	{
-		return $this->model->toSafeHtmlString($this->info ?? false);
+		// an empty template, not null: null would render the model id
+		$info = $this->info ?? '';
+
+		if ($this->layout === 'table') {
+			return $this->model->toString($info);
+		}
+
+		return $this->model->toSafeHtmlString($info);
 	}
 
 	protected function image(): array|null
@@ -76,8 +83,12 @@ class ModelItem extends Item
 		];
 	}
 
-	protected function text(): HtmlString
+	protected function text(): string|HtmlString
 	{
+		if ($this->layout === 'table') {
+			return $this->model->toString($this->text);
+		}
+
 		return $this->model->toSafeHtmlString($this->text);
 	}
 }

--- a/tests/Form/Field/FileListFieldTest.php
+++ b/tests/Form/Field/FileListFieldTest.php
@@ -27,7 +27,8 @@ class FileListFieldTest extends TestCase
 			'blueprints' => [
 				'files/image' => [
 					'fields' => [
-						'alt' => ['type' => 'text']
+						'alt'  => ['type' => 'text'],
+						'tags' => ['type' => 'tags']
 					]
 				]
 			],
@@ -38,17 +39,17 @@ class FileListFieldTest extends TestCase
 						'files' => [
 							[
 								'filename' => 'a.jpg',
-								'content'  => ['alt' => 'Alt A'],
+								'content'  => ['alt' => 'Alt A', 'tags' => 'a, b', 'caption' => 'Caption A'],
 								'template' => 'image'
 							],
 							[
 								'filename' => 'b.jpg',
-								'content'  => ['alt' => 'Alt B'],
+								'content'  => ['alt' => 'Alt B', 'tags' => 'a, b', 'caption' => 'Caption B'],
 								'template' => 'image'
 							],
 							[
 								'filename' => 'c.jpg',
-								'content'  => ['alt' => 'Alt C'],
+								'content'  => ['alt' => 'Alt C', 'tags' => 'a, b', 'caption' => 'Caption C'],
 								'template' => 'image'
 							]
 						],
@@ -221,7 +222,8 @@ class FileListFieldTest extends TestCase
 			'layout'  => 'table'
 		]);
 
-		$this->assertSame('text', $field->columnsWithTypes()['alt']['type']);
+		// the type is resolved from the blueprint of the entries
+		$this->assertSame('text', $field->columns()['alt']['type']);
 	}
 
 	public function testColumnsWithTypesWithoutFiles(): void
@@ -232,7 +234,8 @@ class FileListFieldTest extends TestCase
 			'template' => 'does-not-exist'
 		]);
 
-		$this->assertSame($field->columns(), $field->columnsWithTypes());
+		// without entries there is no blueprint to resolve the type from
+		$this->assertArrayNotHasKey('type', $field->columns()['alt']);
 	}
 
 	public function testDataWithTableLayout(): void
@@ -257,6 +260,41 @@ class FileListFieldTest extends TestCase
 
 		// resolved from the column query
 		$this->assertSame('a.jpg', $item['filename']);
+	}
+
+	public function testDataWithTableLayoutAndFormValues(): void
+	{
+		// only the fields behind the columns are instantiated, but their
+		// values still have to match what the full form would return
+		$field = $this->filelist([
+			'columns' => ['tags' => true],
+			'layout'  => 'table'
+		]);
+
+		$this->assertSame(['a', 'b'], $field->data()[0]['tags']);
+	}
+
+	public function testDataWithTableLayoutAndPassthroughValues(): void
+	{
+		// a column without a matching blueprint field
+		// falls back to the raw content value
+		$field = $this->filelist([
+			'columns' => ['caption' => true],
+			'layout'  => 'table'
+		]);
+
+		$this->assertSame('Caption A', $field->data()[0]['caption']);
+	}
+
+	public function testDataWithTableLayoutAndZeroQuery(): void
+	{
+		// "0" is a valid column query and must not fall back to the field
+		$field = $this->filelist([
+			'columns' => ['alt' => ['value' => '0']],
+			'layout'  => 'table'
+		]);
+
+		$this->assertSame('0', $field->data()[0]['alt']);
 	}
 
 	public function testLimitDefault(): void

--- a/tests/Panel/Ui/Item/ModelItemTest.php
+++ b/tests/Panel/Ui/Item/ModelItemTest.php
@@ -20,6 +20,14 @@ class ModelItemTest extends TestCase
 		$this->model = new Page(['slug' => 'test']);
 	}
 
+	protected function escapable(): Page
+	{
+		return new Page([
+			'slug'    => 'test',
+			'content' => ['title' => 'Fish <b>&</b> Chips']
+		]);
+	}
+
 	public function testComponent(): void
 	{
 		$item = new ModelItem(model: $this->model);
@@ -68,6 +76,45 @@ class ModelItemTest extends TestCase
 		$this->assertSame('test', (string)$item->props()['info']);
 	}
 
+	public function testInfoEmpty(): void
+	{
+		// an empty template, not null: null would render the model id
+		$item = new ModelItem(model: $this->model);
+		$this->assertSame('', (string)$item->props()['info']);
+	}
+
+	public function testInfoEmptyWithTableLayout(): void
+	{
+		$item = new ModelItem(model: $this->model, layout: 'table');
+		$this->assertSame('', $item->props()['info']);
+	}
+
+	public function testInfoWithTableLayout(): void
+	{
+		$item = new ModelItem(
+			model:  $this->escapable(),
+			info:   '{{ page.title }}',
+			layout: 'table'
+		);
+
+		// table cells render as text, so escaping here would show up
+		// as entities in the Panel
+		$this->assertSame('Fish <b>&</b> Chips', $item->props()['info']);
+	}
+
+	public function testInfoWithListLayout(): void
+	{
+		$item = new ModelItem(
+			model: $this->escapable(),
+			info:  '{{ page.title }}'
+		);
+
+		$info = $item->props()['info'];
+
+		$this->assertInstanceOf(HtmlString::class, $info);
+		$this->assertSame('Fish &lt;b&gt;&amp;&lt;/b&gt; Chips', (string)$info);
+	}
+
 	public function testProps(): void
 	{
 		$item = new ModelItem(model: $this->model);
@@ -109,6 +156,32 @@ class ModelItemTest extends TestCase
 		);
 
 		$this->assertSame('test', (string)$item->props()['text']);
+	}
+
+	public function testTextWithTableLayout(): void
+	{
+		$item = new ModelItem(
+			model:  $this->escapable(),
+			text:   '{{ page.title }}',
+			layout: 'table'
+		);
+
+		// table cells render as text, so escaping here would show up
+		// as entities in the Panel
+		$this->assertSame('Fish <b>&</b> Chips', $item->props()['text']);
+	}
+
+	public function testTextWithListLayout(): void
+	{
+		$item = new ModelItem(
+			model: $this->escapable(),
+			text:  '{{ page.title }}'
+		);
+
+		$text = $item->props()['text'];
+
+		$this->assertInstanceOf(HtmlString::class, $text);
+		$this->assertSame('Fish &lt;b&gt;&amp;&lt;/b&gt; Chips', (string)$text);
 	}
 
 }


### PR DESCRIPTION
## Review

- [x] Design & concept
- [x] Rough pass
- [ ] Security check

## Description

So far, `layout: table` built a complete `Form` for every row. `ModelListField::columnsValues()` called `Form::for($model)->toFormValues()` per entry, which instantiates and fills every field in the model's blueprint, in order to read back the handful the table displays.

The cost therefore scaled with the size of the blueprint, not with the number of columns: a table over an 18-field blueprint spent ~78% of its time building fields nobody asked for, if they aren't displayed all in the table.

The fix: resolve query columns first, then build a form containing only the blueprint fields the remaining columns actually need and read. A table whose columns all define a `value` never builds a Form at all.

Since the field classes are new in v6 anyways, took the liberty to also restructure and rename.

### Benchmarks

60 children on an 18-field blueprint (blocks, structure, object, four query-driven option fields):

| scenario | `v6/sections-to-fields/develop` | this branch | |
|---|---|---|---|
| table, 20 rows, no custom columns | 47.2 ms | 10.7 ms | **4.4×** |
| table, 20 rows, 2 content + 1 query column | 47.1 ms | 11.8 ms | **4.0×** |
| table, 60 rows | 114.8 ms | 19.1 ms | **6.0×** |
| list, 20 rows (control) | 10.5 ms | 10.5 ms | — |

## Changelog

### 🏎️ Performance

- Model list fields (`pagelist`, `filelist`) with `layout: table` load faster. Their performance is only tied to the number of columns displayed, not anymore to the size of the blueprint.

### 🐛 Bug fixes

- A table column with `value: "0"` now renders `0` instead of falling back to the field value.

### ♻️ Refactored

- In `layout: table`, `ModelItem` now returns the item's `text` and `info` as plain, unescaped strings, because table cells render as text rather than `v-html`. 


## For review team

- [x] Add changes & docs to release notes draft in Notion
