### PR TITLE
fix: `$model->convertTo()` data loss

### DIFF
--- a/src/Cms/ModelWithContent.php
+++ b/src/Cms/ModelWithContent.php
@@ -6,6 +6,7 @@ use Closure;
 use Kirby\Content\Content;
 use Kirby\Content\ImmutableMemoryStorage;
 use Kirby\Content\Lock;
+use Kirby\Content\LockedContentException;
 use Kirby\Content\MemoryStorage;
 use Kirby\Content\Storage;
 use Kirby\Content\Translation;
@@ -202,6 +203,17 @@ abstract class ModelWithContent implements Identifiable, Stringable
 	 */
 	protected function convertTo(string $blueprint): static
 	{
+		// Make sure that no other user is editing the content
+		// right now before any of the versions get converted
+		$lock = $this->lock();
+
+		if ($lock->isLocked() === true) {
+			throw new LockedContentException(
+				lock: $lock,
+				key: 'content.lock.update'
+			);
+		}
+
 		// Keep a copy of the old model with the original storage handler.
 		// This will be used to delete the old versions.
 		$old = $this->clone();
@@ -230,8 +242,22 @@ abstract class ModelWithContent implements Identifiable, Stringable
 		// Get all languages to loop through
 		$languages = Languages::ensure();
 
-		// Loop through all versions
-		foreach ($old->versions() as $oldVersion) {
+		// Convert the latest version before the changes version.
+		// Creating the changes version tracks the model by its UUID,
+		// which has to be readable from the new latest version by then.
+		$versions = [
+			$old->version('latest'),
+			$old->version('changes')
+		];
+
+		// Keep track of all converted versions
+		$converted = [];
+
+		// Save all converted versions first. The old versions
+		// are only deleted afterwards. This way a failing
+		// storage handler cannot destroy the old content
+		// before the new content has been written.
+		foreach ($versions as $oldVersion) {
 			// Loop through all languages
 			foreach ($languages as $language) {
 				// Skip non-existing versions
@@ -239,18 +265,46 @@ abstract class ModelWithContent implements Identifiable, Stringable
 					continue;
 				}
 
-				// Convert the content to the new blueprint
-				$content = $oldVersion->content($language)->convertTo($blueprint);
+				// Convert the fields of the version to the new blueprint.
+				// The fields are read directly to only convert the fields
+				// of the version itself without the fallback to the
+				// default language.
+				$fields = $oldVersion->read($language) ?? [];
+				unset($fields['lock']);
 
-				// Delete the old versions. This will also remove the
-				// content files from the storage if this is a plain text
-				// storage instance.
-				$oldVersion->delete($language);
+				$content = new Content(
+					parent: $old,
+					data: $fields,
+					normalize: false
+				);
 
-				// Save to re-create the new version
+				// Save to create or update the new version
 				// with the converted/updated content
-				$new->version($oldVersion->id())->save($content, $language);
+				$new->version($oldVersion->id())->save(
+					fields: $content->convertTo($blueprint),
+					language: $language
+				);
+
+				$converted[] = [$oldVersion->id(), $language];
 			}
+		}
+
+		// Delete the old versions. This will also remove the
+		// content files from the storage if this is a plain text
+		// storage instance.
+		foreach ($converted as [$versionId, $language]) {
+			// The old version has already been overwritten if its
+			// storage location does not depend on the template
+			// (e.g. the content files of files)
+			if ($old->storage()->isSameStorageLocation(
+				fromVersionId: $versionId,
+				fromLanguage: $language,
+				toStorage: $new->storage()
+			) === true) {
+				continue;
+			}
+
+			$old->storage()->delete($versionId, $language);
 		}
 
 		return $new;

--- a/tests/Cms/File/FileChangeTemplateTest.php
+++ b/tests/Cms/File/FileChangeTemplateTest.php
@@ -2,7 +2,10 @@
 
 namespace Kirby\Cms;
 
+use Exception;
 use Kirby\Content\PlainTextStorage;
+use Kirby\Content\VersionId;
+use Kirby\Data\Data;
 use Kirby\Exception\LogicException;
 use Kirby\Filesystem\F;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -484,5 +487,84 @@ class FileChangeTemplateTest extends ModelTestCase
 
 		$this->assertSame('pdf', $file->extension());
 		$this->assertSame('pdf', $newFile->extension());
+	}
+
+	public function testChangeTemplateWhenStorageFails(): void
+	{
+		$app = $this->app->clone([
+			'roots' => [
+				'index' => static::TMP
+			],
+			'blueprints' => [
+				'pages/test' => [
+					'sections' => [
+						[
+							'type' => 'files',
+							'template' => 'a'
+						],
+						[
+							'type' => 'files',
+							'template' => 'b'
+						]
+					]
+				],
+				'files/a' => [
+					'title'  => 'a',
+					'fields' => [
+						'text' => [
+							'type' => 'textarea'
+						]
+					]
+				],
+				'files/b' => [
+					'title' => 'b',
+					'fields' => [
+						'text' => [
+							'type' => 'textarea'
+						]
+					]
+				],
+			],
+			'site' => [
+				'children' => [
+					[
+						'slug'     => 'test',
+						'template' => 'test'
+					]
+				]
+			]
+		]);
+
+		$app->impersonate('kirby');
+
+		$file = $app->page('test')->createFile([
+			'filename' => 'test.jpg',
+			'source'   => self::FIXTURES . '/test.jpg',
+			'template' => 'a',
+			'content'  => [
+				'text' => 'Text'
+			]
+		]);
+
+		$contentFile = $file->version('latest')->contentFile();
+		$content     = Data::read($contentFile);
+
+		// storage that fails as soon as the converted content is written
+		$file->changeStorage(new class ($file) extends PlainTextStorage {
+			protected function write(VersionId $versionId, Language $language, array $fields): void
+			{
+				throw new Exception('The storage is not writable');
+			}
+		});
+
+		try {
+			$file->changeTemplate('b');
+			$this->fail('The storage exception must be passed on');
+		} catch (Exception $e) {
+			$this->assertSame('The storage is not writable', $e->getMessage());
+		}
+
+		// the old version must survive the failed conversion
+		$this->assertSame($content, Data::read($contentFile));
 	}
 }

