### PR TITLE
fix: `Database::connect()` incomplete params

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -140,10 +140,9 @@ class Database
 	/**
 	 * Connects to a database
 	 *
-	 * @param array|null $params This can either be a config key or an array of parameters for the connection
 	 * @throws \Kirby\Exception\InvalidArgumentException
 	 */
-	public function connect(array|null $params = null): PDO|null
+	public function connect(array $params = []): PDO|null
 	{
 		$options = [
 			'database' => null,
@@ -152,7 +151,7 @@ class Database
 			'user'     => null,
 			'password' => null,
 			'id'       => uniqid(),
-			...$params ?? []
+			...$params
 		];
 
 		if (isset(static::$types[$options['type']]) === false) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -152,34 +152,44 @@ class Database
 			'user'     => null,
 			'password' => null,
 			'id'       => uniqid(),
-			...$params
+			...$params ?? []
 		];
 
-		// store the database information
-		$this->database = $options['database'];
-		$this->type     = $options['type'];
-		$this->prefix   = $options['prefix'];
-		$this->id       = $options['id'];
-
-		if (isset(static::$types[$this->type]) === false) {
+		if (isset(static::$types[$options['type']]) === false) {
 			throw new InvalidArgumentException(
-				message: 'Invalid database type: ' . $this->type
+				message: 'Invalid database type: ' . $options['type']
 			);
 		}
 
-		// fetch the dsn and store it
-		$this->dsn = (static::$types[$this->type]['dsn'])($options);
+		// fetch the dsn; the connectors validate their own required params
+		$dsn = (static::$types[$options['type']]['dsn'])($options);
+
+		// backstop for connectors registered by plugins, which might not
+		// validate; the property below is a plain string
+		if ($options['database'] === null) {
+			throw new InvalidArgumentException(
+				message: 'The ' . $options['type'] . ' connection requires a "database" parameter'
+			);
+		}
 
 		// try to connect
-		$this->connection = new PDO($this->dsn, $options['user'], $options['password']);
-		$this->connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-		$this->connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+		$connection = new PDO($dsn, $options['user'], $options['password']);
+		$connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+		$connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 
 		// TODO: behavior without this attribute would be preferrable
 		// (actual types instead of all strings) but would be a breaking change
-		if ($this->type === 'sqlite') {
-			$this->connection->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
+		if ($options['type'] === 'sqlite') {
+			$connection->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, true);
 		}
+
+		// only mutate the instance once the connection actually succeeded
+		$this->database   = $options['database'];
+		$this->type       = $options['type'];
+		$this->prefix     = $options['prefix'];
+		$this->id         = $options['id'];
+		$this->dsn        = $dsn;
+		$this->connection = $connection;
 
 		// store the connection
 		static::$connections[$this->id] = $this;

--- a/tests/Database/DatabaseTest.php
+++ b/tests/Database/DatabaseTest.php
@@ -187,6 +187,47 @@ class DatabaseTest extends TestCase
 		]);
 	}
 
+	public function testConnectIncompleteOptions(): void
+	{
+		$db         = new Database(['database' => ':memory:', 'type' => 'sqlite']);
+		$connection = $db->connection();
+
+		try {
+			// incomplete options (here: no database)
+			$db->connect(['type' => 'sqlite']);
+			$this->fail('Expected an exception for incomplete options');
+		} catch (InvalidArgumentException $e) {
+			$this->assertStringContainsString('requires a "database" parameter', $e->getMessage());
+		}
+
+		// the failed connect must not have touched the instance
+		$this->assertSame('sqlite', $db->type());
+		$this->assertSame(':memory:', $db->name());
+		$this->assertSame($connection, $db->connection());
+	}
+
+	public function testConnectFailureKeepsState(): void
+	{
+		$db         = new Database(['database' => ':memory:', 'type' => 'sqlite']);
+		$connection = $db->connection();
+
+		try {
+			// valid options, but PDO itself cannot open this
+			$db->connect([
+				'type'     => 'sqlite',
+				'database' => '/definitely/not/a/directory/test.sqlite',
+				'prefix'   => 'zz_'
+			]);
+			$this->fail('Expected the connection to fail');
+		} catch (PDOException) {
+			// expected
+		}
+
+		$this->assertSame(':memory:', $db->name());
+		$this->assertNull($db->prefix());
+		$this->assertSame($connection, $db->connection());
+	}
+
 	public function testConnectConnection(): void
 	{
 		$this->assertInstanceOf(PDO::class, $this->database->connection());

--- a/tests/Database/DatabaseTest.php
+++ b/tests/Database/DatabaseTest.php
@@ -206,6 +206,28 @@ class DatabaseTest extends TestCase
 		$this->assertSame($connection, $db->connection());
 	}
 
+	public function testConnectTypeWithoutValidation(): void
+	{
+		// plugins can register a type whose connector
+		// doesn't validate the required params itself
+		Database::$types['memory'] = [
+			'sql' => Sql\Sqlite::class,
+			'dsn' => fn (array $params): string => 'sqlite::memory:'
+		];
+
+		try {
+			new Database(['type' => 'memory']);
+			$this->fail('Expected an exception for the missing database param');
+		} catch (InvalidArgumentException $e) {
+			$this->assertSame(
+				'The memory connection requires a "database" parameter',
+				$e->getMessage()
+			);
+		} finally {
+			unset(Database::$types['memory']);
+		}
+	}
+
 	public function testConnectFailureKeepsState(): void
 	{
 		$db         = new Database(['database' => ':memory:', 'type' => 'sqlite']);


### PR DESCRIPTION
## Review

- [ ] Deep read

**Timing:** no rush

## Description

`Database::connect()` assigned `$this->database`/`type`/`prefix`/`id` before validating, so incomplete options threw `TypeError: Cannot assign null to property …$database` instead of the documented `InvalidArgumentException`.

Everything is now built into local variables first and the instance is mutated only once `new PDO()` has succeeded.

## Changelog

### 🐛 Bug fixes

- `Database::connect()` throws a clear `InvalidArgumentException` for incomplete connection options instead of a `TypeError`.
- A failed `Database::connect()` no longer leaves the object with a partially updated configuration; the previous connection stays intact.

### ♻️ Refactored

- `Database::connect()` now takes `array $params = []` instead of `array|null $params = null`, matching the constructor. Passing `null` was never supported.

## For review team

- [x] Add changes & docs to release notes draft in Notion
