### PR TITLE
refact: Fully lazy model list fields

### DIFF
--- a/panel/lab/components/fields/filelist/index.vue
+++ b/panel/lab/components/fields/filelist/index.vue
@@ -2,18 +2,26 @@
 	<k-lab-form>
 		<k-lab-examples class="k-lab-field-examples">
 			<k-box theme="notice" icon="alert">
-				The examples below are rendered from static props. There is no model
-				behind them, so everything that talks to the field endpoint (search,
-				pagination, sorting, uploads and batch deletion) answers with a 404 here
-				and only works in a real model view.
+				The field loads its entries from its own endpoint. There is no model
+				behind the lab, so the examples answer that request with static state
+				instead. Everything that writes (sorting, uploads and batch deletion)
+				still talks to the endpoint and answers with a 404 here.
 			</k-box>
 
 			<k-lab-example label="Default">
-				<k-filelist-field :initial="state(files)" label="Files" />
+				<k-lab-filelist-field :initial="state(files)" label="Files" />
+			</k-lab-example>
+
+			<k-lab-example label="Loading">
+				<k-lab-filelist-field label="Files" />
+			</k-lab-example>
+
+			<k-lab-example label="Loading: table">
+				<k-lab-filelist-field :columns="columns" label="Files" layout="table" />
 			</k-lab-example>
 
 			<k-lab-example label="Help">
-				<k-filelist-field
+				<k-lab-filelist-field
 					:initial="state(files)"
 					help="Every file of this page"
 					label="Files"
@@ -21,14 +29,14 @@
 			</k-lab-example>
 
 			<k-lab-example label="Empty">
-				<k-filelist-field
+				<k-lab-filelist-field
 					:initial="state([], { pagination: empty })"
 					label="Files"
 				/>
 			</k-lab-example>
 
 			<k-lab-example label="Empty with custom text">
-				<k-filelist-field
+				<k-lab-filelist-field
 					:initial="state([], { pagination: empty })"
 					empty="No images have been added yet"
 					label="Files"
@@ -36,7 +44,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Invalid: fewer than min">
-				<k-filelist-field
+				<k-lab-filelist-field
 					:initial="state(files.slice(0, 1), { pagination: single })"
 					:min="2"
 					help="The label marks the field as invalid until a second file is added"
@@ -45,7 +53,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Layout: cardlets">
-				<k-filelist-field
+				<k-lab-filelist-field
 					:initial="state(files)"
 					label="Files"
 					layout="cardlets"
@@ -53,7 +61,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Layout: cards">
-				<k-filelist-field
+				<k-lab-filelist-field
 					:initial="state(files)"
 					label="Files"
 					layout="cards"
@@ -61,7 +69,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Layout: cards, size small">
-				<k-filelist-field
+				<k-lab-filelist-field
 					:initial="state(files)"
 					label="Files"
 					layout="cards"
@@ -70,7 +78,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Layout: table">
-				<k-filelist-field
+				<k-lab-filelist-field
 					:initial="state(tableRows, { columns })"
 					label="Files"
 					layout="table"
@@ -78,7 +86,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Layout: table with columns">
-				<k-filelist-field
+				<k-lab-filelist-field
 					:initial="state(tableRows, { columns: customColumns })"
 					label="Files"
 					layout="table"
@@ -86,7 +94,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Link to another parent">
-				<k-filelist-field
+				<k-lab-filelist-field
 					:initial="state(files)"
 					label="Files"
 					link="/pages/photography"
@@ -94,7 +102,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Pagination">
-				<k-filelist-field
+				<k-lab-filelist-field
 					:endpoints="endpoints"
 					:initial="state(files.slice(0, 3), { pagination: paginated })"
 					label="Files"
@@ -102,7 +110,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Search">
-				<k-filelist-field
+				<k-lab-filelist-field
 					:endpoints="endpoints"
 					:initial="state(files)"
 					:searchable="true"
