### PR TITLE
fix: Model create considering field save handlers

### DIFF
--- a/src/Cms/FileActions.php
+++ b/src/Cms/FileActions.php
@@ -227,11 +227,13 @@ trait FileActions
 		$upload   = $file->assetFactory($props['source']);
 		$existing = null;
 
-		// merge the content with the defaults
-		$props['content'] = [
-			...$file->createDefaultContent(),
-			...$props['content'],
-		];
+		// check the rules before any user input is passed
+		// through the field classes
+		FileRules::create($file, $upload);
+
+		// merge the content with the defaults and run it through
+		// the fields to apply their save handlers
+		$props['content'] = $file->createContent($props['content']);
 
 		// reuse the existing content if the uploaded file
 		// is identical to an existing file
@@ -269,8 +271,11 @@ trait FileActions
 		// inject the content
 		$file->setContent($props['content']);
 
-		// inject the translations
-		$file->setTranslations($props['translations'] ?? null);
+		// inject the translations and run their content through
+		// the fields to apply their save handlers
+		$file->setTranslations(
+			$file->createTranslations($props['translations'] ?? null)
+		);
 
 		// if the format is different from the original,
 		// we need to already rename it so that the correct file rules

--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -17,6 +17,7 @@ use Kirby\Exception\InvalidArgumentException;
 use Kirby\Form\Fields;
 use Kirby\Form\Form;
 use Kirby\Panel\Model;
+use Kirby\Toolkit\A;
 use Kirby\Toolkit\BlockCollectionAccess;
 use Kirby\Toolkit\Str;
 use Kirby\Uuid\Identifiable;
