### PR TITLE
Add extensible cache invalidation component

### DIFF
--- a/config/components.php
+++ b/config/components.php
@@ -1,5 +1,6 @@
 <?php
 
+use Kirby\Cache\Cache;
 use Kirby\Cms\App;
 use Kirby\Cms\Collection;
 use Kirby\Cms\File;
@@ -29,6 +30,20 @@ use Kirby\Toolkit\Str;
 use Kirby\Uuid\Uuid;
 
 return [
+
+	/**
+	 * Invalidates a cache after model changes
+	 */
+	'cache::invalidate' => function (
+		App $kirby,
+		string $name,
+		Cache $cache,
+		ModelWithContent $model,
+		string $action,
+		array $arguments
+	): bool {
+		return $cache->flush();
+	},
 
 	/**
 	 * Used by the `css()` helper

--- a/src/Cms/ModelCommit.php
+++ b/src/Cms/ModelCommit.php
@@ -39,8 +39,15 @@ class ModelCommit
 		$arguments = $this->afterHookArguments($state);
 		$hook      = $this->hook('after', $arguments);
 
-		// flush the page cache after any model action
-		$this->kirby->cache('pages')->flush();
+		// invalidate the page cache after any model action
+		($this->kirby->component('cache::invalidate'))(
+			$this->kirby,
+			'pages',
+			$this->kirby->cache('pages'),
+			$this->model,
+			$this->action,
+			$hook['arguments']
+		);
 
 		return $hook['result'];
 	}

--- a/tests/Cms/Model/ModelCommitTest.php
+++ b/tests/Cms/Model/ModelCommitTest.php
@@ -2,8 +2,21 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Cache\Cache;
 use Kirby\Exception\PermissionException;
 use PHPUnit\Framework\Attributes\CoversClass;
+
+interface CacheInvalidationComponent
+{
+	public function __invoke(
+		App $kirby,
+		string $name,
+		Cache $cache,
+		ModelWithContent $model,
+		string $action,
+		array $arguments
+	): bool;
+}
 
 #[CoversClass(ModelCommit::class)]
 class ModelCommitTest extends TestCase
@@ -105,6 +118,56 @@ class ModelCommitTest extends TestCase
 		$commit->after($page);
 
 		$this->assertSame(null, $this->app->cache('pages')->get('test'));
+	}
+
+	public function testAfterInvalidatesCacheWithCustomComponent(): void
+	{
+		$component = $this->createMock(CacheInvalidationComponent::class);
+
+		$this->app = $this->app->clone([
+			'components' => [
+				'cache::invalidate' => $component
+			],
+			'options' => [
+				'cache' => [
+					'pages' => true
+				]
+			]
+		]);
+
+		$page = new Page([
+			'slug' => 'test',
+		]);
+
+		$cache = $this->app->cache('pages');
+
+		$component
+			->expects($this->once())
+			->method('__invoke')
+			->with(
+				$this->identicalTo($this->app),
+				$this->identicalTo('pages'),
+				$this->identicalTo($cache),
+				$this->identicalTo($page),
+				$this->identicalTo('delete'),
+				$this->identicalTo([
+					'status' => true,
+					'page'   => $page
+				])
+			)
+			->willReturn(true);
+
+		$cache->set('test', 'test');
+		$this->assertSame('test', $cache->get('test'), 'Make sure that the cache is actually set');
+
+		$commit = new ModelCommit(
+			model: $page,
+			action: 'delete'
+		);
+
+		$commit->after(true);
+
+		$this->assertSame('test', $cache->get('test'));
 	}
 
 	public function testAfterHookArgumentsForPageCreate(): void


### PR DESCRIPTION
Hello you all, 

I would like to suggest a change and discuss this with you. 

> This PR introduces a cache::invalidate component and routes the existing pages cache invalidation through it. The default implementation keeps Kirby’s current behavior and still flushes the full pages cache. But plugins can now overwrite this component and have the full model context available to explore the relationship and nature of the content and act accordingly. 

While working on a project I was exploring tag-based cache invalidation. Instead of always flushing the whole pages cache, I would like to only invalidate what really has been changed or affected by change. Kirby does not have this knowledge, but I as a developer do know how my content relates to each other. 

I wrote a small proof-of-concept plugin with a custom cache driver that stores cache tags alongside the pages content and provides methods to only clear specific cache items by tags. To avoid the full cache flush, I made `Cache::flush()` a null-op by always returning `true` and nothing else. I then manually invalidated the cache in the page related hooks. It works, but it still feels quite hacky. Also there is no context to work with, because `flush` does not receive any arguments. 

Happy to hear your thoughts about this. 

Best
Benedict