@@ -111,7 +119,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Batch">
-				<k-filelist-field
+				<k-lab-filelist-field
 					:batch="true"
 					:endpoints="endpoints"
 					:initial="state(files)"
@@ -120,7 +128,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Upload">
-				<k-filelist-field
+				<k-lab-filelist-field
 					:endpoints="endpoints"
 					:initial="state(files, { upload })"
 					label="Files"
@@ -128,7 +136,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="All options">
-				<k-filelist-field
+				<k-lab-filelist-field
 					:batch="true"
 					:endpoints="endpoints"
 					:initial="
@@ -148,7 +156,27 @@
 </template>
 
 <script>
+const field = {
+	extends: window.panel.app.component("k-filelist-field"),
+	props: {
+		initial: Object
+	},
+	methods: {
+		async reload() {
+			if (this.initial === undefined) {
+				return;
+			}
+
+			this.state = this.initial;
+			this.isLoading = false;
+		}
+	}
+};
+
 export default {
+	components: {
+		"k-lab-filelist-field": field
+	},
 	props: {
 		columns: Object,
 		customColumns: Object,

--- a/panel/lab/components/fields/pagelist/index.vue
+++ b/panel/lab/components/fields/pagelist/index.vue
@@ -2,18 +2,26 @@
 	<k-lab-form>
 		<k-lab-examples class="k-lab-field-examples">
 			<k-box theme="notice" icon="alert">
-				The examples below are rendered from static props. There is no model
-				behind them, so everything that talks to the field endpoint (search,
-				pagination, sorting and batch deletion) answers with a 404 here and only
-				works in a real model view.
+				The field loads its entries from its own endpoint. There is no model
+				behind the lab, so the examples answer that request with static state
+				instead. Everything that writes (sorting and batch deletion) still talks
+				to the endpoint and answers with a 404 here.
 			</k-box>
 
 			<k-lab-example label="Default">
-				<k-pagelist-field :initial="state(pages)" label="Pages" />
+				<k-lab-pagelist-field :initial="state(pages)" label="Pages" />
+			</k-lab-example>
+
+			<k-lab-example label="Loading">
+				<k-lab-pagelist-field label="Pages" />
+			</k-lab-example>
+
+			<k-lab-example label="Loading: table">
+				<k-lab-pagelist-field :columns="columns" label="Pages" layout="table" />
 			</k-lab-example>
 
 			<k-lab-example label="Help">
-				<k-pagelist-field
+				<k-lab-pagelist-field
 					:initial="state(pages)"
 					help="Every child of this page"
 					label="Pages"
@@ -21,14 +29,14 @@
 			</k-lab-example>
 
 			<k-lab-example label="Empty">
-				<k-pagelist-field
+				<k-lab-pagelist-field
 					:initial="state([], { pagination: empty })"
 					label="Pages"
 				/>
 			</k-lab-example>
 
 			<k-lab-example label="Empty with custom text">
-				<k-pagelist-field
+				<k-lab-pagelist-field
 					:initial="state([], { pagination: empty })"
 					empty="No pages have been added yet"
 					label="Pages"
@@ -36,7 +44,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Invalid: fewer than min">
-				<k-pagelist-field
+				<k-lab-pagelist-field
 					:initial="state(pages.slice(0, 1), { pagination: single })"
 					:min="2"
 					help="The label marks the field as invalid until a second page is added"
@@ -45,7 +53,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Layout: cardlets">
-				<k-pagelist-field
+				<k-lab-pagelist-field
 					:initial="state(pages)"
 					label="Pages"
 					layout="cardlets"
@@ -53,7 +61,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Layout: cards">
-				<k-pagelist-field
+				<k-lab-pagelist-field
 					:initial="state(pages)"
 					label="Pages"
 					layout="cards"
@@ -61,7 +69,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Layout: cards, size small">
-				<k-pagelist-field
+				<k-lab-pagelist-field
 					:initial="state(pages)"
 					label="Pages"
 					layout="cards"
@@ -70,7 +78,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Layout: table">
-				<k-pagelist-field
+				<k-lab-pagelist-field
 					:initial="state(tableRows, { columns })"
 					label="Pages"
 					layout="table"
@@ -78,7 +86,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Layout: table with columns">
-				<k-pagelist-field
+				<k-lab-pagelist-field
 					:initial="state(tableRows, { columns: customColumns })"
 					label="Pages"
 					layout="table"
@@ -86,7 +94,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Link to another parent">
-				<k-pagelist-field
+				<k-lab-pagelist-field
 					:initial="state(pages)"
 					label="Pages"
 					link="/pages/photography"
@@ -94,7 +102,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Pagination">
-				<k-pagelist-field
+				<k-lab-pagelist-field
 					:endpoints="endpoints"
 					:initial="state(pages.slice(0, 2), { pagination: paginated })"
 					label="Pages"
@@ -102,7 +110,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Search">
-				<k-pagelist-field
+				<k-lab-pagelist-field
 					:endpoints="endpoints"
 					:initial="state(pages)"
 					:searchable="true"
@@ -111,7 +119,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Batch">
-				<k-pagelist-field
+				<k-lab-pagelist-field
 					:batch="true"
 					:endpoints="endpoints"
 					:initial="state(pages)"
@@ -120,7 +128,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="Add">
-				<k-pagelist-field
+				<k-lab-pagelist-field
 					:endpoints="endpoints"
 					:initial="state(pages, { add: true })"
 					label="Pages"
@@ -128,7 +136,7 @@
 			</k-lab-example>
 
 			<k-lab-example label="All options">
-				<k-pagelist-field
+				<k-lab-pagelist-field
 					:batch="true"
 					:endpoints="endpoints"
 					:initial="
@@ -148,7 +156,27 @@
 </template>
 
 <script>
+const field = {
+	extends: window.panel.app.component("k-pagelist-field"),
+	props: {
+		initial: Object
+	},
+	methods: {
+		async reload() {
+			if (this.initial === undefined) {
+				return;
+			}
+
+			this.state = this.initial;
+			this.isLoading = false;
+		}
+	}
+};
+
 export default {
+	components: {
+		"k-lab-pagelist-field": field
+	},
 	props: {
 		columns: Object,
 		customColumns: Object,

--- a/panel/lab/components/tables/4_component/index.vue
+++ b/panel/lab/components/tables/4_component/index.vue
@@ -36,6 +36,9 @@
 				:sortable="true"
 			></k-table>
 		</k-lab-example>
+		<k-lab-example label="Theme: skeleton">
+			<k-table :columns="columns" :rows="skeleton"></k-table>
+		</k-lab-example>
 	</k-lab-examples>
 </template>
 
@@ -85,6 +88,12 @@ export default {
 					date: "2020-01-03",
 					selectable: false
 				}
+			];
+		},
+		skeleton() {
+			return [
+				{ id: "skeleton-1", theme: "skeleton" },
+				{ id: "skeleton-2", theme: "skeleton" }
 			];
 		}
 	}

--- a/panel/src/components/Forms/Field/FileListField.vue
+++ b/panel/src/components/Forms/Field/FileListField.vue
@@ -69,7 +69,13 @@ export default {
 			);
 		},
 		refreshEvents() {
-			return ["file.sort", "model.update"];
+			return [
+				"file.changeName",
+				"file.changeTemplate",
+				"file.delete",
+				"file.sort",
+				"model.update"
+			];
 		}
 	}
 };

