### PR TITLE
perf: Optimize Exception

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -206,7 +206,8 @@
   </file>
   <file src="src/Exception/Exception.php">
     <InvalidPropertyAssignmentValue>
-      <code><![CDATA[self::$prefix . '.' . $this->code]]></code>
+      <code><![CDATA[$this->code()]]></code>
+      <code><![CDATA[$this->code()]]></code>
     </InvalidPropertyAssignmentValue>
     <InvalidReturnStatement>
       <code><![CDATA[$this->getCode()]]></code>

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -2,20 +2,19 @@
 
 namespace Kirby\Exception;
 
+use Closure;
+use Error;
 use Kirby\Http\Environment;
 use Kirby\Toolkit\I18n;
 use Kirby\Toolkit\Str;
 use Throwable;
 
 /**
- * Exception
  * Thrown for general exceptions and extended by
  * other exception classes
  *
  * @copyright Bastian Allgeier
  * @license   https://opensource.org/licenses/MIT
- *
- * @todo remove $arg array once all exception throws have been refactored
  */
 class Exception extends \Exception
 {
@@ -35,14 +34,15 @@ class Exception extends \Exception
 	protected int $httpCode;
 
 	/**
-	 * Whether the exception message could be translated
-	 * into the user's language
+	 * The message key, fallback and translation flag
+	 * needed to resolve a translated message form i18n strings
 	 */
-	protected bool $isTranslated = true;
+	protected string|null $key = null;
+	protected string|null $fallback = null;
+	protected bool $translate = true;
 
 	/**
-	 * Defaults that can be overridden by specific
-	 * exception classes
+	 * Defaults that can be overridden by specific exception classes
 	 */
 	protected static string $defaultKey = 'general';
 	protected static string $defaultFallback = 'An error occurred';
@@ -53,106 +53,82 @@ class Exception extends \Exception
 	/**
 	 * Prefix for the exception key (e.g. 'error.general')
 	 */
-	private static string $prefix = 'error';
+	protected const PREFIX = 'error.';
 
 	public function __construct(
-		array|string $args = [], // @deprecated
-
+		string|null $message = null,
 		string|null $key = null,
 		array|null $data = null,
 		array|null $details = null,
 		string|null $fallback = null,
 		int|null $httpCode = null,
-		string|null $message = null,
 		Throwable|null $previous = null,
 		bool $translate = true
 	) {
-		$key      ??= $args['key'] ?? null;
-		$fallback ??= $args['fallback'] ?? null;
-		$previous ??= $args['previous'] ?? null;
-
-		$this->data =
-			$data ??
-			$args['data'] ??
-			static::$defaultData;
-
-		$this->httpCode =
-			$httpCode ??
-			$args['httpCode'] ??
-			static::$defaultHttpCode;
-
-		$this->details =
-			$details ??
-			$args['details'] ??
-			static::$defaultDetails;
-
-		// set the Exception code to the key
-		$this->code = $key ?? static::$defaultKey;
-
-		if (Str::startsWith($this->code, self::$prefix . '.') === false) {
-			$this->code = self::$prefix . '.' . $this->code;
-		}
-
-		if (is_string($args) === true) {
-			$message ??= $args;
-		}
-
-		if ($message !== null) {
-			$this->isTranslated = false;
-			parent::__construct($message);
-			return;
-		}
-
-		// define whether message can/should be translated
-		$translate = $args['translate'] ?? $translate;
-
-		// a. translation for provided key in current language
-		// b. translation for provided key in default language
-		if ($translate === true && $key !== null) {
-			$message = I18n::translate(self::$prefix . '.' . $key);
-			$this->isTranslated = true;
-		}
-
-		// c. provided fallback message
-		if ($message === null) {
-			$message = $fallback;
-			$this->isTranslated = false;
-		}
-
-		// d. translation for default key in current language
-		// e. translation for default key in default language
-		if ($translate === true && $message === null) {
-			$message = I18n::translate(self::$prefix . '.' . static::$defaultKey);
-			$this->isTranslated = true;
-		}
-
-		// f. default fallback message
-		if ($message === null) {
-			$message = static::$defaultFallback;
-			$this->isTranslated = false;
-		}
-
-		// format message with passed data
-		$message = Str::template($message, $this->data, ['fallback' => '-']);
+		$this->data     = $data ?? static::$defaultData;
+		$this->httpCode = $httpCode ?? static::$defaultHttpCode;
+		$this->details  = $details ?? static::$defaultDetails;
+		$this->key      = $key;
 
 		// hand over to native Exception class constructor
-		parent::__construct($message, 0, $previous);
+		parent::__construct($message ?? '', 0, $previous);
+
+		// the code and the message are both built from the key and
+		// are unset here, so that reading either goes through
+		// `::__get()`. Prefixing the code, translating the key and
+		// templating the result are by far the most expensive part
+		// of building an exception, and an exception that is used
+		// as control flow is dropped without reading either.
+		unset($this->code);
+
+		// a message that was passed in needs no resolution
+		if ($message === null) {
+			$this->fallback  = $fallback;
+			$this->translate = $translate;
+
+			unset($this->message);
+		}
 	}
 
-	/**
-	 * Returns the file in which the Exception was created
-	 * relative to the document root
-	 */
-	final public function getFileRelative(): string
+	public function __debugInfo(): array
 	{
-		$file = $this->getFile();
-		$root = Environment::getGlobally('DOCUMENT_ROOT');
-
-		if (empty($root) === true) {
-			return $file;
+		// PHP cannot propagate exceptions out of `__debugInfo()`,
+		// so a message that fails to resolve must not throw here
+		try {
+			$this->resolve();
+		} catch (Throwable) {
+			// the unresolved properties stay out of the dump
 		}
 
-		return ltrim(Str::after($file, $root), '/');
+		return (array)$this;
+	}
+
+	public function __get(string $name): mixed
+	{
+		return match ($name) {
+			'code'    => $this->code = $this->code(),
+			'message' => $this->message = $this->message(),
+			default   => throw new Error(
+				'Cannot access property ' . static::class . '::$' . $name
+			)
+		};
+	}
+
+	public function __serialize(): array
+	{
+		$this->resolve();
+		return (array)$this;
+	}
+
+	protected function code(): string
+	{
+		$code = $this->key ?? static::$defaultKey;
+
+		if (str_starts_with($code, self::PREFIX) === true) {
+			return $code;
+		}
+
+		return self::PREFIX . $code;
 	}
 
 	/**
@@ -184,11 +160,19 @@ class Exception extends \Exception
 	}
 
 	/**
-	 * Returns the exception key (error type)
+	 * Returns the file in which the Exception was created
+	 * relative to the document root
 	 */
-	final public function getKey(): string
+	final public function getFileRelative(): string
 	{
-		return $this->getCode();
+		$file = $this->getFile();
+		$root = Environment::getGlobally('DOCUMENT_ROOT');
+
+		if ($root === null || $root === '') {
+			return $file;
+		}
+
+		return ltrim(Str::after($file, $root), '/');
 	}
 
 	/**
@@ -201,12 +185,45 @@ class Exception extends \Exception
 	}
 
 	/**
-	 * Returns whether the exception message could
-	 * be translated into the user's language
+	 * Returns the exception key (error type)
 	 */
-	final public function isTranslated(): bool
+	final public function getKey(): string
 	{
-		return $this->isTranslated;
+		return $this->getCode();
+	}
+
+	/**
+	 * Builds the message. The first source that yields one wins:
+	 *
+	 * a. the translation for the given key
+	 * b. the fallback message of the call site
+	 * c. the translation for the default key of the class
+	 * d. the default fallback message of the class
+	 */
+	protected function message(): string
+	{
+		$message =
+			$this->translation($this->key) ??
+			$this->fallback ??
+			$this->translation(static::$defaultKey) ??
+			static::$defaultFallback;
+
+		// fill the placeholders of the message with the data
+		return Str::template($message, $this->data, ['fallback' => '-']);
+	}
+
+	/**
+	 * Puts every lazy property in place
+	 */
+	protected function resolve(): void
+	{
+		if (isset($this->code) === false) {
+			$this->code = $this->code();
+		}
+
+		if (isset($this->message) === false) {
+			$this->message = $this->message();
+		}
 	}
 
 	/**
@@ -223,5 +240,17 @@ class Exception extends \Exception
 			'details'   => $this->getDetails(),
 			'code'      => $this->getHttpCode()
 		];
+	}
+
+	/**
+	 * Translates a single message key
+	 */
+	protected function translation(string|null $key): string|array|Closure|null
+	{
+		if ($this->translate === false || $key === null) {
+			return null;
+		}
+
+		return I18n::translate(self::PREFIX . $key);
 	}
 }

--- a/tests/Exception/ExceptionTest.php
+++ b/tests/Exception/ExceptionTest.php
@@ -2,11 +2,13 @@
 
 namespace Kirby\Exception;
 
+use Error;
 use Kirby\Cms\App;
 use Kirby\Filesystem\F;
 use Kirby\TestCase;
 use Kirby\Toolkit\I18n;
 use PHPUnit\Framework\Attributes\CoversClass;
+use stdClass;
 
 class WillFail
 {
@@ -22,30 +24,57 @@ class ExceptionTest extends TestCase
 	protected function tearDown(): void
 	{
 		App::destroy();
+
+		I18n::$locale       = 'en';
+		I18n::$translations = [];
+	}
+
+	public function testDebugInfo(): void
+	{
+		$exception = new Exception(
+			key: 'test.lazy',
+			fallback: 'The page slug "{ slug }" is invalid',
+			data: ['slug' => 'project/(c']
+		);
+
+		// the lazily resolved message must not show up as an
+		// uninitialized property in debug output
+		$this->assertContains(
+			'The page slug "project/(c" is invalid',
+			$exception->__debugInfo()
+		);
+	}
+
+	public function testDebugInfoWithUnresolvableMessage(): void
+	{
+		$exception = new Exception(
+			key: 'test.lazy',
+			fallback: 'The page slug "{ slug }" is invalid',
+			data: ['slug' => new stdClass()]
+		);
+
+		// PHP cannot propagate exceptions out of `__debugInfo()` and
+		// would turn one into a fatal error, so a message that cannot
+		// be resolved must not break the debug output
+		$debug = $exception->__debugInfo();
+
+		// the code still resolves and the raw fallback stays visible
+		$this->assertContains('error.test.lazy', $debug);
+		$this->assertContains('The page slug "{ slug }" is invalid', $debug);
+	}
+
+	public function testDefaults(): void
+	{
+		$exception = new Exception();
+
+		$this->assertSame('error.general', $exception->getKey());
+		$this->assertSame('An error occurred', $exception->getMessage());
+		$this->assertSame(500, $exception->getHttpCode());
+		$this->assertSame([], $exception->getData());
+		$this->assertSame([], $exception->getDetails());
 	}
 
 	public function testException(): void
-	{
-		$exception = new Exception([
-			'key' => 'page.slug.invalid',
-			'fallback' => 'The page slug "{ slug }" is invalid',
-			'data' => $data = ['slug' => 'project/(c'],
-			'details' => $details = ['some' => 'details'],
-			'httpCode' => $http = 500,
-			'translate' => false
-		]);
-
-		$this->assertInstanceOf(Exception::class, $exception);
-		$this->assertSame('error.page.slug.invalid', $exception->getKey());
-		$this->assertSame('error.page.slug.invalid', $exception->getCode());
-		$this->assertSame('The page slug "project/(c" is invalid', $exception->getMessage());
-		$this->assertSame($http, $exception->getHttpCode());
-		$this->assertSame($data, $exception->getData());
-		$this->assertSame($details, $exception->getDetails());
-		$this->assertFalse($exception->isTranslated());
-	}
-
-	public function testExceptionWithNamedArguments(): void
 	{
 		$exception = new Exception(
 			key: 'page.slug.invalid',
@@ -63,19 +92,6 @@ class ExceptionTest extends TestCase
 		$this->assertSame($http, $exception->getHttpCode());
 		$this->assertSame($data, $exception->getData());
 		$this->assertSame($details, $exception->getDetails());
-		$this->assertFalse($exception->isTranslated());
-	}
-
-	public function testDefaults(): void
-	{
-		$exception = new Exception();
-
-		$this->assertSame('error.general', $exception->getKey());
-		$this->assertSame('An error occurred', $exception->getMessage());
-		$this->assertSame(500, $exception->getHttpCode());
-		$this->assertFalse($exception->isTranslated());
-		$this->assertSame([], $exception->getData());
-		$this->assertSame([], $exception->getDetails());
 	}
 
 	public function testGetDetails(): void
@@ -110,190 +126,18 @@ class ExceptionTest extends TestCase
 		$this->assertSame($expected, $exception->getDetails());
 	}
 
-	public function testJustMessage(): void
-	{
-		$exception = new Exception('Another error occurred');
-
-		$this->assertSame('error.general', $exception->getKey());
-		$this->assertSame('Another error occurred', $exception->getMessage());
-		$this->assertSame(500, $exception->getHttpCode());
-		$this->assertFalse($exception->isTranslated());
-		$this->assertSame([], $exception->getData());
-	}
-
-	public function testJustMessageWithNamedArgument(): void
-	{
-		$exception = new Exception(message: 'Another error occurred');
-
-		$this->assertSame('error.general', $exception->getKey());
-		$this->assertSame('Another error occurred', $exception->getMessage());
-		$this->assertSame(500, $exception->getHttpCode());
-		$this->assertFalse($exception->isTranslated());
-		$this->assertSame([], $exception->getData());
-	}
-
-	public function testPrevious(): void
-	{
-		$previous  = new Exception(message: 'Previous');
-		$exception = new Exception(previous: $previous);
-
-		$this->assertNull($previous->getPrevious());
-		$this->assertSame($previous, $exception->getPrevious());
-	}
-
-	public function testPreviousWithNamedArgument(): void
-	{
-		$previous  = new Exception(message: 'Previous');
-		$exception = new Exception(previous: $previous);
-
-		$this->assertNull($previous->getPrevious());
-		$this->assertSame($previous, $exception->getPrevious());
-	}
-
-	public function testPHPUnitTesting(): void
-	{
-		$this->expectException(Exception::class);
-		$this->expectExceptionCode('error.key.unique');
-
-		$class = new WillFail();
-		$class->fail();
-	}
-
-	public function testTranslation(): void
-	{
-		I18n::$locale = 'test';
-		I18n::$translations = [
-			'test' => [
-				'error.general'      => 'Some general error',
-				'error.translatable' => 'Some other translatable error'
-			]
-		];
-
-		// scenario 1: translation for provided key in current language
-		$exception = new Exception([
-			'key'      => 'translatable',
-			'fallback' => 'Some fallback'
-		]);
-		$this->assertSame('Some other translatable error', $exception->getMessage());
-		$this->assertTrue($exception->isTranslated());
-
-		// scenario 3: provided fallback message
-		$exception = new Exception([
-			'key'      => 'not-translated',
-			'fallback' => 'Some fallback'
-		]);
-		$this->assertSame('Some fallback', $exception->getMessage());
-		$this->assertFalse($exception->isTranslated());
-
-		// scenario 4: translation for default key in current language
-		$exception = new Exception([
-			'key' => 'not-translated'
-		]);
-		$this->assertSame('Some general error', $exception->getMessage());
-		$this->assertTrue($exception->isTranslated());
-
-		I18n::$translations = [
-			'test' => [
-				'error.general'      => 'Some general fallback',
-				'error.translatable' => 'Some other translatable fallback'
-			]
-		];
-
-		// scenario 2: translation for provided key in default language
-		$exception = new Exception([
-			'key'      => 'translatable',
-			'fallback' => 'Some fallback'
-		]);
-		$this->assertSame('Some other translatable fallback', $exception->getMessage());
-		$this->assertTrue($exception->isTranslated());
-
-		// scenario 5: translation for default key in default language
-		$exception = new Exception([
-			'key' => 'not-translated'
-		]);
-		$this->assertSame('Some general fallback', $exception->getMessage());
-		$this->assertTrue($exception->isTranslated());
-
-		I18n::$locale = 'en';
-		I18n::$translations = [];
-
-		// scenario 6: default fallback message
-		$exception = new Exception([
-			'key' => 'translatable'
-		]);
-		$this->assertSame('An error occurred', $exception->getMessage());
-		$this->assertFalse($exception->isTranslated());
-	}
-
-	public function testTranslationWithNamedArguments(): void
-	{
-		I18n::$locale = 'test';
-		I18n::$translations = [
-			'test' => [
-				'error.general'      => 'Some general error',
-				'error.translatable' => 'Some other translatable error'
-			]
-		];
-
-		// scenario 1: translation for provided key in current language
-		$exception = new Exception(
-			key: 'translatable',
-			fallback: 'Some fallback'
-		);
-		$this->assertSame('Some other translatable error', $exception->getMessage());
-		$this->assertTrue($exception->isTranslated());
-
-		// scenario 3: provided fallback message
-		$exception = new Exception(
-			key: 'not-translated',
-			fallback: 'Some fallback'
-		);
-		$this->assertSame('Some fallback', $exception->getMessage());
-		$this->assertFalse($exception->isTranslated());
-
-		// scenario 4: translation for default key in current language
-		$exception = new Exception(
-			key: 'not-translated',
-		);
-		$this->assertSame('Some general error', $exception->getMessage());
-		$this->assertTrue($exception->isTranslated());
-
-		I18n::$translations = [
-			'test' => [
-				'error.general'      => 'Some general fallback',
-				'error.translatable' => 'Some other translatable fallback'
-			]
-		];
-
-		// scenario 2: translation for provided key in default language
-		$exception = new Exception(
-			key: 'translatable',
-			fallback: 'Some fallback'
-		);
-		$this->assertSame('Some other translatable fallback', $exception->getMessage());
-		$this->assertTrue($exception->isTranslated());
-
-		// scenario 5: translation for default key in default language
-		$exception = new Exception(
-			key: 'not-translated'
-		);
-		$this->assertSame('Some general fallback', $exception->getMessage());
-		$this->assertTrue($exception->isTranslated());
-
-		I18n::$locale = 'en';
-		I18n::$translations = [];
-
-		// scenario 6: default fallback message
-		$exception = new Exception(
-			key: 'translatable'
-		);
-		$this->assertSame('An error occurred', $exception->getMessage());
-		$this->assertFalse($exception->isTranslated());
-	}
-
 	public function testGetFileRelative(): void
 	{
 		$exception = new Exception();
+		$this->assertSame(__FILE__, $exception->getFileRelative());
+
+		// an empty document root is the same as none at all
+		new App([
+			'server' => [
+				'DOCUMENT_ROOT' => ''
+			]
+		]);
+
 		$this->assertSame(__FILE__, $exception->getFileRelative());
 
 		new App([
@@ -311,6 +155,151 @@ class ExceptionTest extends TestCase
 		]);
 
 		$this->assertSame(F::filename(__FILE__), $exception->getFileRelative());
+	}
+
+	public function testGetInaccessibleProperty(): void
+	{
+		$exception = new Exception(key: 'test.lazy');
+
+		// `::__get()` only serves the lazy message; it must not
+		// turn the protected properties into public ones
+		$this->expectException(Error::class);
+		$this->expectExceptionMessage(
+			'Cannot access property Kirby\\Exception\\Exception::$data'
+		);
+
+		$exception->data;
+	}
+
+	public function testJustMessage(): void
+	{
+		$exception = new Exception('Another error occurred');
+
+		$this->assertSame('error.general', $exception->getKey());
+		$this->assertSame('Another error occurred', $exception->getMessage());
+		$this->assertSame(500, $exception->getHttpCode());
+		$this->assertSame([], $exception->getData());
+	}
+
+	public function testJustMessageWithNamedArgument(): void
+	{
+		$exception = new Exception(message: 'Another error occurred');
+
+		$this->assertSame('error.general', $exception->getKey());
+		$this->assertSame('Another error occurred', $exception->getMessage());
+		$this->assertSame(500, $exception->getHttpCode());
+		$this->assertSame([], $exception->getData());
+	}
+
+	public function testKeyWithPrefix(): void
+	{
+		// a key that already carries the prefix is not prefixed twice
+		$exception = new Exception(key: 'error.test.lazy');
+
+		$this->assertSame('error.test.lazy', $exception->getKey());
+	}
+
+	public function testMessageIsResolvedLazily(): void
+	{
+		$exception = new Exception(key: 'translatable');
+
+		// the translations are only registered after the exception
+		// was created, so an eagerly resolved message would already
+		// have fallen back to the default
+		I18n::$locale       = 'test';
+		I18n::$translations = [
+			'test' => ['error.translatable' => 'Some translatable error']
+		];
+
+		$this->assertSame('Some translatable error', $exception->getMessage());
+	}
+
+	public function testMessageIsResolvedOnce(): void
+	{
+		I18n::$locale       = 'test';
+		I18n::$translations = [
+			'test' => ['error.translatable' => 'Some translatable error']
+		];
+
+		$exception = new Exception(key: 'translatable');
+		$this->assertSame('Some translatable error', $exception->getMessage());
+
+		// the resolved message is cached in the property, so a
+		// later change to the translations is not picked up again
+		I18n::$translations = [
+			'test' => ['error.translatable' => 'Some other error']
+		];
+
+		$this->assertSame('Some translatable error', $exception->getMessage());
+	}
+
+	public function testPHPUnitTesting(): void
+	{
+		$this->expectException(Exception::class);
+		$this->expectExceptionCode('error.key.unique');
+
+		$class = new WillFail();
+		$class->fail();
+	}
+
+	public function testPrevious(): void
+	{
+		$previous  = new Exception(message: 'Previous');
+		$exception = new Exception(previous: $previous);
+
+		$this->assertNull($previous->getPrevious());
+		$this->assertSame($previous, $exception->getPrevious());
+	}
+
+	public function testPreviousWithMessage(): void
+	{
+		$previous  = new Exception(message: 'Previous');
+		$exception = new Exception(
+			message: 'Something went wrong',
+			previous: $previous
+		);
+
+		$this->assertSame($previous, $exception->getPrevious());
+	}
+
+	public function testSerialize(): void
+	{
+		$exception = new Exception(
+			key: 'test.lazy',
+			fallback: 'The page slug "{ slug }" is invalid',
+			data: ['slug' => 'project/(c'],
+			httpCode: 400
+		);
+
+		// the lazy message has to be resolved before the object is
+		// serialized, as an uninitialized property would not
+		// survive the round trip
+		$this->assertContains(
+			'The page slug "project/(c" is invalid',
+			$exception->__serialize()
+		);
+	}
+
+	public function testSerializeRoundTrip(): void
+	{
+		// a trace that captured its arguments holds the closures of
+		// the test runner, which no exception can serialize
+		$args = ini_set('zend.exception_ignore_args', '1');
+
+		$exception = new Exception(
+			key: 'test.lazy',
+			fallback: 'The page slug "{ slug }" is invalid',
+			data: ['slug' => 'project/(c']
+		);
+
+		$restored = unserialize(serialize($exception));
+
+		ini_set('zend.exception_ignore_args', $args);
+
+		$this->assertSame(
+			'The page slug "project/(c" is invalid',
+			$restored->getMessage()
+		);
 	}
 
 	public function testToArray(): void
@@ -338,4 +327,65 @@ class ExceptionTest extends TestCase
 		$expected['line'] = $exception->getLine();
 		$this->assertSame($expected, $exception->toArray());
 	}
+
+	public function testTranslation(): void
+	{
+		I18n::$locale = 'test';
+		I18n::$translations = [
+			'test' => [
+				'error.general'      => 'Some general error',
+				'error.translatable' => 'Some other translatable error'
+			]
+		];
+
+		// scenario 1: translation for provided key in current language
+		$exception = new Exception(
+			key: 'translatable',
+			fallback: 'Some fallback'
+		);
+		$this->assertSame('Some other translatable error', $exception->getMessage());
+
+		// scenario 3: provided fallback message
+		$exception = new Exception(
+			key: 'not-translated',
+			fallback: 'Some fallback'
+		);
+		$this->assertSame('Some fallback', $exception->getMessage());
+
+		// scenario 4: translation for default key in current language
+		$exception = new Exception(
+			key: 'not-translated',
+		);
+		$this->assertSame('Some general error', $exception->getMessage());
+
+		I18n::$translations = [
+			'test' => [
+				'error.general'      => 'Some general fallback',
+				'error.translatable' => 'Some other translatable fallback'
+			]
+		];
+
+		// scenario 2: translation for provided key in default language
+		$exception = new Exception(
+			key: 'translatable',
+			fallback: 'Some fallback'
+		);
+		$this->assertSame('Some other translatable fallback', $exception->getMessage());
+
+		// scenario 5: translation for default key in default language
+		$exception = new Exception(
+			key: 'not-translated'
+		);
+		$this->assertSame('Some general fallback', $exception->getMessage());
+
+		I18n::$locale = 'en';
+		I18n::$translations = [];
+
+		// scenario 6: default fallback message
+		$exception = new Exception(
+			key: 'translatable'
+		);
+		$this->assertSame('An error occurred', $exception->getMessage());
+	}
+
 }


