### PR TITLE
feat: Prevent robots from indexing the Panel

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -23,6 +23,7 @@ if (
 		version_compare(PHP_VERSION, '8.6.0', '<')  === false
 	)
 ) {
+	http_response_code(503);
 	die(include __DIR__ . '/views/php.php');
 }
 

--- a/src/Panel/Document.php
+++ b/src/Panel/Document.php
@@ -66,7 +66,8 @@ class Document
 		};
 
 		return new Response($body, 'text/html', $code, [
-			'Content-Security-Policy' => 'frame-ancestors ' . $frameAncestors
+			'Content-Security-Policy' => 'frame-ancestors ' . $frameAncestors,
+			'X-Robots-Tag'            => 'noindex, nofollow'
 		]);
 	}
 }

--- a/tests/Panel/DocumentTest.php
+++ b/tests/Panel/DocumentTest.php
@@ -54,6 +54,7 @@ class DocumentTest extends TestCase
 		$this->assertSame('text/html', $response->type());
 		$this->assertSame('UTF-8', $response->charset());
 		$this->assertSame("frame-ancestors 'none'", $response->header('Content-Security-Policy'));
+		$this->assertSame('noindex, nofollow', $response->header('X-Robots-Tag'));
 		$this->assertNotNull($response->body());
 	}
 

--- a/views/panel.php
+++ b/views/panel.php
@@ -17,6 +17,7 @@ use Kirby\Toolkit\Html;
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <meta name="referrer" content="same-origin">
+  <meta name="robots" content="noindex, nofollow">
 
   <title>Kirby Panel</title>
 

--- a/views/snippets/header.php
+++ b/views/snippets/header.php
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
 
   <title>Error</title>
 


### PR DESCRIPTION
## Review

- [x] Rough pass

**Timing:** whenever

## Description

This does:

- `X-Robots-Tag: noindex, nofollow` next to the existing CSP header in   `Panel\Document::response()`
- `<meta name="robots" content="noindex, nofollow">` in `views/panel.php`

## Changelog

### ✨ Enhancements

- Search engines/robots no longer index the Panel. Panel responses now send an  `X-Robots-Tag: noindex, nofollow` header and the Panel document includes a  matching `robots` meta tag.
#8444


## Docs

The Panel is marked with `noindex` and `nofollow` tags for search engines and other robots.

## For review team
<!--
We will take care of the following before merging the PR.
-->

- [ ] Add changes & docs to release notes draft in Notion