--- a/panel/src/components/Forms/Field/ModelListField.test.ts
+++ b/panel/src/components/Forms/Field/ModelListField.test.ts
@@ -1,23 +1,32 @@
 import { beforeEach, describe, expect, it, vi } from "@test/unit";
-import { mount } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import ModelListField from "./ModelListField.vue";
 
-const events = { emit: vi.fn(), off: vi.fn(), on: vi.fn() };
+const listeners: Record<string, () => void> = {};
+
+const events = {
+	emit: vi.fn(),
+	off: vi.fn(),
+	on: vi.fn((event: string, handler: () => void) => {
+		listeners[event] = handler;
+	})
+};
 const api = { get: vi.fn() };
 const panel = { error: vi.fn() };
 
-const initial = {
-	columns: {},
+const state = {
+	columns: { title: { label: "Title", type: "url" } },
 	models: [],
-	pagination: { page: 1, total: 0 }
+	pagination: { limit: 20, offset: 0, page: 1, total: 0 },
+	sortable: true
 };
 
-function factory() {
+function factory(props = {}) {
 	return mount(ModelListField, {
 		props: {
 			endpoints: { field: "pages/test/fields/drafts" },
-			initial,
-			name: "drafts"
+			name: "drafts",
+			...props
 		},
 		shallow: true,
 		global: {
@@ -41,20 +50,73 @@ function lastEmit() {
 describe("ModelListField.vue", () => {
 	beforeEach(() => {
 		api.get.mockReset();
+		api.get.mockResolvedValue(state);
 		events.emit.mockClear();
+		events.off.mockClear();
+		events.on.mockClear();
 		panel.error.mockClear();
 	});
 
-	it("announces itself once it is mounted", () => {
+	it("fetches its entries once it is mounted", async () => {
 		const wrapper = factory();
+
+		expect(api.get).toHaveBeenCalledWith("pages/test/fields/drafts", {
+			page: 1,
+			searchterm: null
+		});
+
+		await flushPromises();
+
+		expect(wrapper.vm.state).toStrictEqual(state);
+		expect(wrapper.vm.isLoading).toBe(false);
+	});
+
+	it("shows a skeleton until the entries arrive", async () => {
+		const wrapper = factory();
+
+		expect(wrapper.vm.isLoading).toBe(true);
+		expect(wrapper.vm.skeleton).toHaveLength(1);
+		expect(wrapper.vm.skeleton[0].theme).toBe("skeleton");
+
+		// the entries are unknown, so the list cannot be validated yet
+		expect(wrapper.vm.validator).toStrictEqual({ count: 0 });
+
+		await flushPromises();
+
+		expect(wrapper.vm.validator).toStrictEqual({
+			count: 0,
+			max: undefined,
+			min: undefined
+		});
+	});
+
+	it("keeps the columns from the props while loading", async () => {
+		const columns = { title: { label: "Title" } };
+		const wrapper = factory({ columns });
+
+		expect(wrapper.vm.state.columns).toStrictEqual(columns);
+
+		await flushPromises();
+
+		// the loaded columns carry the resolved types
+		expect(wrapper.vm.state.columns).toStrictEqual(state.columns);
+	});
+
+	it("announces itself once the entries have arrived", async () => {
+		const wrapper = factory();
+
+		expect(events.emit).not.toHaveBeenCalled();
+
+		await flushPromises();
 
 		expect(events.emit).toHaveBeenCalledTimes(1);
 		expect(lastEmit()[0]).toBe("field.loaded");
 		expect(lastEmit()[1]).toBe(wrapper.vm);
 	});
 
-	it("listens to model updates while mounted", () => {
+	it("listens to its refresh events while mounted", async () => {
 		const wrapper = factory();
+		await flushPromises();
 
 		expect(events.on).toHaveBeenCalledWith("model.update", expect.anything());
 
@@ -63,37 +125,63 @@ describe("ModelListField.vue", () => {
 		expect(events.off).toHaveBeenCalledWith("model.update", expect.anything());
 	});
 
-	it("announces itself again after a reload", async () => {
-		const state = { ...initial, pagination: { page: 2, total: 25 } };
-		api.get.mockResolvedValue(state);
+	it("reloads when one of its refresh events fires", async () => {
+		factory();
+		await flushPromises();
+		api.get.mockClear();
 
+		vi.useFakeTimers();
+
+		// a dialog that answers with two events is worth one reload
+		listeners["model.update"]();
+		listeners["model.update"]();
+
+		await vi.advanceTimersByTimeAsync(1);
+		vi.useRealTimers();
+
+		expect(api.get).toHaveBeenCalledOnce();
+	});
+
+	it("announces itself again after a reload", async () => {
 		const wrapper = factory();
+		await flushPromises();
+
+		const reloaded = { ...state, pagination: { page: 2, total: 25 } };
+		api.get.mockResolvedValue(reloaded);
+
 		await wrapper.vm.reload({ page: 2 });
 
-		expect(api.get).toHaveBeenCalledWith("pages/test/fields/drafts", {
+		expect(api.get).toHaveBeenLastCalledWith("pages/test/fields/drafts", {
 			page: 2,
 			searchterm: null
 		});
 
-		// the fresh state replaces the initial one
-		expect(wrapper.vm.state).toStrictEqual(state);
+		expect(wrapper.vm.state).toStrictEqual(reloaded);
 
-		// once on mount, once after the reload
+		// once after the initial load, once after the reload
 		expect(events.emit).toHaveBeenCalledTimes(2);
 		expect(lastEmit()[0]).toBe("field.loaded");
 		expect(lastEmit()[1]).toBe(wrapper.vm);
 	});
 
-	it("announces itself even when the reload fails", async () => {
+	it("announces itself even when the load fails", async () => {
 		const error = new Error("Nope");
 		api.get.mockRejectedValue(error);
 
 		const wrapper = factory();
-		await wrapper.vm.reload();
+		await flushPromises();
 
 		expect(panel.error).toHaveBeenCalledWith(error);
+		expect(wrapper.vm.isLoading).toBe(false);
+
+		// the list must not look empty when it could not be loaded
+		expect(wrapper.vm.emptyProps).toStrictEqual({
+			icon: "alert",
+			text: "Nope"
+		});
+
 		expect(wrapper.vm.isProcessing).toBe(false);
-		expect(events.emit).toHaveBeenCalledTimes(2);
+		expect(events.emit).toHaveBeenCalledOnce();
 		expect(lastEmit()[0]).toBe("field.loaded");
 		expect(lastEmit()[1]).toBe(wrapper.vm);
 	});

--- a/panel/src/components/Forms/Field/ModelListField.vue
+++ b/panel/src/components/Forms/Field/ModelListField.vue
@@ -32,7 +32,7 @@
 					:columns="state.columns"
 					:empty="emptyProps"
 					:fields="fields"
-					:items="items"
+					:items="isLoading ? skeleton : items"
 					:layout="layout"
 					:pagination="state.pagination"
 					:selected="selected"
@@ -72,12 +72,15 @@ export default {
 		 * Shows the batch select interface
 		 */
 		batch: Boolean,
+		columns: {
+			type: [Array, Object],
+			default: () => ({})
+		},
 		/**
 		 * Text for the empty state box
 		 */
 		empty: String,
 		endpoints: Object,
-		initial: Object,
 		/**
 		 * Layout of the collection
 		 * @values list, cardlets, cards, table
@@ -110,9 +113,16 @@ export default {
 	},
 	data() {
 		return {
-			fetched: null,
+			error: null,
+			isLoading: true,
 			isSearching: false,
-			searchterm: null
+			searchterm: null,
+			state: {
+				columns: this.columns,
+				models: [],
+				pagination: { limit: 0, offset: 0, page: 1, total: 0 },
+				sortable: false
+			}
 		};
 	},
 	computed: {
@@ -161,11 +171,24 @@ export default {
 		},
 		emptyProps() {
 			return {
-				icon: this.icon,
-				text: this.isSearching
-					? this.$t("search.results.none")
-					: (this.empty ?? this.$t(this.$options.type + ".empty"))
+				icon: this.error !== null ? "alert" : this.icon,
+				text: this.emptyText
 			};
+		},
+		emptyText() {
+			if (this.isLoading === true) {
+				return this.$t("loading");
+			}
+
+			if (this.error !== null) {
+				return this.error;
+			}
+
+			if (this.isSearching === true) {
+				return this.$t("search.results.none");
+			}
+
+			return this.empty ?? this.$t(this.$options.type + ".empty");
 		},
 		/**
 		 * The icon of the empty state
@@ -215,17 +238,24 @@ export default {
 				};
 			});
 		},
-		state() {
-			return this.fetched ?? this.initial;
+		skeleton() {
+			return [
+				{
+					id: "skeleton",
+					image: this.layout !== "table" ? { icon: "loader" } : null,
+					theme: "skeleton"
+				}
+			];
 		},
 		/**
-		 * The list is only validated while it shows everything,
-		 * as a search narrows it down to a part of the collection
+		 * The list is only validated while it shows everything.
+		 * A search narrows it down to a part of the collection
+		 * and the loading list knows no entries at all.
 		 */
 		validator() {
 			const count = this.state.pagination.total;
 
-			if (this.searchterm) {
+			if (this.isLoading === true || this.searchterm) {
 				return { count };
 			}
 
@@ -233,28 +263,20 @@ export default {
 		}
 	},
 	watch: {
-		// a new view always brings unfiltered state for the first page,
-		// so an active search or page has to be restored through the endpoint
-		initial() {
-			if (this.searchterm || this.state.pagination.page > 1) {
-				this.reload();
-			} else {
-				this.fetched = null;
-			}
-		},
 		searchterm() {
 			this.filter();
 		}
 	},
 	created() {
 		this.filter = debounce(this.filter, 200);
+		this.onRefresh = debounce(this.onRefresh, 0);
 
 		for (const event of this.refreshEvents()) {
 			this.$events.on(event, this.onRefresh);
 		}
 	},
 	mounted() {
-		this.$events.emit("field.loaded", this);
+		this.reload();
 	},
 	unmounted() {
 		for (const event of this.refreshEvents()) {
@@ -287,6 +309,12 @@ export default {
 			this.searchterm = null;
 		},
 		onSort() {},
+		/**
+		 * Events after which the list has to load its entries
+		 * again. Every action that changes what the list shows
+		 * has to be in here, as the view no longer carries the
+		 * entries along when it reloads.
+		 */
 		refreshEvents() {
 			return ["model.update"];
 		},
@@ -298,14 +326,17 @@ export default {
 			this.isProcessing = true;
 
 			try {
-				this.fetched = await this.$api.get(this.endpoints.field, {
+				this.state = await this.$api.get(this.endpoints.field, {
 					page: this.state.pagination.page,
 					searchterm: this.searchterm,
 					...query
 				});
+				this.error = null;
 			} catch (error) {
+				this.error = error.message;
 				this.$panel.error(error);
 			} finally {
+				this.isLoading = false;
 				this.isProcessing = false;
 			}
 

--- a/panel/src/components/Forms/Field/PageListField.vue
+++ b/panel/src/components/Forms/Field/PageListField.vue
@@ -84,7 +84,16 @@ export default {
 			);
 		},
 		refreshEvents() {
-			return ["model.update", "page.changeStatus", "page.sort"];
+			return [
+				"model.update",
+				"page.changeSlug",
+				"page.changeStatus",
+				"page.changeTemplate",
+				"page.changeTitle",
+				"page.create",
+				"page.delete",
+				"page.sort"
+			];
 		}
 	}
 };

--- a/panel/src/components/Layout/Table.vue
+++ b/panel/src/components/Layout/Table.vue
@@ -83,6 +83,7 @@
 						:data-selecting="selecting"
 						:data-selectable="rowIsSelectable(row)"
 						:data-sortable="rowIsSortable(row)"
+						:data-theme="row.theme"
 					>
 						<!-- Index & drag handle -->
 						<td
@@ -97,7 +98,12 @@
 									rowIndex
 								}"
 							>
-								<div class="k-table-index" v-text="index + rowIndex" />
+								<k-icon
+									v-if="row.theme === 'skeleton'"
+									class="k-table-index"
+									type="loader"
+								/>
+								<div v-else class="k-table-index" v-text="index + rowIndex" />
 							</slot>
 
 							<k-sort-handle
@@ -648,6 +654,16 @@ export default {
 	--button-width: 100%;
 	--button-height: 100%;
 	outline-offset: -2px;
+}
+
+/* Theme: skeleton */
+.k-table tr[data-theme="skeleton"] .k-table-column::after {
+	content: "";
+	display: block;
+	height: 0.75em;
+	margin-inline: var(--table-cell-padding);
+	border-radius: var(--rounded-sm);
+	background: light-dark(var(--color-gray-250), var(--color-gray-800));
 }
 
 /* Empty */

--- a/panel/src/components/Misc/Draggable.vue
+++ b/panel/src/components/Misc/Draggable.vue
@@ -95,6 +95,10 @@ export default {
 	watch: {
 		dragOptions: {
 			handler(newOptions, oldOptions) {
+				if (this.sortable === null) {
+					return;
+				}
+
 				for (const option in newOptions) {
 					if (newOptions[option] !== oldOptions[option]) {
 						this.sortable.option(option, newOptions[option]);

--- a/src/Form/Field/ModelListField.php
+++ b/src/Form/Field/ModelListField.php
@@ -153,8 +153,8 @@ abstract class ModelListField extends DisplayField
 	}
 
 	/**
-	 * The list is not part of the form values, so it refreshes
-	 * itself through its own endpoint
+	 * The list is not part of the form values, so it loads and
+	 * refreshes itself through its own endpoint
 	 */
 	public function api(): array
 	{
@@ -521,8 +521,8 @@ abstract class ModelListField extends DisplayField
 		return [
 			...parent::props(),
 			'batch'      => $this->batch(),
+			'columns'    => $this->defineColumns(),
 			'empty'      => $this->empty(),
-			'initial'    => $this->state(),
 			'layout'     => $this->layout(),
 			'link'       => $this->link(),
 			'max'        => $this->max(),


### PR DESCRIPTION
## Review

- [x] Design & concept
- [x] Rough pass

**Timing:**

## Description

List fields sent their entries along in the view props (`initial`), so a slow field slows down the whole view. They now load again (like the sections) fully lazily from the endpoint.

Only the column definitions still travel with the props: they come from the field config and give the table layout its shape while loading.

Slowed down version to see the styling of the loading state:

https://github.com/user-attachments/assets/43312483-af95-4913-abf5-43ac02c8718f


### Benchmarks

Measured `boot + PageViewController::props()`:

| view | before | after |
|---|---|---|
| 3 pagelists over separate 300-page trees | 74 ms | **26 ms** |
| 1 pagelist, `query: site.index`, 2900 pages | 118 ms | **25 ms** |
| props payload per list | 9.6 KB | 0 |

```php
$kirby = new App([
	'roots'      => [...],
	'blueprints' => ['pages/bench' => ['title' => 'Bench', 'fields' => $fields]],
	'users'      => [['email' => 'admin@getkirby.com', 'role' => 'admin']],
]);

$kirby->impersonate('admin@getkirby.com');
$page = $kirby->page('bench');

$start = hrtime(true);
$props = (new PageViewController($page))->props();
printf("%.1f ms\n", (hrtime(true) - $start) / 1e6);
```

## Changelog

### ✨ Enhancements

- Skeleton theme also for `k-collection` with `table` layout

### 🐛 Bug fixes

- Sorting no longer breaks when a collection becomes sortable while the drag  library is still loading.

## For review team

- [x] Add lab and/or sandbox examples (wherever helpful)
- [ ] Add changes & docs to release notes draft in Notion
