### PR TITLE
refact: Use model guards, not deprecated `->can()`

### DIFF
--- a/config/api/routes/files.php
+++ b/config/api/routes/files.php
@@ -69,7 +69,7 @@ return [
 						'template' => $template
 					]);
 
-					if ($file->permissions()->can('create') !== true) {
+					if ($file->guards()->isAvailable('create') !== true) {
 						throw new PermissionException(
 							message: 'The file cannot be created'
 						);
@@ -134,7 +134,7 @@ return [
 			return $this->upload(
 				callback: fn ($source) => $file->replace($source, move: true),
 				preflight: function () use ($file) {
-					if ($file->permissions()->can('replace') !== true) {
+					if ($file->guards()->isAvailable('replace') !== true) {
 						throw new PermissionException(
 							message: 'The file cannot be replaced'
 						);

--- a/config/api/routes/users.php
+++ b/config/api/routes/users.php
@@ -102,7 +102,7 @@ return [
 				preflight: function () use ($id) {
 					$user = Find::user($id);
 
-					if ($user->permissions()->can('update') !== true) {
+					if ($user->guards()->isAvailable('update') !== true) {
 						throw new PermissionException(
 							key: 'user.update.permission',
 							data: ['name' => $user->username()]

--- a/src/Api/Controller/Changes.php
+++ b/src/Api/Controller/Changes.php
@@ -38,7 +38,7 @@ class Changes
 	 */
 	public static function discard(ModelWithContent $model): array
 	{
-		if ($model->permissions()->can('update') === false) {
+		if ($model->guards()->isAvailable('update') === false) {
 			throw new PermissionException(
 				key: 'version.discard.permission',
 			);
@@ -60,7 +60,7 @@ class Changes
 	 */
 	public static function publish(ModelWithContent $model, array $input): array
 	{
-		if ($model->permissions()->can('update') === false) {
+		if ($model->guards()->isAvailable('update') === false) {
 			throw new PermissionException(
 				key: 'version.publish.permission',
 			);
@@ -101,7 +101,7 @@ class Changes
 	 */
 	public static function save(ModelWithContent $model, array $input): array
 	{
-		if ($model->permissions()->can('update') === false) {
+		if ($model->guards()->isAvailable('update') === false) {
 			throw new PermissionException(
 				key: 'version.save.permission',
 			);
@@ -156,7 +156,7 @@ class Changes
 	 */
 	public static function unlock(ModelWithContent $model): array
 	{
-		if ($model->permissions()->can('update') === false) {
+		if ($model->guards()->isAvailable('update') === false) {
 			throw new PermissionException(
 				key: 'version.unlock.permission',
 			);

--- a/src/Auth/Method/PasswordMethod.php
+++ b/src/Auth/Method/PasswordMethod.php
@@ -89,7 +89,7 @@ class PasswordMethod extends Method
 				icon:     static::icon(),
 				text:     static::i18n('password'),
 				dialog:   $user->panel()->url(true) . '/changePassword',
-				disabled: !$user->permissions()->can('changePassword'),
+				disabled: $user->guards()->isAvailable('changePassword') === false,
 			)
 		];
 	}

--- a/src/Blueprint/PageBlueprint.php
+++ b/src/Blueprint/PageBlueprint.php
@@ -179,7 +179,7 @@ class PageBlueprint extends Blueprint
 			return $this->model->toString($preview);
 		}
 
-		return $this->model->guards()->isAvailable('preview', true);
+		return $this->model->guards()->isAvailable('preview', default: true);
 	}
 
 	/**

--- a/src/Blueprint/PageBlueprint.php
+++ b/src/Blueprint/PageBlueprint.php
@@ -179,7 +179,7 @@ class PageBlueprint extends Blueprint
 			return $this->model->toString($preview);
 		}
 
-		return $this->model->permissions()->can('preview', true);
+		return $this->model->guards()->isAvailable('preview', true);
 	}
 
 	/**

--- a/src/Blueprint/SiteBlueprint.php
+++ b/src/Blueprint/SiteBlueprint.php
@@ -56,6 +56,6 @@ class SiteBlueprint extends Blueprint
 			return $this->model->toString($preview);
 		}
 
-		return $this->model->permissions()->can('preview', true);
+		return $this->model->guards()->isAvailable('preview', true);
 	}
 }

--- a/src/Blueprint/SiteBlueprint.php
+++ b/src/Blueprint/SiteBlueprint.php
@@ -56,6 +56,6 @@ class SiteBlueprint extends Blueprint
 			return $this->model->toString($preview);
 		}
 
-		return $this->model->guards()->isAvailable('preview', true);
+		return $this->model->guards()->isAvailable('preview', default: true);
 	}
 }

--- a/src/Cms/Model.php
+++ b/src/Cms/Model.php
@@ -2,6 +2,7 @@
 
 namespace Kirby\Cms;
 
+use Kirby\Guards\ModelGuards;
 use Stringable;
 
 /**
@@ -13,4 +14,5 @@ use Stringable;
  */
 abstract class Model implements Stringable
 {
+	abstract public function guards(): ModelGuards;
 }

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -766,7 +766,7 @@ class Page extends ModelWithContent
 	 */
 	public function isSortable(): bool
 	{
-		return $this->permissions()->can('sort');
+		return $this->guards()->isAvailable('sort');
 	}
 
 	/**
@@ -904,7 +904,7 @@ class Page extends ModelWithContent
 	#[BlockCollectionAccess]
 	public function previewUrl(VersionId|string $versionId = 'latest'): string|null
 	{
-		if ($this->permissions()->can('preview') !== true) {
+		if ($this->guards()->isAvailable('preview') !== true) {
 			return null;
 		}
 

--- a/src/Cms/Roles.php
+++ b/src/Cms/Roles.php
@@ -43,7 +43,7 @@ class Roles extends Collection
 					'role'  => $role->id()
 				]);
 
-				return $newUser->permissions()->can('changeRole');
+				return $newUser->guards()->isAvailable('changeRole');
 			});
 		}
 
@@ -69,7 +69,7 @@ class Roles extends Collection
 					'role'  => $role->id()
 				]);
 
-				return $newUser->permissions()->can('create');
+				return $newUser->guards()->isAvailable('create');
 			});
 		}
 

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -393,14 +393,14 @@ class Site extends ModelWithContent
 	public function previewUrl(VersionId|string $versionId = 'latest'): string|null
 	{
 		// the site needs its own preview permission
-		if ($this->permissions()->can('preview') !== true) {
+		if ($this->guards()->isAvailable('preview') !== true) {
 			return null;
 		}
 
 		// the site preview defaults to the home page, so for backward
 		// compatibility we also check the home page's preview permission
 		// @todo Remove in 6.0.0, only check `site.preview`
-		if ($this->homePage()?->permissions()->can('preview') !== true) {
+		if ($this->homePage()?->guards()->isAvailable('preview') !== true) {
 			return null;
 		}
 

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -670,7 +670,7 @@ class User extends ModelWithContent
 
 		// if the authenticated user doesn't have the permission to change
 		// the role of this user, only the current role is available
-		if ($this->permissions()->can('changeRole') === false) {
+		if ($this->guards()->isAvailable('changeRole') === false) {
 			return $kirby->roles()->filter('isAccessible', true)->filter('id', $this->role()->id());
 		}
 

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -380,7 +380,7 @@ class Fields extends Collection
 		$fields      = $this->data;
 		$props       = [];
 		$language    = $this->language();
-		$permissions = $this->model->permissions()->can('update');
+		$permissions = $this->model->guards()->isAvailable('update');
 
 		foreach ($fields as $name => $field) {
 			$props[$name] = $field->toArray();

--- a/src/Panel/Controller/Dialog/PageChangeTitleDialogController.php
+++ b/src/Panel/Controller/Dialog/PageChangeTitleDialogController.php
@@ -20,21 +20,21 @@ class PageChangeTitleDialogController extends PageDialogController
 {
 	public function load(): Dialog
 	{
-		$permissions = $this->page->permissions();
-		$select      = $this->request->get('select', 'title');
+		$guards = $this->page->guards();
+		$select = $this->request->get('select', 'title');
 
 		return new FormDialog(
 			fields: [
 				'title' => Field::title([
 					'required'  => true,
 					'preselect' => $select === 'title',
-					'disabled'  => $permissions->can('changeTitle') === false
+					'disabled'  => $guards->isAvailable('changeTitle') === false
 				]),
 				'slug' => Field::slug([
 					'required'  => true,
 					'preselect' => $select === 'slug',
 					'path'      => $this->path(),
-					'disabled'  => $permissions->can('changeSlug') === false,
+					'disabled'  => $guards->isAvailable('changeSlug') === false,
 					'wizard'    => [
 						'text'  => $this->i18n('page.changeSlug.fromTitle'),
 						'field' => 'title'

--- a/src/Panel/Controller/Drawer/UserSecurityDrawerController.php
+++ b/src/Panel/Controller/Drawer/UserSecurityDrawerController.php
@@ -58,7 +58,7 @@ class UserSecurityDrawerController extends UserDrawerController
 				'text'     => $this->i18n('email'),
 				'icon'     => 'email',
 				'dialog'   => $this->user->panel()->url(true) . '/changeEmail',
-				'disabled' => !$this->user->permissions()->can('changeEmail'),
+				'disabled' => $this->user->guards()->isAvailable('changeEmail') === false,
 			]
 		];
 

--- a/src/Panel/Controller/View/SiteViewController.php
+++ b/src/Panel/Controller/View/SiteViewController.php
@@ -50,8 +50,8 @@ class SiteViewController extends ModelViewController
 				// the home page check is kept for backward compatibility
 				// @todo Remove the home page check in 6.0.0
 				'preview' =>
-					$this->model->permissions()->can('preview') === true &&
-					$this->model->homePage()?->permissions()->can('preview') === true,
+					$this->model->guards()->isAvailable('preview') === true &&
+					$this->model->homePage()?->guards()->isAvailable('preview') === true,
 			],
 		];
 	}

--- a/src/Panel/Ui/Button/PageStatusButton.php
+++ b/src/Panel/Ui/Button/PageStatusButton.php
@@ -20,7 +20,7 @@ class PageStatusButton extends ViewButton
 	) {
 		$status    = $page->status();
 		$blueprint = $page->blueprint()->status()[$status] ?? null;
-		$disabled  = $page->permissions()->cannot('changeStatus') || $page->lock()->isLocked();
+		$disabled  = $page->guards()->isAvailable('changeStatus') === false || $page->lock()->isLocked();
 
 		$text   = $blueprint['label'] ?? null;
 		$text ??= $this->i18n('page.status.' . $status);

--- a/src/Panel/Ui/Button/PageStatusButton.php
+++ b/src/Panel/Ui/Button/PageStatusButton.php
@@ -20,7 +20,7 @@ class PageStatusButton extends ViewButton
 	) {
 		$status    = $page->status();
 		$blueprint = $page->blueprint()->status()[$status] ?? null;
-		$disabled  = $page->guards()->isAvailable('changeStatus') === false || $page->lock()->isLocked();
+		$disabled  = $page->guards()->isAvailable('changeStatus') === false || $page->lock()->isLocked() === true;
 
 		$text   = $blueprint['label'] ?? null;
 		$text ??= $this->i18n('page.status.' . $status);

--- a/src/Panel/Ui/Item/FileItem.php
+++ b/src/Panel/Ui/Item/FileItem.php
@@ -37,11 +37,11 @@ class FileItem extends ModelItem
 
 	protected function permissions(): array
 	{
-		$permissions = $this->model->permissions();
+		$guards = $this->model->guards();
 
 		return [
-			'delete' => $permissions->can('delete'),
-			'sort'   => $permissions->can('sort'),
+			'delete' => $guards->isAvailable('delete'),
+			'sort'   => $guards->isAvailable('sort'),
 		];
 	}
 

--- a/src/Panel/Ui/Item/PageItem.php
+++ b/src/Panel/Ui/Item/PageItem.php
@@ -36,14 +36,14 @@ class PageItem extends ModelItem
 
 	protected function permissions(): array
 	{
-		$permissions = $this->model->permissions();
+		$guards = $this->model->guards();
 
 		return [
-			'changeSlug'   => $permissions->can('changeSlug'),
-			'changeStatus' => $permissions->can('changeStatus'),
-			'changeTitle'  => $permissions->can('changeTitle'),
-			'delete'       => $permissions->can('delete'),
-			'sort'         => $permissions->can('sort'),
+			'changeSlug'   => $guards->isAvailable('changeSlug'),
+			'changeStatus' => $guards->isAvailable('changeStatus'),
+			'changeTitle'  => $guards->isAvailable('changeTitle'),
+			'delete'       => $guards->isAvailable('delete'),
+			'sort'         => $guards->isAvailable('sort'),
 		];
 	}
 

--- a/tests/Auth/Method/PasswordMethodTest.php
+++ b/tests/Auth/Method/PasswordMethodTest.php
@@ -191,7 +191,7 @@ class PasswordMethodTest extends TestCase
 
 	public function testSettings(): void
 	{
-		$user     = $this->createStub(User::class);
+		$user     = new User(['id' => 'test', 'email' => 'test@getkirby.com']);
 		$settings = PasswordMethod::settings($user);
 		$this->assertCount(1, $settings);
 	}

--- a/tests/Cms/Model/ModelWithContentTest.php
+++ b/tests/Cms/Model/ModelWithContentTest.php
@@ -9,6 +9,8 @@ use Kirby\Content\Version;
 use Kirby\Content\VersionId;
 use Kirby\Content\Versions;
 use Kirby\Exception\NotFoundException;
+use Kirby\Guards\ModelGuards;
+use Kirby\Guards\PageGuards;
 use Kirby\Panel\Page as PanelPage;
 use Kirby\Toolkit\HtmlString;
 use Kirby\Uuid\PageUuid;
@@ -34,6 +36,14 @@ class ExtendedModelWithContent extends ModelWithContent
 		Closure $callback
 	): mixed {
 		// nothing to commit in the test
+	}
+
+	public function guards(): ModelGuards
+	{
+		return new PageGuards(
+			model: new Page(['slug' => 'test']),
+			user: User::ensure()
+		);
 	}
 
 	public function panel(): PanelPage


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Design & concept
- [x] Security


## Description
<!--
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.

You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR.

If something is deliberately out of scope, say so here.
-->

Replace leftover model permission `::can()` calls with new guards `::isAvailable()` calls.

I think we can ignore the failing test coverage check as that is pre-existing.