### PR TITLE
perf: Use `icons.svg` as cachable sprite

### DIFF
--- a/panel/lab/basics/icons/1_iconset/index.php
+++ b/panel/lab/basics/icons/1_iconset/index.php
@@ -1,11 +1,10 @@
 <?php
 
-use Kirby\Panel\Assets;
+use Kirby\Filesystem\F;
 
-$assets = new Assets();
-$file   = $assets->icons();
-$svg    = new SimpleXMLElement($file);
-$icons = [];
+$assets = kirby()->panel()->assets();
+$svg    = new SimpleXMLElement(F::read($assets->iconsRoot()));
+$icons  = [];
 
 foreach ($svg->defs->children() as $symbol) {
 	$slug = str_replace('icon-', '', $symbol->attributes()->id);

--- a/panel/src/components/Misc/Icon.test.ts
+++ b/panel/src/components/Misc/Icon.test.ts
@@ -3,10 +3,12 @@ import { mount as vueMount } from "@vue/test-utils";
 import { hasEmoji } from "@/helpers/string.js";
 import Icon from "./Icon.vue";
 
+const sprite = "/media/panel/1234/img/icons.svg";
+
 /**
- * Custom mount which injects a $helper stub
+ * Custom mount which injects $helper and $panel stubs
  */
-function mount(props = {}, attrs = {}) {
+function mount(props = {}, attrs = {}, panel: Record<string, unknown> = {}) {
 	return vueMount(Icon, {
 		props,
 		attrs,
@@ -15,6 +17,11 @@ function mount(props = {}, attrs = {}) {
 				$helper: {
 					color: (c: string) => c ?? null,
 					string: { hasEmoji }
+				},
+				$panel: {
+					plugins: { icons: {} },
+					urls: { icons: sprite },
+					...panel
 				}
 			}
 		}
@@ -39,9 +46,22 @@ describe("Icon.vue", () => {
 			expect(wrapper.attributes("data-type")).toBe("edit");
 		});
 
-		it("sets the use href to the icon id", () => {
+		it("references the icon in the sprite file", () => {
 			const wrapper = mount({ type: "edit" });
-			expect(wrapper.find("use").attributes("href")).toBe("#icon-edit");
+			expect(wrapper.find("use").attributes("href")).toBe(
+				sprite + "#icon-edit"
+			);
+		});
+
+		it("references plugin icons in the document", () => {
+			const wrapper = mount(
+				{ type: "plugin" },
+				{},
+				{
+					plugins: { icons: { plugin: "<path />" } }
+				}
+			);
+			expect(wrapper.find("use").attributes("href")).toBe("#icon-plugin");
 		});
 	});
 

--- a/panel/src/components/Misc/Icon.vue
+++ b/panel/src/components/Misc/Icon.vue
@@ -9,7 +9,7 @@
 		class="k-icon"
 		:style="{ color: $helper.color(color) }"
 	>
-		<use :xlink:href="'#icon-' + type" />
+		<use :href="href" />
 	</svg>
 </template>
 
@@ -49,8 +49,20 @@ export const props = {
 export default {
 	mixins: [props],
 	computed: {
+		href() {
+			// plugin icons are inlined into the document by `k-icons`,
+			// all other icons are loaded from the sprite file
+			if (this.isPlugin === true) {
+				return "#icon-" + this.type;
+			}
+
+			return this.$panel.urls.icons + "#icon-" + this.type;
+		},
 		isEmoji() {
 			return this.$helper.string.hasEmoji(this.type);
+		},
+		isPlugin() {
+			return this.$panel.plugins.icons[this.type] !== undefined;
 		}
 	}
 };

--- a/panel/src/panel/panel.ts
+++ b/panel/src/panel/panel.ts
@@ -42,7 +42,12 @@ type Config = {
 type Languages = Record<string, LanguageState>[];
 type Permissions = Record<string, Record<string, boolean>>;
 type Searches = Record<string, SearchType>;
-type Urls = { api: string; panel: string; site: string };
+type Urls = {
+	api: string;
+	icons: string;
+	panel: string;
+	site: string;
+};
 
 export type PanelState = {
 	config: Config;
@@ -141,7 +146,7 @@ export default class Panel {
 	multilang: boolean = false;
 	permissions: Permissions = {};
 	searches: Searches = {};
-	urls: Urls = { api: "/", panel: "/", site: "/" };
+	urls: Urls = { api: "/", icons: "", panel: "/", site: "/" };
 
 	// modules
 	activation: ReturnType<typeof Activation>;

--- a/src/Panel/Assets.php
+++ b/src/Panel/Assets.php
@@ -180,17 +180,34 @@ class Assets
 	}
 
 	/**
-	 * Load the SVG icon sprite
-	 * This will be injected in the
-	 * initial HTML document for the Panel
+	 * URL for the SVG icon sprite, which is referenced by
+	 * all `<use>` elements in the Panel.
 	 */
 	public function icons(): string
 	{
-		$dir   = $this->kirby->root('panel') . '/';
-		$dir  .= $this->isDev ? 'public' : 'dist';
-		$icons = F::read($dir . '/img/icons.svg');
-		$icons = preg_replace('/<!--(.|\s)*?-->/', '', $icons) ?? '';
-		return $icons;
+		$path = '/panel/' . $this->kirby->versionHash() . '/img/icons.svg';
+
+		if ($this->isDev === true) {
+			$source   = $this->iconsRoot();
+			$target   = $this->kirby->root('media') . $path;
+			$modified = F::modified($source);
+
+			if (F::modified($target) !== $modified) {
+				F::copy($source, $target, true);
+				touch($target, $modified);
+			}
+		}
+
+		return $this->kirby->url('media') . $path;
+	}
+
+	/**
+	 * Root of the SVG icon sprite file
+	 */
+	public function iconsRoot(): string
+	{
+		$dir = $this->isDev === true ? 'public' : 'dist';
+		return $this->kirby->root('panel') . '/' . $dir . '/img/icons.svg';
 	}
 
 	/**

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -23,6 +23,7 @@ class Panel
 {
 	protected Access|null $access = null;
 	protected Areas|null $areas = null;
+	protected Assets|null $assets = null;
 	protected Home|null $home = null;
 	protected Router|null $router = null;
 
@@ -46,6 +47,15 @@ class Panel
 	public function areas(): Areas
 	{
 		return $this->areas ??= Areas::for($this->kirby);
+	}
+
+	/**
+	 * Returns the Panel Assets object
+	 * @since 6.0.0
+	 */
+	public function assets(): Assets
+	{
+		return $this->assets ??= new Assets();
 	}
 
 	/**

--- a/src/Panel/Response/ViewDocumentResponse.php
+++ b/src/Panel/Response/ViewDocumentResponse.php
@@ -33,8 +33,8 @@ class ViewDocumentResponse extends ViewResponse
 			code: $code,
 		);
 
-		$this->assets = new Assets();
 		$this->kirby  = App::instance();
+		$this->assets = $this->kirby->panel()->assets();
 	}
 
 	/**
@@ -58,7 +58,6 @@ class ViewDocumentResponse extends ViewResponse
 
 		return Tpl::load($template, [
 			'assets'     => $this->assets->external(),
-			'icons'      => $this->assets->icons(),
 			'nonce'      => $this->kirby->nonce(),
 			'state'      => $this->payload(),
 			'panelUrl'   => $this->url(),

--- a/src/Panel/State.php
+++ b/src/Panel/State.php
@@ -313,6 +313,7 @@ class State
 	{
 		return [
 			'api'   => $this->kirby->url('api'),
+			'icons' => $this->panel->assets()->icons(),
 			'panel' => $this->kirby->url('panel'),
 			'site'  => $this->kirby->url('index')
 		];

--- a/tests/Panel/AssetsTest.php
+++ b/tests/Panel/AssetsTest.php
@@ -305,10 +305,88 @@ class AssetsTest extends TestCase
 	public function testIcons(): void
 	{
 		$assets = new Assets();
-		$icons = $assets->icons();
 
-		$this->assertNotNull($icons);
-		$this->assertTrue(str_contains($icons, '<svg'));
+		$this->assertSame(
+			'/media/panel/' . $this->app->versionHash() . '/img/icons.svg',
+			$assets->icons()
+		);
+	}
+
+	public function testIconsInDevMode(): void
+	{
+		$this->setDevMode();
+
+		$assets = new Assets();
+		$target = $this->app->root('media') . '/panel/' . $this->app->versionHash() . '/img/icons.svg';
+
+		$this->assertFileDoesNotExist($target);
+
+		// the sprite is not served by Vite, but synced to the media folder
+		$this->assertSame(
+			'/media/panel/' . $this->app->versionHash() . '/img/icons.svg',
+			$assets->icons()
+		);
+
+		$this->assertFileEquals(
+			$this->app->root('panel') . '/public/img/icons.svg',
+			$target
+		);
+	}
+
+	public function testIconsInDevModeWithCurrentCopy(): void
+	{
+		$this->setDevMode();
+
+		$assets = new Assets();
+		$source = $this->app->root('panel') . '/public/img/icons.svg';
+		$target = $this->app->root('media') . '/panel/' . $this->app->versionHash() . '/img/icons.svg';
+
+		F::write($target, 'current');
+		touch($target, F::modified($source));
+
+		$assets->icons();
+
+		// the copy is up to date and does not get repeated
+		$this->assertSame('current', F::read($target));
+	}
+
+	public function testIconsInDevModeWithOutdatedCopy(): void
+	{
+		$this->setDevMode();
+
+		$assets = new Assets();
+		$source = $this->app->root('panel') . '/public/img/icons.svg';
+		$target = $this->app->root('media') . '/panel/' . $this->app->versionHash() . '/img/icons.svg';
+
+		F::write($target, 'outdated');
+		touch($target, 1);
+
+		$assets->icons();
+
+		$this->assertFileEquals($source, $target);
+		$this->assertSame(F::modified($source), F::modified($target));
+	}
+
+	public function testIconsRoot(): void
+	{
+		$assets = new Assets();
+
+		$this->assertSame(
+			$this->app->root('panel') . '/dist/img/icons.svg',
+			$assets->iconsRoot()
+		);
+	}
+
+	public function testIconsRootInDevMode(): void
+	{
+		$this->setDevMode();
+
+		$assets = new Assets();
+
+		$this->assertSame(
+			$this->app->root('panel') . '/public/img/icons.svg',
+			$assets->iconsRoot()
+		);
 	}
 
 	public function testImportMaps(): void

--- a/tests/Panel/PanelTest.php
+++ b/tests/Panel/PanelTest.php
@@ -36,6 +36,13 @@ class PanelTest extends TestCase
 		$this->assertInstanceOf(Areas::class, $panel->areas());
 	}
 
+	public function testAssets(): void
+	{
+		$panel = $this->app->panel();
+		$this->assertInstanceOf(Assets::class, $panel->assets());
+		$this->assertSame($panel->assets(), $panel->assets());
+	}
+
 	public function testGo(): void
 	{
 		$thrown = false;

--- a/tests/Panel/StateTest.php
+++ b/tests/Panel/StateTest.php
@@ -159,6 +159,7 @@ class StateTest extends TestCase
 			'a' => 'A',
 			'urls' => [
 				'api'   => '/api',
+				'icons' => '/media/panel/' . $this->app->versionHash() . '/img/icons.svg',
 				'panel' => '/panel',
 				'site'  => '/'
 			]
@@ -569,6 +570,7 @@ class StateTest extends TestCase
 		$state = new State();
 		$urls  = $state->urls();
 		$this->assertArrayHasKey('api', $urls);
+		$this->assertArrayHasKey('icons', $urls);
 		$this->assertArrayHasKey('panel', $urls);
 		$this->assertArrayHasKey('site', $urls);
 	}

--- a/views/panel.php
+++ b/views/panel.php
@@ -4,7 +4,6 @@ use Kirby\Toolkit\Html;
 
 /**
  * @var \Kirby\Cms\App $kirby
- * @var string $icons
  * @var array<string, mixed> $assets
  * @var array<string, mixed> $state
  * @var string $panelUrl
@@ -58,8 +57,6 @@ use Kirby\Toolkit\Html;
 	<noscript>
 		Please enable JavaScript in your browser
 	</noscript>
-
-	<?= $icons ?>
 
 	<script nonce="<?= $nonce ?>">
 	// Panel state setup


### PR DESCRIPTION
## Review

- [ ] Design & concept
- [x] Rough pass
- [ ] Deep read
- [ ] Security check

**Timing:** no rush

## Description

The Panel inlined the full SVG icon sprite into every Panel document: `Assets::icons()` read `panel/dist/img/icons.svg` (117 KB), stripped its comments, and `views/panel.php` dumped it into the body. Because it lived in the HTML, it was re-sent on every full document load and could never be cached on its own.

The sprite is now referenced with `<use href="icons.svg#icon-name">`, so the browser fetches the file once and reuses it across loads.

Plugin icons are still inlined into the document by `k-icons`, so `k-icon` resolves those to the document-local `#icon-…`.

## Changelog

### 🏎️ Performance

- The Panel's icon sprite is no longer inlined into every Panel document.

### ♻️ Refactored

- New `Kirby\Panel\Panel::assets()`
- `Kirby\Panel\Assets::icons()` now returns the URL of the icon sprite instead of its
  markup.

## Docs

Plugin developers who registered custom icons don't need to change anything.

Anything that rendered a `<use xlink:href="#icon-…">` by hand against the Panel's sprite will stop working, because the sprite is no longer part of the document. The reference needs the file URL, which the Panel exposes as `window.panel.urls.icons`:

```js
const href = window.panel.urls.icons + "#icon-edit";
```

## For review team

- [x] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion
