### PR TITLE
refact: Cache model guards in `ModelGuards::for()`

### DIFF
--- a/src/Cms/File.php
+++ b/src/Cms/File.php
@@ -291,10 +291,7 @@ class File extends ModelWithContent
 	 */
 	public function guards(): FileGuards
 	{
-		return new FileGuards(
-			model: $this,
-			user: User::ensure()
-		);
+		return FileGuards::for($this);
 	}
 
 	/**

--- a/src/Cms/Language.php
+++ b/src/Cms/Language.php
@@ -307,10 +307,7 @@ class Language extends Model
 	 */
 	public function guards(): LanguageGuards
 	{
-		return new LanguageGuards(
-			model: $this,
-			user: User::ensure()
-		);
+		return LanguageGuards::for($this);
 	}
 
 	/**

--- a/src/Cms/Page.php
+++ b/src/Cms/Page.php
@@ -433,10 +433,7 @@ class Page extends ModelWithContent
 	 */
 	public function guards(): PageGuards
 	{
-		return new PageGuards(
-			model: $this,
-			user: User::ensure()
-		);
+		return PageGuards::for($this);
 	}
 
 	/**

--- a/src/Cms/Site.php
+++ b/src/Cms/Site.php
@@ -229,10 +229,7 @@ class Site extends ModelWithContent
 	 */
 	public function guards(): SiteGuards
 	{
-		return new SiteGuards(
-			model: $this,
-			user: User::ensure()
-		);
+		return SiteGuards::for($this);
 	}
 
 	/**

--- a/src/Cms/User.php
+++ b/src/Cms/User.php
@@ -231,10 +231,7 @@ class User extends ModelWithContent
 	 */
 	public function guards(): UserGuards
 	{
-		return new UserGuards(
-			model: $this,
-			user: User::ensure()
-		);
+		return UserGuards::for($this);
 	}
 
 	/**

--- a/src/Guards/ModelGuards.php
+++ b/src/Guards/ModelGuards.php
@@ -7,6 +7,7 @@ use Kirby\Cms\User;
 use Kirby\Exception\AbilityException;
 use Kirby\Exception\Exception;
 use Kirby\Exception\PermissionException;
+use WeakMap;
 
 /**
  * Bundles all guard layers for a model object: the abilities,
@@ -21,6 +22,8 @@ use Kirby\Exception\PermissionException;
 abstract class ModelGuards
 {
 	use HasActions;
+
+	protected static WeakMap|null $cache = null;
 
 	public function __construct(
 		protected ModelAbilities $abilities,
@@ -74,6 +77,32 @@ abstract class ModelGuards
 
 		$this->ensureAvailable($action);
 		$this->validators()->ensure($action, ...$arguments);
+	}
+
+	/**
+	 * Returns the guards for the model,
+	 * bound to the currently authenticated user.
+	 */
+	public static function for(Model $model): static
+	{
+		$user   = User::ensure();
+		$cache  = static::$cache ??= new WeakMap();
+		$cached = $cache[$model] ?? null;
+
+		// the guards are bound to the current user and must
+		// be rebuilt whenever the user changes
+		if (
+			$cached instanceof static === true &&
+			$cached->user() === $user
+		) {
+			return $cached;
+		}
+
+		/** @psalm-suppress TooFewArguments */
+		return $cache[$model] = new static(
+			model: $model,
+			user: $user
+		);
 	}
 
 	/**

--- a/tests/Guards/ModelGuardsTest.php
+++ b/tests/Guards/ModelGuardsTest.php
@@ -203,6 +203,49 @@ class ModelGuardsTest extends ModelTestCase
 		$this->assertFalse($this->guards()->isExecutable('update'));
 	}
 
+	public function testFor(): void
+	{
+		$this->app->impersonate('kirby');
+
+		$page   = new Page(['slug' => 'test']);
+		$guards = PageGuards::for($page);
+
+		$this->assertInstanceOf(PageGuards::class, $guards);
+		$this->assertSame($this->app->user(), $guards->user());
+	}
+
+	public function testForIsMemoizedPerModel(): void
+	{
+		$this->app->impersonate('kirby');
+
+		$a = new Page(['slug' => 'a']);
+		$b = new Page(['slug' => 'b']);
+
+		$this->assertSame(PageGuards::for($a), PageGuards::for($a));
+		$this->assertNotSame(PageGuards::for($a), PageGuards::for($b));
+	}
+
+	public function testForIsRebuiltWhenTheUserChanges(): void
+	{
+		$this->app = $this->app->clone([
+			'users' => [
+				['email' => 'a@getkirby.com', 'role' => 'admin'],
+				['email' => 'b@getkirby.com', 'role' => 'admin'],
+			]
+		]);
+
+		$page = new Page(['slug' => 'test']);
+
+		$this->app->impersonate('a@getkirby.com');
+		$first = PageGuards::for($page);
+
+		$this->app->impersonate('b@getkirby.com');
+		$second = PageGuards::for($page);
+
+		$this->assertNotSame($first, $second);
+		$this->assertSame($this->app->user(), $second->user());
+	}
+
 	public function testIsAvailable(): void
 	{
 		$this->app->impersonate('kirby');


### PR DESCRIPTION
<!--
Make sure to point your PR to the relevant develop branches, e.g.
`develop-patch`, `develop-minor` or `v6/develop`.

How to contribute: https://contribute.getkirby.com
-->

## Review
<!--
What do you need from the reviewer? Check what applies, delete the rest.
-->

- [x] Design & concept
- [x] Deep read

## Description
<!--
Add info about why this PR exists and the decisions that went into it.
This info is meant for the reviewer of this PR.

You may keep it short or omit it if it's a simple PR. Please add more
context and a summary of changes if it's a more complex PR.

If something is deliberately out of scope, say so here.
-->

It makes sense to cache the model's guards object. However, we must renew the object when the user has changed (e.g. via `$kirby->impersonate()`). That would not be very DRY to do it in each model class itself. So that's why `ModelGuards::for()` becomes a helper that looks up the cache, renews if needed, and returns the guards object.