### PR TITLE
fix: Panel browser requirements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,12 +13,13 @@ psalm.xml.dist export-ignore
 tests/ export-ignore
 
 # panel
+# .browserslistrc is intentionally not ignored, it is read at runtime
 panel/.env.example export-ignore
+panel/.gitignore export-ignore
 panel/.prettierignore export-ignore
 panel/.prettierrc.json export-ignore
 panel/dist/ui export-ignore
-panel/eslint.config.mjs export-ignore
-panel/jsconfig.json export-ignore
+panel/eslint.config.js export-ignore
 panel/lab export-ignore
 panel/package-lock.json export-ignore
 panel/package.json export-ignore
@@ -27,8 +28,8 @@ panel/README.md export-ignore
 panel/scripts export-ignore
 panel/src export-ignore
 panel/tests export-ignore
-panel/vite.config.mjs export-ignore
-panel/vitest.setup.js export-ignore
+panel/tsconfig.json export-ignore
+panel/vite.config.ts export-ignore
 
 # other
 .tx export-ignore

--- a/panel/.browserslistrc
+++ b/panel/.browserslistrc
@@ -1,0 +1,16 @@
+# The single source of truth for Panel browser support.
+# Read by vite.config.ts (build target) and views/browser.php.
+#
+# Policy: Baseline "widely available" (roughly 30 months after a feature
+# has landed in all core browsers) when the major version is released.
+# Recompute for the next major and paste the result below:
+# npx baseline-browser-mapping --widely-available-on-date YYYY-MM-DD --include-downstream-browsers
+#
+Chrome >= 124
+ChromeAndroid >= 124
+Edge >= 124
+Firefox >= 125
+Opera >= 110
+Safari >= 17.5
+iOS >= 17.5
+Android >= 124

--- a/panel/README.md
+++ b/panel/README.md
@@ -69,3 +69,9 @@ To upate the dist files
 ```
 npm run build
 ```
+
+## Browser support
+
+`.browserslistrc` is the single source of truth. It feeds the Vite build target (`createTarget()` in `vite.config.ts`) and the "browser too old" page ( `views/browser.php`). Don't repeat the versions anywhere else.
+
+To move the floor for the next major, see the instructions in `.browserslistrc`.

--- a/panel/package.json
+++ b/panel/package.json
@@ -54,16 +54,6 @@
 		"vue-docgen-api": "^4.79.2",
 		"vue-tsc": "^3.3.7"
 	},
-	"browserslist": [
-		"Chrome >= 123",
-		"ChromeAndroid >= 126",
-		"Edge >= 123",
-		"Firefox >= 120",
-		"Opera >= 109",
-		"Safari >= 17.5",
-		"iOS >= 17.5",
-		"Android >= 126"
-	],
 	"allowScripts": {
 		"fsevents@2.3.3": true
 	}

--- a/panel/vite.config.ts
+++ b/panel/vite.config.ts
@@ -1,4 +1,5 @@
 /* eslint-env node */
