### PR TITLE
perf: Only render block toolbar when needed

### DIFF
--- a/panel/src/components/Forms/Blocks/Block.vue
+++ b/panel/src/components/Forms/Blocks/Block.vue
@@ -36,7 +36,7 @@
 		</div>
 
 		<k-block-options
-			v-if="!isDisabled"
+			v-if="isLastSelected && !isDisabled"
 			ref="options"
 			v-bind="{
 				isBatched,
@@ -406,14 +406,10 @@ export default {
 }
 
 .k-block-container .k-block-options {
-	display: none;
 	position: absolute;
 	top: 0;
 	inset-inline-end: var(--spacing-3);
 	margin-top: calc(-1.75rem + 2px);
-}
-.k-block-container[data-last-selected="true"] > .k-block-options {
-	display: flex;
 }
 .k-block-container[data-hidden="true"] .k-block {
 	opacity: 0.25;


### PR DESCRIPTION
## Review

- [x] Rough pass

## Description

`Block.vue` rendered `k-block-options` for every non-disabled block, while the CSS showed exactly one:

```css
.k-block-container .k-block-options { display: none; }
.k-block-container[data-last-selected="true"] > .k-block-options { display: flex; }
```

Each instance is a `k-toolbar` with 5 `k-button`s and a `k-dropdown`, and its `buttons` computed runs ~15 `$t()` lookups (the 13-entry dropdown array is built eagerly even though `k-dropdown` renders its items lazily). So a 100-block field mounted 100 toolbars to show one.

This moves the condition into the `v-if` and drops the now-redundant CSS:

```vue
<k-block-options v-if="isLastSelected && !isDisabled" … />
```

`isLastSelected` is exactly also what steers the CSS `[data-last-selected]` attribute/selector. 

### Benchmarks

| blocks | | mount | DOM nodes | `k-button`s | `$t()` calls |
|---:|---|---:|---:|---:|---:|
| 100 | current | 28.1 ms | 901 | 500 | 1500 |
| 100 | this branch | **9.7 ms** | **208** | **5** | **15** |
| 500 | current | 87.6 ms | 4501 | 2500 | 7500 |
| 500 | this branch | **23.1 ms** | **1008** | **5** | **15** |

## Changelog

### 🏎️ Performance

- The blocks field only renders the block toolbar for the currently selected block that actually shows it, instead of one hidden toolbar per block.

### 🐛 Bug fixes

- The "Split" option is no longer missing from the block options on first render.


## For review team

- [x] Add changes & docs to release notes draft in Notion
