### PR TITLE
fix: Default bindings in `Sql::insert()`

### DIFF
--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -436,9 +436,9 @@ abstract class Sql
 	 */
 	public function insert(array $params = []): array
 	{
-		$table    = $params['table']  ?? null;
-		$values   = $params['values'] ?? null;
-		$bindings = $params['bindings'];
+		$table    = $params['table']    ?? null;
+		$values   = $params['values']   ?? null;
+		$bindings = $params['bindings'] ?? [];
 		$query    = ['INSERT INTO ' . $this->tableName($table)];
 
 		// add the values

--- a/tests/Database/SqlTest.php
+++ b/tests/Database/SqlTest.php
@@ -580,6 +580,23 @@ class SqlTest extends TestCase
 		$this->assertSame(['id' => 1], $delete['bindings']);
 	}
 
+	public function testInsertWithoutBindings(): void
+	{
+		$this->database->createTable('users', [
+			'id'   => ['type' => 'int'],
+			'name' => ['type' => 'varchar']
+		]);
+
+		$insert = $this->sql->insert([
+			'table'  => 'users',
+			'values' => ['name' => 'John Doe']
+		]);
+
+		$this->assertStringStartsWith('INSERT INTO `users` (`users`.`name`) VALUES (', $insert['query']);
+		$this->assertCount(1, $insert['bindings']);
+		$this->assertSame('John Doe', array_values($insert['bindings'])[0]);
+	}
+
 	public function testSelectHelpers(): void
 	{
 		$this->database->createTable('users', [


### PR DESCRIPTION
<!-- branch: fix/db-insert-bindings-default  →  target: develop-patch -->

## Review

- [ ] Rough pass

**Timing:** no rush

## Description

`Sql::insert()` read `$params['bindings']` without a default, while `::select()`, `::update()` and `::delete()` all default it via their options merge. 

## Changelog

### 🐛 Bug fixes

- `Sql::insert()` no longer fails with a `TypeError` when called without explicit bindings.

## For review team

- [x] Add changes & docs to release notes draft in Notion