@@ -256,16 +257,62 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	}
 
 	/**
+	 * Creates the content for a new model by merging the given
+	 * values with the defaults from the model's blueprint and
+	 * converting all of them to their storable values
+	 *
+	 * @since 5.6.0
+	 */
+	public function createContent(array $content = []): array
+	{
+		$fields = Fields::for($this, 'default');
+
+		return $fields
+			->fill($fields->defaults())
+			->fill($content)
+			->toStoredValues();
+	}
+
+	/**
 	 * Creates default content for the model, by using our
 	 * Form class to generate the defaults, based on the
 	 * model's blueprint setup.
 	 *
 	 * @since 5.0.0
+	 * @deprecated 5.6.0 Use `::createContent()` instead
 	 */
 	public function createDefaultContent(): array
 	{
-		$fields = Fields::for($this, 'default');
-		return $fields->fill($fields->defaults())->toStoredValues();
+		return $this->createContent();
+	}
+
+	/**
+	 * Converts the content of the given translations to the values
+	 * that will be stored by running each of them through the fields
+	 * of the model's blueprint
+	 *
+	 * @since 5.6.0
+	 */
+	public function createTranslations(array|null $translations = null): array|null
+	{
+		if ($translations === null) {
+			return null;
+		}
+
+		return A::map($translations, function (array $translation): array {
+			$content = array_change_key_case($translation['content'] ?? []);
+			$fields  = Fields::for($this, $translation['code'] ?? 'default');
+
+			// only convert the values that have been passed;
+			// fields that are missing in the translation
+			// must not be added to it
+			$translation['content'] = array_intersect_key(
+				$fields->fill($content)->toStoredValues(),
+				$content
+			);
+
+			return $translation;
+		});
 	}
 
 	/**

--- a/src/Cms/PageActions.php
+++ b/src/Cms/PageActions.php
@@ -457,18 +457,6 @@ trait PageActions
 			'translations' => null
 		]);
 
-		// merge the content with the defaults
-		$props['content'] = [
-			...$page->createDefaultContent(),
-			...$props['content'],
-		];
-
-		// make sure that a UUID gets generated
-		// and added to content right away
-		if (Uuids::enabled() === true) {
-			$props['content']['uuid'] ??= Uuid::generate();
-		}
-
 		// keep the initial storage class
 		$storage = $page->storage()::class;
 
@@ -477,14 +465,27 @@ trait PageActions
 		// an existing page before we can even run the checks.
 		PageRules::create($page);
 
+		// merge the content with the defaults and run it through
+		// the fields to apply their save handlers
+		$props['content'] = $page->createContent($props['content']);
+
+		// make sure that a UUID gets generated
+		// and added to content right away
+		if (Uuids::enabled() === true) {
+			$props['content']['uuid'] ??= Uuid::generate();
+		}
+
 		// make sure that the temporary page is stored in memory
 		$page->changeStorage(MemoryStorage::class);
 
 		// inject the content
 		$page->setContent($props['content']);
 
-		// inject the translations
-		$page->setTranslations($props['translations'] ?? null);
+		// inject the translations and run their content through
+		// the fields to apply their save handlers
+		$page->setTranslations(
+			$page->createTranslations($props['translations'] ?? null)
+		);
 
 		// run the hooks and creation action
 		$page = $page->commit(

--- a/src/Cms/UserActions.php
+++ b/src/Cms/UserActions.php
@@ -187,11 +187,13 @@ trait UserActions
 			'translations' => null
 		]);
 
-		// merge the content with the defaults
-		$props['content'] = [
-			...$user->createDefaultContent(),
-			...$props['content'],
-		];
+		// check the rules before any user input is passed
+		// through the field classes
+		UserRules::create($user, $input);
+
+		// merge the content with the defaults and run it through
+		// the fields to apply their save handlers
+		$props['content'] = $user->createContent($props['content']);
 
 		// keep the initial storage class
 		$storage = $user->storage()::class;
@@ -202,8 +204,11 @@ trait UserActions
 		// inject the content
 		$user->setContent($props['content']);
 
-		// inject the translations
-		$user->setTranslations($props['translations'] ?? null);
+		// inject the translations and run their content through
+		// the fields to apply their save handlers
+		$user->setTranslations(
+			$user->createTranslations($props['translations'] ?? null)
+		);
 
 		// run the hook
 		return $user->commit('create', ['user' => $user, 'input' => $input], function ($user) use ($storage) {

--- a/tests/Cms/File/FileCreateTest.php
+++ b/tests/Cms/File/FileCreateTest.php
@@ -223,6 +223,43 @@ class FileCreateTest extends ModelTestCase
 		$this->assertSame('B', $result->b()->value());
 	}
 
+	/**
+	 * @see https://github.com/getkirby/kirby/issues/8411
+	 */
+	public function testCreateWithSaveHandlers(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'files/test' => [
+					'name'   => 'test',
+					'fields' => [
+						'categories' => [
+							'type'    => 'checkboxes',
+							'options' => ['one', 'two', 'three']
+						]
+					]
+				]
+			]
+		]);
+		$this->app->impersonate('kirby');
+
+		$parent = new Page(['slug' => 'test']);
+		$source = static::TMP . '/source.md';
+
+		F::write($source, '# Test');
+
+		$result = File::create([
+			'content'  => ['categories' => ['one', 'two']],
+			'filename' => 'test.md',
+			'source'   => $source,
+			'parent'   => $parent,
+			'template' => 'test',
+		]);
+
+		$this->assertSame('one, two', $result->version()->read()['categories']);
+		$this->assertSame(['one', 'two'], $result->categories()->split());
+	}
+
 	public function testCreateImage(): void
 	{
 		$parent = new Page(['slug' => 'test']);

--- a/tests/Cms/Model/ModelWithContentTest.php
+++ b/tests/Cms/Model/ModelWithContentTest.php
@@ -269,6 +269,159 @@ class ModelWithContentTest extends TestCase
 		$this->assertSame('Original Title', $page->content()->title()->value());
 	}
 
+	public function testCreateContent(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'blueprints' => [
+				'pages/test' => [
+					'fields' => [
+						'categories' => [
+							'type'    => 'checkboxes',
+							'options' => ['a', 'b', 'c']
+						]
+					]
+				]
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'foo',
+						'template' => 'test'
+					]
+				],
+			]
+		]);
+
+		$page = $app->page('foo');
+
+		// the array must be converted by the save handler of the field
+		$this->assertSame(
+			['categories' => 'a, b'],
+			$page->createContent(['categories' => ['a', 'b']])
+		);
+
+		// values without a matching field are passed through
+		$this->assertSame(
+			['categories' => 'a', 'custom' => 'value'],
+			$page->createContent(['categories' => ['a'], 'custom' => 'value'])
+		);
+	}
+
+	public function testCreateContentWithDefaults(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'blueprints' => [
+				'pages/test' => [
+					'fields' => [
+						'categories' => [
+							'type'    => 'checkboxes',
+							'default' => 'a, b',
+							'options' => ['a', 'b', 'c']
+						],
+						'text' => [
+							'type' => 'text'
+						]
+					]
+				]
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'foo',
+						'template' => 'test'
+					]
+				],
+			]
+		]);
+
+		$page = $app->page('foo');
+
+		$this->assertSame(
+			['categories' => 'a, b', 'text' => ''],
+			$page->createContent()
+		);
+
+		// the given content overwrites the defaults
+		$this->assertSame(
+			['categories' => 'c', 'text' => ''],
+			$page->createContent(['categories' => ['c']])
+		);
+	}
+
+	public function testCreateTranslations(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'blueprints' => [
+				'pages/test' => [
+					'fields' => [
+						'categories' => [
+							'type'    => 'checkboxes',
+							'options' => ['a', 'b', 'c']
+						],
+						'text' => [
+							'type' => 'text'
+						]
+					]
+				]
+			],
+			'languages' => [
+				[
+					'code'    => 'en',
+					'default' => true
+				],
+				[
+					'code' => 'de'
+				]
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'foo',
+						'template' => 'test'
+					]
+				],
+			]
+		]);
+
+		$page = $app->page('foo');
+
+		$this->assertNull($page->createTranslations());
+
+		$translations = $page->createTranslations([
+			[
+				'code'    => 'en',
+				'content' => ['categories' => ['a', 'b'], 'custom' => 'value']
+			],
+			[
+				'code'    => 'de',
+				'content' => ['categories' => ['c']]
+			]
+		]);
+
+		// the values must be converted by the save handler of the
+		// field, while values without a matching field are passed
+		// through and missing fields are not added
+		$this->assertSame([
+			[
+				'code'    => 'en',
+				'content' => ['categories' => 'a, b', 'custom' => 'value']
+			],
+			[
+				'code'    => 'de',
+				'content' => ['categories' => 'c']
+			]
+		], $translations);
+	}
+
 	#[DataProvider('modelsProvider')]
 	public function testBlueprints(ModelWithContent $model): void
 	{

--- a/tests/Cms/Page/PageCreateTest.php
+++ b/tests/Cms/Page/PageCreateTest.php
@@ -118,6 +118,38 @@ class PageCreateTest extends ModelTestCase
 		$this->assertSame('B', $page->b()->value());
 	}
 
