### PR TITLE
fix: `$field->isActive()` for display fields

### DIFF
--- a/src/Form/Mixin/When.php
+++ b/src/Form/Mixin/When.php
@@ -33,7 +33,11 @@ trait When
 
 		foreach ($when as $field => $value) {
 			$field = $siblings->get($field);
-			$input = $field?->value() ?? '';
+			$input = '';
+
+			if ($field?->hasValue() === true) {
+				$input = $field->value() ?? '';
+			}
 
 			// if the input data doesn't match the requested `when` value,
 			// that means that this field is not required and can be saved

--- a/tests/Form/FieldTest.php
+++ b/tests/Form/FieldTest.php
@@ -111,6 +111,35 @@ class FieldTest extends TestCase
 		$this->assertTrue($field->hasValue());
 	}
 
+	public function testIsActive(): void
+	{
+		$fields = new Fields([
+			'a' => ['type' => 'text', 'value' => 'b'],
+			'b' => ['type' => 'text', 'when' => ['a' => 'b']],
+		]);
+
+		$this->assertTrue($fields->get('b')->isActive());
+	}
+
+	public function testIsActiveWithFieldWithoutValue(): void
+	{
+		$fields = new Fields([
+			'a' => ['type' => 'info'],
+			'b' => ['type' => 'text', 'when' => ['a' => true]],
+		]);
+
+		$this->assertFalse($fields->get('b')->isActive());
+	}
+
+	public function testIsActiveWithMissingField(): void
+	{
+		$fields = new Fields([
+			'b' => ['type' => 'text', 'when' => ['a' => true]],
+		]);
+
+		$this->assertFalse($fields->get('b')->isActive());
+	}
+
 	public function testisHidden(): void
 	{
 		$field = new MockField();


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [ ] Deep read

## Description
<!--
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.

You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR.

If something is deliberately out of scope, say so here.
-->

Display fields do not have a value, so a when condition with a display field was throwing, as it called `$field->value()`. Now guarding with `$field->hasValue()`.