### PR TITLE
perf: Resolve plain permission checks without exceptions

### DIFF
--- a/src/Guards/ModelGuards.php
+++ b/src/Guards/ModelGuards.php
@@ -112,8 +112,26 @@ abstract class ModelGuards
 	 */
 	public function isAvailable(string $action, bool $default = false): bool
 	{
+		// A permission without its own action method comes down to the
+		// plain rule, which is the cheapest check there is. A denial
+		// settles the question on its own, whatever the abilities would say.
+		$plain = $this->permissions()->has($action) === false;
+
+		if (
+			$plain === true &&
+			$this->permissions()->setting($action, $default) !== true
+		) {
+			return false;
+		}
+
 		try {
-			$this->ensureAvailable($action, $default);
+			// with the permission settled, only the ability is left;
+			// `::ensure()` is a no-op for an action without a method
+			if ($plain === true) {
+				$this->abilities()->ensure($action);
+			} else {
+				$this->ensureAvailable($action, $default);
+			}
 
 			return true;
 		} catch (AbilityException | PermissionException) {

--- a/tests/Guards/ModelGuardsTest.php
+++ b/tests/Guards/ModelGuardsTest.php
@@ -18,6 +18,34 @@ class ModelGuardsTestValidators extends PageValidators
 	}
 }
 
