### PR TITLE
perf: Cache the resolved action methods of the guards

### DIFF
--- a/src/Guards/HasActions.php
+++ b/src/Guards/HasActions.php
@@ -24,6 +24,12 @@ use ReflectionMethod;
 trait HasActions
 {
 	/**
+	 * Cache of the resolved action methods per class and action.
+	 * Lookup only depends on the class, never on the model or user.
+	 */
+	protected static array $actions = [];
+
+	/**
 	 * Returns the name of the action for the given
 	 * dedicated action method
 	 */
@@ -38,10 +44,14 @@ trait HasActions
 	 */
 	public function has(string $action): bool
 	{
+		if (isset(static::$actions[static::class][$action]) === true) {
+			return static::$actions[static::class][$action];
+		}
+
 		$method = $this->method($action);
 
 		if (method_exists($this, $method) === false) {
-			return false;
+			return static::$actions[static::class][$action] = false;
 		}
 
 		$reflection = new ReflectionMethod($this, $method);
@@ -53,12 +63,12 @@ trait HasActions
 		// name keeps both in sync, so that a case variant of an action can
 		// never resolve to a real action method while missing its rule.
 		if ($this->action($reflection->getName()) !== $action) {
-			return false;
+			return static::$actions[static::class][$action] = false;
 		}
 
 		// action methods are protected, as they are only ever called
 		// through `::ensure()`.
-		return $reflection->isPrivate() === false;
+		return static::$actions[static::class][$action] = $reflection->isPrivate() === false;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Rough pass

## Description
<!--
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.

You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR.

If something is deliberately out of scope, say so here.
-->

Small performance tweak: We can cache the `ModelGuards::has($action)` calls as they only depend on the guards class, but never on the model or user.

### Benchmark

PHP 8.4.23, `php -n` (no Xdebug or extensions), fresh process per sample, 8 samples.

**Isolated `has()`**: 280,000 calls (20,000 × the 14 actions a default page blueprint declares options for:

| | median | min–max |
| --- | --- | --- |
| `v6/develop` | 55.3 ms | 53.9–58.5 |
| this branch | 20.5 ms | 20.1–20.6 |

**2.7× faster (−63%)**

**Panel page list**: 500 pages × 5 renders of `permissions()->toArray()`:

| | median | min–max |
| --- | --- | --- |
| `v6/develop` | 80.1 ms | 78.9–80.1 |
| this branch | 73.5 ms | 72.4–73.7 |

**−8%**

**Work avoided**": one render of a 500-page list:

| | before | after |
| --- | --- | --- |
| `has()` calls | 13,000 | 13,000 |
| `ReflectionMethod` constructions | 3,000 | **6** |

The resolved cache holds 26 entries for the whole request. The lookup depends only on the class and the action, never on the model or the user, so a request touching one model or a thousand pays for it exactly once.
