### PR TITLE
[remove fields] fix: Protect fields against single field error

### DIFF
--- a/src/Form/Field.php
+++ b/src/Form/Field.php
@@ -2,12 +2,16 @@
 
 namespace Kirby\Form;
 
+use Kirby\Blueprint\Blueprint;
 use Kirby\Cms\HasStringTemplate;
 use Kirby\Cms\Language;
+use Kirby\Cms\ModelWithContent;
 use Kirby\Exception\InvalidArgumentException;
+use Kirby\Form\Field\InfoField;
 use Kirby\Form\Field\ValueField;
 use Kirby\Reflection\Constructor;
 use Stringable;
+use Throwable;
 
 /**
  * Base class for any field type
@@ -62,6 +66,26 @@ abstract class Field implements Stringable
 	public function drawers(): array
 	{
 		return [];
+	}
+
+	/**
+	 * Creates an info field that shows an error message in place
+	 * of a field that could not be created or rendered
+	 * @since 6.0.0
+	 */
+	public static function error(
+		string $name,
+		string $message,
+		ModelWithContent|null $model = null,
+		Fields|null $siblings = null
+	): InfoField {
+		return InfoField::factory(
+			props: [
+				...Blueprint::fieldError($name, $message),
+				'model' => $model
+			],
+			siblings: $siblings
+		);
 	}
 
 	/**
@@ -206,7 +230,17 @@ abstract class Field implements Stringable
 	 */
 	public function toArray(): array
 	{
-		$props = $this->props();
+		// a field that fails to resolve its props must not take
+		// down the entire view. It is replaced by an error field.
+		try {
+			$props = $this->props();
+		} catch (Throwable $e) {
+			$props = static::error(
+				name:    $this->name(),
+				message: $e->getMessage(),
+				model:   $this->model()
+			)->props();
+		}
 
 		ksort($props);
 

--- a/src/Form/Field/FileListField.php
+++ b/src/Form/Field/FileListField.php
@@ -42,7 +42,7 @@ class FileListField extends ModelListField
 		array|string|null $empty = null,
 		bool|null $flip = null,
 		array|string|null $help = null,
-		array|false|null $image = null,
+		array|string|false|null $image = null,
 		array|string|null $info = null,
 		array|string|null $label = null,
 		string|null $layout = null,

--- a/src/Form/Field/ModelListField.php
+++ b/src/Form/Field/ModelListField.php
@@ -53,9 +53,10 @@ abstract class ModelListField extends DisplayField
 	protected bool|null $flip;
 
 	/**
-	 * Image options for each entry or `false` to disable previews
+	 * Image options for each entry, a query string for the preview
+	 * image or `false` to disable previews
 	 */
-	protected array|false|null $image;
+	protected array|string|false|null $image;
 
 	/**
 	 * Info text shown next to or below the main text of each entry
@@ -103,7 +104,7 @@ abstract class ModelListField extends DisplayField
 		array|string|null $empty = null,
 		bool|null $flip = null,
 		array|string|null $help = null,
-		array|false|null $image = null,
+		array|string|false|null $image = null,
 		array|string|null $info = null,
 		array|string|null $label = null,
 		string|null $layout = null,
@@ -376,6 +377,10 @@ abstract class ModelListField extends DisplayField
 
 	public function image(): array|false
 	{
+		if (is_string($this->image) === true) {
+			return ['query' => $this->image];
+		}
+
 		return $this->image ?? [];
 	}
 

--- a/src/Form/Field/PageListField.php
+++ b/src/Form/Field/PageListField.php
@@ -60,7 +60,7 @@ class PageListField extends ModelListField implements ProvidesAcceptedBlueprints
 		array|string|null $empty = null,
 		bool|null $flip = null,
 		array|string|null $help = null,
-		array|false|null $image = null,
+		array|string|false|null $image = null,
 		array|string|null $info = null,
 		array|string|null $label = null,
 		string|null $layout = null,

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -12,6 +12,7 @@ use Kirby\Exception\NotFoundException;
 use Kirby\Form\Interface\ProvidesNestedForm;
 use Kirby\Toolkit\A;
 use Kirby\Toolkit\Str;
+use Throwable;
 
 /**
  * A collection of Field objects
@@ -63,8 +64,20 @@ class Fields extends Collection
 			// use the array key as name if the name is not set
 			$field['model'] ??= $this->model;
 			$field['name']  ??= $name;
-			$class = Field::resolve($field['type'], $field['name']);
-			$field = $class::factory($field, $this);
+
+			// a field that fails to be created must not take down
+			// the entire view. It is replaced by an error field.
+			try {
+				$class = Field::resolve($field['type'], $field['name']);
+				$field = $class::factory($field, $this);
+			} catch (Throwable $e) {
+				$field = Field::error(
+					name:     $field['name'],
+					message:  $e->getMessage(),
+					model:    $field['model'],
+					siblings: $this
+				);
+			}
 		}
 
 		parent::__set($field->name(), $field);

--- a/tests/Form/Field/FileListFieldTest.php
+++ b/tests/Form/Field/FileListFieldTest.php
@@ -107,6 +107,33 @@ class FileListFieldTest extends TestCase
 		$this->assertSame(3, $this->filelist()->total());
 	}
 
+	public function testImage(): void
+	{
+		$field = $this->filelist(['image' => ['back' => 'black']]);
+
+		$this->assertSame(['back' => 'black'], $field->image());
+		$this->assertSame('black', $field->data()[0]['image']['back']);
+	}
+
+	public function testImageDisabled(): void
+	{
+		$this->assertFalse($this->filelist(['image' => false])->image());
+	}
+
+	public function testImageQuery(): void
+	{
+		// a query string is a shortcut for the image source
+		$field = $this->filelist(['image' => 'file.parent.image("b.jpg")']);
+
+		$this->assertSame(['query' => 'file.parent.image("b.jpg")'], $field->image());
+
+		// the query is resolved per entry
+		$this->assertStringContainsString(
+			'b.jpg',
+			$field->data()[0]['image']['url']
+		);
+	}
+
 	public function testTextDefault(): void
 	{
 		$this->assertSame('{{ file.filename }}', $this->filelist()->text());
@@ -449,6 +476,13 @@ class FileListFieldTest extends TestCase
 			'multiple'   => true,
 			'preview'    => []
 		], $this->filelist()->upload());
+	}
+
+	public function testUploadWithImageQuery(): void
+	{
+		$upload = $this->filelist(['image' => 'file.parent.image("b.jpg")'])->upload();
+
+		$this->assertSame(['query' => 'file.parent.image("b.jpg")'], $upload['preview']);
 	}
 
 	public function testUploadWithMax(): void

--- a/tests/Form/Field/PageListFieldTest.php
+++ b/tests/Form/Field/PageListFieldTest.php
@@ -35,7 +35,12 @@ class PageListFieldTest extends TestCase
 					[
 						'slug'     => 'photography',
 						'children' => [
-							['slug' => 'trees', 'num' => 1, 'template' => 'album'],
+							[
+								'slug'     => 'trees',
+								'num'      => 1,
+								'template' => 'album',
+								'files'    => [['filename' => 'cover.jpg']]
+							],
 							['slug' => 'sky', 'num' => 2, 'template' => 'album'],
 							['slug' => 'ocean', 'template' => 'note']
 						],
@@ -86,6 +91,33 @@ class PageListFieldTest extends TestCase
 		// all statuses, including the draft
 		$this->assertCount(4, $data);
 		$this->assertSame('photography/trees', $data[0]['id']);
+	}
+
+	public function testImage(): void
+	{
+		$field = $this->pagelist(['image' => ['back' => 'black']]);
+
+		$this->assertSame(['back' => 'black'], $field->image());
+		$this->assertSame('black', $field->data()[0]['image']['back']);
+	}
+
+	public function testImageDisabled(): void
+	{
+		$this->assertFalse($this->pagelist(['image' => false])->image());
+	}
+
+	public function testImageQuery(): void
+	{
+		// a query string is a shortcut for the image source
+		$field = $this->pagelist(['image' => 'page.image("cover.jpg")']);
+
+		$this->assertSame(['query' => 'page.image("cover.jpg")'], $field->image());
+
+		// the query is resolved per entry
+		$this->assertStringContainsString(
+			'cover.jpg',
+			$field->data()[0]['image']['url']
+		);
 	}
 
 	public function testTextDefault(): void

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -6,11 +6,20 @@ use Kirby\Cms\Language;
 use Kirby\Cms\Page;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Form\Field\HiddenField;
+use Kirby\Form\Field\InfoField;
 use Kirby\Form\Field\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 class MockField extends Field
 {
+}
+
+class BrokenField extends Field
+{
+	public function props(): array
+	{
+		throw new InvalidArgumentException(message: 'Broken props');
+	}
 }
 
 #[CoversClass(Field::class)]
@@ -32,6 +41,17 @@ class FieldTest extends TestCase
 	{
 		$field = new MockField();
 		$this->assertSame([], $field->drawers());
+	}
+
+	public function testError(): void
+	{
+		$field = Field::error('test', 'Something went wrong');
+
+		$this->assertInstanceOf(InfoField::class, $field);
+		$this->assertSame('test', $field->name());
+		$this->assertSame('Error', $field->label());
+		$this->assertSame('negative', $field->theme());
+		$this->assertSame('<p>Something went wrong</p>', (string)$field->text());
 	}
 
 	public function testErrors(): void
@@ -229,5 +249,19 @@ class FieldTest extends TestCase
 		];
 
 		$this->assertSame($expected, $array);
+	}
+
+	public function testToArrayWithBrokenProps(): void
+	{
+		// a field that cannot resolve its props is replaced
+		// by an info field with the error message
+		$field = new BrokenField(name: 'test');
+		$array = $field->toArray();
+
+		$this->assertSame('info', $array['type']);
+		$this->assertSame('test', $array['name']);
+		$this->assertSame('Error', $array['label']);
+		$this->assertSame('negative', $array['theme']);
+		$this->assertSame('<p>Broken props</p>', (string)$array['text']);
 	}
 }

--- a/tests/Form/FieldsTest.php
+++ b/tests/Form/FieldsTest.php
@@ -11,6 +11,7 @@ use Kirby\Cms\TestCase;
 use Kirby\Cms\User;
 use Kirby\Exception\FormValidationException;
 use Kirby\Exception\NotFoundException;
+use Kirby\Form\Field\InfoField;
 use Kirby\Form\Field\InputField;
 use Kirby\Form\Interface\ProvidesNestedForm;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -68,6 +69,53 @@ class FieldsTest extends TestCase
 
 		$this->assertSame($this->app->site(), $fields->first()->model());
 		$this->assertSame($this->app->site(), $fields->last()->model());
+	}
+
+	public function testConstructWithBrokenField(): void
+	{
+		// a field that cannot be created is replaced by
+		// an info field that shows the error message
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type' => 'does-not-exist',
+				],
+				'b' => [
+					'type' => 'text',
+				],
+			],
+			model: $this->model
+		);
+
+		$field = $fields->get('a');
+
+		$this->assertInstanceOf(InfoField::class, $field);
+		$this->assertSame('a', $field->name());
+		$this->assertSame($this->model, $field->model());
+		$this->assertSame($fields, $field->siblings());
+		$this->assertSame(
+			'<p>Field "a": The field type "does-not-exist" does not exist</p>',
+			(string)$field->text()
+		);
+
+		// the other fields are not affected
+		$this->assertSame('text', $fields->get('b')->type());
+	}
+
+	public function testConstructWithBrokenFieldProps(): void
+	{
+		// a valid type with invalid props is caught as well
+		$fields = new Fields(
+			fields: [
+				'a' => [
+					'type'      => 'text',
+					'maxlength' => 'nope',
+				],
+			],
+			model: $this->model
+		);
+
+		$this->assertInstanceOf(InfoField::class, $fields->get('a'));
 	}
 
 	public function testDefaults(): void

--- a/tests/Form/FormTest.php
+++ b/tests/Form/FormTest.php
@@ -7,7 +7,7 @@ use Kirby\Cms\File;
 use Kirby\Cms\Language;
 use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\Page;
-use Kirby\Exception\InvalidArgumentException;
+use Kirby\Form\Field\InfoField;
 use Kirby\Form\Field\InputField;
 use Kirby\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -98,18 +98,25 @@ class FormTest extends TestCase
 		$this->assertSame($expected, $form->errors());
 	}
 
-	public function testFieldException(): void
+	public function testFieldError(): void
 	{
-		$this->expectException(InvalidArgumentException::class);
-		$this->expectExceptionMessage('Field "test": The field type "does-not-exist" does not exist');
-
-		new Form(
+		// an invalid field does not take down the whole form,
+		// but is replaced by an info field with the error message
+		$form = new Form(
 			fields: [
 				'test' => [
 					'type'  => 'does-not-exist',
 					'model' => $this->model
 				]
 			]
+		);
+
+		$field = $form->fields()->get('test');
+
+		$this->assertInstanceOf(InfoField::class, $field);
+		$this->assertSame(
+			'<p>Field "test": The field type "does-not-exist" does not exist</p>',
+			(string)$field->text()
 		);
 	}
 


### PR DESCRIPTION
## Review

- [x] Rough pass

## Description

This restores the old resilience on field level: creating a field and resolving its props are both wrapped, and a failing field is replaced by a info field (`Blueprint::fieldError()`) that shows the exception message in place of the field.

Concretely, the `image` prop of the model list fields turned out to only accept an array or `false`, so the common `image: page.cover` shorthand threw. It now also accepts a query string.