+class ModelGuardsTestAbilities extends PageAbilities
+{
+	public static bool $consulted = false;
+
+	protected function ensureToDelete(): void
+	{
+		static::$consulted = true;
+	}
+}
+
+class ModelGuardsTestAbilitiesGuards extends PageGuards
+{
+	public function __construct(
+		Page $model,
+		User $user
+	) {
+		parent::__construct(
+			model: $model,
+			user: $user
+		);
+
+		$this->abilities = new ModelGuardsTestAbilities(
+			model: $model,
+			user: $user
+		);
+	}
+}
+
 class ModelGuardsTestGuards extends PageGuards
 {
 	public function __construct(
@@ -253,6 +281,100 @@ class ModelGuardsTest extends ModelTestCase
 		$this->assertTrue($this->guards()->isAvailable('update'));
 	}
 
+	public function testIsAvailableMatchesEnsureAvailable(): void
+	{
+		$this->app = $this->app->clone([
+			'roles' => [['name' => 'editor']],
+			'site'  => ['children' => [['slug' => 'home']]],
+			'users' => [['email' => 'editor@getkirby.com', 'role' => 'editor']]
+		]);
+
+		$actions = [
+			'update',         // resolved from the permission setting
+			'publish',        // dedicated permission action method
+			'delete',         // dedicated ability action method
+			'changeTitle',    // dedicated validator action method
+			'does-not-exist', // no rule at all
+		];
+
+		foreach (['kirby', 'editor@getkirby.com', 'nobody'] as $id) {
+			$this->app->impersonate($id);
+
+			$guards = $this->guards($this->app->page('home'));
+
+			foreach ($actions as $action) {
+				foreach ([false, true] as $default) {
+					try {
+						$guards->ensureAvailable($action, $default);
+						$expected = true;
+					} catch (AbilityException | PermissionException) {
+						$expected = false;
+					}
+
+					$this->assertSame(
+						$expected,
+						$guards->isAvailable($action, $default),
+						$action . ' as ' . $id . ' (default: ' . ($default === true ? 'true' : 'false') . ')'
+					);
+				}
+			}
+		}
+	}
+
+	public function testIsAvailableSkipsTheAbilityWhenThePermissionDenies(): void
+	{
+		$this->app = $this->app->clone([
+			'roles' => [
+				[
+					'name'        => 'editor',
+					'permissions' => ['pages' => ['delete' => false]]
+				]
+			],
+			'users' => [
+				['email' => 'editor@getkirby.com', 'role' => 'editor']
+			]
+		]);
+
+		$this->app->impersonate('editor@getkirby.com');
+
+		$guards = new ModelGuardsTestAbilitiesGuards(
+			model: new Page(['slug' => 'test']),
+			user: $this->user()
+		);
+
+		ModelGuardsTestAbilities::$consulted = false;
+
+		// the permission rule already settles the question, so the
+		// ability must not be consulted at all
+		$this->assertFalse($guards->isAvailable('delete'));
+		$this->assertFalse(ModelGuardsTestAbilities::$consulted);
+
+		// …while an allowed permission still hands over to the ability
+		$this->assertTrue($guards->isAvailable('update'));
+	}
+
+	public function testIsAvailableForKirbyUserAndAdmin(): void
+	{
+		$this->app = $this->app->clone([
+			'blueprints' => [
+				'pages/restricted' => ['options' => ['access' => false]]
+			],
+			'site'  => ['children' => [['slug' => 'home', 'template' => 'restricted']]],
+			'users' => [['email' => 'admin@getkirby.com', 'role' => 'admin']]
+		]);
+
+		$page = $this->app->page('home');
+
+		// the almighty `kirby` user overrules the blueprint …
+		$this->app->impersonate('kirby');
+		$this->assertTrue($this->guards($page)->isAvailable('access'));
+
+		// … but a regular admin shares its role and must not
+		// inherit that answer
+		$this->app->impersonate('admin@getkirby.com');
+		$this->assertFalse($this->guards($page)->isAvailable('access'));
+	}
+
 	public function testIsAvailableWithActionMethod(): void
 	{
 		$this->app->impersonate('kirby');
@@ -280,6 +402,44 @@ class ModelGuardsTest extends ModelTestCase
 		$this->app->impersonate('nobody');
 
 		$this->assertFalse($this->guards()->isAvailable('update'));
+	}
+
+	public function testIsAvailableWithPermissionActionMethod(): void
+	{
+		$this->app = $this->app->clone([
+			'roles' => [
+				['name' => 'editor'],
+				[
+					'name'        => 'restricted',
+					'permissions' => ['pages' => ['changeStatus' => false]]
+				]
+			],
+			'site'  => [
+				'children' => [
+					['slug' => 'home'],
+					['slug' => 'error']
+				]
+			],
+			'users' => [
+				['email' => 'editor@getkirby.com', 'role' => 'editor'],
+				['email' => 'restricted@getkirby.com', 'role' => 'restricted']
+			]
+		]);
+
+		$this->app->impersonate('editor@getkirby.com');
+
+		// `publish` has no rule of its own. Its permission action method
+		// maps it onto `changeStatus`, so the fast path must hand over
+		// instead of resolving it against the missing rule.
+		$this->assertTrue($this->guards($this->app->page('home'))->isAvailable('publish'));
+
+		// the ability is still consulted for such an action
+		$this->assertFalse($this->guards($this->app->page('error'))->isAvailable('publish'));
+
+		// … and so is the rule that the action method delegates to
+		$this->app->impersonate('restricted@getkirby.com');
+
+		$this->assertFalse($this->guards($this->app->page('home'))->isAvailable('publish'));
 	}
 
 	public function testIsAvailableWithUndefinedAction(): void


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Deep read
- [x] Security check

## Description
<!--
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.

You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR.

If something is deliberately out of scope, say so here.
-->

The performance-heave part with the new guards package are checking permissions etc. through exceptions.

Here, we try to be smart and only really check what's needed and take fast-paths where we can inside `::isAvailable()`.

### Benchmark

PHP 8.4.23, `php -n` (no Xdebug or extensions), fresh process per sample, 15 samples.
Workload: 500 pages × 5 renders of `permissions()->toArray()` (14 blueprint options each).

**Denied**: role with `pages: false`, i.e. the permission rule settles every action:

| | median | min |
| --- | --- | --- |
| `v6/develop` | 170.0 ms | 165.1 |
| this branch | 57.4 ms | 55.8 |

**3.0× faster (−66%)**

**Allowed**: `editor` role with default permissions:

| | median | min |
| --- | --- | --- |
| `v6/develop` | 80.9 ms | 79.6 |
| this branch | 84.9 ms | 83.2 |

**~5% slower**

**Exceptions thrown**, one render of a 500-page list:

| | before | after |
| --- | --- | --- |
| denied role | 7,000 | **0** |
| editor role | 1,000 | 1,000 |

The 7,000 avoided throws are the whole win: a denied plain rule now returns `false` without constructing a `PermissionException`.

The remaining 1,000 on the editor path are thrown by the **abilities**, not the permissions  (`changeTemplate` on a page with a single blueprint, `sort` on an unlisted page) so the fast path can't remove them. That's also where the ~5% comes from: the new order reads the permission rule first, so when the ability is what denies, we've paid for the rule lookup before finding out. The trade is a small cost on the fully-allowed path against a 3× win wherever a role actually restricts something. And the Panel walks `isAvailable()` for every model in every list.