--- a/tests/Cms/Page/PageChangeTemplateTest.php
+++ b/tests/Cms/Page/PageChangeTemplateTest.php
@@ -2,6 +2,11 @@
 
 namespace Kirby\Cms;
 
+use Exception;
+use Kirby\Content\LockedContentException;
+use Kirby\Content\PlainTextStorage;
+use Kirby\Content\VersionId;
+use Kirby\Data\Data;
 use Kirby\Exception\PermissionException;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -115,6 +120,61 @@ class PageChangeTemplateTest extends ModelTestCase
 		$this->assertSame('Täxt', $modified->content('de')->get('text')->value());
 	}
 
+	public function testChangeTemplateInMultiLanguageModeWithPartialTranslation(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/video' => [
+					'options' => [
+						'template' => [
+							'article'
+						]
+					],
+					'fields' => [
+						'text' => [
+							'type' => 'textarea'
+						]
+					]
+				],
+				'pages/article' => [
+					'fields' => [
+						'text' => [
+							'type' => 'textarea'
+						]
+					]
+				]
+			],
+			'languages' => [
+				[
+					'code' => 'en',
+					'name' => 'English',
+					'default' => true
+				],
+				[
+					'code' => 'de',
+					'name' => 'Deutsch',
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		$page = Page::create([
+			'slug'     => 'test',
+			'template' => 'video',
+		]);
+
+		$page->version('latest')->save(['title' => 'Test', 'text' => 'Text'], 'en');
+		$page->version('latest')->save(['title' => 'Prüfen'], 'de');
+
+		$modified = $page->changeTemplate('article');
+
+		// the translation must not inherit the text from the default language
+		$this->assertSame('Text', $modified->version('latest')->read('en')['text']);
+		$this->assertArrayNotHasKey('text', $modified->version('latest')->read('de'));
+		$this->assertSame('Text', $modified->content('de')->text()->value(), 'should still fall back to the default language');
+	}
+
 	public function testChangeTemplateInSingleLanguageMode(): void
 	{
 		$calls = 0;
@@ -222,6 +282,105 @@ class PageChangeTemplateTest extends ModelTestCase
 		$this->assertSame($page, $modified);
 	}
 
+	public function testChangeTemplateWhenLockedByAnotherUser(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/video' => [
+					'options' => [
+						'template' => [
+							'article'
+						]
+					]
+				],
+				'pages/article' => []
+			],
+			'users' => [
+				[
+					'id'    => 'editor',
+					'email' => 'editor@getkirby.com'
+				]
+			]
+		]);
+
+		$this->app->impersonate('kirby');
+
+		$page = Page::create([
+			'slug'     => 'test',
+			'template' => 'video',
+		]);
+
+		$page->version('latest')->save(['title' => 'Title (latest)']);
+
+		Data::write($page->version('changes')->contentFile(), [
+			'title' => 'Title (changed)',
+			'lock'  => 'editor'
+		]);
+
+		try {
+			$page->changeTemplate('article');
+			$this->fail('The locked page must not be converted');
+		} catch (LockedContentException $e) {
+			$this->assertSame('error.content.lock.update', $e->getCode());
+		}
+
+		// nothing must have been converted or deleted
+		$this->assertFileExists($page->root() . '/video.txt');
+		$this->assertFileExists($page->root() . '/_changes/video.txt');
+		$this->assertFileDoesNotExist($page->root() . '/article.txt');
+		$this->assertFileDoesNotExist($page->root() . '/_changes/article.txt');
+	}
+
+	public function testChangeTemplateWhenStorageFails(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/video' => [
+					'options' => [
+						'template' => [
+							'article'
+						]
+					]
+				],
+				'pages/article' => []
+			],
+		]);
+
+		$this->app->impersonate('kirby');
+
+		$page = Page::create([
+			'slug'     => 'test',
+			'template' => 'video',
+		]);
+
+		$page->version('latest')->save(['title' => 'Title (latest)']);
+		$page->version('changes')->save(['title' => 'Title (changed)']);
+
+		$latest  = Data::read($page->root() . '/video.txt');
+		$changes = Data::read($page->root() . '/_changes/video.txt');
+
+		// storage that fails as soon as the converted content is written
+		$page->changeStorage(new class ($page) extends PlainTextStorage {
+			protected function write(VersionId $versionId, Language $language, array $fields): void
+			{
+				throw new Exception('The storage is not writable');
+			}
+		});
+
+		try {
+			$page->changeTemplate('article');
+			$this->fail('The storage exception must be passed on');
+		} catch (Exception $e) {
+			$this->assertSame('The storage is not writable', $e->getMessage());
+		}
+
+		// the old versions must survive the failed conversion
+		$this->assertSame($latest, Data::read($page->root() . '/video.txt'));
+		$this->assertSame($changes, Data::read($page->root() . '/_changes/video.txt'));
+		$this->assertFileDoesNotExist($page->root() . '/article.txt');
+		$this->assertFileDoesNotExist($page->root() . '/_changes/article.txt');
+	}
+
 	public function testChangeTemplateWithChanges(): void
 	{
 		$this->app = $this->app->clone([
@@ -251,5 +410,8 @@ class PageChangeTemplateTest extends ModelTestCase
 
 		$this->assertSame('Title (latest)', $modified->version('latest')->content()->title()->value());
 		$this->assertSame('Title (changed)', $modified->version('changes')->content()->title()->value());
+
+		// the page must still be tracked as having unsaved changes
+		$this->assertSame([$modified->uuid()->toString()], $this->app->cache('changes')->get('pages'));
 	}
 }


### PR DESCRIPTION
## Review

- [ ] Deep read

## Description

`ModelWithContent::convertTo()` deleted all old versions before the converted versions had been written. If the storage handler failed in between (full disk, permission error, custom storage throwing), the model was left with neither the old nor the new content for that language.

The conversion now runs in two phases: 
1. All converted versions are written first
2. The old storage entries are only removed afterwards
3. A failing write leaves the old content untouched

Some considerations that went into the implementation:

- We are using the storage to remove the old entries, not `Version::delete()`. Cause `Version::delete()` would now with the changed order remove the new changes version from the changes cache at the end of all. And leave changed untracked. But it meant that we have to add the lock check at the top of `::convertTo()` that otherwise `Version::delete()` handled.
- We ensure to convert first latest, then changes version. This is to ensure that latest exists again first, as it carries `uuid`. If changes lands first, it might try to regenerate a new `uuid`.
- Conversion reads the fields directly, and does not use `Version::content()` as the latter merges in the default language. 
- For files the content file name does not depend on the template, so the new version could overwrite the old one in place. We use now `::isSameStorageLocation()` to check this before deleting.

## Changelog

### 🐛 Bug fixes

- `$page->changeTemplate()` and `$file->changeTemplate()` no longer delete the existing content before the converted content has been written. If writing fails, the old content stays intact.
- Changing the template of a page with unsaved changes keeps the page listed as changed.
- Changing the template no longer copies fields from the default language into partial translations.
- Changing the template of content that is currently edited by another user fails before anything is modified.

## For review team

- [x] Add changes & docs to release notes draft in Notion
