### PR TITLE
fix: Decode percent-encoded page IDs in Panel and API routes

### DIFF
--- a/src/Cms/Find.php
+++ b/src/Cms/Find.php
@@ -71,7 +71,7 @@ class Find
 	public static function page(string $id): Page|null
 	{
 		// decode API ID encoding
-		$id    = str_replace(['+', ' '], '/', $id);
+		$id    = str_replace(['+', ' '], '/', rawurldecode($id));
 		$kirby = App::instance();
 		$page  = $kirby->page($id, null, true);
 

--- a/tests/Cms/FindTest.php
+++ b/tests/Cms/FindTest.php
@@ -186,6 +186,8 @@ class FindTest extends TestCase
 		$this->assertSame($a, Find::page('a'));
 		$this->assertSame($aa, Find::page('a/aa'));
 		$this->assertSame($aa, Find::page('a+aa'));
+		$this->assertSame($aa, Find::page('a%2Baa'));
+		$this->assertSame($aa, Find::page('a%2Faa'));
 		$this->assertSame($b, Find::page('page://my-uuid'));
 	}
 


### PR DESCRIPTION
## Review

- [x] Rough pass

**Timing:** whenever

## Description

Some servers (o2switch with LiteSpeed cache in this case) turn the `+` in Panel URLs into `%2B`. `Find::page()` didn't decode that, so the page could not be found.

`+` and `%2B` mean the same thing in a URL path, so we just decode it. `Find::file()` already does this. Raw `+` still works.

https://forum.getkirby.com/t/kirby-urls-is-converted-to-2b-by-o2switch/35607

## Changelog

### 🐛 Bug fixes

- Fix Panel page URLs when the server encodes `+` as `%2B`

## For review team

- [ ] Add lab and/or sandbox examples (wherever helpful)
- [x] Add changes & docs to release notes draft in Notion