### PR TITLE
fix: Only strip pairs in `::unquoteIdentifier()`

### DIFF
--- a/src/Database/Sql.php
+++ b/src/Database/Sql.php
@@ -730,23 +730,23 @@ abstract class Sql
 	 */
 	public function unquoteIdentifier(string $identifier): string
 	{
-		// remove quotes around the identifier
-		if (
-			str_starts_with($identifier, '"') ||
-			str_starts_with($identifier, '`')
-		) {
-			$identifier = Str::substr($identifier, 1);
+		foreach (['`', '"'] as $quote) {
+			if (
+				Str::length($identifier) >= 2 &&
+				str_starts_with($identifier, $quote) === true &&
+				str_ends_with($identifier, $quote) === true
+			) {
+				// only the wrapping quote can be escaped inside
+				return str_replace(
+					$quote . $quote,
+					$quote,
+					Str::substr($identifier, 1, -1)
+				);
+			}
 		}
 
-		if (
-			str_ends_with($identifier, '"') ||
-			str_ends_with($identifier, '`')
-		) {
-			$identifier = Str::substr($identifier, 0, -1);
-		}
-
-		// unescape duplicated quotes
-		return str_replace(['""', '``'], ['"', '`'], $identifier);
+		// not quoted, so nothing to unwrap or unescape
+		return $identifier;
 	}
 
 	/**

--- a/tests/Database/SqlTest.php
+++ b/tests/Database/SqlTest.php
@@ -597,8 +597,6 @@ class SqlTest extends TestCase
 			'query'    => null,
 			'bindings' => []
 		], $this->sql->limit());
-		$this->assertSame('table`name', $this->sql->unquoteIdentifier('`table``name`'));
-		$this->assertSame('table"name', $this->sql->unquoteIdentifier('"table""name"'));
 	}
 
 	public function testJoinInvalid(): void
@@ -607,6 +605,29 @@ class SqlTest extends TestCase
 		$this->expectExceptionMessage('Invalid join type SIDEWAYS JOIN');
 
 		$this->sql->join('SIDEWAYS JOIN', 'test', 'test.id = another.id');
+	}
+
+	public function testUnquoteIdentifierRequiresMatchingQuotes(): void
+	{
+		// matching pairs
+		$this->assertSame('table`name', $this->sql->unquoteIdentifier('`table``name`'));
+		$this->assertSame('table"name', $this->sql->unquoteIdentifier('"table""name"'));
+
+		// mismatched pair
+		$this->assertSame('`foo"', $this->sql->unquoteIdentifier('`foo"'));
+		$this->assertSame('"foo`', $this->sql->unquoteIdentifier('"foo`'));
+
+		// a single stray quote
+		$this->assertSame('"', $this->sql->unquoteIdentifier('"'));
+		$this->assertSame('`', $this->sql->unquoteIdentifier('`'));
+
+		// the non-wrapping quote is not an escape and must survive
+		foreach (['a"b', 'a""b', 'a`b', 'a``b', 'plain'] as $name) {
+			$this->assertSame(
+				$name,
+				$this->sql->unquoteIdentifier($this->sql->quoteIdentifier($name))
+			);
+		}
 	}
 
 	public function testValueSet(): void


### PR DESCRIPTION
<!-- branch: fix/db-unquote-identifier-pairs  →  target: develop-patch -->

## Review

- [ ] Rough pass

**Timing:** no rush

## Description

`Sql::unquoteIdentifier()` treated the two quote characters as interchangeable. It stripped a leading and a trailing quote independently, so mismatched quotes (`` `foo" ``) were unwrapped as if they were a pair and a lone quote collapsed to an empty string.

Now only a matching pair is stripped, and only that quote is unescaped inside.

## Changelog

### 🐛 Bug fixes

- `Sql::unquoteIdentifier()` no longer unwraps identifiers whose opening and closing quotes don't match, and no longer  mangles the other quote character inside a quoted identifier.


## For review team

- [x] Add changes & docs to release notes draft in Notion