### PR DESCRIPTION
## Review

- [ ] Design & concept
- [ ] Deep read

## Description

Turns out our new `Guards` are significantly slower than the former permissions implementation. And that is to a large extent due to working off exceptions. So this is all about making `Exception` more performant.

At the core, the message handling is the culprit: `Exception` did the expensive work eagerly (`I18n::translate()` for the key, then `Str::template()`). But in the case of the guards, we actually almost never need the message.

This PR makes the two relevant properties lazy:`$code` and `$message` are now built on first read and cached in the property, so an exception that nobody looks at costs only a little more than a native `\Exception`.

While at it:
- Removed deprecated `$args` array.
- removed dead `::isTranslated()`

### Benchmarks

**Building one exception**, 200k iterations, 15 samples, `new PermissionException(key: …, data: […])`:

| | `v6/develop` | this PR | |
| --- | --- | --- | --- |
| construct with a key | 2362.9ns | **319.1ns** | 7.4× |
| throw + catch + discard | 2369.5ns | **334.8ns** | 7.1× |
| construct with a literal message | 514.5ns | **318.3ns** | 1.6× |
| construct with neither | 1302.6ns | **325.7ns** | 4.0× |

For reference a bare `new \Exception()` is 178ns on my machine.

**One pass of `$page->permissions()->toArray()` over 2000 distinct pages**

| tree | `allowed` (2 of 14 denied) | `mixed` (8 denied) | `denied` (14 denied) |
| --- | --- | --- | --- |
| Kirby 5.5.3 | 27.21ms | 27.46ms | 27.44ms |
| `v6/develop` | 72.28ms (+166%) | 108.99ms (+297%) | 142.13ms (+418%) |
| **this PR** | **65.73ms (+142%)** | **78.69ms (+187%)** | **90.48ms (+230%)** |

It doesn't solve our problem fully on its own, but it helps.

## Changelog

### 🏎️ Performance

- `Kirby\Exception\Exception` and subclasses resolve code and message now lazily.

### 🐛 Bug fixes

- `new Exception(message: '…', previous: $previous)` no longer discards `$previous`.

### ♻️ Refactored

- `Kirby\Exception\Exception::$prefix` is a class constant.

### 🚨 Breaking changes

- Passing a single array argument to`Kirby\Exception\Exception` has been removed. Use named arguments instead. The string shorthand `new Exception('Some message')` is unchanged.
- `Kirby\Exception\Exception::isTranslated()` has been removed.


## For review team

- [x] Add changes & docs to release notes draft in Notion
