### PR TITLE
fix: Collect field names in a single namespace

### DIFF
--- a/src/Blueprint/Blueprint.php
+++ b/src/Blueprint/Blueprint.php
@@ -28,8 +28,7 @@ class Blueprint
 
 	protected AcceptRules|null $acceptRules = null;
 
-	protected array $fields = [];
-	protected array|null $fieldsLower = null;
+	protected FieldsRegistry $fields;
 	protected ModelWithContent $model;
 	protected array $props;
 	protected Tabs|null $tabs = null;
@@ -174,13 +173,7 @@ class Blueprint
 	 */
 	public function field(string $name): array|null
 	{
-		if (isset($this->fields[$name]) === true) {
-			return $this->fields[$name];
-		}
-
-		// field objects use normalized lowercase keys
-		$this->fieldsLower ??= array_change_key_case($this->fields);
-		return $this->fieldsLower[Str::lower($name)] ?? null;
+		return $this->fields->get($name);
 	}
 
 	/**
@@ -213,7 +206,7 @@ class Blueprint
 	 */
 	public function fields(): array
 	{
-		return $this->fields;
+		return $this->fields->toArray();
 	}
 
 	/**
@@ -221,7 +214,7 @@ class Blueprint
 	 * types and widths.
 	 * Facade for `Normalizer::normalizeFieldsProps()`
 	 *
-	 * @return array<string, array>
+	 * @return array<string|int, array>
 	 */
 	public static function fieldsProps(mixed $fields): array
 	{

--- a/src/Blueprint/FieldsRegistry.php
+++ b/src/Blueprint/FieldsRegistry.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Kirby\Blueprint;
+
+use Kirby\Toolkit\Str;
+
+/**
+ * Collects the props of all fields in a blueprint
+ *
+ * @copyright Bastian Allgeier
+ * @license   https://getkirby.com/license
+ * @since     6.0.0
+ * @unstable
+ */
+class FieldsRegistry
+{
+	// Props of all fields, keyed by their declared name
+	protected array $fields = [];
+
+	// Declared names of all fields, keyed by their lowercase name
+	protected array $names = [];
+
+	/**
+	 * Claims the given names without touching their props.
+	 * The props can still be any of the shortcuts a blueprint
+	 * allows, as they are only normalized later.
+	 */
+	public function __construct(array $fields = [])
+	{
+		foreach ($fields as $name => $props) {
+			$this->fields[$name] = $props;
+			$this->names[Str::lower((string)$name)] = $name;
+		}
+	}
+
+	/**
+	 * Adds the props of the given fields under names that are
+	 * not taken yet and returns them, keyed by the names they
+	 * ended up with. A list is keyed by the name in the props.
+	 */
+	public function add(array $fields): array
+	{
+		$added = [];
+
+		foreach ($fields as $name => $props) {
+			if (is_int($name) === true) {
+				$name = $props['name'];
+			}
+
+			if ($this->has($name) === true) {
+				$props = $this->conflict($name, $props);
+				$name  = $props['name'];
+			}
+
+			$this->names[Str::lower((string)$name)] = $name;
+			$added[$name] = $this->fields[$name] = $props;
+		}
+
+		return $added;
+	}
+
+	/**
+	 * Creates an error field for a name that is already taken.
+	 * The error gets a unique name of its own, so that the field
+	 * which claimed the name first can stay intact.
+	 */
+	protected function conflict(string|int $name, array $props): array
+	{
+		$count = 1;
+
+		while ($this->has($name . '-duplicate-' . $count) === true) {
+			$count++;
+		}
+
+		return [
+			'label' => $props['label'] ?? 'Error',
+			'name'  => $name . '-duplicate-' . $count,
+			'text'  => 'The field <strong>"' . $name . '"</strong> already exists in your blueprint',
+			'theme' => 'negative',
+			'type'  => 'info',
+		];
+	}
+
+	/**
+	 * Returns the props of a single field. The lookup is
+	 * case-insensitive, just like the namespace.
+	 */
+	public function get(string|int $name): array|null
+	{
+		$name = $this->names[Str::lower((string)$name)] ?? null;
+
+		return $name !== null ? $this->fields[$name] : null;
+	}
+
+	/**
+	 * Checks if a name is already taken
+	 */
+	public function has(string|int $name): bool
+	{
+		return isset($this->names[Str::lower((string)$name)]) === true;
+	}
+
+	/**
+	 * Returns the props of all fields,
+	 * keyed by their declared name
+	 */
+	public function toArray(): array
+	{
+		return $this->fields;
+	}
+}

--- a/src/Blueprint/Normalizer.php
+++ b/src/Blueprint/Normalizer.php
@@ -13,8 +13,7 @@ use Throwable;
  * The Normalizer takes the raw props of a blueprint and
  * converts them into a proper tab layout. Sections are
  * converted to fields, loose fields are wrapped in a column
- * and loose columns in a tab. On the way, it collects the
- * props of all fields in the blueprint.
+ * and loose columns in a tab.
  *
  * @copyright Bastian Allgeier
  * @license   https://getkirby.com/license
@@ -41,34 +40,34 @@ class Normalizer
 	 * Global field definitions that can be referenced
 	 * in tabs, columns and fields.
 	 */
-	protected array $fieldDefinitions = [];
+	protected FieldsRegistry $definitions;
 
 	// Collected props of all fields in the blueprint
-	protected array $fields = [];
+	protected FieldsRegistry $fields;
 
 	// Collected blueprint props
 	protected array $props;
 
 	public function __construct(array $props)
 	{
-		$this->props = $this->normalize($props);
+		$this->definitions = new FieldsRegistry();
+		$this->fields      = new FieldsRegistry();
+		$this->props       = $this->normalize($props);
 	}
 
 	/**
 	 * Converts all column definitions, that
 	 * are not wrapped in a tab, into a generic tab
 	 */
-	protected function convertColumnsToTabs(
-		string $tabName,
-		array $props
-	): array {
+	protected function convertColumnsToTabs(array $props): array
+	{
 		if (isset($props['columns']) === false) {
 			return $props;
 		}
 
 		// wrap everything in a main tab
 		$props['tabs'] = [
-			$tabName => [
+			'main' => [
 				'columns' => $props['columns']
 			]
 		];
@@ -112,20 +111,7 @@ class Normalizer
 			return $props;
 		}
 
-		// field references have to be resolved before the merge,
-		// otherwise their numeric keys collide with each other
-		$fields = $this->resolveFieldReferences($props['fields'] ?? []);
-
-		// sections and fields share a single namespace
-		$add = static function (array $fields, $name, $props): array {
-			if (isset($fields[$name]) === true) {
-				$fields[$name] = static::duplicateFieldError($name, $props);
-				return $fields;
-			}
-
-			$fields[$name] = $props;
-			return $fields;
-		};
+		$fields = static::resolve($props['fields'] ?? [], $this->definitions);
 
 		foreach ($props['sections'] as $name => $section) {
 			// unset / remove section if its property is false
@@ -143,14 +129,11 @@ class Normalizer
 
 			// a fields section is unwrapped into the parent's own fields
 			if (($section['type'] ?? $name) === 'fields') {
-				foreach ($this->unwrapFieldsSection($section) as $key => $field) {
-					$fields = $add($fields, $key, $field);
-				}
-
+				$fields = [...$fields, ...$this->unwrapFieldsSection($section)];
 				continue;
 			}
 
-			$fields = $add($fields, $name, static::sectionToField($name, $section));
+			$fields[] = static::sectionToField($name, $section);
 		}
 
 		$props['fields'] = $fields;
@@ -161,27 +144,46 @@ class Normalizer
 	}
 
 	/**
-	 * Creates an error field for a field name that is already taken
+	 * Expands all field shortcuts into full props and splices the
+	 * members of a field group into their siblings. The result is a
+	 * list, which cannot lose a field to a name that is already
+	 * taken, so the names are only claimed afterwards.
+	 *
+	 * @return array<int, array>
 	 */
-	protected static function duplicateFieldError(
-		string|int $name,
-		array|string|bool|null $props = null
+	protected static function expand(
+		mixed $fields,
+		FieldsRegistry|null $definitions = null
 	): array {
-		return [
-			'label' => (is_array($props) === true ? $props['label'] ?? null : null) ?? 'Error',
-			'name'  => $name,
-			'text'  => 'The field <strong>"' . $name . '"</strong> already exists in your blueprint',
-			'theme' => 'negative',
-			'type'  => 'info',
-		];
+		$expanded = [];
+
+		foreach (static::resolve($fields, $definitions) as $props) {
+			try {
+				$props = static::normalizeFieldProps($props, $definitions);
+			} catch (Throwable $e) {
+				$props = Blueprint::fieldError($props['name'], $e->getMessage());
+			}
+
+			// a field group takes the place of its own members,
+			// which are already expanded at this point
+			if ($props['type'] === 'group') {
+				$expanded = [
+					...$expanded,
+					...array_values($props['fields'] ?? [])
+				];
+
+				continue;
+			}
+
+			$expanded[] = $props;
+		}
+
+		return $expanded;
 	}
 
 	/**
-	 * Extracts global field definitions from root level.
-	 * When layout elements exist, adds fields to the registry
-	 * and removes them from props so they can be referenced.
-	 * When no layout exists, fields stay in props for the
-	 * existing backwards-compatible behavior.
+	 * Extracts the field definitions at root level, which can be
+	 * referenced by name from tabs, columns and fields
 	 */
 	protected function extractFieldReferences(array $props): array
 	{
@@ -189,27 +191,29 @@ class Normalizer
 			return $props;
 		}
 
-		// Check if layout elements exist
-		$hasLayout = isset($props['tabs']) === true ||
-					 isset($props['sections']) === true ||
-					 isset($props['columns']) === true;
-
-		// Only store definitions and remove from props when layout exists
-		// (fields will be referenced from layout, not processed inline)
-		if ($hasLayout === true) {
-			$this->fieldDefinitions = static::normalizeFieldsProps($props['fields']);
-			unset($props['fields']);
+		// without a layout to reference them from, the fields
+		// stay in the props and are processed inline
+		if (
+			isset($props['tabs']) === false &&
+			isset($props['sections']) === false &&
+			isset($props['columns']) === false
+		) {
+			return $props;
 		}
+
+		$this->definitions = new FieldsRegistry(
+			static::normalizeFieldsProps($props['fields'])
+		);
+
+		unset($props['fields']);
 
 		return $props;
 	}
 
 	/**
-	 * Returns the props of all fields in the blueprint
-	 *
-	 * @return array<string, array>
+	 * Returns the collected fields of the blueprint
 	 */
-	public function fields(): array
+	public function fields(): FieldsRegistry
 	{
 		return $this->fields;
 	}
@@ -243,7 +247,7 @@ class Normalizer
 		// convert all shortcuts
 		$props = $this->convertSectionsToFields($props);
 		$props = $this->convertFieldsToColumns($props);
-		$props = $this->convertColumnsToTabs('main', $props);
+		$props = $this->convertColumnsToTabs($props);
 
 		// normalize all tabs
 		$props['tabs'] = $this->normalizeTabs($props['tabs'] ?? []);
@@ -258,34 +262,35 @@ class Normalizer
 	 */
 	protected function normalizeColumns(string $tabName, array $columns): array
 	{
-		foreach ($columns as $columnKey => $columnProps) {
-			// unset/remove column if its property is not array
-			if (is_array($columnProps) === false) {
-				unset($columns[$columnKey]);
+		$normalized = [];
+
+		foreach ($columns as $key => $props) {
+			// unset / remove column if its props are not an array
+			if (is_array($props) === false) {
 				continue;
 			}
 
-			$columnProps = $this->convertSectionsToFields($columnProps);
+			$props = $this->convertSectionsToFields($props);
 
 			// inject getting started info, if the fields are empty
-			if (empty($columnProps['fields']) === true) {
-				$columnProps['fields'] = [
-					$tabName . '-info-' . $columnKey => [
-						'label' => 'Column (' . ($columnProps['width'] ?? '1/1') . ')',
+			if (empty($props['fields']) === true) {
+				$props['fields'] = [
+					$tabName . '-info-' . $key => [
+						'label' => 'Column (' . ($props['width'] ?? '1/1') . ')',
 						'type'  => 'info',
 						'text'  => 'No fields yet'
 					]
 				];
 			}
 
-			$columns[$columnKey] = [
-				...$columnProps,
-				'width'  => $columnProps['width'] ?? '1/1',
-				'fields' => $this->normalizeFields($columnProps['fields'])
+			$normalized[$key] = [
+				...$props,
+				'width'  => $props['width'] ?? '1/1',
+				'fields' => $this->normalizeFields($props['fields'])
 			];
 		}
 
-		return $columns;
+		return $normalized;
 	}
 
 	/**
@@ -293,8 +298,10 @@ class Normalizer
 	 *
 	 * @throws InvalidArgumentException If the filed name is missing or the field type is invalid
 	 */
-	public static function normalizeFieldProps(array|string $props): array
-	{
+	public static function normalizeFieldProps(
+		array|string $props,
+		FieldsRegistry|null $definitions = null
+	): array {
 		$props = Blueprint::extend($props);
 
 		if (isset($props['name']) === false) {
@@ -314,22 +321,19 @@ class Normalizer
 
 		// support for nested fields
 		if (isset($props['fields']) === true) {
-			$props['fields'] = static::normalizeFieldsProps($props['fields']);
+			$props['fields'] = static::normalizeFieldsProps(
+				$props['fields'],
+				$definitions
+			);
 		}
 
-		// groups don't need all the crap
+		// a group is nothing but a wrapper for its own fields
 		if ($type === 'group') {
-			$fields = $props['fields'];
-
-			if (isset($props['when']) === true) {
-				$fields = array_map(
-					fn ($field) => array_replace_recursive(['when' => $props['when']], $field),
-					$fields
-				);
-			}
-
 			return [
-				'fields' => $fields,
+				'fields' => static::when(
+					$props['fields'] ?? [],
+					$props['when'] ?? null
+				),
 				'name'   => $name,
 				'type'   => $type
 			];
@@ -349,89 +353,26 @@ class Normalizer
 	 * Normalizes all fields of a column and registers
 	 * them in the global field collection
 	 *
-	 * @return array<string, array>
+	 * @return array<string|int, array>
 	 */
 	protected function normalizeFields(array $fields): array
 	{
-		// resolve field references before normalizing
-		$fields = $this->resolveFieldReferences($fields);
-		$fields = static::normalizeFieldsProps($fields);
-
-		foreach ($fields as $name => $props) {
-			if (isset($this->fields[$name]) === true) {
-				$fields[$name] = static::duplicateFieldError($name, $props);
-				continue;
-			}
-
-			$this->fields[$name] = $props;
-		}
-
-		return $fields;
+		// the fields of the entire blueprint share a single
+		// namespace, so their names are only claimed here
+		return $this->fields->add(static::expand($fields, $this->definitions));
 	}
 
 	/**
 	 * Normalizes all fields and adds automatic labels,
 	 * types and widths.
 	 *
-	 * @return array<string, array>
+	 * @return array<string|int, array>
 	 */
-	public static function normalizeFieldsProps(mixed $fields): array
-	{
-		if (is_array($fields) === false) {
-			$fields = [];
-		}
-
-		foreach ($fields as $fieldName => $fieldProps) {
-			// extend field from string
-			if (is_string($fieldProps) === true) {
-				$fieldProps = [
-					'extends' => $fieldProps,
-					'name'    => $fieldName
-				];
-			}
-
-			// use the name as type definition
-			if ($fieldProps === true) {
-				$fieldProps = [];
-			}
-
-			// unset / remove field if its property is false
-			if ($fieldProps === false) {
-				unset($fields[$fieldName]);
-				continue;
-			}
-
-			// inject the name
-			$fieldProps['name'] = $fieldName;
-
-			// create all props
-			try {
-				$fieldProps = static::normalizeFieldProps($fieldProps);
-			} catch (Throwable $e) {
-				$fieldProps = Blueprint::fieldError($fieldName, $e->getMessage());
-			}
-
-			// resolve field groups
-			if ($fieldProps['type'] === 'group') {
-				if (
-					empty($fieldProps['fields']) === false &&
-					is_array($fieldProps['fields']) === true
-				) {
-					$index  = array_search($fieldName, array_keys($fields));
-					$fields = [
-						...array_slice($fields, 0, $index),
-						...$fieldProps['fields'] ?? [],
-						...array_slice($fields, $index + 1)
-					];
-				} else {
-					unset($fields[$fieldName]);
-				}
-			} else {
-				$fields[$fieldName] = $fieldProps;
-			}
-		}
-
-		return $fields;
+	public static function normalizeFieldsProps(
+		mixed $fields,
+		FieldsRegistry|null $definitions = null
+	): array {
+		return (new FieldsRegistry())->add(static::expand($fields, $definitions));
 	}
 
 	/**
@@ -477,32 +418,32 @@ class Normalizer
 	protected function normalizeTabs(mixed $tabs): array
 	{
 		if (is_array($tabs) === false) {
-			$tabs = [];
+			return [];
 		}
 
-		foreach ($tabs as $tabName => $tabProps) {
-			// unset / remove tab if its property is false
-			if ($tabProps === false) {
-				unset($tabs[$tabName]);
+		$normalized = [];
+
+		foreach ($tabs as $name => $props) {
+			// unset / remove tab if its props are false
+			if ($props === false) {
 				continue;
 			}
 
 			// inject all tab extensions
-			$tabProps = Blueprint::extend($tabProps);
+			$props = Blueprint::extend($props);
+			$props = $this->convertSectionsToFields($props);
+			$props = $this->convertFieldsToColumns($props);
 
-			$tabProps = $this->convertSectionsToFields($tabProps);
-			$tabProps = $this->convertFieldsToColumns($tabProps);
-
-			$tabs[$tabName] = [
-				...$tabProps,
-				'columns' => $this->normalizeColumns($tabName, $tabProps['columns'] ?? []),
-				'icon'    => $tabProps['icon']  ?? null,
-				'label'   => $this->i18n($tabProps['label'] ?? Str::label($tabName)),
-				'name'    => $tabName,
+			$normalized[$name] = [
+				...$props,
+				'columns' => $this->normalizeColumns($name, $props['columns'] ?? []),
+				'icon'    => $props['icon'] ?? null,
+				'label'   => $this->i18n($props['label'] ?? Str::label($name)),
+				'name'    => $name,
 			];
 		}
 
-		return $tabs;
+		return $normalized;
 	}
 
 	/**
@@ -514,33 +455,59 @@ class Normalizer
 	}
 
 	/**
-	 * Resolves field references (numeric keys with string values)
-	 * to full definitions from the global registry
+	 * Resolves every field shortcut (an `extends` string, `true`
+	 * or a reference to a field definition) into plain props and
+	 * returns them as a list in which each entry carries its own name.
+	 *
+	 * @return array<int, array>
 	 */
-	protected function resolveFieldReferences(array $fields): array
-	{
-		$resolved = [];
-
-		foreach ($fields as $key => $value) {
-			// Numeric key with string value = field reference
-			if (is_int($key) === true && is_string($value) === true) {
-				$fieldName = $value;
-
-				if (isset($this->fieldDefinitions[$fieldName]) === true) {
-					$resolved[$fieldName] = $this->fieldDefinitions[$fieldName];
-				} else {
-					$resolved[$fieldName] = Blueprint::fieldError(
-						$fieldName,
-						'Referenced field "' . $fieldName . '" is not defined in fields'
-					);
-				}
-			} else {
-				// Inline field definition - keep as is
-				$resolved[$key] = $value;
-			}
+	protected static function resolve(
+		mixed $fields,
+		FieldsRegistry|null $definitions = null
+	): array {
+		if (is_array($fields) === false) {
+			return [];
 		}
 
-		return $resolved;
+		$list = [];
+
+		foreach ($fields as $key => $props) {
+			// a numeric key with a string value references
+			// one of the field definitions by name
+			if (is_int($key) === true && is_string($props) === true) {
+				$list[] = $definitions?->get($props) ?? Blueprint::fieldError(
+					$props,
+					'Referenced field "' . $props . '" is not defined in fields'
+				);
+
+				continue;
+			}
+
+			// extend field from string
+			if (is_string($props) === true) {
+				$props = ['extends' => $props];
+			}
+
+			// use the name as type definition
+			if ($props === true) {
+				$props = [];
+			}
+
+			// unset / remove field if its props are false
+			if (is_array($props) === false) {
+				continue;
+			}
+
+			// inject the name, unless the entry carries it already
+			$props['name'] = match (is_int($key)) {
+				true  => $props['name'] ?? $key,
+				false => $key
+			};
+
+			$list[] = $props;
+		}
+
+		return $list;
 	}
 
 	/**
@@ -607,31 +574,31 @@ class Normalizer
 	}
 
 	/**
-	 * Unwraps a `fields` section into its own fields. A `when`
-	 * condition on the section is pushed down onto every field,
-	 * the same way it works for field groups.
+	 * Unwraps a `fields` section into a list of its own fields
+	 *
+	 * @return array<int, array>
 	 */
 	protected function unwrapFieldsSection(array $props): array
 	{
-		$fields = $props['fields'] ?? [];
+		return static::when(
+			static::resolve($props['fields'] ?? [], $this->definitions),
+			$props['when'] ?? null
+		);
+	}
 
-		if (is_array($fields) === false) {
-			return [];
+	/**
+	 * Pushes the `when` condition of a wrapper (a fields group or
+	 * a `fields` section) down onto every field it wraps
+	 */
+	protected static function when(array $fields, mixed $when): array
+	{
+		if ($when === null) {
+			return $fields;
 		}
 
-		// references are resolved first, so that the `when` condition
-		// can be pushed down onto them just like onto inline fields
-		$fields = $this->resolveFieldReferences($fields);
-
-		if (isset($props['when']) === true) {
-			$fields = A::map(
-				$fields,
-				fn ($field) => is_array($field) === true
-					? array_replace_recursive(['when' => $props['when']], $field)
-					: $field
-			);
-		}
-
-		return $fields;
+		return A::map(
+			$fields,
+			fn ($field) => array_replace_recursive(['when' => $when], $field)
+		);
 	}
 }

--- a/src/Blueprint/Normalizer.php
+++ b/src/Blueprint/Normalizer.php
@@ -455,8 +455,8 @@ class Normalizer
 	}
 
 	/**
-	 * Resolves every field shortcut (an `extends` string, `true`
-	 * or a reference to a field definition) into plain props and
+	 * Resolves every field shortcut (an `extends` string, `true`,
+	 * `null` or a reference to a field definition) into plain props and
 	 * returns them as a list in which each entry carries its own name.
 	 *
 	 * @return array<int, array>
@@ -488,8 +488,9 @@ class Normalizer
 				$props = ['extends' => $props];
 			}
 
-			// use the name as type definition
-			if ($props === true) {
+			// fall back to the default props, which use
+			// the name as type definition
+			if ($props === true || $props === null) {
 				$props = [];
 			}
 
@@ -498,10 +499,15 @@ class Normalizer
 				continue;
 			}
 
-			// inject the name, unless the entry carries it already
-			$props['name'] = match (is_int($key)) {
-				true  => $props['name'] ?? $key,
-				false => $key
+			// inject the key as name, unless the entry carries
+			// a name of its own that can be used as one
+			$name = $props['name'] ?? null;
+
+			$props['name'] = match (true) {
+				is_int($key) === false    => $key,
+				is_string($name) === true => $name,
+				is_int($name) === true    => $name,
+				default                   => $key
 			};
 
 			$list[] = $props;

--- a/src/Cms/Fieldset.php
+++ b/src/Cms/Fieldset.php
@@ -3,6 +3,7 @@
 namespace Kirby\Cms;
 
 use Kirby\Blueprint\Blueprint;
+use Kirby\Blueprint\FieldsRegistry;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Form\Form;
 use Kirby\Toolkit\I18n;
@@ -28,6 +29,7 @@ class Fieldset extends Item
 	protected string|null $label;
 	protected string $name;
 	protected string|bool|null $preview;
+	protected FieldsRegistry|null $registry = null;
 	protected array|null $tabs = null;
 	protected bool $translate;
 	protected string $type;
@@ -73,8 +75,9 @@ class Fieldset extends Item
 
 	protected function createFields(array $fields = []): array
 	{
-		$fields = Blueprint::fieldsProps($fields);
-		$fields = $this->form($fields)->fields()->toProps(defaults: true);
+		$this->registry ??= new FieldsRegistry();
+		$resolved         = $this->registry->add(Blueprint::fieldsProps($fields));
+		$fields           = $this->form($resolved)->fields()->toProps(defaults: true);
 
 		// collect all fields
 		$this->fields = [...$this->fields ?? [], ...$fields];

--- a/tests/Blueprint/BlueprintFieldReferencesTest.php
+++ b/tests/Blueprint/BlueprintFieldReferencesTest.php
@@ -382,10 +382,11 @@ class BlueprintFieldReferencesTest extends TestCase
 
 		// Second tab should show an error because field is already used
 		$tab2Fields = $tabs['tab2']['columns'][0]['fields'];
-		$this->assertArrayHasKey('sharedField', $tab2Fields);
-		$this->assertSame('info', $tab2Fields['sharedField']['type']);
-		$this->assertSame('negative', $tab2Fields['sharedField']['theme']);
-		$this->assertStringContainsString('already exists', $tab2Fields['sharedField']['text']);
+		$this->assertArrayNotHasKey('sharedField', $tab2Fields);
+		$this->assertArrayHasKey('sharedField-duplicate-1', $tab2Fields);
+		$this->assertSame('info', $tab2Fields['sharedField-duplicate-1']['type']);
+		$this->assertSame('negative', $tab2Fields['sharedField-duplicate-1']['theme']);
+		$this->assertStringContainsString('already exists', $tab2Fields['sharedField-duplicate-1']['text']);
 	}
 
 	public function testSectionWhenPushedToReferencedFields(): void

--- a/tests/Blueprint/BlueprintTest.php
+++ b/tests/Blueprint/BlueprintTest.php
@@ -9,6 +9,7 @@ use Kirby\Cms\Page;
 use Kirby\Data\Data;
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Filesystem\Dir;
+use Kirby\Form\Fields;
 use Kirby\TestCase;
 use Kirby\Toolkit\I18n;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -584,7 +585,18 @@ class BlueprintTest extends TestCase
 			]
 		]);
 
-		$this->assertSame('Last', $blueprint->field('MIXEDCASING')['label']);
+		// names are lowercased further down the line, so both
+		// definitions are the same field and collide with each other
+		$this->assertSame('First', $blueprint->field('MIXEDCASING')['label']);
+		$this->assertSame('text', $blueprint->field('MIXEDCASING')['type']);
+
+		$error = $blueprint->field('MixedCasing-duplicate-1');
+
+		$this->assertSame('info', $error['type']);
+		$this->assertSame(
+			'The field <strong>"MixedCasing"</strong> already exists in your blueprint',
+			$error['text']
+		);
 	}
 
 	public function testNestedFields(): void
@@ -716,19 +728,118 @@ class BlueprintTest extends TestCase
 			]
 		]);
 
-		// sections and fields share a single namespace, so the
-		// second definition is replaced by a duplicate name error
+		// sections and fields share a single namespace, so the first
+		// definition keeps the name and the second one is turned
+		// into a duplicate name error with a name of its own
 		$field = $blueprint->field('info');
 
-		$this->assertSame('info', $field['type']);
-		$this->assertSame('negative', $field['theme']);
+		$this->assertSame('text', $field['type']);
+
+		$error = $blueprint->field('info-duplicate-1');
+
+		$this->assertSame('info', $error['type']);
+		$this->assertSame('negative', $error['theme']);
 		$this->assertSame(
 			'The field <strong>"info"</strong> already exists in your blueprint',
-			$field['text']
+			$error['text']
 		);
 	}
 
+	public function testSectionAndFieldOfSameNameKeepStoredValues(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'blueprints' => [
+				'pages/note' => [
+					'fields' => [
+						'shared' => ['type' => 'text'],
+						'other'  => ['type' => 'text']
+					],
+					'sections' => [
+						'main' => [
+							'type'   => 'fields',
+							'fields' => ['shared', 'other']
+						],
+						'aside' => [
+							'type'   => 'fields',
+							'fields' => ['shared']
+						]
+					]
+				]
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'note',
+						'template' => 'note',
+						'content'  => [
+							'shared' => 'keepme',
+							'other'  => 'old'
+						]
+					]
+				]
+			]
+		]);
 
+		$page = $app->page('note');
+
+		// the first reference keeps a storable field, so its value
+		// survives when an unrelated field is submitted
+		$this->assertSame('text', $page->blueprint()->field('shared')['type']);
+		$this->assertSame('info', $page->blueprint()->field('shared-duplicate-1')['type']);
+
+		$fields = Fields::for($page);
+		$fields->fill(input: $page->content()->toArray());
+		$fields->submit(input: ['other' => 'new']);
+
+		$this->assertSame('keepme', $fields->toStoredValues()['shared']);
+	}
+
+	public function testSectionAndFieldOfSameNameRenderInTheTab(): void
+	{
+		$app = new App([
+			'roots' => [
+				'index' => '/dev/null'
+			],
+			'blueprints' => [
+				'pages/album' => [
+					'tabs' => [
+						'images' => [
+							'sections' => [
+								'files' => ['type' => 'files', 'template' => 'image']
+							]
+						],
+						'docs' => [
+							'sections' => [
+								'files' => ['type' => 'files', 'template' => 'document']
+							]
+						]
+					]
+				]
+			],
+			'site' => [
+				'children' => [
+					['slug' => 'album', 'template' => 'album']
+				]
+			]
+		]);
+
+		$page   = $app->page('album');
+		$fields = Fields::for($page);
+
+		// the Panel resolves each column from the field registry, so
+		// both the surviving field and the error need an entry of their own
+		$images = $page->blueprint()->tab('images')->columns($fields);
+		$docs   = $page->blueprint()->tab('docs')->columns($fields);
+
+		$this->assertSame(['files'], array_keys($images[0]['fields']));
+		$this->assertSame('filelist', $images[0]['fields']['files']['type']);
+
+		$this->assertSame(['files-duplicate-1'], array_keys($docs[0]['fields']));
+		$this->assertSame('info', $docs[0]['fields']['files-duplicate-1']['type']);
+	}
 
 	public function testAutomaticLabelForFields()
 	{

--- a/tests/Blueprint/FieldsRegistryTest.php
+++ b/tests/Blueprint/FieldsRegistryTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Kirby\Blueprint;
+
+use Kirby\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(FieldsRegistry::class)]
+class FieldsRegistryTest extends TestCase
+{
+	public function testConstruct(): void
+	{
+		$fields = new FieldsRegistry([
+			'alpha' => ['type' => 'text'],
+			'beta'  => false
+		]);
+
+		// the props are claimed as they are and only normalized later
+		$this->assertSame(
+			['alpha' => ['type' => 'text'], 'beta' => false],
+			$fields->toArray()
+		);
+	}
+
+	public function testAdd(): void
+	{
+		$fields = new FieldsRegistry();
+
+		$added = $fields->add([
+			'alpha' => ['type' => 'text'],
+			'beta'  => ['type' => 'date']
+		]);
+
+		$this->assertSame(['alpha', 'beta'], array_keys($added));
+		$this->assertSame(['type' => 'text'], $fields->get('alpha'));
+		$this->assertSame(['type' => 'date'], $fields->get('beta'));
+	}
+
+	public function testAddWithDuplicateName(): void
+	{
+		$fields = new FieldsRegistry();
+
+		$fields->add(['alpha' => ['type' => 'text']]);
+		$added = $fields->add(['alpha' => ['type' => 'textarea']]);
+
+		// the first field keeps the name it claimed
+		$this->assertSame(['alpha-duplicate-1'], array_keys($added));
+		$this->assertSame('text', $fields->get('alpha')['type']);
+
+		$error = $fields->get('alpha-duplicate-1');
+
+		$this->assertSame('info', $error['type']);
+		$this->assertSame('negative', $error['theme']);
+		$this->assertSame(
+			'The field <strong>"alpha"</strong> already exists in your blueprint',
+			$error['text']
+		);
+	}
+
+	public function testAddWithDuplicateNameInDifferentCase(): void
+	{
+		$fields = new FieldsRegistry();
+
+		$fields->add(['Alpha' => ['type' => 'text']]);
+
+		// names are lowercased further down the line, so `Alpha`
+		// and `alpha` are the same field
+		$added = $fields->add(['alpha' => ['type' => 'textarea']]);
+
+		$this->assertSame(['alpha-duplicate-1'], array_keys($added));
+		$this->assertSame('text', $fields->get('Alpha')['type']);
+	}
+
+	public function testAddWithTakenErrorName(): void
+	{
+		$fields = new FieldsRegistry();
+
+		$fields->add([
+			'alpha'             => ['type' => 'text'],
+			'alpha-duplicate-1' => ['type' => 'date']
+		]);
+
+		// the error skips the name that is already taken by a real field
+		$added = $fields->add(['alpha' => ['type' => 'textarea']]);
+
+		$this->assertSame(['alpha-duplicate-2'], array_keys($added));
+		$this->assertSame('date', $fields->get('alpha-duplicate-1')['type']);
+	}
+
+	public function testGet(): void
+	{
+		$fields = new FieldsRegistry(['Alpha' => ['type' => 'text']]);
+
+		$this->assertSame(['type' => 'text'], $fields->get('Alpha'));
+		$this->assertSame(['type' => 'text'], $fields->get('alpha'));
+		$this->assertNull($fields->get('beta'));
+	}
+
+	public function testHas(): void
+	{
+		$fields = new FieldsRegistry(['Alpha' => ['type' => 'text']]);
+
+		$this->assertTrue($fields->has('Alpha'));
+		$this->assertTrue($fields->has('alpha'));
+		$this->assertFalse($fields->has('beta'));
+	}
+
+	public function testToArray(): void
+	{
+		$fields = new FieldsRegistry();
+
+		$this->assertSame([], $fields->toArray());
+
+		$fields->add(['alpha' => ['type' => 'text']]);
+
+		$this->assertSame(['alpha' => ['type' => 'text']], $fields->toArray());
+	}
+}

--- a/tests/Blueprint/NormalizerTest.php
+++ b/tests/Blueprint/NormalizerTest.php
@@ -175,11 +175,53 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$fields = $normalizer->fields();
+		$fields = $normalizer->fields()->toArray();
 
 		$this->assertSame(['title'], array_keys($fields));
 		$this->assertSame('text', $fields['title']['type']);
 		$this->assertSame('Title', $fields['title']['label']);
+	}
+
+	public function testFieldReferenceInGroup(): void
+	{
+		$normalizer = $this->normalizer([
+			'fields' => [
+				'title' => ['type' => 'text', 'maxlength' => 5]
+			],
+			'tabs' => [
+				'main' => [
+					'fields' => [
+						'meta' => ['type' => 'group', 'fields' => ['title']]
+					]
+				]
+			]
+		]);
+
+		$field = $normalizer->fields()->get('title');
+
+		$this->assertSame('text', $field['type']);
+		$this->assertSame(5, $field['maxlength']);
+	}
+
+	public function testFieldReferenceInNestedFields(): void
+	{
+		$normalizer = $this->normalizer([
+			'fields' => [
+				'title' => ['type' => 'text', 'maxlength' => 5]
+			],
+			'tabs' => [
+				'main' => [
+					'fields' => [
+						'items' => ['type' => 'structure', 'fields' => ['title']]
+					]
+				]
+			]
+		]);
+
+		$field = $normalizer->fields()->get('items')['fields']['title'];
+
+		$this->assertSame('text', $field['type']);
+		$this->assertSame(5, $field['maxlength']);
 	}
 
 	public function testFieldReferenceMissing(): void
@@ -196,7 +238,7 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$field = $normalizer->fields()['nonsense'];
+		$field = $normalizer->fields()->toArray()['nonsense'];
 
 		$this->assertSame('info', $field['type']);
 		$this->assertSame('Error', $field['label']);
@@ -204,6 +246,53 @@ class NormalizerTest extends TestCase
 			'Referenced field "nonsense" is not defined in fields',
 			$field['text']
 		);
+	}
+
+	public function testFieldReferenceInDifferentCase(): void
+	{
+		$normalizer = $this->normalizer([
+			'fields' => [
+				'MixedCase' => ['type' => 'text']
+			],
+			'sections' => [
+				'content' => [
+					'type'   => 'fields',
+					'fields' => ['mixedcase']
+				]
+			]
+		]);
+
+		// the lookup is case-insensitive and the definition keeps
+		// the name it was declared with, so that the automatic
+		// label is derived from that spelling
+		$fields = $normalizer->fields()->toArray();
+
+		$this->assertSame(['MixedCase'], array_keys($fields));
+		$this->assertSame('text', $fields['MixedCase']['type']);
+		$this->assertSame('Mixed case', $fields['MixedCase']['label']);
+	}
+
+	public function testFieldReferenceTwice(): void
+	{
+		$normalizer = $this->normalizer([
+			'fields' => [
+				'title' => ['type' => 'text']
+			],
+			'sections' => [
+				'content' => [
+					'type'   => 'fields',
+					'fields' => ['title', 'title']
+				]
+			]
+		]);
+
+		// a reference claims the name like any other field, so the
+		// same definition cannot be pulled in twice
+		$fields = $normalizer->fields()->toArray();
+
+		$this->assertSame(['title', 'title-duplicate-1'], array_keys($fields));
+		$this->assertSame('text', $fields['title']['type']);
+		$this->assertSame('info', $fields['title-duplicate-1']['type']);
 	}
 
 	public function testFields(): void
@@ -215,7 +304,7 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$fields = $normalizer->fields();
+		$fields = $normalizer->fields()->toArray();
 
 		$this->assertSame(['title', 'date'], array_keys($fields));
 		$this->assertSame('Title', $fields['title']['label']);
@@ -225,7 +314,7 @@ class NormalizerTest extends TestCase
 
 	public function testFieldsEmpty(): void
 	{
-		$this->assertSame([], $this->normalizer()->fields());
+		$this->assertSame([], $this->normalizer()->fields()->toArray());
 	}
 
 	public function testFieldsWithDuplicateName(): void
@@ -243,13 +332,17 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$field = $normalizer->fields()['title'];
+		// the first field keeps the name it claimed
+		$this->assertSame('text', $normalizer->fields()->toArray()['title']['type']);
 
-		$this->assertSame('info', $field['type']);
-		$this->assertSame('negative', $field['theme']);
+		// the duplicate becomes an error field with a name of its own
+		$error = $normalizer->fields()->toArray()['title-duplicate-1'];
+
+		$this->assertSame('info', $error['type']);
+		$this->assertSame('negative', $error['theme']);
 		$this->assertSame(
 			'The field <strong>"title"</strong> already exists in your blueprint',
-			$field['text']
+			$error['text']
 		);
 	}
 
@@ -272,22 +365,117 @@ class NormalizerTest extends TestCase
 
 		// the first occurrence keeps the registry entry, so everything
 		// that reads the blueprint by name still gets a working field
-		$field = $normalizer->fields()['files'];
+		$field = $normalizer->fields()->toArray()['files'];
 
 		$this->assertSame('filelist', $field['type']);
 		$this->assertSame('image', $field['template']);
+
+		// the error field is registered under its own name, so that
+		// the Panel can resolve and render it from the registry
+		$error = $normalizer->fields()->toArray()['files-duplicate-1'];
+
+		$this->assertSame('info', $error['type']);
 
 		// only the duplicate is rendered as an error field
 		$tabs = $normalizer->tabs();
 
 		$this->assertSame(
-			'filelist',
-			$tabs['images']['columns'][0]['fields']['files']['type']
+			['files'],
+			array_keys($tabs['images']['columns'][0]['fields'])
+		);
+		$this->assertSame(
+			['files-duplicate-1'],
+			array_keys($tabs['docs']['columns'][0]['fields'])
 		);
 		$this->assertSame(
 			'info',
-			$tabs['docs']['columns'][0]['fields']['files']['type']
+			$tabs['docs']['columns'][0]['fields']['files-duplicate-1']['type']
 		);
+	}
+
+	public function testFieldsWithDuplicateNameInDifferentCase(): void
+	{
+		$normalizer = $this->normalizer([
+			'tabs' => [
+				'one' => [
+					'fields' => [
+						'Alpha' => [
+							'type'      => 'text',
+							'label'     => 'First',
+							'required'  => true,
+							'maxlength' => 3
+						]
+					]
+				],
+				'two' => [
+					'fields' => [
+						'alpha' => ['type' => 'textarea', 'label' => 'Second']
+					]
+				]
+			]
+		]);
+
+		// names are lowercased further down the line, so `Alpha` and
+		// `alpha` are the same field and collide with each other
+		$fields = $normalizer->fields()->toArray();
+
+		$this->assertSame(
+			['Alpha', 'alpha-duplicate-1'],
+			array_keys($fields)
+		);
+
+		// the first field keeps its validation
+		$this->assertSame('text', $fields['Alpha']['type']);
+		$this->assertTrue($fields['Alpha']['required']);
+		$this->assertSame(3, $fields['Alpha']['maxlength']);
+
+		$this->assertSame('info', $fields['alpha-duplicate-1']['type']);
+	}
+
+	public function testFieldsWithDuplicateNameInGroup(): void
+	{
+		$normalizer = $this->normalizer([
+			'fields' => [
+				'alpha' => ['type' => 'text', 'label' => 'Plain'],
+				'group' => [
+					'type'   => 'group',
+					'fields' => [
+						'alpha' => ['type' => 'textarea', 'label' => 'Grouped']
+					]
+				]
+			]
+		]);
+
+		// a group is spliced into its siblings, so its members
+		// share a single namespace with them
+		$fields = $normalizer->fields()->toArray();
+
+		$this->assertSame('text', $fields['alpha']['type']);
+		$this->assertSame('Plain', $fields['alpha']['label']);
+		$this->assertSame('info', $fields['alpha-duplicate-1']['type']);
+	}
+
+	public function testFieldsWithDuplicateNameInGroupFirst(): void
+	{
+		$normalizer = $this->normalizer([
+			'fields' => [
+				'group' => [
+					'type'   => 'group',
+					'fields' => [
+						'alpha' => ['type' => 'textarea', 'label' => 'Grouped']
+					]
+				],
+				'alpha' => ['type' => 'text', 'label' => 'Plain']
+			]
+		]);
+
+		// a group member claims its name like every other field,
+		// so the one that comes first keeps it
+		$fields = $normalizer->fields()->toArray();
+
+		$this->assertSame('textarea', $fields['alpha']['type']);
+		$this->assertSame('Grouped', $fields['alpha']['label']);
+		$this->assertSame('info', $fields['alpha-duplicate-1']['type']);
 	}
 
 	public function testNormalizeFieldProps(): void
@@ -360,6 +548,28 @@ class NormalizerTest extends TestCase
 
 		$this->assertSame('Date', $props['fields']['date']['label']);
 		$this->assertSame('date', $props['fields']['date']['type']);
+	}
+
+	public function testNormalizeFieldPropsWithNestedFieldsInDifferentCase(): void
+	{
+		$props = Normalizer::normalizeFieldProps([
+			'name'   => 'entries',
+			'type'   => 'structure',
+			'fields' => [
+				'Date' => ['type' => 'date'],
+				'date' => ['type' => 'text']
+			]
+		]);
+
+		// nested fields share a namespace of their own, in which
+		// `Date` and `date` are the same field
+		$this->assertSame(
+			['Date', 'date-duplicate-1'],
+			array_keys($props['fields'])
+		);
+
+		$this->assertSame('date', $props['fields']['Date']['type']);
+		$this->assertSame('info', $props['fields']['date-duplicate-1']['type']);
 	}
 
 	public function testNormalizeFieldPropsWithTypeFromName(): void
@@ -609,7 +819,7 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$fields = $normalizer->fields();
+		$fields = $normalizer->fields()->toArray();
 
 		$this->assertSame(['pages', 'files', 'notes'], array_keys($fields));
 
@@ -628,7 +838,7 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$this->assertSame(['pages'], array_keys($normalizer->fields()));
+		$this->assertSame(['pages'], array_keys($normalizer->fields()->toArray()));
 	}
 
 	public function testSectionsWithFieldsType(): void
@@ -643,7 +853,7 @@ class NormalizerTest extends TestCase
 		]);
 
 		// a fields section is unwrapped into the parent's own fields
-		$this->assertSame(['title'], array_keys($normalizer->fields()));
+		$this->assertSame(['title'], array_keys($normalizer->fields()->toArray()));
 	}
 
 	public function testSectionsWithInvalidType(): void
@@ -654,7 +864,7 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$field = $normalizer->fields()['test'];
+		$field = $normalizer->fields()->toArray()['test'];
 
 		$this->assertSame('info', $field['type']);
 		$this->assertSame(
@@ -671,7 +881,7 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$this->assertSame('pagelist', $normalizer->fields()['pages']['type']);
+		$this->assertSame('pagelist', $normalizer->fields()->toArray()['pages']['type']);
 	}
 
 	public function testSectionsWithTypeFromName(): void
@@ -682,7 +892,7 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$this->assertSame('pagelist', $normalizer->fields()['pages']['type']);
+		$this->assertSame('pagelist', $normalizer->fields()->toArray()['pages']['type']);
 	}
 
 	public function testSectionsWithUnknownType(): void
@@ -693,10 +903,26 @@ class NormalizerTest extends TestCase
 			]
 		]);
 
-		$field = $normalizer->fields()['test'];
+		$field = $normalizer->fields()->toArray()['test'];
 
 		$this->assertSame('info', $field['type']);
 		$this->assertSame('Invalid section type ("nonsense")', $field['label']);
+	}
+
+	public function testSectionsWithUnsetField(): void
+	{
+		$normalizer = $this->normalizer([
+			'columns' => [
+				[
+					'fields'   => ['foo' => false],
+					'sections' => ['foo' => ['type' => 'pages']]
+				]
+			]
+		]);
+
+		// the field is unset, so the section can claim its name
+		$this->assertSame(['foo'], array_keys($normalizer->fields()->toArray()));
+		$this->assertSame('pagelist', $normalizer->fields()->get('foo')['type']);
 	}
 
 	public function testSectionsWithoutFields(): void
@@ -713,7 +939,7 @@ class NormalizerTest extends TestCase
 			'text'  => 'No fields yet',
 			'name'  => 'main-info-0',
 			'width' => '1/1'
-		], $normalizer->fields()['main-info-0']);
+		], $normalizer->fields()->toArray()['main-info-0']);
 	}
 
 	public function testTabs(): void

--- a/tests/Blueprint/NormalizerTest.php
+++ b/tests/Blueprint/NormalizerTest.php
@@ -632,6 +632,17 @@ class NormalizerTest extends TestCase
 		$this->assertSame(['date', 'title'], array_keys($fields));
 	}
 
+	public function testNormalizeFieldsPropsWithInvalidName(): void
+	{
+		$fields = Normalizer::normalizeFieldsProps([
+			['name' => ['nonsense'], 'type' => 'text']
+		]);
+
+		// a name that cannot be used as such falls back to the key
+		$this->assertSame(0, $fields[0]['name']);
+		$this->assertSame('text', $fields[0]['type']);
+	}
+
 	public function testNormalizeFieldsPropsWithInvalidType(): void
 	{
 		$fields = Normalizer::normalizeFieldsProps([
@@ -652,6 +663,15 @@ class NormalizerTest extends TestCase
 		$this->assertSame([], Normalizer::normalizeFieldsProps(false));
 		$this->assertSame([], Normalizer::normalizeFieldsProps(null));
 		$this->assertSame([], Normalizer::normalizeFieldsProps('nonsense'));
+	}
+
+	public function testNormalizeFieldsPropsWithNull(): void
+	{
+		$fields = Normalizer::normalizeFieldsProps([
+			'text' => null
+		]);
+
+		$this->assertSame('text', $fields['text']['type']);
 	}
 
 	public function testNormalizeFieldsPropsWithString(): void

--- a/tests/Cms/Fieldsets/FieldsetTest.php
+++ b/tests/Cms/Fieldsets/FieldsetTest.php
@@ -102,6 +102,37 @@ class FieldsetTest extends TestCase
 		$this->assertSame('text', $fieldset->fields()['text']['type']);
 	}
 
+	public function testFieldsInTabsWithDuplicateName(): void
+	{
+		$fieldset = new Fieldset([
+			'type' => 'test',
+			'tabs' => [
+				'one' => [
+					'fields' => [
+						'shared' => ['type' => 'text']
+					]
+				],
+				'two' => [
+					'fields' => [
+						'shared' => ['type' => 'number']
+					]
+				]
+			]
+		]);
+
+		// the fields of all tabs end up in a single flat map, so the
+		// second tab must not overwrite the field of the first one
+		$fields = $fieldset->fields();
+
+		$this->assertSame('text', $fields['shared']['type']);
+		$this->assertSame('info', $fields['shared-duplicate-1']['type']);
+
+		$tabs = $fieldset->tabs();
+
+		$this->assertSame(['shared'], array_keys($tabs['one']['fields']));
+		$this->assertSame(['shared-duplicate-1'], array_keys($tabs['two']['fields']));
+	}
+
 	public function testFieldsWithDisabledTabs(): void
 	{
 		$fieldset = new Fieldset([

--- a/tests/Guards/PageValidatorsTest.php
+++ b/tests/Guards/PageValidatorsTest.php
@@ -354,6 +354,42 @@ class PageValidatorsTest extends ModelTestCase
 		$validators->validateMoveToTemplate($this->app->page('parent-b'));
 	}
 
+	public function testMoveToTemplateWithDuplicateName(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/parent' => [
+					'sections' => [
+						'photos' => [
+							'type'     => 'pages',
+							'template' => 'child'
+						],
+						'details' => [
+							'type'   => 'fields',
+							'fields' => [
+								'photos' => ['type' => 'text']
+							]
+						]
+					]
+				]
+			],
+			'site' => [
+				'children' => [
+					['slug' => 'parent-a', 'template' => 'child'],
+					['slug' => 'parent-b', 'template' => 'parent']
+				]
+			]
+		]);
+
+		$validators = $this->validators($this->app->page('parent-a'));
+
+		// the pages section claimed the name first, so it keeps its
+		// page list field and the parent stays parentable
+		$validators->validateMoveToTemplate($this->app->page('parent-b'));
+
+		$this->assertTrue(true);
+	}
+
 	public function testMoveToTemplateWithInvalidTemplate(): void
 	{
 		$this->app = $this->app->clone([


### PR DESCRIPTION
## Review

- [x] Design & concept
- [x] Deep read

## Description

Field names share one flat, case-insensitive namespace, because `Fields::__set()` re-keys by `strtolower($field->name())`. 

The Normalizer represented them as arrays keyed by the raw YAML key and composed the blueprint by merging those arrays, so the two disagreed.

New `Kirby\Blueprint\FieldsRegistry` now owns the namespace. `add()` is the only place a field name is claimed, so the check, the error field and the unique name exist once. `Normalizer`, `Blueprint` and `Fieldset` all go through it.

### Decisions

- The error field keeps a name of its own (`<name>-duplicate-N`).
- Collision precedence is uniformly *first declaration wins*, groups   included.

### Regressions on `v6/remove-sections/develop` fixed

- A duplicate field name no longer destroys the field that claimed it first. The duplicate becomes an error field named `<name>-duplicate-N`, so saving a page no longer wipes the first field's value from disk, and the publish gate and page move allowlist keep working.
- Duplicate field names are detected regardless of case. `Alpha` and `alpha` are the same field and now raise an error instead of silently collapsing.
- A field group member that collides with one of its siblings now raises a duplicate name error instead of silently overwriting it.
- Two tabs of a fieldset (blocks/layout) that declare the same field name now raise a duplicate name error. The last tab used to silently win.
- Duplicate subfield names in a `structure` or `object` field are now detected.
- A field reference resolves regardless of case. Referencing `mixedcase` for a field defined as `MixedCase` reported it as undefined.