+import fs from "fs";
 import path from "path";
 
 import {
@@ -103,6 +104,43 @@ function createPlugins(mode: string): Plugin[] {
 }
 
 /**
+ * Returns the build target, based on `.browserslistrc`
+ */
+function createTarget(): string[] {
+	const engines: Record<string, string> = {
+		Chrome: "chrome",
+		Edge: "edge",
+		Firefox: "firefox",
+		iOS: "ios",
+		Opera: "opera",
+		Safari: "safari"
+	};
+
+	const file = fs.readFileSync(
+		path.resolve(__dirname, ".browserslistrc"),
+		"utf-8"
+	);
+
+	const target: string[] = [];
+
+	for (const raw of file.split("\n")) {
+		// strip comments, browserslist allows them at the end of a line
+		const line = raw.replace(/#.*$/, "").trim();
+		const match = line.match(/^(\w+)\s*>=\s*([\d.]+)$/);
+
+		if (match !== null && engines[match[1]] !== undefined) {
+			target.push(engines[match[1]] + match[2]);
+		}
+	}
+
+	if (target.length === 0) {
+		throw new Error("No build target could be read from .browserslistrc");
+	}
+
+	return target;
+}
+
+/**
  * Returns vitest configuration
  */
 function createTest() {
@@ -149,7 +187,7 @@ export default defineConfig(({ mode }) => {
 		plugins,
 		base: "./",
 		build: {
-			target: ["chrome123", "edge123", "firefox120", "safari17.5", "ios17.5"],
+			target: createTarget(),
 			cssCodeSplit: false,
 			rolldownOptions: {
 				checks: { pluginTimings: false },

--- a/src/Panel/Panel.php
+++ b/src/Panel/Panel.php
@@ -59,6 +59,34 @@ class Panel
 	}
 
 	/**
+	 * Minimum supported browser versions, read from
+	 * the browserslist config the Panel is built against
+	 * @since 6.0.0
+	 */
+	public function browsers(): array
+	{
+		$file = $this->kirby->root('panel') . '/.browserslistrc';
+
+		if (is_file($file) === false) {
+			return [];
+		}
+
+		$browsers = [];
+		$lines    = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
+		foreach ($lines as $line) {
+			// strip comments, browserslist allows them at the end of a line
+			$line = trim(preg_replace('!#.*$!', '', $line));
+
+			if (preg_match('!^(\w+)\s*>=\s*([\d.]+)$!', $line, $match) === 1) {
+				$browsers[$match[1]] = $match[2];
+			}
+		}
+
+		return $browsers;
+	}
+
+	/**
 	 * Redirect to a Panel url
 	 *
 	 * @throws Redirect

--- a/src/Panel/Router.php
+++ b/src/Panel/Router.php
@@ -164,7 +164,10 @@ class Router
 				'pattern' => 'browser',
 				'auth'    => false,
 				'action'  => fn () => new Response(
-					Tpl::load($kirby->root('kirby') . '/views/browser.php')
+					Tpl::load(
+						$kirby->root('kirby') . '/views/browser.php',
+						['browsers' => $panel->browsers()]
+					)
 				),
 			]
 		];

--- a/tests/Panel/PanelTest.php
+++ b/tests/Panel/PanelTest.php
@@ -3,7 +3,9 @@
 namespace Kirby\Panel;
 
 use Kirby\Filesystem\Dir;
+use Kirby\Filesystem\F;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(Panel::class)]
 class PanelTest extends TestCase
@@ -41,6 +43,42 @@ class PanelTest extends TestCase
 		$panel = $this->app->panel();
 		$this->assertInstanceOf(Assets::class, $panel->assets());
 		$this->assertSame($panel->assets(), $panel->assets());
+	}
+
+	public static function browsersProvider(): array
+	{
+		return [
+			["# a comment\n\nChrome >= 124\n  Safari >= 17.5  ", ['Chrome' => '124', 'Safari' => '17.5']],
+			["last 2 versions\nnot dead\nChrome > 124", []],
+			['Safari >= 17.5 # macOS Monterey', ['Safari' => '17.5']],
+			['', []],
+		];
+	}
+
+	#[DataProvider('browsersProvider')]
+	public function testBrowsers(string $content, array $expected): void
+	{
+		$root = static::TMP . '/browserslist';
+		F::write($root . '/.browserslistrc', $content);
+
+		$app = $this->app->clone(['roots' => ['panel' => $root]]);
+
+		$this->assertSame($expected, $app->panel()->browsers());
+	}
+
+	public function testBrowsersWithDefaultRoot(): void
+	{
+		$browsers = $this->app->panel()->browsers();
+
+		$this->assertNotSame([], $browsers);
+		$this->assertArrayHasKey('Chrome', $browsers);
+	}
+
+	public function testBrowsersWithMissingFile(): void
+	{
+		$app = $this->app->clone(['roots' => ['panel' => static::TMP]]);
+
+		$this->assertSame([], $app->panel()->browsers());
 	}
 
 	public function testGo(): void

--- a/views/browser.php
+++ b/views/browser.php
@@ -1,3 +1,17 @@
+<?php
+
+use Kirby\Toolkit\Html;
+
+/**
+ * @var array<string, string> $browsers
+ */
+$list = [];
+
+foreach ($browsers as $browser => $version) {
+	$list[] = Html::encode($browser . ' ' . $version);
+}
+
+?>
 <?php include __DIR__ . '/snippets/header.php' ?>
 
   <p class="notice">
@@ -7,14 +21,11 @@
 
   <div class="admin-advice">
     <p>
-        <strong>Fetch</strong><br>
-        We use Javascript's new Fetch API. You can find a list of supported browsers for this feature on
-        <strong><a href="https://caniuse.com/#feat=fetch">caniuse.com</a></strong>
+      The Panel needs one of these browsers or higher:<br>
+      <strong><?= implode(', ', $list) ?></strong>
     </p>
     <p>
-        <strong>CSS Grid</strong><br>
-        We use CSS Grids for all our layouts. You can find a list of supported browsers for this feature on
-        <strong><a href="https://caniuse.com/#feat=css-grid">caniuse.com</a></strong>
+      Please update your browser or switch to a different one.
     </p>
   </div>
 

--- a/views/panel.php
+++ b/views/panel.php
@@ -27,11 +27,13 @@ use Kirby\Toolkit\Html;
 
 	<script nonce="<?= $nonce ?>">
 	if (
-			!window.CSS ||
-			window.CSS.supports("display", "grid") === false ||
-			!window.fetch
+		!window.CSS ||
+		window.CSS.supports("color", "light-dark(#fff, #000)") === false ||
+		!window.HTMLScriptElement.supports ||
+		window.HTMLScriptElement.supports("importmap") === false ||
+		!window.Promise.withResolvers
 	) {
-		window.location.href = "<?= $panelUrl ?>browser";
+		window.location.replace("<?= $panelUrl ?>browser");
 	}
 	</script>
 


### PR DESCRIPTION
## Review

- [x] Design & concept
- [x] Deep read

**Timing:** Before the v6 final release

## Description

I stumbled over the fact that the Panel's browser check has not been touched since v3. It tests for CSS Grid and `fetch`. We require higher browser versions now and so our checks should also test for the edge case features.

In addition, the browser requirements were also spread over many places that had already drifted apart: `package.json` said Firefox 120, `vite.config.ts` repeated the same numbers by hand, `views/browser.php` named different features entirely, and the website docs also have to name them.

#### One source of truth

`panel/.browserslistrc` now holds the versions. It is the canonical location, it ships in releases (`panel/package.json` does not), and PHP can parse it in a few lines. Both consumers read it:

- `createTarget()` in `vite.config.ts` → the esbuild build target
- `Panel::browsers()` → `views/browser.php`

We can also use it to read it on getkirby.com for creating the requirement list there then.

#### Which baseline

The floor is Baseline *widely available*:  features that have been in all core browsers for 30 months, measured by the potential release date. 

#### The check

Now built on three checks:

- `light-dark()` → Chrome/Edge 123, Safari 17.5
- `Promise.withResolvers` → Firefox 121 (also covers `:has()`, same release)
- `HTMLScriptElement.supports("importmap")` → how the Panel loads at all;   dominated on the big three, but the failure mode is a blank page, so it is   worth the line for embedded webviews and older forks

More permissive than the declared floor: Baseline says Firefox 125, but nothing in the code currently needs more than 121. The declared floor is the support promise; the check is the "this will visibly break" gate.

## Changelog

### ✨ Enhancements

- The "browser not supported" page now names the browser versions the Panel needs .

### 🧹 Housekeeping

- Panel browser support is defined in one place, `panel/.browserslistrc`.

## Docs

Panel browser support, for the requirements page:

> The Kirby Panel needs Chrome 124, Edge 124, Firefox 125, Safari 17.5 or higher.
> Browsers released from roughly mid-2024 onwards. Kirby follows
> Baseline "widely available", which means we only rely on web platform
> features that have been in every major browser for at least 30 months

To move the floor for the next major:

```
npx baseline-browser-mapping --widely-available-on-date YYYY-MM-DD --include-downstream-browsers
```


## For review team

- [x] Add changes & docs to release notes draft in Notion
