### PR TITLE
perf: Use `k-validator` for more fields

### DIFF
--- a/panel/src/components/Forms/Field/BlocksField.vue
+++ b/panel/src/components/Forms/Field/BlocksField.vue
@@ -29,10 +29,7 @@
 			</k-button-group>
 		</template>
 
-		<k-input-validator
-			v-bind="{ min, max, required }"
-			:value="JSON.stringify(value)"
-		>
+		<k-validator v-bind="{ min, max, required }" :count="value.length">
 			<k-blocks
 				ref="blocks"
 				v-bind="$props"
@@ -40,7 +37,7 @@
 				@open="opened = $event"
 				@input="$emit('input', $event)"
 			/>
-		</k-input-validator>
+		</k-validator>
 
 		<footer v-if="!disabled && !isEmpty && !isFull && hasFieldsets">
 			<k-button

--- a/panel/src/components/Forms/Field/EntriesField.vue
+++ b/panel/src/components/Forms/Field/EntriesField.vue
@@ -30,10 +30,7 @@
 			</k-button-group>
 		</template>
 
-		<k-input-validator
-			v-bind="{ min, max, required }"
-			:value="JSON.stringify(entries)"
-		>
+		<k-validator v-bind="{ min, max, required }" :count="entries.length">
 			<!-- Empty State -->
 			<k-empty
 				v-if="entries.length === 0"
@@ -105,7 +102,7 @@
 					</k-button-group>
 				</div>
 			</k-draggable>
-		</k-input-validator>
+		</k-validator>
 
 		<footer v-if="more" class="k-entries-field-footer">
 			<k-button

--- a/panel/src/components/Forms/Field/LayoutField.vue
+++ b/panel/src/components/Forms/Field/LayoutField.vue
@@ -26,16 +26,13 @@
 			</k-button-group>
 		</template>
 
-		<k-input-validator
-			v-bind="{ min, max, required }"
-			:value="JSON.stringify(value)"
-		>
+		<k-validator v-bind="{ min, max, required }" :count="value.length">
 			<k-layouts
 				ref="layouts"
 				v-bind="$props"
 				@input="$emit('input', $event)"
 			/>
-		</k-input-validator>
+		</k-validator>
 
 		<footer v-if="!disabled && hasFieldsets">
 			<k-button

--- a/panel/src/components/Forms/Field/ModelPickerField.vue
+++ b/panel/src/components/Forms/Field/ModelPickerField.vue
@@ -17,10 +17,7 @@
 		</template>
 
 		<k-dropzone :disabled="!hasDropzone" @drop="drop">
-			<k-input-validator
-				v-bind="{ min, max, required }"
-				:value="JSON.stringify(value)"
-			>
+			<k-validator v-bind="{ min, max, required }" :count="value.length">
 				<k-collection
 					v-bind="collection"
 					v-on="!disabled ? { empty: open } : {}"
@@ -35,7 +32,7 @@
 						/>
 					</template>
 				</k-collection>
-			</k-input-validator>
+			</k-validator>
 		</k-dropzone>
 	</k-field>
 </template>

--- a/panel/src/components/Forms/Field/StructureField.vue
+++ b/panel/src/components/Forms/Field/StructureField.vue
@@ -60,10 +60,7 @@
 			</k-button-group>
 		</template>
 
-		<k-input-validator
-			v-bind="{ min, max, required }"
-			:value="JSON.stringify(items)"
-		>
+		<k-validator v-bind="{ min, max, required }" :count="items.length">
 			<template v-if="hasFields">
 				<!-- Empty State -->
 				<k-empty
@@ -110,7 +107,7 @@
 			<template v-else>
 				<k-empty icon="list-bullet">{{ $t("fields.empty") }}</k-empty>
 			</template>
-		</k-input-validator>
+		</k-validator>
 	</k-field>
 </template>
 


### PR DESCRIPTION
## Review

- [x] Rough pass

## Description

Five fields bound their validator like this:

```vue
<k-input-validator v-bind="{ min, max, required }" :value="JSON.stringify(value)">
```

`InputValidator` does exactly one thing with that `value` string: `JSON.parse` it and take `entries.length`. 

So the whole data is serialized to JSON and parsed back to get a number the caller already has. 
This PR changes those usages to `k-validator` with `:count="X.length"`.

Not changed: option-based inputs (radio, checkboxes, ...) keep `k-input-validator`. They do use `.has()` on the parsed entries, so `count` is not enough there.

### Benchmarks

**Cost A: serialization.** `value` is a Vue reactive proxy, so every property read goes through a `get` trap:

| payload | size | plain object | reactive proxy | deps registered |
|---|---|---:|---:|---:|
| 100 blocks | 18 KB | 0.021 ms | **0.284 ms** | 1252 |
| 500 blocks | 90 KB | 0.096 ms | **1.432 ms** | 6252 |
| layout, 20 rows × 2 × 10 blocks | 75 KB | 0.081 ms | **1.238 ms** | 5402 |
| `value.length` | — | — | **0.00006 ms** | **1** |

**Cost B**  `JSON.stringify` leads to re-render the field on every keystroke:

Replaying 20 keystrokes into one block through that exact path:

| binding | blocks | `BlocksField` renders | per keystroke |
|---|---:|---:|---:|
| `JSON.stringify(value)` | 100 | 20 | 0.46 ms |
| `value.length` | 100 | **0** | 0.05 ms |
| `JSON.stringify(value)` | 500 | 20 | 1.69 ms |
| `value.length` | 500 | **0** | 0.05 ms |

## Changelog

### 🏎️ Performance

- Typing inside a block, layout, entries or structure row no longer re-renders the surrounding field at all on every keystroke.

## For review team

- [ ] Add changes & docs to release notes draft in Notion