+	/**
+	 * @see https://github.com/getkirby/kirby/issues/8411
+	 */
+	public function testCreateDraftWithSaveHandlers(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/test' => [
+					'name'   => 'test',
+					'fields' => [
+						'categories' => [
+							'type'    => 'checkboxes',
+							'options' => ['one', 'two', 'three']
+						]
+					]
+				]
+			]
+		]);
+		$this->app->impersonate('kirby');
+
+		$page = Page::create([
+			'content'  => ['categories' => ['one', 'two']],
+			'slug'     => 'new-page',
+			'template' => 'test',
+		]);
+
+		// the save handler of the field must be applied,
+		// just like it would be in `$page->update()`
+		$this->assertSame('one, two', $page->version()->read()['categories']);
+		$this->assertSame(['one', 'two'], $page->categories()->split());
+	}
+
 	public function testCreateChild(): void
 	{
 		Dir::make($this->app->root('content'));
@@ -454,6 +486,65 @@ class PageCreateTest extends ModelTestCase
 
 		$this->assertSame('Title EN', $page->content('en')->title()->value());
 		$this->assertSame('Title DE', $page->content('de')->title()->value());
+	}
+
+	/**
+	 * @see https://github.com/getkirby/kirby/issues/8411
+	 */
+	public function testCreateWithTranslationsAndSaveHandlers(): void
+	{
+		$this->setupMultiLanguage();
+
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/default' => [
+					'fields' => [
+						'categories' => [
+							'type'    => 'checkboxes',
+							'options' => ['one', 'two', 'three']
+						]
+					]
+				]
+			]
+		]);
+		$this->app->impersonate('kirby');
+
+		Page::create([
+			'slug' => 'test',
+			'translations' => [
+				[
+					'code' => 'en',
+					'content' => [
+						'title'      => 'Title EN',
+						'categories' => ['one', 'two']
+					]
+				],
+				[
+					'code' => 'de',
+					'content' => [
+						'title'      => 'Title DE',
+						'categories' => ['two', 'three']
+					]
+				],
+			],
+		]);
+
+		$page = $this->app->page('test');
+
+		// the save handler of the field must be applied
+		// for every translation
+		$this->assertSame('one, two', $page->version()->read('en')['categories']);
+		$this->assertSame('two, three', $page->version()->read('de')['categories']);
+
+		$this->assertSame(['one', 'two'], $page->content('en')->categories()->split());
+		$this->assertSame(['two', 'three'], $page->content('de')->categories()->split());
+
+		// fields that are not part of the translation
+		// must not be added to it
+		$this->assertSame(
+			['title', 'categories'],
+			array_keys($page->version()->read('de'))
+		);
 	}
 
 	/**

--- a/tests/Cms/User/UserCreateTest.php
+++ b/tests/Cms/User/UserCreateTest.php
@@ -152,6 +152,38 @@ class UserCreateTest extends ModelTestCase
 		$this->assertSame('B', $user->b()->value());
 	}
 
+	/**
+	 * @see https://github.com/getkirby/kirby/issues/8411
+	 */
+	public function testCreateWithSaveHandlers(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'users/editor' => [
+					'name'   => 'editor',
+					'fields' => [
+						'categories' => [
+							'type'    => 'checkboxes',
+							'options' => ['one', 'two', 'three']
+						]
+					]
+				]
+			]
+		]);
+		$this->app->impersonate('kirby');
+
+		$user = User::create([
+			'content' => ['categories' => ['one', 'two']],
+			'email'   => 'new@domain.com',
+			'role'    => 'editor',
+		]);
+
+		// the save handler of the field must be applied,
+		// just like it would be in `$user->update()`
+		$this->assertSame('one, two', $user->version()->read()['categories']);
+		$this->assertSame(['one', 'two'], $user->categories()->split());
+	}
+
 	public function testCreateWithContentMultilang(): void
 	{
 		$this->app = $this->app->clone([


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Deep read

## Description
<!--
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.

You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR.

If something is deliberately out of scope, say so here.
-->

See https://forum.getkirby.com/t/checkboxes-content-storage-discrepancy/35571/5
`::update()` would run values through the Form and thus apply fields' `save` handlers. `::create()` so far would not.


## Changelog
<!--
Add relevant release notes, one bullet per change. Keep the target audience
(Kirby user) in mind. Reference issues from the `kirby` repo or ideas from
`feedback.getkirby.com`. For breaking changes and deprecations, always say
what to do instead, e.g. "`Page::foo()` has been removed, use `Page::bar()`".

Copy the sections you need from this list:

### 🎉 Features
### ✨ Enhancements
### 🔒 Security
### 🏎️ Performance
### ♻️ Refactored
### ☠️ Deprecated
### 🧹 Housekeeping
### 🚨 Breaking changes
-->

### 🐛 Bug fixes
- `Page::create()`, `File::create()` and `User::create()` use the fields' `save` handlers again, just like `::update()` does. This restores the v4 behavior. Values a field can't handle are normalized or dropped. #8411
- Rules and permissions for `Page::create()`, `File::create()` and `User::create()` are checked before the given content is processed, so unauthorized requests are rejected upfront.

### ☠️ Deprecated
- `$model->createDefaultContent()` has been deprecated, use `$model->createContent()` instead


## For review team
<!--
We will take care of the following before merging the PR.
-->

- [x] Add changes & docs to release notes draft in Notion
