### PR TITLE
fix: Type `Query::filterQuery()` param and return

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -821,14 +821,14 @@ class Query
 	/**
 	 * Builder for where and having clauses
 	 *
-	 * @param array $args Arguments, see where() description
-	 * @param mixed $current Current value (like $this->where)
+	 * @param $args Arguments, see where() description
+	 * @param $current Current value (like $this->where)
 	 */
 	protected function filterQuery(
 		array $args,
-		$current,
+		string|null $current,
 		string $mode = 'AND'
-	) {
+	): string|null {
 		$result = '';
 
 		switch (count($args)) {


### PR DESCRIPTION
## Review

- [ ] Rough pass

**Timing:** no rush

## Description

`Query::filterQuery()` had an untyped `$current` and no return type in an otherwise fully typed class. The actual contract is `string|null` in and out.

