### PR TITLE
feat: Add `ModelGuards::availability()`

### DIFF
--- a/config/api/models/Site.php
+++ b/config/api/models/Site.php
@@ -14,7 +14,7 @@ return [
 		'content'    => fn (Site $site) => Form::for($site)->toFormValues(),
 		'drafts'     => fn (Site $site) => $site->drafts()->filter('isListable', true),
 		'files'      => fn (Site $site) => $site->files()->sorted()->filter('isListable', true),
-		'options'    => fn (Site $site) => $site->permissions()->toArray(),
+		'options'    => fn (Site $site) => $site->guards()->availability(),
 		'previewUrl' => fn (Site $site) => $site->previewUrl(),
 		'title'      => fn (Site $site) => $site->title()->value(),
 		'url'        => fn (Site $site) => $site->url(),

--- a/src/Cms/ModelPermissions.php
+++ b/src/Cms/ModelPermissions.php
@@ -16,8 +16,6 @@ namespace Kirby\Cms;
  */
 abstract class ModelPermissions
 {
-	protected array $options;
-
 	/**
 	 * @var TModel
 	 */
@@ -28,11 +26,7 @@ abstract class ModelPermissions
 	 */
 	public function __construct(ModelWithContent|Language $model)
 	{
-		$this->model   = $model;
-		$this->options = match (true) {
-			$model instanceof ModelWithContent => $model->blueprint()->options(),
-			default                            => []
-		};
+		$this->model = $model;
 	}
 
 	public function __call(string $method, array $arguments = []): bool
@@ -89,12 +83,6 @@ abstract class ModelPermissions
 
 	public function toArray(): array
 	{
-		$array = [];
-
-		foreach (array_keys($this->options) as $key) {
-			$array[$key] = $this->can($key);
-		}
-
-		return $array;
+		return $this->model->guards()->availability();
 	}
 }

--- a/src/Guards/ModelGuards.php
+++ b/src/Guards/ModelGuards.php
@@ -3,6 +3,7 @@
 namespace Kirby\Guards;
 
 use Kirby\Cms\Model;
+use Kirby\Cms\ModelWithContent;
 use Kirby\Cms\User;
 use Kirby\Exception\AbilityException;
 use Kirby\Exception\Exception;
@@ -37,6 +38,28 @@ abstract class ModelGuards
 	public function abilities(): ModelAbilities
 	{
 		return $this->abilities;
+	}
+
+	/**
+	 * Returns the availability of every action that the
+	 * blueprint of the model defines an option for.
+	 */
+	public function availability(): array
+	{
+		// only models with a blueprint can define options
+		if ($this->model instanceof ModelWithContent === false) {
+			return [];
+		}
+
+		/** @var array<string, mixed> $options */
+		$options = $this->model->blueprint()->options();
+		$array   = [];
+
+		foreach (array_keys($options) as $action) {
+			$array[$action] = $this->isAvailable($action);
+		}
+
+		return $array;
 	}
 
 	/**
@@ -142,6 +165,7 @@ abstract class ModelGuards
 	{
 		return $this->permissions;
 	}
+
 
 	public function user(): User
 	{

--- a/src/Panel/Controller/View/ModelViewController.php
+++ b/src/Panel/Controller/View/ModelViewController.php
@@ -127,7 +127,7 @@ abstract class ModelViewController extends ViewController
 			'link'        => $this->panel->url(true),
 			'lock'        => $this->model->lock()->toArray(),
 			'next'        => $this->next(...),
-			'permissions' => $this->model->permissions()->toArray(),
+			'permissions' => $this->model->guards()->availability(),
 			'prev'        => $this->prev(...),
 			'tabs'        => $this->tabs(),
 			'title'       => $this->title(),

--- a/src/Panel/Controller/View/SiteViewController.php
+++ b/src/Panel/Controller/View/SiteViewController.php
@@ -46,7 +46,7 @@ class SiteViewController extends ModelViewController
 			'blueprint'   => 'site',
 			'id'          => '/',
 			'permissions' => [
-				...$this->model->permissions()->toArray(),
+				...$this->model->guards()->availability(),
 				// the home page check is kept for backward compatibility
 				// @todo Remove the home page check in 6.0.0
 				'preview' =>

--- a/src/Panel/Model.php
+++ b/src/Panel/Model.php
@@ -310,7 +310,7 @@ abstract class Model
 	 */
 	public function options(array $unlock = []): array
 	{
-		$options = $this->model->permissions()->toArray();
+		$options = $this->model->guards()->availability();
 
 		if ($this->model->lock()->isLocked() === true) {
 			foreach ($options as $key => $value) {

--- a/src/Panel/Ui/Item/ModelItem.php
+++ b/src/Panel/Ui/Item/ModelItem.php
@@ -69,7 +69,7 @@ class ModelItem extends Item
 
 	protected function permissions(): array
 	{
-		return $this->model->permissions()->toArray();
+		return $this->model->guards()->availability();
 	}
 
 	public function props(): array

--- a/tests/Guards/ModelGuardsTest.php
+++ b/tests/Guards/ModelGuardsTest.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Guards;
 
+use Kirby\Cms\Language;
 use Kirby\Cms\ModelTestCase;
 use Kirby\Cms\Page;
 use Kirby\Cms\User;
@@ -57,6 +58,51 @@ class ModelGuardsTest extends ModelTestCase
 	public function testAbilities(): void
 	{
 		$this->assertInstanceOf(PageAbilities::class, $this->guards()->abilities());
+	}
+
+	public function testAvailability(): void
+	{
+		$this->app = $this->app->clone([
+			'users' => [
+				['email' => 'admin@getkirby.com', 'role' => 'admin']
+			]
+		]);
+
+		$this->app->impersonate('admin@getkirby.com');
+
+		$page = new Page([
+			'slug'      => 'test',
+			'blueprint' => [
+				'name'    => 'pages/test',
+				'options' => [
+					'delete' => false,
+					'update' => true
+				]
+			]
+		]);
+
+		$array = $page->guards()->availability();
+
+		// the blueprint options are resolved to their availability
+		$this->assertFalse($array['delete']);
+		$this->assertTrue($array['update']);
+
+		// every option of the blueprint is covered
+		$this->assertSame(
+			array_keys($page->blueprint()->options()),
+			array_keys($array)
+		);
+		$this->assertContainsOnlyBool($array);
+	}
+
+	public function testAvailabilityWithoutBlueprint(): void
+	{
+		$this->app->impersonate('kirby');
+
+		$language = new Language(['code' => 'en']);
+
+		// languages have no blueprint and therefore no options
+		$this->assertSame([], $language->guards()->availability());
 	}
 
 	public function testEnsureAvailable(): void


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Design & concept
- [x] Rough pass

## Description
<!--
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.

You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR.

If something is deliberately out of scope, say so here.
-->

We hadn't yet migrated `ModelPermissions::toArray()`.

However, in the context of `ModelGuards`, `::toArray()` doesn't seem so fitting. Went with `::availability()` as this seems to be fitting in the lingo of the guards package. However, it leaves some naming/phrasing in the integration a bit weird (see comments).
