### PR TITLE
fix: Copy inside drawers and dialogs

### DIFF
--- a/panel/src/helpers/clipboard.test.ts
+++ b/panel/src/helpers/clipboard.test.ts
@@ -91,6 +91,7 @@ describe("clipboard.write()", () => {
 
 	afterEach(() => {
 		vi.restoreAllMocks();
+		document.body.innerHTML = "";
 	});
 
 	it("should use clipboardData.setData when a ClipboardEvent is provided", () => {
@@ -140,5 +141,42 @@ describe("clipboard.write()", () => {
 		write({ foo: "bar" });
 
 		expect(copiedValue).toBe('{\n  "foo": "bar"\n}');
+	});
+	it("should add the textarea to an open dialog", () => {
+		const dialog = document.createElement("dialog");
+		dialog.setAttribute("open", "");
+		document.body.append(dialog);
+
+		let parent: Element | null = null;
+		document.execCommand = vi.fn().mockImplementation(() => {
+			parent = document.querySelector("textarea")?.parentElement ?? null;
+			return true;
+		});
+
+		write("hello");
+
+		expect(parent).toBe(dialog);
+	});
+
+	it("should add the textarea to the dialog with the focused element", () => {
+		const dialogs = [0, 1].map(() => {
+			const dialog = document.createElement("dialog");
+			dialog.setAttribute("open", "");
+			dialog.innerHTML = "<button></button>";
+			document.body.append(dialog);
+			return dialog;
+		});
+
+		dialogs[0].querySelector("button")?.focus();
+
+		let parent: Element | null = null;
+		document.execCommand = vi.fn().mockImplementation(() => {
+			parent = document.querySelector("textarea")?.parentElement ?? null;
+			return true;
+		});
+
+		write("hello");
+
+		expect(parent).toBe(dialogs[0]);
 	});
 });

--- a/panel/src/helpers/clipboard.ts
+++ b/panel/src/helpers/clipboard.ts
@@ -31,6 +31,24 @@ export function read(
 	return null;
 }
 
+/**
+ * Returns the element that the temporary textarea
+ * for the `execCommand` fallback can be added to.
+ *
+ * An open modal dialog turns the rest of the document
+ * inert, which would keep the textarea from being
+ * selected and thus from being copied.
+ */
+function container(): HTMLElement {
+	const dialogs = document.querySelectorAll<HTMLDialogElement>("dialog[open]");
+
+	return (
+		document.activeElement?.closest<HTMLElement>("dialog[open]") ??
+		dialogs[dialogs.length - 1] ??
+		document.body
+	);
+}
+
 export function write(value: unknown, e?: Event) {
 	// create pretty json of objects and arrays
 	if (typeof value !== "string") {
@@ -50,7 +68,7 @@ export function write(value: unknown, e?: Event) {
 	// fall back to little execCommand hack with a temporary textarea
 	const input = document.createElement("textarea");
 	input.value = string;
-	document.body.append(input);
+	container().append(input);
 
 	// iOS
 	if (navigator.userAgent.match(/ipad|ipod|iphone/i)) {


### PR DESCRIPTION
## Review

- [ ] Rough pass
- [ ] Deep read

**Timing:** Not urgent

## Description

Copying from within a drawer or dialog did nothing: the "Copied" notification appeared, but the clipboard stayed empty. Not specific to layouts — it affected every copy action inside a drawer or dialog.

**Cause:** Without a real `ClipboardEvent`, `clipboard.write()` falls back to appending an invisible `<textarea>` to `document.body` and copying its selection. Since Kirby 4, drawers and dialogs are native `<dialog>` elements opened with `showModal()`, which makes the rest of the document inert — so that textarea can't be selected and nothing gets copied.

**Fix:** Append the textarea to the topmost open dialog instead, falling back to `document.body` when no dialog is open. The topmost dialog is determined via `document.activeElement`, since focus can't leave the topmost modal dialog.

Includes two regression tests.

## Changelog

### 🐛 Bug fixes

- Fix copying inside drawers and dialogs #8455

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion